### PR TITLE
feat: Add technical extensions page to customizations, stub in import and detail page

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 src/config.json
 src/config.json.bak
 users.json
+scripts/swagger.json
+src/app/_model.ts

--- a/ui/src/app/customizations/customizations.component.html
+++ b/ui/src/app/customizations/customizations.component.html
@@ -1,12 +1,9 @@
 <ul class="row nav nav-tabs nav-tabs-pf toolbar-pf">
   <li routerLinkActive="active">
-    <a [routerLink]="['api-connectors']">API Client Connector</a>
+    <a [routerLink]="['api-connectors']">API Client Connectors</a>
   </li>
-  <li>
-    <a>Technical Extension</a>
-  </li>
-  <li>
-    <a>Custom Connector</a>
+  <li routerLinkActive="active">
+    <a [routerLink]="['tech-extensions']">Technical Extensions</a>
   </li>
 </ul>
 

--- a/ui/src/app/customizations/customizations.module.ts
+++ b/ui/src/app/customizations/customizations.module.ts
@@ -1,18 +1,25 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule, ListModule } from 'patternfly-ng';
 import { SyndesisCommonModule } from '../common/common.module';
 import { PatternflyUIModule } from '../common/ui-patternfly/ui-patternfly.module';
 
 import { CustomizationsComponent } from './customizations.component';
 import { ApiConnectorListComponent } from './api-connectors/api-connector-list.component';
+import { TechExtensionsListComponent } from './tech-extensions/tech-extensions-list.component';
+import { TechExtensionImportComponent } from './tech-extensions/import/tech-extension-import.component';
+import { TechExtensionDetailComponent } from './tech-extensions/detail/tech-extension-detail.component';
 
 const routes: Routes = [
   {
     path: '',
     component: CustomizationsComponent,
     children: [
+      {
+        path: 'tech-extensions',
+        component: TechExtensionsListComponent,
+      },
       {
         path: 'api-connectors',
         component: ApiConnectorListComponent
@@ -22,6 +29,14 @@ const routes: Routes = [
         redirectTo: 'api-connectors'
       }
     ]
+  },
+  {
+    path: 'tech-extensions/import',
+    component: TechExtensionImportComponent
+  },
+  {
+    path: 'tech-extensions/:id',
+    component: TechExtensionDetailComponent
   }
 ];
 
@@ -30,13 +45,17 @@ const routes: Routes = [
     CommonModule,
     PatternflyUIModule,
     ToolbarModule,
+    ListModule,
     RouterModule.forChild(routes),
     SyndesisCommonModule
   ],
   exports: [],
   declarations: [
     CustomizationsComponent,
-    ApiConnectorListComponent
+    ApiConnectorListComponent,
+    TechExtensionsListComponent,
+    TechExtensionImportComponent,
+    TechExtensionDetailComponent
   ],
   providers: []
 })

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
@@ -1,0 +1,1 @@
+<div>WIP - Detail</div>

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+import { ExtensionStore } from '../../../store/extension/extension.store';
+
+@Component({
+  selector: 'syndesis-tech-extension-detail',
+  templateUrl: 'tech-extension-detail.component.html'
+})
+export class TechExtensionDetailComponent implements OnInit {
+  constructor(private store: ExtensionStore) { }
+
+  ngOnInit() {
+    // WIP
+   }
+}

--- a/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
+++ b/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
@@ -1,0 +1,1 @@
+<div>WIP - import</div>

--- a/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
+++ b/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+import { ExtensionStore } from '../../../store/extension/extension.store';
+
+@Component({
+  selector: 'syndesis-tech-extentions-import',
+  templateUrl: 'tech-extension-import.component.html'
+})
+
+export class TechExtensionImportComponent implements OnInit {
+  constructor(private store: ExtensionStore) { }
+
+  ngOnInit() {
+    // WIP
+  }
+}

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
@@ -1,0 +1,53 @@
+<div class="row">
+  <div class="col-xs-12">
+    <h1>Technical Extensions</h1>
+    <p>A technical extension defines one or more custom steps for use in integrations.  Find out more at <a>Syndesis Help</a></p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-12">
+    <syndesis-loading [loading]="loading | async">
+      <syndesis-list-toolbar [items]="extensions"
+                             [filterTags]="false"
+                             [filteredItems]="filteredExtensions"
+                             [viewTemplate]="viewTemplate">
+        <ng-template #viewTemplate>
+          <div class="toolbar-pf-action-right">
+            <button type="button"
+                    class="btn btn-primary"
+                    [routerLink]="['/customizations/tech-extensions/import']">
+                    Import Technical Extension
+            </button>
+          </div>
+        </ng-template>
+
+      </syndesis-list-toolbar>
+      <pfng-list [items]="filteredExtensions"
+                [config]="listConfig"
+                [itemTemplate]="itemTemplate"
+                [actionTemplate]="actionTemplate">
+        <ng-template #itemTemplate
+                    let-item="item"
+                    let-index="index">
+          <div class="list-pf-content-wrapper">
+            <div class="list-pf-main-content">
+              <div class="list-pf-title">{{ item.name }}</div>
+              <div class="list-pf-description" text-overflow-pf>{{ item.description }}</div>
+            </div>
+            <div class="list-pf-additional-content">
+              <div *ngIf="item.integrations">
+                <strong>Used by {{ item.integrations }}</strong>
+              </div>
+            </div>
+          </div>
+        </ng-template>
+        <ng-template #actionTemplate
+                     let-item="item"
+                     let-index="index">
+            <button type="button" class="btn btn-default">Update</button>
+            <button type="button" class="btn btn-default">Delete</button>
+        </ng-template>
+      </pfng-list>
+    </syndesis-loading>
+  </div>
+</div>

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+import { ExtensionStore } from '../../store/extension/extension.store';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import {
+  Action,
+  ActionConfig,
+  ListConfig,
+  ListEvent,
+  EmptyStateConfig,
+} from 'patternfly-ng';
+import { Extensions } from '../../model';
+
+@Component({
+  selector: 'syndesis-tech-extensions-list',
+  templateUrl: 'tech-extensions-list.component.html'
+})
+export class TechExtensionsListComponent implements OnInit {
+  extensions: Observable<Extensions>;
+  filteredExtensions: Subject<Extensions> = new BehaviorSubject(<Extensions>{});
+  loading: Observable<boolean>;
+  listConfig: ListConfig;
+
+  constructor(private store: ExtensionStore) {
+    this.extensions = this.store.list;
+    this.loading = this.store.loading;
+    this.listConfig = {
+      dblClick: false,
+      multiSelect: false,
+      selectItems: false,
+      showCheckbox: false,
+      emptyStateConfig: {
+        iconStyleClass: 'pficon pficon-add-circle-o',
+        title: 'Import Technical Extension',
+        info:
+          'There are no technical extensions available',
+        actions: {
+          primaryActions: [
+            {
+              id: 'importTechnicalExtension',
+              title: 'Import Technical Extension',
+              tooltip: 'Import Technical Extension'
+            }
+          ],
+          moreActions: []
+        } as ActionConfig
+      } as EmptyStateConfig
+    };
+  }
+
+  ngOnInit() {
+    this.store.loadAll();
+  }
+
+}

--- a/ui/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
+++ b/ui/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
@@ -83,8 +83,9 @@ export class IntegrationBasicsComponent extends FlowPage implements OnInit {
       this.tourService.initialize([{
           anchorId: 'integrations.publish',
           title: 'Publish',
-          content: `Click Publish to start running the integration, which will take a moment or two. 
-                    Click Save as Draft to save the integration without deploying it.`,
+          content: `Click Publish to start running the integration, which will
+            take a moment or two.  Click Save as Draft to save the integration
+            without deploying it.`,
           placement: 'left',
         }],
       );

--- a/ui/src/app/integrations/list-page/list-page.component.html
+++ b/ui/src/app/integrations/list-page/list-page.component.html
@@ -16,8 +16,7 @@
                 Create Integration
         </button>
     </div>
-
-</ng-template>
+  </ng-template>
 </syndesis-list-toolbar>
 
 <syndesis-loading [loading]="loading | async">

--- a/ui/src/app/model.ts
+++ b/ui/src/app/model.ts
@@ -1,5 +1,3 @@
-/* tslint:disable */
-
 export interface BaseEntity {
   readonly id?: string;
   // TODO we'll make this optional for now
@@ -7,12 +5,50 @@ export interface BaseEntity {
 }
 
 // TODO local hack to avoid deleting all the related code
+/* tslint:disable */
 export interface IntegrationTemplate extends BaseEntity {}
+/* tslint:enable */
 export type IntegrationTemplates = Array<IntegrationTemplate>;
+
+export interface Extension extends BaseEntity {
+  name: string;
+  description: string;
+  icon: string;
+  extensionId: string;
+  version: string;
+  tags: Array<string>;
+  actions: Array<ExtensionAction>;
+  dependencies: Array<string>;
+  status: 'Draft' | 'Installed' | 'Deleted';
+  id: string;
+  properties: {};
+}
+export type Extensions = Array<Extension>;
+
+export interface ExtensionAction extends BaseEntity {
+  id: string;
+  name: string;
+  description: string;
+  descriptor: ExtensionDescriptor;
+  tags: Array<string>;
+  actionType: string;
+  pattern: 'From' | 'To';
+}
+export type ExtensionActions = Array<ExtensionAction>;
+
+export interface ExtensionDescriptor extends BaseEntity {
+  kind: 'STEP' | 'BEAN' | 'ENDPOINT';
+  entrypoint: string;
+  propertyDefinitionSteps: Array<ActionDescriptorStep>;
+  inputDataShape: DataShape;
+  outputDataShape: DataShape;
+}
+export type ExtensionDescriptors = Array<ExtensionDescriptor>;
 
 export interface Action extends BaseEntity {
   actionType: string;
-  pattern: "From" | "To";
+  pattern: 'From' | 'To';
+  // TODO migrate this to ActionDescriptor
   descriptor: ActionDefinition;
   connectorId: string;
   description: string;
@@ -22,6 +58,22 @@ export interface Action extends BaseEntity {
 }
 export type Actions = Array<Action>;
 
+export interface ActionDescriptor extends BaseEntity {
+  propertyDefinitionSteps: Array<ActionDescriptorStep>;
+  inputDataShape: DataShape;
+  outputDataShape: DataShape;
+}
+export type ActionDescriptors = Array<ActionDescriptor>;
+
+export interface ActionDescriptorStep extends BaseEntity {
+  description: string;
+  name: string;
+  configuredProperties: {};
+  properties: {};
+}
+export type ActionDescriptorSteps = Array<ActionDescriptorStep>;
+
+// TODO deprecate should be ActionDescriptor
 export interface ActionDefinition extends BaseEntity {
   camelConnectorGAV: string;
   camelConnectorPrefix: string;
@@ -31,6 +83,7 @@ export interface ActionDefinition extends BaseEntity {
 }
 export type ActionDefinitions = Array<ActionDefinition>;
 
+// TODO deprecate should be ActionDescriptorStep
 export interface ActionDefinitionStep extends BaseEntity {
   description: string;
   name: string;
@@ -224,7 +277,9 @@ export interface WithIdObject extends BaseEntity {
 }
 export type WithIdObjects = Array<WithIdObject>;
 
+/* tslint:disable */
 export interface Violation extends BaseEntity {}
+/* tslint:enable */
 export type Violations = Array<Violation>;
 
 export interface ListResultAction extends BaseEntity {
@@ -396,6 +451,44 @@ class TypeFactoryClass {
     return <Environment>{
       id: undefined,
       name: undefined
+    };
+  }
+
+  createExtension() {
+    return <Extension>{
+      name: undefined,
+      description: undefined,
+      icon: undefined,
+      extensionId: undefined,
+      version: undefined,
+      tags: undefined,
+      actions: undefined,
+      dependencies: undefined,
+      status: undefined,
+      id: undefined,
+      properties: undefined
+    };
+  }
+
+  createExtensionAction() {
+    return <ExtensionAction>{
+      id: undefined,
+      name: undefined,
+      description: undefined,
+      descriptor: undefined,
+      tags: undefined,
+      actionType: undefined,
+      pattern: undefined
+    };
+  }
+
+  createExtensionDescriptor() {
+    return <ExtensionDescriptor>{
+      kind: undefined,
+      entrypoint: undefined,
+      propertyDefinitionSteps: undefined,
+      inputDataShape: undefined,
+      outputDataShape: undefined
     };
   }
 
@@ -595,4 +688,6 @@ class TypeFactoryClass {
   }
 }
 
+/* tslint:disable */
+// TODO change this to suit lint
 export const TypeFactory = new TypeFactoryClass();

--- a/ui/src/app/store/extension/extension.service.ts
+++ b/ui/src/app/store/extension/extension.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+import { Restangular } from 'ngx-restangular';
+
+import { RESTService } from '../entity/rest.service';
+import { Extension, Extensions } from '../../model';
+
+@Injectable()
+export class ExtensionService extends RESTService<Extension, Extensions> {
+  constructor(restangular: Restangular) {
+    super(restangular.service('../v1beta1/extensions'), 'extension');
+  }
+}

--- a/ui/src/app/store/extension/extension.store.ts
+++ b/ui/src/app/store/extension/extension.store.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { ExtensionService } from './extension.service';
+import { Extension, Extensions, TypeFactory } from '../../model';
+import { AbstractStore } from '../entity/entity.store';
+import { EventsService } from '../entity/events.service';
+
+@Injectable()
+export class ExtensionStore extends AbstractStore<
+  Extension,
+  Extensions,
+  ExtensionService
+> {
+  constructor(extensionService: ExtensionService, eventService: EventsService) {
+    super(extensionService, eventService, [], TypeFactory.createExtension());
+  }
+
+  protected get kind() {
+    return 'Extension';
+  }
+}

--- a/ui/src/app/store/store.module.ts
+++ b/ui/src/app/store/store.module.ts
@@ -9,6 +9,8 @@ import { ConnectionStore } from './connection/connection.store';
 import { ConnectorService } from './connector/connector.service';
 import { ConnectorStore } from './connector/connector.store';
 import { EventsService } from './entity/events.service';
+import { ExtensionService } from './extension/extension.service';
+import { ExtensionStore } from './extension/extension.store';
 import { IntegrationSupportService } from './integration-support.service';
 import { IntegrationService } from './integration/integration.service';
 import { IntegrationStore } from './integration/integration.store';
@@ -29,6 +31,8 @@ import { TestSupportService } from './test-support.service';
     IntegrationSupportService,
     TemplateService,
     EventsService,
+    ExtensionService,
+    ExtensionStore,
     ActionStore,
     ConnectionStore,
     ConnectorStore,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -196,9 +196,9 @@
   dependencies:
     tsickle "^0.21.0"
 
-"@atlasmap/atlasmap.data.mapper@^1.32.0-SNAPSHOT.20171018190510":
-  version "1.32.0-SNAPSHOT.20171018190510"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap.data.mapper/-/atlasmap.data.mapper-1.32.0-SNAPSHOT.20171018190510.tgz#c62a6726aff0bb7db8565d3c84b91c27dee4d91e"
+"@atlasmap/atlasmap.data.mapper@^1.32.0-SNAPSHOT":
+  version "1.32.0-SNAPSHOT.20171114015036"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap.data.mapper/-/atlasmap.data.mapper-1.32.0-SNAPSHOT.20171114015036.tgz#d0c46edc506798241dc8a94f4d6bf33dcc364760"
   dependencies:
     "@angular/common" "4.4.5"
     "@angular/compiler" "4.4.5"


### PR DESCRIPTION
Also adds some updates to the generated model file.

Changed the generator code so it no longer will overwrite model.ts since changes have been manually added in past commits.  Added `Extension` and related types to the model.

Relates to #264 #262 and #263