### PR TITLE
feat: introduce errorprone checks

### DIFF
--- a/rest/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
+++ b/rest/controllers/src/main/java/io/syndesis/controllers/integration/DemoHandlerProvider.java
@@ -47,6 +47,7 @@ public class DemoHandlerProvider implements StatusChangeHandlerProvider {
             this.waitMillis = waitMillis;
         }
 
+        @Override
         public Set<Integration.Status> getTriggerStatuses() {
             return Collections.singleton(status);
         }

--- a/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -124,7 +124,7 @@ public class IntegrationController {
     }
 
     private void scanIntegrationsForWork() {
-        executor.submit(() -> {
+        executor.execute(() -> {
             dataManager.fetchAll(Integration.class).getItems().forEach(integration -> {
                 LOG.info("Checking integrations for their status.");
                 checkIntegrationStatus(integration);
@@ -144,7 +144,7 @@ public class IntegrationController {
                     StatusChangeHandlerProvider.StatusChangeHandler statusChangeHandler = handlers.get(desiredStatus);
                     if (statusChangeHandler != null) {
                         LOG.info("Integration {} : Desired status \"{}\" != current status \"{}\" --> calling status change handler",
-                                               integrationId, desiredStatus.toString(), current.map(Enum::toString).orElse("[none]"));
+                                               integrationId, desiredStatus.toString(), current.map(Object::toString).orElse("[none]"));
                         callStatusChangeHandler(statusChangeHandler, integrationId);
                     }
                 }));
@@ -160,7 +160,7 @@ public class IntegrationController {
     }
 
     /* default */ void callStatusChangeHandler(StatusChangeHandlerProvider.StatusChangeHandler handler, String integrationId) {
-        executor.submit(() -> {
+        executor.execute(() -> {
             Integration integration = dataManager.fetch(Integration.class, integrationId);
             String checkKey = getIntegrationMarkerKey(integration);
             scheduledChecks.add(checkKey);
@@ -233,6 +233,7 @@ public class IntegrationController {
         });
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored")
     private void reschedule(String integrationId) {
         scheduler.schedule(() -> {
             Integration i = dataManager.fetch(Integration.class, integrationId);

--- a/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationSupport.java
+++ b/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationSupport.java
@@ -38,12 +38,15 @@ public final class IntegrationSupport {
     private IntegrationSupport() {
     }
 
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <K, V> Map<K, V> aggregate(Map<K, V> ... maps) {
         return Stream.of(maps)
             .flatMap(map -> map.entrySet().stream())
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> newValue));
     }
 
+    @SafeVarargs
     public static <T> Predicate<T> or(Predicate<T>... predicates) {
         Predicate<T> predicate = predicates[0];
 

--- a/rest/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
+++ b/rest/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(value = "controllers.integration.enabled", havingValue = "noop")
 public class NoopHandlerProvider implements StatusChangeHandlerProvider.StatusChangeHandler, StatusChangeHandlerProvider {
 
+    @Override
     public Set<Integration.Status> getTriggerStatuses() {
         return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             Integration.Status.Activated,

--- a/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -35,6 +35,7 @@ import io.syndesis.core.SyndesisServerException;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionState;
 import io.syndesis.openshift.DeploymentData;
 import io.syndesis.openshift.OpenShiftService;
 import io.syndesis.project.converter.ProjectGenerator;
@@ -185,7 +186,7 @@ public class ActivateHandler extends BaseHandler implements StatusChangeHandlerP
             .stream()
             .filter(i -> !i.idEquals(id)) //The "current" integration will already be in the database.
             .filter(i -> i.getUserId().map(username::equals).orElse(Boolean.FALSE))
-            .filter(i -> Integration.Status.Activated.equals(i.getStatus()))
+            .filter(i -> IntegrationRevisionState.Active == i.getStatus())
             .count();
     }
 

--- a/rest/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
+++ b/rest/controllers/src/test/java/io/syndesis/controllers/integration/IntegrationControllerTest.java
@@ -34,6 +34,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,10 +69,10 @@ public class IntegrationControllerTest {
         final AtomicReference<Integration> currentIntegration = new AtomicReference<>(integration);
         when(dataManager.fetch(Integration.class, INTEGRATION_ID)).thenAnswer(invocation -> currentIntegration.get());
 
-        when(integrationController.executor.submit(any(Runnable.class))).then(invocation -> {
+        doAnswer(invocation -> {
             invocation.getArgumentAt(0, Runnable.class).run();
             return null;
-        });
+        }).when(integrationController.executor).execute(any(Runnable.class));
 
         final ArgumentCaptor<Integration> updatedIntegrations = ArgumentCaptor.forClass(Integration.class);
         doNothing().when(dataManager).update(updatedIntegrations.capture());

--- a/rest/credential/src/main/java/io/syndesis/credential/OAuth1CredentialFlowState.java
+++ b/rest/credential/src/main/java/io/syndesis/credential/OAuth1CredentialFlowState.java
@@ -31,6 +31,7 @@ import org.springframework.social.oauth1.OAuthToken;
 
 @Value.Immutable
 @JsonDeserialize(builder = OAuth1CredentialFlowState.Builder.class)
+@SuppressWarnings("immutables")
 public interface OAuth1CredentialFlowState extends CredentialFlowState {
 
     final class Builder extends ImmutableOAuth1CredentialFlowState.Builder implements CredentialFlowState.Builder {

--- a/rest/credential/src/main/java/io/syndesis/credential/OAuth2CredentialFlowState.java
+++ b/rest/credential/src/main/java/io/syndesis/credential/OAuth2CredentialFlowState.java
@@ -33,6 +33,7 @@ import org.springframework.social.oauth2.AccessGrant;
 
 @Value.Immutable
 @JsonDeserialize(builder = OAuth2CredentialFlowState.Builder.class)
+@SuppressWarnings("immutables")
 public interface OAuth2CredentialFlowState extends CredentialFlowState {
 
     final class AccessGrantConverter implements Converter<Map<String, String>, AccessGrant> {

--- a/rest/dao/pom.xml
+++ b/rest/dao/pom.xml
@@ -99,6 +99,13 @@
       <artifactId>jsr305</artifactId>
     </dependency>
 
+    <dependency>
+      <!-- We need the net.jcip.annotations.GuardedBy for Infinispan (at compile time only) -->
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- === Test ============================================================================ -->
 
     <dependency>

--- a/rest/dao/src/main/java/io/syndesis/dao/manager/DataAccessObjectRegistry.java
+++ b/rest/dao/src/main/java/io/syndesis/dao/manager/DataAccessObjectRegistry.java
@@ -15,13 +15,9 @@
  */
 package io.syndesis.dao.manager;
 
-import java.util.Map;
-
 import io.syndesis.model.WithId;
 
 public interface DataAccessObjectRegistry {
-
-    <T extends WithId<T>> Map<Class<T>, DataAccessObject<T>> getDataAccessObjectMapping();
 
     /**
      * Finds the {@link DataAccessObject} for the specified type.
@@ -29,10 +25,7 @@ public interface DataAccessObjectRegistry {
      * @param <T>   The specified type.
      * @return      The {@link DataAccessObject} if found, or null no matching {@link DataAccessObject} was found.
      */
-    default <T extends WithId<T>> DataAccessObject<T> getDataAccessObject(Class<T> type) {
-        return this.<T>getDataAccessObjectMapping().get(type);
-    }
-
+    <T extends WithId<T>> DataAccessObject<T> getDataAccessObject(Class<T> type);
 
     /**
      * Finds the {@link DataAccessObject} for the specified type.
@@ -41,7 +34,7 @@ public interface DataAccessObjectRegistry {
      * @return      The {@link DataAccessObject} or throws SyndesisServerException.
      */
     default <T extends WithId<T>> DataAccessObject<T> getDataAccessObjectRequired(Class<T> type) {
-        final DataAccessObject<T> dao = this.<T>getDataAccessObjectMapping().get(type);
+        final DataAccessObject<T> dao = getDataAccessObject(type);
         if (dao != null) {
             return dao;
         }
@@ -53,7 +46,5 @@ public interface DataAccessObjectRegistry {
      * @param dataAccessObject  The {@link DataAccessObject} to register.
      * @param <T>               The type of the {@link DataAccessObject}.
      */
-    default <T extends WithId<T>> void registerDataAccessObject(DataAccessObject<T> dataAccessObject) {
-        this.<T>getDataAccessObjectMapping().put(dataAccessObject.getType(), dataAccessObject);
-    }
+    <T extends WithId<T>> void registerDataAccessObject(DataAccessObject<T> dataAccessObject);
 }

--- a/rest/inspector/pom.xml
+++ b/rest/inspector/pom.xml
@@ -71,6 +71,13 @@
     </dependency>
 
     <dependency>
+      <!-- We need the net.jcip.annotations.GuardedBy for Infinispan (at compile time only) -->
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/rest/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
+++ b/rest/inspector/src/test/java/io/syndesis/inspector/DataMapperClassInspectorTest.java
@@ -16,6 +16,7 @@
 
 package io.syndesis.inspector;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -30,13 +31,13 @@ public class DataMapperClassInspectorTest {
 
     @Rule
     public InfinispanCache infinispan = new InfinispanCache();
+
     private DefaultMockServer mockServer = new DefaultMockServer();
+
     private ClassInspectorConfigurationProperties config = new ClassInspectorConfigurationProperties(mockServer.getHostName(), mockServer.getPort(), false);
 
-
-
     @Test
-    public void shouldHandleNesting() throws Exception {
+    public void shouldHandleNesting() throws IOException {
         DataMapperClassInspector dataMapperClassInspector = new DataMapperClassInspector(infinispan.getCaches(), new RestTemplate(), config);
 
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.StatusJSONImpl").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.StatusJSONImpl.json"), Charset.defaultCharset())).always();
@@ -50,7 +51,7 @@ public class DataMapperClassInspectorTest {
     }
 
     @Test
-    public void shouldHandleInterfaces() throws Exception {
+    public void shouldHandleInterfaces() throws IOException {
         DataMapperClassInspector dataMapperClassInspector = new DataMapperClassInspector(infinispan.getCaches(), new RestTemplate(), config);
         mockServer.expect().get().withPath("/v2/atlas/java/class?className=twitter4j.Status").andReturn(200, Resources.toString(getClass().getResource("/twitter4j.Status.json"), Charset.defaultCharset())).always();
 
@@ -61,10 +62,9 @@ public class DataMapperClassInspectorTest {
     }
 
     @Test
-    public void shouldExtractClassName() throws Exception {
-        DataMapperClassInspector dataMapperClassInspector = new DataMapperClassInspector(infinispan.getCaches(), new RestTemplate(), config);
-        Assert.assertEquals("Status", dataMapperClassInspector.getClassName("Status"));
-        Assert.assertEquals("Status", dataMapperClassInspector.getClassName("twitter4j.Status"));
-        Assert.assertEquals("Status", dataMapperClassInspector.getClassName("more.twitter4j.Status"));
+    public void shouldExtractClassName() {
+        Assert.assertEquals("Status", DataMapperClassInspector.getClassName("Status"));
+        Assert.assertEquals("Status", DataMapperClassInspector.getClassName("twitter4j.Status"));
+        Assert.assertEquals("Status", DataMapperClassInspector.getClassName("more.twitter4j.Status"));
     }
 }

--- a/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/JsonRecordSupport.java
+++ b/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/JsonRecordSupport.java
@@ -233,6 +233,7 @@ public final class JsonRecordSupport {
         private final JsonGenerator jg;
         private final OutputStream output;
         private final GetOptions options;
+        @SuppressWarnings("JdkObsolete")
         private final LinkedList<PathPart> currentPath = new LinkedList<>();
         private final Set<String> shallowObjects = new LinkedHashSet<>();
 

--- a/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/SqlJsonDB.java
+++ b/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/SqlJsonDB.java
@@ -20,10 +20,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -345,7 +346,7 @@ public class SqlJsonDB implements JsonDB {
 
     private int deleteJsonRecords(Handle dbi, String baseDBPath, String like) {
 
-        LinkedList<String> params = getAllParentPaths(baseDBPath);
+        Deque<String> params = getAllParentPaths(baseDBPath);
 
         StringBuilder sql = new StringBuilder("DELETE from jsondb where path LIKE ?");
         if( !params.isEmpty() ) {
@@ -358,8 +359,8 @@ public class SqlJsonDB implements JsonDB {
         return dbi.update(sql.toString(), params.toArray());
     }
 
-    private static LinkedList<String> getAllParentPaths(String baseDBPath) {
-        LinkedList<String> params = new LinkedList<String>();
+    private static Deque<String> getAllParentPaths(String baseDBPath) {
+        Deque<String> params = new ArrayDeque<String>();
         Pattern compile = Pattern.compile("/[^/]*$");
         String current = Strings.trimSuffix(baseDBPath, "/");
         while( true ) {

--- a/rest/model/src/main/java/io/syndesis/model/ChangeEvent.java
+++ b/rest/model/src/main/java/io/syndesis/model/ChangeEvent.java
@@ -30,16 +30,10 @@ import org.immutables.value.Value;
 public interface ChangeEvent extends ToJson, Serializable {
 
     Optional<String> getAction();
-    ChangeEvent withAction(String kind);
 
     Optional<String> getKind();
-    ChangeEvent withKind(String kind);
 
     Optional<String> getId();
-
-    default ChangeEvent withId(String id) {
-        return new ChangeEvent.Builder().createFrom(this).id(id).build();
-    }
 
     static ChangeEvent of(String action, String kind, String id) {
         return new ChangeEvent.Builder().action(action).kind(kind).id(id).build();

--- a/rest/model/src/main/java/io/syndesis/model/DataShape.java
+++ b/rest/model/src/main/java/io/syndesis/model/DataShape.java
@@ -23,6 +23,8 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = DataShape.Builder.class)
+// Immutables generates code that fails these checks
+@SuppressWarnings({ "ArrayEquals", "ArrayHashCode", "ArrayToString" })
 public interface DataShape extends Serializable {
 
     String getKind();
@@ -30,11 +32,8 @@ public interface DataShape extends Serializable {
     String getType();
 
     String getSpecification();
-
     Optional<byte[]> getExemplar();
-
     class Builder extends ImmutableDataShape.Builder {
     }
-
 
 }

--- a/rest/model/src/main/java/io/syndesis/model/EventMessage.java
+++ b/rest/model/src/main/java/io/syndesis/model/EventMessage.java
@@ -30,10 +30,8 @@ import org.immutables.value.Value;
 public interface EventMessage extends ToJson, Serializable {
 
     Optional<String> getEvent();
-    EventMessage withEvent(String kind);
 
     Optional<Object> getData();
-    EventMessage withData(Object kind);
 
     static EventMessage of(String event, Object data) {
         return ImmutableEventMessage.builder().event(event).data(data).build();

--- a/rest/model/src/main/java/io/syndesis/model/ListResult.java
+++ b/rest/model/src/main/java/io/syndesis/model/ListResult.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(builder = ListResult.Builder.class)
+@SuppressWarnings({"rawtypes", "varargs"})
 public interface ListResult<T> {
 
     /**

--- a/rest/model/src/main/java/io/syndesis/model/ModelExport.java
+++ b/rest/model/src/main/java/io/syndesis/model/ModelExport.java
@@ -26,14 +26,15 @@ import java.util.List;
  */
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableModelExport.Builder.class)
+@SuppressWarnings("varargs")
 public interface ModelExport {
 
     String schemaVersion();
 
     @SkipNulls
-    List<ModelData> models();
+    List<ModelData<?>> models();
 
-    static ModelExport of(String version, List<ModelData> models) {
+    static ModelExport of(String version, List<ModelData<?>> models) {
         return ImmutableModelExport.builder().schemaVersion(version).models(models).build();
     }
 

--- a/rest/model/src/main/java/io/syndesis/model/ResourceIdentifier.java
+++ b/rest/model/src/main/java/io/syndesis/model/ResourceIdentifier.java
@@ -26,6 +26,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @JsonDeserialize(builder = ResourceIdentifier.Builder.class)
+@SuppressWarnings("immutables")
 public interface ResourceIdentifier extends WithId<ResourceIdentifier>, WithKind, Serializable {
 
     Optional<String> name();

--- a/rest/model/src/main/java/io/syndesis/model/action/Action.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/Action.java
@@ -92,6 +92,7 @@ public interface Action<D extends ActionDescriptor> extends WithKind, WithName, 
 
     @JsonIgnore
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Override
     default Map<String, ConfigurationProperty> getProperties() {
         ActionDescriptor descriptor = getDescriptor();
 

--- a/rest/model/src/main/java/io/syndesis/model/action/ActionDescriptor.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ActionDescriptor.java
@@ -26,6 +26,7 @@ import io.syndesis.model.WithName;
 import io.syndesis.model.WithProperties;
 import org.immutables.value.Value;
 
+@SuppressWarnings("immutables")
 public interface ActionDescriptor {
     @Value.Immutable
     @JsonDeserialize(builder = ActionDescriptor.ActionDescriptorStep.Builder.class)

--- a/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorAction.Builder.class)
+@SuppressWarnings("immutables")
 public interface ConnectorAction extends Action<ConnectorDescriptor>, WithId<ConnectorAction> {
     @Override
     default ConnectorAction withId(String id) {

--- a/rest/model/src/main/java/io/syndesis/model/action/ConnectorDescriptor.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ConnectorDescriptor.java
@@ -27,6 +27,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorDescriptor.Builder.class)
+@SuppressWarnings("immutables")
 public interface ConnectorDescriptor extends ActionDescriptor, Serializable {
 
     final class Builder extends ImmutableConnectorDescriptor.Builder {

--- a/rest/model/src/main/java/io/syndesis/model/action/ExtensionAction.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ExtensionAction.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ExtensionAction.Builder.class)
+@SuppressWarnings("immutables")
 public interface ExtensionAction extends Action<ExtensionDescriptor>, WithId<ExtensionAction> {
     @Override
     default ExtensionAction withId(String id) {

--- a/rest/model/src/main/java/io/syndesis/model/action/ExtensionDescriptor.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ExtensionDescriptor.java
@@ -27,6 +27,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ExtensionDescriptor.Builder.class)
+@SuppressWarnings("immutables")
 public interface ExtensionDescriptor extends ActionDescriptor, Serializable {
 
     final class Builder extends ImmutableExtensionDescriptor.Builder {

--- a/rest/model/src/main/java/io/syndesis/model/connection/ConfigurationProperty.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/ConfigurationProperty.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.model.connection;
 
+import java.io.Serializable;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -27,7 +28,8 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ConfigurationProperty.Builder.class)
-public interface ConfigurationProperty extends WithTags {
+@SuppressWarnings("immutables")
+public interface ConfigurationProperty extends WithTags, Serializable {
 
     class Builder extends ImmutableConfigurationProperty.Builder {
         // make ImmutableConfigurationProperty.Builder accessible

--- a/rest/model/src/main/java/io/syndesis/model/connection/Connection.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/Connection.java
@@ -39,6 +39,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = Connection.Builder.class)
 @UniqueProperty(value = "name", groups = UniquenessRequired.class)
+@SuppressWarnings("immutables")
 public interface Connection extends WithId<Connection>, WithTags, WithName, Serializable {
 
     @Override
@@ -79,11 +80,6 @@ public interface Connection extends WithId<Connection>, WithTags, WithName, Seri
      * and reconnect OAuth views.
      */
     boolean isDerived();
-
-    @Override
-    default Connection withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableConnection.Builder {
     }

--- a/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Connector.Builder.class)
+@SuppressWarnings("immutables")
 public interface Connector extends WithId<Connector>, WithActions<ConnectorAction>, WithName, WithProperties, Serializable {
 
     @Override
@@ -51,11 +52,6 @@ public interface Connector extends WithId<Connector>, WithActions<ConnectorActio
 
     @Override
     Map<String, String> getConfiguredProperties();
-
-    @Override
-    default Connector withId(String id) {
-        return builder().id(id).build();
-    }
 
     default Builder builder() {
         return new Builder().createFrom(this);

--- a/rest/model/src/main/java/io/syndesis/model/connection/ConnectorGroup.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/ConnectorGroup.java
@@ -31,16 +31,12 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorGroup.Builder.class)
+@SuppressWarnings("immutables")
 public interface ConnectorGroup extends WithId<ConnectorGroup>, WithName, Serializable {
 
     @Override
     default Kind getKind() {
         return Kind.ConnectorGroup;
-    }
-
-    @Override
-    default ConnectorGroup withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
     }
 
     class Builder extends ImmutableConnectorGroup.Builder {

--- a/rest/model/src/main/java/io/syndesis/model/connection/ConnectorTemplate.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/ConnectorTemplate.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorTemplate.Builder.class)
+@SuppressWarnings("immutables")
 public interface ConnectorTemplate extends WithId<ConnectorTemplate>, WithName, WithProperties, Serializable {
 
     class Builder extends ImmutableConnectorTemplate.Builder implements WithPropertiesBuilder<Builder> {

--- a/rest/model/src/main/java/io/syndesis/model/connection/WithPropertiesBuilder.java
+++ b/rest/model/src/main/java/io/syndesis/model/connection/WithPropertiesBuilder.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import io.syndesis.model.WithProperties;
 
-public interface WithPropertiesBuilder<T extends WithPropertiesBuilder> {
+public interface WithPropertiesBuilder<T extends WithPropertiesBuilder<T>> {
 
     WithProperties build();
 

--- a/rest/model/src/main/java/io/syndesis/model/environment/Environment.java
+++ b/rest/model/src/main/java/io/syndesis/model/environment/Environment.java
@@ -32,6 +32,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(builder = Environment.Builder.class)
+@SuppressWarnings("immutables")
 public interface Environment extends WithId<Environment>, WithName, Serializable {
 
     @Override
@@ -42,11 +43,6 @@ public interface Environment extends WithId<Environment>, WithName, Serializable
     EnvironmentType environmentType();
 
     List<Organization> organizations();
-
-    @Override
-    default Environment withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableEnvironment.Builder {
     }

--- a/rest/model/src/main/java/io/syndesis/model/environment/EnvironmentType.java
+++ b/rest/model/src/main/java/io/syndesis/model/environment/EnvironmentType.java
@@ -25,16 +25,12 @@ import java.io.Serializable;
 
 @Value.Immutable
 @JsonDeserialize(builder = EnvironmentType.Builder.class)
+@SuppressWarnings("immutables")
 public interface EnvironmentType extends WithId<EnvironmentType>, WithName, Serializable {
 
     @Override
     default Kind getKind() {
         return Kind.EnvironmentType;
-    }
-
-    @Override
-    default EnvironmentType withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
     }
 
     class Builder extends ImmutableEnvironmentType.Builder {

--- a/rest/model/src/main/java/io/syndesis/model/environment/Organization.java
+++ b/rest/model/src/main/java/io/syndesis/model/environment/Organization.java
@@ -27,6 +27,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Organization.Builder.class)
+@SuppressWarnings("immutables")
 public interface Organization extends WithId<Organization>, WithName, Serializable {
 
     @Override
@@ -37,11 +38,6 @@ public interface Organization extends WithId<Organization>, WithName, Serializab
     List<Environment> getEnvironments();
 
     List<User> getUsers();
-
-    @Override
-    default Organization withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableOrganization.Builder {
     }

--- a/rest/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/rest/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -37,6 +37,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = Extension.Builder.class)
 @NoDuplicateExtension(groups = NonBlockingValidations.class)
 @JsonPropertyOrder({ "name", "description", "icon", "extensionId", "version", "tags", "actions", "dependencies"})
+@SuppressWarnings("immutables")
 public interface Extension extends WithId<Extension>, WithActions<ExtensionAction>, WithName, WithTags, WithConfigurationProperties, Serializable {
 
     enum Status {

--- a/rest/model/src/main/java/io/syndesis/model/filter/ExpressionFilterStep.java
+++ b/rest/model/src/main/java/io/syndesis/model/filter/ExpressionFilterStep.java
@@ -22,7 +22,8 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = ExpressionFilterStep.Builder.class)
-@JsonIgnoreProperties({"filterExpression"})
+@JsonIgnoreProperties("filterExpression")
+@SuppressWarnings("immutables")
 public interface ExpressionFilterStep extends FilterStep {
 
     String STEP_KIND = "filter";
@@ -31,19 +32,23 @@ public interface ExpressionFilterStep extends FilterStep {
      * Filter in the simple expression language. This can be overwritten, but fectched
      * by default from the configured properties.
      */
+    @Override
     default String getFilterExpression() {
         return getConfiguredProperties().get("filter");
     }
 
-    class Builder extends ImmutableExpressionFilterStep.Builder { }
+    class Builder extends ImmutableExpressionFilterStep.Builder {
+    }
 
     @Override
-    @Value.Default default String getStepKind() {
+    @Value.Default
+    default String getStepKind() {
         return STEP_KIND;
     }
 
     @Override
-    @Value.Default default Kind getKind() {
+    @Value.Default
+    default Kind getKind() {
         return Kind.Step;
     }
 

--- a/rest/model/src/main/java/io/syndesis/model/filter/RuleFilterStep.java
+++ b/rest/model/src/main/java/io/syndesis/model/filter/RuleFilterStep.java
@@ -33,7 +33,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(builder = RuleFilterStep.Builder.class)
-@JsonIgnoreProperties({"filterExpression"})
+@JsonIgnoreProperties("filterExpression")
+@SuppressWarnings("immutables")
 public interface RuleFilterStep extends FilterStep {
 
     String STEP_KIND = "rule-filter";
@@ -41,6 +42,7 @@ public interface RuleFilterStep extends FilterStep {
     /**
      * Filter in the simple expression language.
      */
+    @Override
     default String getFilterExpression() {
         final Map<String, String> props = getConfiguredProperties();
 

--- a/rest/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -39,9 +39,12 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
 @UniqueProperty(value = "name", groups = UniquenessRequired.class)
+@SuppressWarnings("immutables")
 public interface Integration extends WithId<Integration>, WithTags, WithName, Serializable {
 
-    enum Status { Draft, Pending, Activated, Deactivated, Deleted }
+    enum Status {
+        Draft, Pending, Activated, Deactivated, Deleted
+    }
 
     @Override
     default Kind getKind() {
@@ -58,7 +61,6 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
     Optional<IntegrationRevision> getDraftRevision();
 
     Optional<Integer> getDeployedRevisionId();
-
 
     @JsonIgnore
     default Optional<IntegrationRevision> getDeployedRevision() {
@@ -111,11 +113,6 @@ public interface Integration extends WithId<Integration>, WithTags, WithName, Se
         Optional<IntegrationRevision> deployedRevision = getDeployedRevision();
 
         return deployedRevision.map(r -> r.getCurrentState()).orElse(IntegrationRevisionState.Pending);
-    }
-
-    @Override
-    default Integration withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
     }
 
     default IntegrationRevision lastRevision() {

--- a/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
@@ -41,14 +41,13 @@ public abstract class IntegrationRevision {
      */
     public abstract Integer getParentVersion();
 
-
     public abstract IntegrationRevisionSpec getSpec();
 
     /**
      * The desired state of the revision.
      * @return
      */
-     public abstract IntegrationRevisionState getTargetState();
+    public abstract IntegrationRevisionState getTargetState();
 
     /**
      * The current state of the revision.
@@ -62,14 +61,11 @@ public abstract class IntegrationRevision {
      */
     public abstract Optional<String> getCurrentMessage();
 
-
-
     /**
      * Message which should become the currentMessage after reconciliation
      * @return
      */
     public abstract Optional<String> getTargetMessage();
-
 
     public abstract Optional<BigInteger> getTimesUsed();
 
@@ -87,19 +83,8 @@ public abstract class IntegrationRevision {
         return getTargetState() != getCurrentState();
     }
 
-    public IntegrationRevision withVersion(Integer version) {
-        return new IntegrationRevision.Builder().createFrom(this).version(version).build();
-    }
-
     public IntegrationRevision withCurrentState(IntegrationRevisionState state) {
         return new IntegrationRevision.Builder().createFrom(this).currentState(state).build();
-    }
-
-    public IntegrationRevision withCurrentState(IntegrationRevisionState state, String message) {
-        return new IntegrationRevision.Builder().createFrom(this)
-            .currentState(state)
-            .currentMessage(message)
-            .build();
     }
 
     public IntegrationRevision withTargetState(IntegrationRevisionState state) {
@@ -113,11 +98,11 @@ public abstract class IntegrationRevision {
 
     @Override
     public boolean equals(Object other) {
-       if (!(other instanceof IntegrationRevision)) {
-           return false;
-       }
-       IntegrationRevision revision = (IntegrationRevision) other;
-       return  getVersion().orElse(1).equals(revision.getVersion().orElse(1));
+        if (!(other instanceof IntegrationRevision)) {
+            return false;
+        }
+        IntegrationRevision revision = (IntegrationRevision) other;
+        return getVersion().orElse(1).equals(revision.getVersion().orElse(1));
     }
 
     public static IntegrationRevision createNewRevision(Integration integration) {

--- a/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
@@ -36,7 +36,7 @@ public interface IntegrationRevisionSpec {
     }
 
     @Value.Default
-    default List<? extends Step> getSteps() {
+    default List<Step> getSteps() {
         return Collections.emptyList();
     }
 

--- a/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRuntime.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/IntegrationRuntime.java
@@ -25,6 +25,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationRuntime.Builder.class)
+@SuppressWarnings("immutables")
 public interface IntegrationRuntime extends WithId<IntegrationRuntime>, Serializable {
 
     @Override
@@ -37,11 +38,6 @@ public interface IntegrationRuntime extends WithId<IntegrationRuntime>, Serializ
     Integration getIntegration();
 
     Environment getEnvironment();
-
-    @Override
-    default IntegrationRuntime withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableIntegrationRuntime.Builder {
         // allow access to ImmutableIntegrationRuntime.Builder

--- a/rest/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
@@ -29,15 +29,17 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = SimpleStep.Builder.class)
+@SuppressWarnings("immutables")
 public interface SimpleStep extends Step {
 
     @Override
-    @Value.Default default Kind getKind() {
+    @Value.Default
+    default Kind getKind() {
         return Kind.Step;
     }
 
     @Override
-    Optional<Action> getAction();
+    Optional<Action<?>> getAction();
 
     @Override
     Optional<Connection> getConnection();
@@ -54,11 +56,6 @@ public interface SimpleStep extends Step {
 
     @Override
     String getName();
-
-    @Override
-    default SimpleStep withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableSimpleStep.Builder {
         // allow access to ImmutableSimpleStep.Builder

--- a/rest/model/src/main/java/io/syndesis/model/integration/Step.java
+++ b/rest/model/src/main/java/io/syndesis/model/integration/Step.java
@@ -36,7 +36,7 @@ public interface Step extends WithId<Step>, Serializable {
         return Kind.Step;
     }
 
-    Optional<Action> getAction();
+    Optional<Action<?>> getAction();
 
     Optional<Connection> getConnection();
 
@@ -54,6 +54,5 @@ public interface Step extends WithId<Step>, Serializable {
     class Builder extends ImmutableIntegration.Builder {
         // allow access to ImmutableIntegration.Builder
     }
-
 
 }

--- a/rest/model/src/main/java/io/syndesis/model/user/Permission.java
+++ b/rest/model/src/main/java/io/syndesis/model/user/Permission.java
@@ -25,6 +25,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Permission.Builder.class)
+@SuppressWarnings("immutables")
 public interface Permission extends WithId<Permission>, WithName, Serializable {
 
     @Override
@@ -33,11 +34,6 @@ public interface Permission extends WithId<Permission>, WithName, Serializable {
     }
 
     String getDescription();
-
-    @Override
-    default Permission withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutablePermission.Builder {
     }

--- a/rest/model/src/main/java/io/syndesis/model/user/Role.java
+++ b/rest/model/src/main/java/io/syndesis/model/user/Role.java
@@ -26,6 +26,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Role.Builder.class)
+@SuppressWarnings("immutables")
 public interface Role extends WithId<Role>, WithName, Serializable {
 
     @Override
@@ -34,11 +35,6 @@ public interface Role extends WithId<Role>, WithName, Serializable {
     }
 
     List<Permission> getPermissions();
-
-    @Override
-    default Role withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableRole.Builder {
     }

--- a/rest/model/src/main/java/io/syndesis/model/user/User.java
+++ b/rest/model/src/main/java/io/syndesis/model/user/User.java
@@ -27,6 +27,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = User.Builder.class)
+@SuppressWarnings("immutables")
 public interface User extends WithId<User>, Serializable {
 
     @Override
@@ -49,11 +50,6 @@ public interface User extends WithId<User>, Serializable {
     Optional<String> getRoleId();
 
     Optional<String> getOrganizationId();
-
-    @Override
-    default User withId(String id) {
-        return new Builder().createFrom(this).id(id).build();
-    }
 
     class Builder extends ImmutableUser.Builder {
     }

--- a/rest/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
+++ b/rest/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
@@ -16,21 +16,28 @@
 
 package io.syndesis.model.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.syndesis.model.filter.*;
+
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import io.syndesis.model.filter.ExpressionFilterStep;
+import io.syndesis.model.filter.FilterPredicate;
+import io.syndesis.model.filter.RuleFilterStep;
 
 public class StepDeserializerTest {
 
     @Test
-    public void shouldDeserializeRuleFilterStep() throws Exception {
-        RuleFilterStep step = readTestFilter("/rule-filter-step.json");
+    public void shouldDeserializeRuleFilterStep() throws IOException {
+        RuleFilterStep step = readTestFilter("/rule-filter-step.json", RuleFilterStep.class);
         assertEquals("1", step.getId().get());
         assertFalse(step.getConfiguredProperties().isEmpty());
         Map<String, String> props = step.getConfiguredProperties();
@@ -41,8 +48,8 @@ public class StepDeserializerTest {
     }
 
     @Test
-    public void shouldDeserializeExpressionFilterStep() throws Exception {
-        ExpressionFilterStep step = readTestFilter("/filter-step.json");
+    public void shouldDeserializeExpressionFilterStep() throws IOException {
+        ExpressionFilterStep step = readTestFilter("/filter-step.json", ExpressionFilterStep.class);
         ExpressionFilterStep exprFilterStep = step;
         String expr = "${body.text} contains '#RHSummit'";
         assertEquals("2", exprFilterStep.getId().get());
@@ -52,8 +59,9 @@ public class StepDeserializerTest {
         assertEquals(expr, exprFilterStep.getConfiguredProperties().get("filter"));
     }
 
-    private <T extends Step> T readTestFilter(String resource) throws java.io.IOException {
-        return (T) new ObjectMapper().registerModule(new Jdk8Module()).readValue(this.getClass().getResourceAsStream(resource), Step.class);
+    private <T extends Step> T readTestFilter(String resource, Class<T> stepType) throws IOException {
+        return new ObjectMapper().registerModule(new Jdk8Module())
+                .readValue(this.getClass().getResourceAsStream(resource), stepType);
     }
 
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -40,6 +40,8 @@
     <basepom.check.skip-all>true</basepom.check.skip-all>
     <basepom.test.timeout>150</basepom.test.timeout>
     <basepom.failsafe.timeout>0</basepom.failsafe.timeout>
+    <basepom.compiler.fail-warnings>true</basepom.compiler.fail-warnings>
+    <dep.plugin.compiler.version>3.7.0</dep.plugin.compiler.version>
 
     <syndesis-connectors.version>0.5.8</syndesis-connectors.version>
     <syndesis-integration-runtime.version>${project.version}</syndesis-integration-runtime.version>
@@ -51,7 +53,7 @@
     <derby.version>10.14.1.0</derby.version>
     <jdbi.version>2.78</jdbi.version>
     <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
-    <immutables.version>2.5.1</immutables.version>
+    <immutables.version>2.5.6</immutables.version>
     <infinispan.version>9.0.0.Final</infinispan.version>
     <jackson.version>2.8.10</jackson.version>
     <junit.version>4.12</junit.version>
@@ -111,8 +113,9 @@
     <module>filestore</module>
     <module>inspector</module>
     <module>jsondb</module>
+    <!-- not used anywhere currently -->
+    <!--<module>model2</module>-->
     <module>model</module>
-    <module>model2</module>
     <module>openshift</module>
     <module>project-generator</module>
     <module>rest</module>
@@ -573,6 +576,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>2.0.19</version>
@@ -662,6 +671,12 @@
         <artifactId>mockwebserver</artifactId>
         <version>${mockwebserver.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>io.sundr</groupId>
+            <artifactId>builder-annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1230,6 +1245,48 @@
                 <phase />
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>non-m2e</id>
+      <activation>
+        <!-- active only when not running under M2E in Eclipse -->
+        <property>
+          <name>!m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>javac-with-errorprone</compilerId>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <compilerArgs>
+                <arg>-Xlint:all</arg>
+                <arg>-Xlint:-deprecation</arg>
+                <arg>-Xlint:-processing</arg>
+                <arg>-Xlint:-serial</arg>
+                <arg>-Werror</arg>
+                <arg>-XepDisableWarningsInGeneratedCode</arg>
+              </compilerArgs>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>2.8.2</version>
+              </dependency>
+              <!-- override plexus-compiler-javac-errorprone's dependency on
+               Error Prone with the latest version -->
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.1.2</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/rest/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
+++ b/rest/project-generator/src/main/java/io/syndesis/project/converter/DefaultProjectGenerator.java
@@ -28,11 +28,11 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -146,7 +146,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         final PipedOutputStream os = new PipedOutputStream(is);
 
-        executor.submit(generateAddProjectTarEntries(integration, os));
+        executor.execute(generateAddProjectTarEntries(integration, os));
 
         return is;
     }
@@ -316,7 +316,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
                     }
                 );
 
-            Queue<Step> remaining = new LinkedList<>(steps);
+            Queue<Step> remaining = new ArrayDeque<>(steps);
             Step first = remaining.remove();
             if (first != null) {
                 StepVisitorContext stepContext = new StepVisitorContext.Builder()

--- a/rest/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
+++ b/rest/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
@@ -56,7 +56,7 @@ public class ProjectGeneratorConfiguration {
     }
 
     @Bean
-    public StepVisitorFactoryRegistry registry(List<StepVisitorFactory> factories) {
+    public StepVisitorFactoryRegistry registry(List<StepVisitorFactory<?>> factories) {
         return new StepVisitorFactoryRegistry(factories);
     }
 

--- a/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/EndpointStepVisitor.java
+++ b/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/EndpointStepVisitor.java
@@ -144,10 +144,13 @@ public class EndpointStepVisitor implements StepVisitor {
         return new Endpoint(endpointUri);
     }
 
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     private static Map<String, String> aggregate(Map<String, String> ... maps) throws IOException {
         return Stream.of(maps).flatMap(map -> map.entrySet().stream()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> newValue));
     }
 
+    @SafeVarargs
     private static <T> Predicate<T> or(Predicate<T>... predicates) {
         Predicate<T> predicate = predicates[0];
 

--- a/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorContext.java
+++ b/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorContext.java
@@ -38,10 +38,12 @@ public interface StepVisitorContext extends Iterator<StepVisitorContext> {
 
     Function<Step, Optional<String>> getConnectorIdSupplier();
 
+    @Override
     default boolean hasNext() {
         return !getRemaining().isEmpty();
     }
 
+    @Override
     default StepVisitorContext next() {
         final int index = getIndex();
         final Queue<Step> remaining = getRemaining();

--- a/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorFactoryRegistry.java
+++ b/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/StepVisitorFactoryRegistry.java
@@ -22,26 +22,26 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public final class StepVisitorFactoryRegistry {
-    private final ConcurrentMap<String, StepVisitorFactory> MAP = new ConcurrentHashMap<>();
-    private final StepVisitorFactory FALLBACK_STEP_FACTORY = new GenericStepVisitor.Factory();
+    private final ConcurrentMap<String, StepVisitorFactory<?>> MAP = new ConcurrentHashMap<>();
+    private final StepVisitorFactory<?> FALLBACK_STEP_FACTORY = new GenericStepVisitor.Factory();
 
-    public StepVisitorFactoryRegistry(StepVisitorFactory... factories) {
-        for (StepVisitorFactory factory:  factories) {
+    public StepVisitorFactoryRegistry(StepVisitorFactory<?>... factories) {
+        for (StepVisitorFactory<?> factory:  factories) {
             register(factory);
         }
     }
 
-    public StepVisitorFactoryRegistry(List<StepVisitorFactory> factories) {
+    public StepVisitorFactoryRegistry(List<StepVisitorFactory<?>> factories) {
         factories.forEach(this::register);
     }
 
-    public void register(StepVisitorFactory factory) {
+    public void register(StepVisitorFactory<?> factory) {
         MAP.put(factory.getStepKind(), factory);
     }
 
-    public StepVisitorFactory get(String kind) {
+    public StepVisitorFactory<?> get(String kind) {
         return MAP.computeIfAbsent(kind, k -> {
-            for (StepVisitorFactory factory : ServiceLoader.load(StepVisitorFactory.class, Thread.currentThread().getContextClassLoader())) {
+            for (StepVisitorFactory<?> factory : ServiceLoader.load(StepVisitorFactory.class, Thread.currentThread().getContextClassLoader())) {
                 if (factory.getStepKind().equals(k)) {
                     return factory;
                 }

--- a/rest/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/rest/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -413,7 +413,7 @@ public class DefaultProjectGeneratorTest {
         runtimePath.toFile().deleteOnExit();
 
         assertFileContents(generatorProperties, runtimePath.resolve("src/main/resources/syndesis.yml"), "test-mapper-syndesis.yml");
-        assertThat(new String(Files.readAllBytes(runtimePath.resolve("src/main/resources/mapping-step-2.json")))).isEqualTo("{}");
+        assertThat(new String(Files.readAllBytes(runtimePath.resolve("src/main/resources/mapping-step-2.json")), StandardCharsets.UTF_8)).isEqualTo("{}");
     }
 
     @Test
@@ -575,9 +575,9 @@ public class DefaultProjectGeneratorTest {
         assertFileContents(generatorProperties, runtimeDir.resolve("pom.xml"), "test-pom-extension.xml");
         assertFileContents(generatorProperties, runtimeDir.resolve(".s2i/bin/assemble"), "test-s2i-assemble");
 
-        assertThat(Files.exists(runtimeDir.resolve("extensions/my-extension-1.jar")));
-        assertThat(Files.exists(runtimeDir.resolve("extensions/my-extension-2.jar")));
-        assertThat(Files.exists(runtimeDir.resolve("extensions/my-extension-3.jar")));
+        assertThat(runtimeDir.resolve("extensions/my-extension-1.jar")).exists();
+        assertThat(runtimeDir.resolve("extensions/my-extension-2.jar")).exists();
+        assertThat(runtimeDir.resolve("extensions/my-extension-3.jar")).exists();
     }
 
     // ************************************************
@@ -641,7 +641,7 @@ public class DefaultProjectGeneratorTest {
             throw new IllegalArgumentException("Unable to find te required resource (" + expectedFileName + ")");
         }
 
-        final String actual = new String(Files.readAllBytes(actualFilePath));
+        final String actual = new String(Files.readAllBytes(actualFilePath), StandardCharsets.UTF_8);
         final String expected = new String(Files.readAllBytes(Paths.get(resource.toURI())), StandardCharsets.UTF_8);
 
         assertThat(actual).isEqualTo(expected);

--- a/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveSorter.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveSorter.java
@@ -17,6 +17,7 @@ package io.syndesis.rest.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -36,7 +37,7 @@ public class ReflectiveSorter<T> implements Function<ListResult<T>, ListResult<T
 
     @Override
     public ListResult<T> apply(ListResult<T> result) {
-        List<T> list = result.getItems();
+        List<T> list = new ArrayList<>(result.getItems());
         if (delegate != null) {
             // We are sorting inline when a delegate is given. Otherwise its a no-op
             list.sort(this);

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -132,19 +132,19 @@ public class IntegrationHandler extends BaseHandler
     @Path("/{id}/export.zip")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public StreamingOutput export(@NotNull @PathParam("id") @ApiParam(required = true) String id) throws IOException {
-        ArrayList<ModelData> models = new ArrayList<>();
+        ArrayList<ModelData<?>> models = new ArrayList<>();
 
         Integration integration = this.get(id);
-        models.add(new ModelData(Kind.Integration, integration));
+        models.add(new ModelData<Integration>(Kind.Integration, integration));
 
         for (Step step : integration.getSteps()) {
             Optional<Connection> c = step.getConnection();
             if( c.isPresent() ) {
                 Connection connection = c.get();
-                models.add(new ModelData(Kind.Connection, connection));
+                models.add(new ModelData<Connection>(Kind.Connection, connection));
                 Connector connector = getDataManager().fetch(Connector.class, connection.getConnectorId().get());
                 if( connector != null ) {
-                    models.add(new ModelData(Kind.Connector, connector));
+                    models.add(new ModelData<Connector>(Kind.Connector, connector));
                 }
             }
         }

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationSupportHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationSupportHandler.java
@@ -69,7 +69,7 @@ public class IntegrationSupportHandler {
 
     @POST
     @Path("/import")
-    public Response importIntegration(InputStream is) throws IOException {
+    public Response importIntegration(InputStream is) {
         try (ZipInputStream zis = new ZipInputStream(is)) {
             int imported = 0;
             while (true) {
@@ -110,7 +110,7 @@ public class IntegrationSupportHandler {
 
         // Now do the actual import.
         int count = 0;
-        for (ModelData model : export.models()) {
+        for (ModelData<?> model : export.models()) {
             switch (model.getKind()) {
                 case Integration:
 
@@ -160,7 +160,7 @@ public class IntegrationSupportHandler {
             throw new IOException("Cannot import an export at schema version level: " + export.schemaVersion());
         }
 
-        for (ModelData model : export.models()) {
+        for (ModelData<?> model : export.models()) {
             switch (model.getKind()) {
                 case Integration:
                 case Connection:

--- a/rest/rest/src/test/java/io/syndesis/rest/util/ReflectiveSorterTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/util/ReflectiveSorterTest.java
@@ -89,7 +89,7 @@ public class ReflectiveSorterTest {
         ListResult<TestPersonInterface> toSort = new ListResult.Builder<TestPersonInterface>().items(getTestData()).totalCount(getTestData().size()).build();
         Function<ListResult<TestPersonInterface>, ListResult<TestPersonInterface>> operator =
             new ReflectiveSorter<>(TestPersonInterface.class, getOptions(null, null));
-        operator.apply(toSort);
+        ListResult<TestPersonInterface> sorted = operator.apply(toSort);
 
         String[] expectedNames = {
             "Schrödinger",
@@ -99,9 +99,9 @@ public class ReflectiveSorterTest {
         };
 
         for (int i = 0; i < expectedNames.length; i++) {
-            assertEquals(toSort.getItems().get(i).getLastName(), expectedNames[i]);
+            assertEquals(sorted.getItems().get(i).getLastName(), expectedNames[i]);
         }
-        assertEquals(getTestData().size(), toSort.getTotalCount());
+        assertEquals(getTestData().size(), sorted.getTotalCount());
 
     }
 

--- a/rest/rest/src/test/java/io/syndesis/rest/v1/state/ClientSideStateTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/v1/state/ClientSideStateTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClientSideStateTest {
 
-    private static final Edition RFC_EDITION = new Edition(new BigInteger("tid".getBytes()).longValue(),
+    private static final Edition RFC_EDITION = new Edition(new BigInteger("tid".getBytes(StandardCharsets.US_ASCII)).longValue(),
         "AES/CBC/PKCS5Padding", "HmacSHA1") {
         private final SecretKeySpec authenticationKey = new SecretKeySpec(
             "12345678901234567890".getBytes(StandardCharsets.US_ASCII), "HmacSHA1");
@@ -72,9 +72,9 @@ public class ClientSideStateTest {
 
     private static final LongSupplier RFC_TIME = () -> 1347265955L;
 
-    private static final BiFunction<Class<?>, byte[], Object> SIMPLE_DESERIALIZATION = (t, v) -> String.valueOf(v);
+    private static final BiFunction<Class<?>, byte[], Object> SIMPLE_DESERIALIZATION = (t, v) -> new String(v, StandardCharsets.UTF_8);
 
-    private static final Function<Object, byte[]> SIMPLE_SERIALIZATION = o -> ((String) o).getBytes();
+    private static final Function<Object, byte[]> SIMPLE_SERIALIZATION = o -> ((String) o).getBytes(StandardCharsets.UTF_8);
 
     @Immutable
     @JsonDeserialize(builder = ImmutableData.Builder.class)

--- a/rest/rest/src/test/java/io/syndesis/rest/v1/util/UrlsTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/v1/util/UrlsTest.java
@@ -77,6 +77,7 @@ public class UrlsTest {
         }
     }
 
+    @SuppressWarnings("JdkObsolete")
     public static class UnitTests {
         @Test
         public void shouldAbsolutizeReturnUrl() {

--- a/rest/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -229,12 +229,12 @@ public abstract class BaseITCase {
         headers.set("X-Forwarded-Access-Token", token);
     }
 
-    final class YamlJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    /* default */ static final class YamlJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
         YamlJackson2HttpMessageConverter() {
             super(new YAMLMapper(), MediaType.parseMediaType("application/yaml"));
         }
     }
-    final class JsonJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    /* default */ static final class JsonJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
         JsonJackson2HttpMessageConverter() {
             super(Json.mapper(), MediaType.parseMediaType("application/json"));
         }

--- a/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
@@ -15,22 +15,25 @@
  */
 package io.syndesis.runtime;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import io.syndesis.model.ListResult;
-import io.syndesis.model.connection.Connector;
-import io.syndesis.verifier.AlwaysOkVerifier;
-import io.syndesis.verifier.Verifier;
-import org.junit.Assume;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import io.syndesis.model.ListResult;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.verifier.AlwaysOkVerifier;
+import io.syndesis.verifier.Verifier;
 
 public class ConnectorsITCase extends BaseITCase {
 
@@ -64,7 +67,8 @@ public class ConnectorsITCase extends BaseITCase {
     }
 
     // Disabled as it works only for the LocalProcessVerifier which would needs some update
-    //@Test
+    @Test
+    @Ignore
     public void verifyGoodTwitterConnectionSettings() throws IOException {
         Properties credentials = new Properties();
         try (InputStream is = getClass().getResourceAsStream("/valid-twitter-keys.properties")) {
@@ -79,7 +83,8 @@ public class ConnectorsITCase extends BaseITCase {
         assertThat(result.getErrors()).isEmpty();
     }
 
-    //@Test
+    @Test
+    @Ignore
     public void verifyBadTwitterConnectionSettings() throws IOException {
 
         // AlwaysOkVerifier never fails.. do don't try this test case, if that's whats being used.

--- a/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
@@ -63,7 +63,7 @@ public class ExtensionsITCase extends BaseITCase {
         assertThat(created.getBody().getId()).isNotEmpty();
         assertThat(created.getBody().getName()).isNotBlank();
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         // GET
@@ -93,13 +93,13 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         ResponseEntity<Extension> updated = post("/api/v1beta1/extensions?updatedId=" + id, multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(updated.getBody().getId().isPresent());
+        assertThat(updated.getBody().getId()).isPresent();
     }
 
     @Test
@@ -107,7 +107,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         // Using wrong extensionId="extension2"
@@ -120,7 +120,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         // Install it
@@ -138,7 +138,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created1 = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created1.getBody().getId().isPresent());
+        assertThat(created1.getBody().getId()).isPresent();
         String id1 = created1.getBody().getId().get();
 
         // Install it
@@ -149,7 +149,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created2 = post("/api/v1beta1/extensions?updatedId=" + id1, multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created2.getBody().getId().isPresent());
+        assertThat(created2.getBody().getId()).isPresent();
         String id2 = created2.getBody().getId().get();
 
         // 200 status code: it's just a warning
@@ -167,14 +167,14 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created1 = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created1.getBody().getId().isPresent());
+        assertThat(created1.getBody().getId()).isPresent();
         String id1 = created1.getBody().getId().get();
 
         // Create another extension (id-2)
         ResponseEntity<Extension> created2 = post("/api/v1beta1/extensions", multipartBody(extensionData(2)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created2.getBody().getId().isPresent());
+        assertThat(created2.getBody().getId()).isPresent();
         String id2 = created2.getBody().getId().get();
 
         // Install them
@@ -198,7 +198,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> createdCopy1 = post("/api/v1beta1/extensions?updatedId=" + id1, multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(createdCopy1.getBody().getId().isPresent());
+        assertThat(createdCopy1.getBody().getId()).isPresent();
         String idCopy1 = createdCopy1.getBody().getId().get();
 
         // Install copy
@@ -227,7 +227,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         // Get extensions using it
@@ -293,7 +293,7 @@ public class ExtensionsITCase extends BaseITCase {
         ResponseEntity<Extension> created = post("/api/v1beta1/extensions", multipartBody(extensionData(1)),
             Extension.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
 
-        assertThat(created.getBody().getId().isPresent());
+        assertThat(created.getBody().getId()).isPresent();
         String id = created.getBody().getId().get();
 
         // Get extension details

--- a/rest/runtime/src/test/java/io/syndesis/runtime/Recordings.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/Recordings.java
@@ -108,14 +108,14 @@ public class Recordings {
     static public <T> T recorder(Object object, Class<T> as) {
         if (as.isInterface()) {
             // If it's just an interface, use standard java reflect proxying
-            return as.cast(Proxy.newProxyInstance(as.getClassLoader(), new Class[]{as}, new RecordingInvocationHandler(object)));
+            return as.cast(Proxy.newProxyInstance(as.getClassLoader(), new Class<?>[] { as }, new RecordingInvocationHandler(object)));
         }
 
         // If it's a class then use gclib to implement a subclass to implement proxying
         RecordingInvocationHandler ih = new RecordingInvocationHandler(object);
         Enhancer enhancer = new Enhancer();
         enhancer.setSuperclass(as);
-        enhancer.setInterfaces(new Class[]{RecordingProxy.class});
+        enhancer.setInterfaces(new Class<?>[]{RecordingProxy.class});
         enhancer.setCallback(new org.springframework.cglib.proxy.InvocationHandler() {
             @Override
             public Object invoke(Object o, Method method, Object[] objects) throws Throwable {

--- a/rest/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
@@ -44,8 +44,8 @@ public class T3stSupportITCase extends BaseITCase {
         assertThat(r1.getBody().length).isGreaterThan(1);
 
         // restoring to no data should.. leave us with no data.
-        ModelData<?>[] NO_DATA = new ModelData[]{};
-        post("/api/v1/test-support/restore-db", NO_DATA, (Class<?>) null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
+        ModelData<?>[] noData = new ModelData<?>[]{};
+        post("/api/v1/test-support/restore-db", noData, (Class<?>) null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
 
         // Lets add an integration...
         Integration integration = new Integration.Builder()

--- a/rest/runtime/src/test/java/io/syndesis/runtime/TagsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/TagsITCase.java
@@ -32,7 +32,7 @@ public class TagsITCase extends BaseITCase {
 
         assertThat(list.getBody().getTotalCount()).as("total count").isGreaterThan(1);
         assertThat(list.getBody().getItems()).as("items").size().isGreaterThan(1);
-        assertThat(list.getBody().getItems().get(0).equals("example"));
+        assertThat(list.getBody().getItems().get(0)).isEqualTo("example");
 
     }
 

--- a/rest/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionSqlStoredITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/action/DynamicActionSqlStoredITCase.java
@@ -107,8 +107,8 @@ public class DynamicActionSqlStoredITCase extends BaseITCase {
             ConnectorDescriptor.class, tokenRule.validToken(), headers, HttpStatus.OK);
 
         ConfigurationProperty procedureNames = firstResponse.getBody().getPropertyDefinitionSteps().iterator().next().getProperties().get("procedureName");
-        assertThat(procedureNames.getEnum().size() == 2);
-        assertThat(procedureNames.getEnum().iterator().next().getLabel().startsWith("DEMO_ADD"));
+        assertThat(procedureNames.getEnum()).hasSize(2);
+        assertThat(procedureNames.getEnum().iterator().next().getLabel()).startsWith("DEMO_ADD");
 
         final ResponseEntity<ConnectorDescriptor> secondResponse = http(HttpMethod.POST,
                 "/api/v1/connections/" + connectionId + "/actions/io.syndesis:sql-stored-connector:latest",

--- a/rest/runtime/src/test/java/io/syndesis/runtime/credential/TestCredentialProviderFactory.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/credential/TestCredentialProviderFactory.java
@@ -53,10 +53,12 @@ public class TestCredentialProviderFactory implements CredentialProviderFactory 
         final CredentialProvider credentialProvider = new OAuth2CredentialProvider<>("test-provider", connectionFactory,
             applicator);
 
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final Class<MultiValueMap<String, String>> additionalParametersType = (Class) MultiValueMap.class;
         final OAuth2Operations operations = spy(new OAuth2Template("testClientId", "testClientSecret",
             "https://test/oauth2/authorize", "https://test/oauth2/token"));
         doReturn(new AccessGrant("token")).when(operations).exchangeForAccess(Matchers.anyString(),
-            Matchers.anyString(), Matchers.any(MultiValueMap.class));
+            Matchers.anyString(), Matchers.any(additionalParametersType));
 
         when(connectionFactory.getOAuthOperations()).thenReturn(operations);
 

--- a/rest/syndesis-annotation-processor/src/main/java/io/syndesis/maven/annotation/processing/SyndesisExtensionActionProcessor.java
+++ b/rest/syndesis-annotation-processor/src/main/java/io/syndesis/maven/annotation/processing/SyndesisExtensionActionProcessor.java
@@ -285,9 +285,11 @@ public class SyndesisExtensionActionProcessor extends AbstractProcessor {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message);
     }
 
-    protected Class<?> mandatoryFindClass(String name) {
+    private Class<? extends Annotation> mandatoryFindClass(String name) {
         try {
-            return Class.forName(name);
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Class<? extends Annotation> ret = (Class) Class.forName(name);
+            return ret;
         } catch (ClassNotFoundException e) {
             error("Unable to find Class " +  name + " on Classpath");
         }
@@ -295,9 +297,11 @@ public class SyndesisExtensionActionProcessor extends AbstractProcessor {
         return null;
     }
 
-    protected Class<?> findClass(String name) {
+    private Class<? extends Annotation> findClass(String name) {
         try {
-            return Class.forName(name);
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Class<? extends Annotation> ret = (Class) Class.forName(name);
+            return ret;
         } catch (ClassNotFoundException e) {
             warning("Unable to find Class " +  name + " on Classpath");
         }

--- a/rest/syndesis-build-helper-maven-plugin/pom.xml
+++ b/rest/syndesis-build-helper-maven-plugin/pom.xml
@@ -379,4 +379,38 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>non-m2e</id>
+      <activation>
+        <!-- active only when not running under M2E in Eclipse -->
+        <property>
+          <name>!m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <!-- no way to influence generated HelpMojo.java to contain
+                the required @Override, or to be marked as @Generated, next
+                errorprone version will add exclusions by path:
+                -XepExcludedPaths:.*/generated-sources/.*
+                -->
+                <arg>-Xep:MissingOverride:OFF</arg>
+                <!-- no way to influence generated HelpMojo.java not to throw
+                from finally block, or to be marked as @Generated, next
+                errorprone version will add exclusions by path:
+                -XepExcludedPaths:.*/generated-sources/.* -->
+                <arg>-Xep:Finally:OFF</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/rest/syndesis-build-helper-maven-plugin/src/main/java/io/syndesis/maven/ExtractConnectorDescriptorsMojo.java
+++ b/rest/syndesis-build-helper-maven-plugin/src/main/java/io/syndesis/maven/ExtractConnectorDescriptorsMojo.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -118,6 +119,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
 
     private URLClassLoader createClassLoader(File jar) throws MalformedURLException {
         return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
+            @Override
             public URLClassLoader run() {
                 try {
                     return new URLClassLoader(new URL[]{jar.toURI().toURL()});

--- a/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
+++ b/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
@@ -90,7 +90,7 @@ public class Application implements ApplicationRunner {
         for (final ModelData<?> model : modelList) {
             if (model.getKind() == Kind.Connector) {
                 final Connector connector = (Connector) model.getData();
-                for (final Action action : connector.getActions()) {
+                for (final Action<?> action : connector.getActions()) {
                     steps.add(
                         new SimpleStep.Builder()
                             .stepKind("endpoint").

--- a/rest/syndesis-maven-plugin/pom.xml
+++ b/rest/syndesis-maven-plugin/pom.xml
@@ -231,6 +231,13 @@
     </dependency>
 
     <dependency>
+      <!-- Needed by Guava at compile time -->
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       <exclusions>
@@ -387,5 +394,39 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>non-m2e</id>
+      <activation>
+        <!-- active only when not running under M2E in Eclipse -->
+        <property>
+          <name>!m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <!-- no way to influence generated HelpMojo.java to contain
+                the required @Override, or to be marked as @Generated, next
+                errorprone version will add exclusions by path:
+                -XepExcludedPaths:.*/generated-sources/.*
+                -->
+                <arg>-Xep:MissingOverride:OFF</arg>
+                <!-- no way to influence generated HelpMojo.java not to throw
+                from finally block, or to be marked as @Generated, next
+                errorprone version will add exclusions by path:
+                -XepExcludedPaths:.*/generated-sources/.* -->
+                <arg>-Xep:Finally:OFF</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/GenerateMetadataMojo.java
+++ b/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/GenerateMetadataMojo.java
@@ -16,18 +16,18 @@
 package io.syndesis.maven;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -131,7 +131,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
                 final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**.properties");
 
                 Files.find(dir, Integer.MAX_VALUE, (path, attributes) -> matcher.matches(path)).sorted().forEach(path -> {
-                    try (Reader reader = new FileReader(path.toFile())) {
+                    try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
                         getLog().info("Loading annotations properties from: " + path);
                         p.clear();
                         p.load(reader);
@@ -217,7 +217,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
     }
 
     protected List<ActionDescriptor.ActionDescriptorStep> createPropertiesDefinitionSteps(Properties p) {
-        List<ActionDescriptor.ActionDescriptorStep> propertyDefinitionSteps = new LinkedList<>();
+        List<ActionDescriptor.ActionDescriptorStep> propertyDefinitionSteps = new ArrayList<>();
         int idx = 0;
         while (getPropertyValue(p, idx, "name") != null) {
             String name = getPropertyValue(p, idx, "name");
@@ -235,7 +235,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
             String type = getPropertyValue(p, idx, "type");
 
             String pTags = getPropertyValue(p, idx, "tags");
-            List<String> propTagList = new LinkedList<>();
+            List<String> propTagList = new ArrayList<>();
             if(StringUtils.isNotEmpty(pTags)){
                 for (String tag : pTags.trim().split(",")) {
                     propTagList.add(tag);
@@ -243,7 +243,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
             }
 
             int idy = 0;
-            List<ConfigurationProperty.PropertyValue> propertyValues = new LinkedList<>();
+            List<ConfigurationProperty.PropertyValue> propertyValues = new ArrayList<>();
             while (getPropertyValue(p, idx, "enums", idy, "value") != null) {
                 String enumValue = getPropertyValue(p, idx, "enums", idy, "value");
                 String enumLabel = getPropertyValue(p, idx, "enums", idy, "label");

--- a/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/RepackageExtensionMojo.java
+++ b/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/RepackageExtensionMojo.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.syndesis.maven.layouts.ModuleLayoutFactory;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -53,6 +52,8 @@ import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSessionContainer;
 import org.springframework.boot.maven.Exclude;
 import org.springframework.boot.maven.ExcludeFilter;
 
+import io.syndesis.maven.layouts.ModuleLayoutFactory;
+
 /**
  * Helper Maven plugin
  *
@@ -73,6 +74,7 @@ public class RepackageExtensionMojo extends SupportMojo {
 
     @Parameter
     protected String blackListedBoms;
+
     @Parameter
     protected String blackListedGAVs;
 
@@ -81,6 +83,7 @@ public class RepackageExtensionMojo extends SupportMojo {
 
     @Parameter(readonly = true, defaultValue = "${repositorySystemSession}")
     private RepositorySystemSession repoSession;
+
     @Parameter(readonly = true, defaultValue = "${project.remotePluginRepositories}")
     private List<RemoteRepository> remoteRepos;
 
@@ -92,7 +95,7 @@ public class RepackageExtensionMojo extends SupportMojo {
     }
 
     @Override
-    protected Collection getAdditionalFilters() {
+    protected Collection<ArtifactsFilter> getAdditionalFilters() {
         Collection<MavenDependency> dependencies = new HashSet<>();
 
         if(StringUtils.isNotBlank(blackListedBoms)){
@@ -175,7 +178,6 @@ public class RepackageExtensionMojo extends SupportMojo {
         }
     }
 
-
     protected void addCustomGAVs(Collection<MavenDependency> dependencies) {
         String[] gavs = blackListedGAVs.split(",");
 
@@ -183,7 +185,6 @@ public class RepackageExtensionMojo extends SupportMojo {
             dependencies.add(newMavenDependency(gav));
         }
     }
-
 
     protected Set<MavenDependency> obtainBomDependencies(String urlLocation) throws IOException, MojoExecutionException {
         ArtifactResult artifact = downloadAndInstallArtifact(urlLocation);

--- a/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/SupportMojo.java
+++ b/rest/syndesis-maven-plugin/src/main/java/io/syndesis/maven/SupportMojo.java
@@ -15,21 +15,22 @@
  */
 package io.syndesis.maven;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
-import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
-import org.springframework.boot.maven.RepackageMojo;
-
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
+import org.springframework.boot.maven.RepackageMojo;
 
 /**
  * Base Mojo Support class to provide helper methods from the specialized Mojos
@@ -93,7 +94,9 @@ public abstract class SupportMojo extends RepackageMojo {
         try {
             Set<Artifact> filtered = new LinkedHashSet<Artifact>(dependencies);
 
-            filters.getFilters().addAll(getAdditionalFilters());
+            @SuppressWarnings("unchecked")
+            Collection<ArtifactsFilter> filtersToUse = filters.getFilters();
+            filtersToUse.addAll(getAdditionalFilters());
 
             filtered.retainAll(filters.filter(dependencies));
             return filtered;
@@ -107,8 +110,8 @@ public abstract class SupportMojo extends RepackageMojo {
      * Defines the defualt set of artifacts to exclude from the repackaged module
      * @return
      */
-    protected Collection getAdditionalFilters() {
-        return new ArrayList();
+    protected Collection<ArtifactsFilter> getAdditionalFilters() {
+        return new ArrayList<>();
     }
 
     /**
@@ -118,7 +121,7 @@ public abstract class SupportMojo extends RepackageMojo {
      * @throws NoSuchFieldException
      */
     protected Field obtainAccessibleFieldInAncestors(String fieldName) throws NoSuchFieldException {
-        Class clazz = SupportMojo.class.getSuperclass();
+        Class<?> clazz = SupportMojo.class.getSuperclass();
         while(clazz != null){
             for (Field field : clazz.getDeclaredFields()) {
                 if(fieldName.equals(field.getName())){
@@ -135,9 +138,5 @@ public abstract class SupportMojo extends RepackageMojo {
         Field field = obtainAccessibleFieldInAncestors(fieldName);
         field.set(this, value);
     }
-
-
-
-
 
 }

--- a/rest/verifier/src/main/java/io/syndesis/verifier/LocalProcessVerifier.java
+++ b/rest/verifier/src/main/java/io/syndesis/verifier/LocalProcessVerifier.java
@@ -99,12 +99,12 @@ public class LocalProcessVerifier {
     private ImmutableResult createResult(Verifier.Scope scope, Verifier.Result.Status status, Properties response) {
         ImmutableResult.Builder builder = ImmutableResult.builder().scope(scope).status(status);
         if( response != null ) {
-            LinkedHashMap<String, ImmutableError.Builder> errors = new LinkedHashMap<>();
+            LinkedHashMap<String, ImmutableVerifierError.Builder> errors = new LinkedHashMap<>();
             for (Map.Entry<Object, Object> entry : response.entrySet()) {
                 String key = (String) entry.getKey();
                 if( key.startsWith("error.") ) {
                     String errorId = key.substring("error.".length()).replaceFirst("\\..*", "");
-                    ImmutableError.Builder error = errors.getOrDefault(errorId, ImmutableError.builder());
+                    ImmutableVerifierError.Builder error = errors.getOrDefault(errorId, ImmutableVerifierError.builder());
                     String value = (String) entry.getValue();
                     if( key.endsWith(".code") ) {
                         error.code(value);
@@ -115,7 +115,7 @@ public class LocalProcessVerifier {
                     errors.put(errorId, error);
                 }
             }
-            builder.addAllErrors(errors.values().stream().map(ImmutableError.Builder::build).collect(Collectors.toList()));
+            builder.addAllErrors(errors.values().stream().map(ImmutableVerifierError.Builder::build).collect(Collectors.toList()));
         }
         return builder.build();
     }

--- a/rest/verifier/src/main/java/io/syndesis/verifier/Verifier.java
+++ b/rest/verifier/src/main/java/io/syndesis/verifier/Verifier.java
@@ -51,8 +51,8 @@ public interface Verifier {
 
     // Detailed error object
     @Value.Immutable
-    @JsonDeserialize(builder = ImmutableError.Builder.class)
-    interface Error {
+    @JsonDeserialize(builder = ImmutableVerifierError.Builder.class)
+    interface VerifierError {
         // Connector specific error code
         String getCode();
 
@@ -75,7 +75,7 @@ public interface Verifier {
         // scope with which the verifier has been called
         Scope getScope();
         // list of errors or an empty list if
-        List<Error> getErrors();
+        List<VerifierError> getErrors();
 
         // Status of the result
         enum Status {


### PR DESCRIPTION
This adds errorprone[1] compiler extension that provides several new
checks[2] some of which were not caught by our existing checks.

Also goes one step more and declares all compiler warnings as errors.

Well, you know me, I need my checks :)

To argument this one -- actual bugs not caught by other checks:
 - Not using correct enum in comparison (https://github.com/syndesisio/syndesis-rest/compare/master...zregvart:errorprone?expand=1#diff-e9da60db20876b6c73daa9758bf6fb50L184)
 - Using platform charset (numerous places)
 - Not checking return values of methods (numerous places, most notably fluent assertThat from AssertJ)

[1] http://errorprone.info/
[2] http://errorprone.info/bugpatterns