### PR TITLE
feat(filter-step-tooltips): add tooltip hints in the basic filter model

### DIFF
--- a/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -41,7 +41,7 @@
                [value]="model.value"
                (blur)="onFocusChange($event)"
                (change)="onValueChange($event)"
-               (focus)="onFocusChange($event)" />
+               (focus)="onFocusChange($event)">
         <span [innerHTML]="model.label"
               [ngClass]="[model.cls.element.label, model.cls.grid.label]">
         </span>
@@ -135,6 +135,7 @@
                [maxlength]="model.maxLength"
                [minlength]="model.minLength"
                [name]="model.name"
+               [tooltip]="model.hint"
                [ngClass]="model.cls.element.control"
                [pattern]="model.pattern"
                [placeholder]="model.placeholder"
@@ -188,13 +189,13 @@
         </div>
       </fieldset>
 
-
       <select *ngSwitchCase="6"
               class="form-control"
               [attr.tabindex]="model.tabIndex"
               [dynamicId]="bindId && model.id"
               [formControlName]="model.id"
               [name]="model.name"
+              [tooltip]="model.hint"
               [ngClass]="model.cls.element.control"
               [required]="model.required"
               (blur)="onFocusChange($event)"

--- a/ui/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
+++ b/ui/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
@@ -59,6 +59,7 @@ export function createBasicFilterModel(
           id: 'path',
           maxLength: 51,
           required: true,
+          hint: 'The data you want to evaluate',
           validators: {
             required: null
           },
@@ -82,6 +83,7 @@ export function createBasicFilterModel(
       new DynamicSelectModel<string>(
         {
           id: 'op',
+          hint: 'Must meet this condition',
           value: rule ? rule.op : 'contains',
           options: Observable.of(<any>ops)
         },
@@ -97,6 +99,7 @@ export function createBasicFilterModel(
       ),
       new DynamicInputModel(
         {
+          hint: 'For this value',
           id: 'value',
           value: rule ? rule.value : undefined,
           placeholder: 'Keywords...'


### PR DESCRIPTION
supply hint properties to the basic filter model and bind those hints as tooltips

A limitation I realized while working through this story was that ng-dynamic-forms does not have out of the box support for configuring tooltips and their placement.

Right now the tooltips are placed at "top" by default, we can add support for making this configurable if/when it becomes necessary.