### PR TITLE
refactor: use `git checkout` instead of `git co`

### DIFF
--- a/patch_pr.sh
+++ b/patch_pr.sh
@@ -54,7 +54,7 @@ fi
 patch_file=/tmp/pr_${module_dir}_${pr}.patch
 curl -L $url.patch > $patch_file
 cd $module_dir
-git co -b "pr/${module_dir}-$pr"
+git checkout -b "pr/${module_dir}-$pr"
 patch -p1 < $patch_file
 git status -s | grep -v -e '^ M ' | sed -e 's/^?? //' | xargs git add
 git commit -a -m "Applied PR $url (Module: $module_dir, PR: $pr)"


### PR DESCRIPTION
`git co` was causing an error on my end:

    git: 'co' is not a git command. See 'git --help'.