### PR TITLE
refactor: build and pipelines

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,15 @@
 
 # Exit if any error occurs
 set -e
+set -x
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Save global script args
 ARGS="$@"
+
+CURRENT_TOKEN=""
+CURRENT_SERVER=""
 
 # Display a help message.
 function displayHelp() {
@@ -16,6 +20,7 @@ function displayHelp() {
     echo " --skip-image-builds     Skips image builds."
     echo " --with-image-streams    Builds everything using image streams."
     echo " --namespace N           Specifies the namespace to use."
+    echo " --pool-namespace N      Specifies the pool namespace to use."
     echo " --resume-from           Resume build from module."
     echo " --clean                 Cleans up the projects."
     echo " --batch-mode            Runs mvn in batch mode."
@@ -50,11 +55,146 @@ function readopt() {
         done
 }
 
+#
+# Gets the current user token.
+function current_token() {
+    local TMP_FILE=$(mktemp /tmp/syndesis-build-script.XXXXXX)
+    oc whoami --loglevel=8 > /dev/null 2> $TMP_FILE
+    cat $TMP_FILE | grep Authorization | awk -F "Bearer " '{print $2}'
+    rm $TMP_FILE 2> /dev/null
+}
+
+# ======================================================
+# Lock functions (secret lock strategy)
+
+# Displays the data of the lock. A project lock is a secret that contains the following:
+# 1. annotations:
+#    i)  syndesis.io/lock-for-project: The project that this lock corresponds to.
+#    ii) syndesis.io/allocated-by:     The owner of the lock.
+# 2. data:
+#    i)  connection information for the project (token)
+function project_lock_data() {
+    local SECRET_NAME=$1
+    local POOL_NAMESPACE=$2
+    oc get secret $SECRET_NAME -n $POOL_NAMESPACE -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}} {{.metadata.resourceVersion}} {{index .metadata.annotations "syndesis.io/allocated-by"}}{{"\n"}}'
+}
+
+#
+# Obtains a project lock. (See above).
+function obtain_project_lock() {
+    local BUILD_NAME=$1
+    local POOL_NAMESPACE=$2
+    for lock in `oc get secret -n $POOL_NAMESPACE | grep project-lock- | awk -F " " '{print $1}'`; do
+        echo "Trying to obtain lock data from secret $lock" > /tmp/log
+        status=$(project_lock_data $lock $POOL_NAMESPACE)
+        project=`echo $status | awk -F " " '{print $1}'`
+        version=`echo $status | awk -F " " '{print $2}'`
+        allocator=`echo $status | awk -F " " '{print $3}'`
+
+        if [ -z "$allocator" ] || [ "$BUILD_NAME" == "$allocator" ]; then
+            oc annotate secret $lock syndesis.io/allocated-by=$BUILD_NAME --resource-version=$version --overwrite -n $POOL_NAMESPACE > /dev/null
+            newstatus=$(project_lock_data $lock $POOL_NAMESPACE)
+            newallocator=`echo $newstatus | awk -F " " '{print $3}'`
+            if [ "$newallocator" == "$BUILD_NAME" ]; then
+                echo $lock
+                return
+            fi
+        fi
+    done
+}
+
+function project_lock_token() {
+    local SECRET_NAME=$1
+    local POOL_NAMESPACE=$2
+    oc get secret $SECRET_NAME -n $POOL_NAMESPACE -o yaml | grep token: | awk -F ": " '{print $2}' | base64 -d
+}
+
+function project_lock_name() {
+    local SECRET_NAME=$1
+    local POOL_NAMESPACE=$2
+    oc get secret $SECRET_NAME -n $POOL_NAMESPACE -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}}{{"\n"}}'
+}
+
+function release_project_lock() {
+    local POOL_NAMESPACE=$2
+    oc annotate secret $1 syndesis.io/allocated-by="" --overwrite -n $POOL_NAMESPACE > /dev/null
+}
+
+function init_project_pool() {
+    BUILD_ID=$JOB_NAME$BUILD_NUMBER
+    if [ -z "$BUILD_ID" ]; then
+        BUILD_ID="cli"
+    fi
+
+    echo "Trying to allocate project for: $BUILD_ID"
+
+    if [ $(which oc) ] ; then
+        echo "oc binary found. Proceeding with pool initialization."
+    else
+        echo "Warning: oc binary not found in path. Disabling allocation of test project!"
+        return
+    fi
+
+    CURRENT_TOKEN=$(current_token)
+    CURRENT_SERVER=`oc whoami --show-server`
+    INITIAL_NAMESPACE=$(oc project -q)
+    POOL_NAMESPACE=$(readopt --pool-namespace $ARGS 2> /dev/null)
+    if [ -z "$POOL_NAMESPACE" ]; then
+        POOL_NAMESPACE="syndesis-ci"
+    fi
+
+    echo "Using pool namespace: $POOL_NAMESPACE"
+
+    LOCK=$(obtain_project_lock $BUILD_ID $POOL_NAMESPACE)
+    if [ -n "$LOCK" ]; then
+        echo "Obtained lock: $LOCK"
+    fi
+
+    NAMESPACE=$(project_lock_name $LOCK $POOL_NAMESPACE)
+    TOKEN=$(project_lock_token $LOCK $POOL_NAMESPACE)
+    while [ -z "$NAMESPACE" ]; do
+        echo "Couldn't obtain lock. Retrying in 1 minute."
+        sleep 1m
+
+        if [ -n "$LOCK" ]; then
+            LOCK=$(obtain_project_lock $BUILD_ID $POOL_NAMESPACE)
+            NAMESPACE=$(project_lock_name $LOCK $POOL_NAMESPACE)
+            TOKEN=$(project_lock_token $LOCK $POOL_NAMESPACE)
+        fi
+    done
+
+    echo "Allocated project: $NAMESPACE for: $BUILD_ID"
+    oc login --token=$TOKEN --server=$CURRENT_SERVER
+    trap 'teardown_project_pool $NAMESPACE $POOL_NAMESPACE $INITIAL_NAMESPACE' EXIT
+    MAVEN_PARAMS="$MAVEN_PARAMS -Dfabric8.namespace=$NAMESPACE"
+    OC_OPTS=" -n $NAMESPACE"
+}
+
+function teardown_project_pool() {
+    local NAMESPACE=$1
+    local POOL_NAMESPACE=$2
+    local INITIAL_NAMESPACE=$3
+
+    #1. We need to login to the original project first, before releasing the lock.
+    if [ -n "$CURRENT_TOKEN" ]; then
+        oc login --token=$CURRENT_TOKEN --server=$CURRENT_SERVER || true
+        oc project $POOL_NAMESPACE
+    fi
+
+    if [ -n "$NAMESPACE" ]; then
+        $(release_project_lock $NAMESPACE $POOL_NAMESPACE) || true
+    fi
+
+    if [ -n "$INITIAL_NAMESPACE" ]; then
+        oc project $INITIAL_NAMESPACE || true
+    fi
+}
+
 # ======================================================
 # Build functions
 
 function modules_to_build() {
-  modules="parent"
+  modules="parent tests"
   resume_from=$(readopt --resume-from $ARGS 2> /dev/null)
   if [ "x${resume_from}" != x ]; then
     modules=$(echo $modules | sed -e "s/^.*$resume_from/$resume_from/")
@@ -67,9 +207,7 @@ function init_options() {
   SKIP_IMAGE_BUILDS=$(hasflag --skip-image-builds $ARGS 2> /dev/null)
   CLEAN=$(hasflag --clean $ARGS 2> /dev/null)
   WITH_IMAGE_STREAMS=$(hasflag --with-image-streams $ARGS 2> /dev/null)
-
   NAMESPACE=$(readopt --namespace $ARGS 2> /dev/null)
-
   HELP=$(hasflag --help $ARGS 2> /dev/null)
 
   # Internal variable default values
@@ -78,6 +216,7 @@ function init_options() {
   MAVEN_CLEAN_GOAL="clean"
   MAVEN_IMAGE_BUILD_GOAL="fabric8:build"
   MAVEN_CMD="${MAVEN_CMD:-${BASEDIR}/mvnw}"
+  LOCK=""
 
   # If  we are running in cicleci lets configure thigs to avoid running out of memory:
   if [ "$CIRCLECI" == "true" ] ; then
@@ -99,10 +238,16 @@ function init_options() {
       MAVEN_IMAGE_BUILD_GOAL=""
   fi
 
+  if [ -z "$POOL_NAMESPACE" ];then
+      POOL_NAMESPACE="syndesis-ci"
+  fi
+
   if [ -n "$NAMESPACE" ]; then
       echo "Namespace: $NAMESPACE"
       MAVEN_PARAMS="$MAVEN_PARAMS -Dfabric8.namespace=$NAMESPACE"
       OC_OPTS=" -n $NAMESPACE"
+  else
+      init_project_pool
   fi
 
   if [ -z "$CLEAN" ];then
@@ -115,10 +260,26 @@ function init_options() {
   else
     MAVEN_PARAMS="$MAVEN_PARAMS -Dfabric8.mode=kubernetes"
   fi
+
+  if [ -z "$BUILD_ID" ]; then
+      BUILD_ID="cli"
+  fi
 }
 
 function parent() {
   "${MAVEN_CMD}" $MAVEN_CLEAN_GOAL install $MAVEN_PARAMS
+}
+
+function rest() {
+  pushd rest
+  "${MAVEN_CMD}" $MAVEN_CLEAN_GOAL install $MAVEN_IMAGE_BUILD_GOAL $MAVEN_PARAMS
+  popd
+}
+
+function s2i() {
+  pushd s2i
+  "${MAVEN_CMD}" $MAVEN_CLEAN_GOAL install $MAVEN_PARAMS
+  popd
 }
 
 function ui() {
@@ -140,6 +301,23 @@ function ui() {
   #     fi
   # fi
   popd
+}
+
+function tests() {
+    if [ $(which oc) ] ; then
+        echo "oc binary found. Proceeding with system tests."
+    else
+        echo "Warning: oc binary not found in path. Disabling system tests!"
+        return
+    fi
+
+    pushd tests
+    export NAMESPACE_USE_EXISTING=$NAMESPACE
+    export KUBERNETES_NAMESPACE=$NAMESPACE
+    export OPENSHIFT_TEMPLATE_FROM_WORKSPACE=true
+    export WORKSPACE=../deploy
+    mvn clean install
+    popd
 }
 
 # ============================================================================

--- a/create-lock.sh
+++ b/create-lock.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# This is a samples script that can be used to create all the necessary locks that can be used for handling a project pool.
+#
+# Usage: create-lock.sh <project prefix>
+
+PREFIX=$1
+SERVICE_ACCOUNT="default"
+
+function find_secret() {
+	local NAMESPACE=$1
+	local SERVICE_ACCOUNT=$2
+	oc get sa $SERVICE_ACCOUNT -n $NAMESPACE -o yaml | grep $SERVICE_ACCOUNT-token- | awk -F ": " '{print $2}'
+}
+
+function read_token() {
+	local SECRET=$1
+	local NAMESPACE=$2
+	oc get secret $SECRET -n $NAMESPACE -o yaml | grep token: | awk -F ": " '{print $2}' | base64 -d
+}
+
+function read_token_of_sa() {
+	local NAMESPACE=$1
+	local SERVICE_ACCOUNT=$2
+	local SECRET=$(find_secret $NAMESPACE $SERVICE_ACCOUNT)
+	local TOKEN=$(read_token $SECRET $NAMESPACE)
+	echo $TOKEN
+}
+
+
+for p in `oc get projects | grep $PREFIX | awk -F " " '{print $1}'`; do
+	echo "Creating a secret lock for project $p"
+	SECRET=$(find_secret $p "default")
+	echo "Found secret: $SECRET"
+	TOKEN=$(read_token_of_sa $p $SERVICE_ACCOUNT)
+	echo "Found token: $TOKEN"
+	oc delete secret project-lock-$p || true
+	oc create secret generic project-lock-$p --from-literal=token=$TOKEN 
+	oc annotate secret project-lock-$p syndesis.io/lock-for-project=$p
+	oc annotate secret project-lock-$p syndesis.io/allocated-by=""
+
+	oc adm policy add-role-to-user edit system:serviceaccount:$p:$SERVICE_ACCOUNT -n $p
+	oc adm policy add-role-to-user system:image-puller system:serviceaccount:$p:$SERVICE_ACCOUNT -n $p
+	oc adm policy add-role-to-user system:image-builder system:serviceaccount:$p:$SERVICE_ACCOUNT -n $p
+done

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
-    <node.version>v8.9.1</node.version>
+    <node.version>v6.11.5</node.version>
     <yarn.version>v1.2.1</yarn.version>
 
     <jackson.version>2.8.10</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
-    <node.version>v6.11.5</node.version>
+    <node.version>v8.9.1</node.version>
     <yarn.version>v1.2.1</yarn.version>
 
     <jackson.version>2.8.10</jackson.version>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -1043,6 +1043,7 @@
                 <arg>-Xlint:-serial</arg>
                 <arg>-Werror</arg>
                 <arg>-XepDisableWarningsInGeneratedCode</arg>
+                <arg>-implicit:none</arg>
               </compilerArgs>
             </configuration>
             <dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -218,6 +218,14 @@
           </ignoredResourcePatterns>
         </configuration>
       </plugin>
+      <plugin>
+	      <groupId>org.apache.maven.plugins</groupId>
+	      <artifactId>maven-surefire-plugin</artifactId>
+	      <configuration>
+		      <forkCount>0</forkCount>
+		      <reuseForks>false</reuseForks>
+      </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/tests/src/test/resources/arquillian.xml
+++ b/tests/src/test/resources/arquillian.xml
@@ -5,6 +5,8 @@
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <extension qualifier="kubernetes">
+      <property name="namespace.init.enabled">true</property>
+      <property name="namespace.cleanup.enabled">true</property>
       <property name="env.setup.script.url">setup.sh</property>
       <property name="env.teardown.script.url">teardown.sh</property>
       <property name="wait.for.service.list">syndesis-rest syndesis-ui syndesis-keycloak</property>

--- a/tests/src/test/resources/setup.sh
+++ b/tests/src/test/resources/setup.sh
@@ -52,8 +52,7 @@ if [ -n "${SYNDESIS_RELEASED_IMAGES}" ]; then
     # no op required
 else
     # Move image streams (one by one) inside the test namespace
-    echo "ImageStreams from CI namespace will be used"
-    for i in `oc get istag -n syndesis-ci | cut -f1 -d " " | grep -v NAME`;do oc tag syndesis-ci/$i ${KUBERNETES_NAMESPACE}/$i; done
+    echo "Local ImageStreams will be used"
 fi
 
 oc create -f ${SYNDESIS_TEMPLATE_URL} -n ${KUBERNETES_NAMESPACE}  || oc replace -f ${SYNDESIS_TEMPLATE_URL} -n ${KUBERNETES_NAMESPACE}


### PR DESCRIPTION
This pull request completely changes our Jenkins pipeline to be `kubernetes-less`.
The pipeline now use plain old jenkins tools, to require and setup the build environment and the actual build is performed in a single step by invoking the build.sh script.

The build.sh script has been updated to also execute the system-tests. For the needs of system testing, we now use a `pool of projects`. For each project in the pool, we have a secret that contains credentials to access the project and also locking information. Whenever a test project is needed a secret is marked in the pool, and a new connection to the project is made using the token read.

Pool handling and system tests rely on `oc` and they are skipped if `oc` is not present in the PATH.