### PR TITLE
chore: use latest 1.32.0 SNAPSHOT of datamapper

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "4.4.5",
     "@angular/platform-browser-dynamic": "4.4.5",
     "@angular/router": "4.4.5",
-    "@atlasmap/atlasmap.data.mapper": "^1.32.0-SNAPSHOT.20171018190510",
+    "@atlasmap/atlasmap.data.mapper": "^1.32.0-SNAPSHOT",
     "@ng-dynamic-forms/core": "1.4.31",
     "@ng-dynamic-forms/ui-bootstrap": "1.4.31",
     "angular2-text-mask": "^8.0.1",


### PR DESCRIPTION
So for me this change just worked to retrieve latest 1.32.0 SNAPSHOT while it was always retrieving `20171018190510` before. @syndesisio/ui-api WDYT?