### PR TITLE
chore(tools): IDE and System files added to git ignore manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,15 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-
-# IDEA files
-.idea
+# IDEs and editors
+/.idea
 *.iml
+.project
+.classpath
+*.launch
+.settings/
+.vscode/
+
+# System Files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
The original purpose was to ensure that no Mac OS system file will make it to the repo, but decided to extend ignore to system files generated by IDEs other than IntelliJ and stuff...