### PR TITLE
feat: implement tech extension upload and most of the detail page

### DIFF
--- a/ui/src/app/customizations/customizations.module.ts
+++ b/ui/src/app/customizations/customizations.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { ToolbarModule, ListModule } from 'patternfly-ng';
 import { SyndesisCommonModule } from '../common/common.module';
 import { PatternflyUIModule } from '../common/ui-patternfly/ui-patternfly.module';
+import { FileUploadModule } from 'ng2-file-upload-base/src';
 
 import { CustomizationsComponent } from './customizations.component';
 
@@ -62,6 +63,7 @@ const routes: Routes = [
     ToolbarModule,
     ListModule,
     RouterModule.forChild(routes),
+    FileUploadModule,
     SyndesisCommonModule
   ],
   exports: [],

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
@@ -23,8 +23,8 @@
     </div>
   </div>
 </div>
-<syndesis-loading [loading]="loading | async">
-  <div class="row">
+<syndesis-loading [loading]="loading$ | async">
+  <div class="row" *ngIf="extension$ | async; let extension">
     <div class="col-xs-12">
       <p></p>
       <div class="panel panel-default">

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
@@ -1,1 +1,82 @@
-<div>WIP - Detail</div>
+<div class="row toolbar-pf">
+  <div class="col-sm-12">
+    <div class="toolbar-pf-actions">
+      <div class="inline-block">
+        <ol class="breadcrumb no-bottom-margin">
+          <li>
+            <a [routerLink]="['/customizations']">
+              Customizations
+            </a>
+          </li>
+          <li>
+            <a [routerLink]="['..']">
+              Technical Extensions
+            </a>
+          </li>
+          <li class="active">
+            <strong>
+              Technical Extension Details
+            </strong>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+<syndesis-loading [loading]="loading | async">
+  <div class="row">
+    <div class="col-xs-12">
+      <p></p>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h1 class="panel-title">
+            {{ extension.name }}
+            <small>({{ extension.id }})</small>
+          </h1>
+        </div>
+        <div class="panel-body">
+          <h4>Overview</h4>
+          <dl class="dl-horizontal">
+            <dt>
+              Name
+            </dt>
+            <dd>
+              {{ extension.name }}
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              Description
+            </dt>
+            <dd>
+              {{ extension.description }}
+            </dd>
+          </dl>
+          <p></p>
+          <h4>Supported Steps</h4>
+          <div class="row">
+            <div class="col-xs-1">
+            </div>
+            <div class="col-xs-11">
+              <div *ngFor="let action of extension.actions">
+                <strong>
+                  {{ action.name }}
+                </strong>
+                - {{ action.description }}
+              </div>
+            </div>
+          </div>
+          <p></p>
+          <h4>Usage</h4>
+          <div class="row">
+            <div class="col-xs-1">
+            </div>
+            <div class="col-xs-11">
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</syndesis-loading>

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
@@ -1,14 +1,32 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+import { Extension } from '../../../model';
 import { ExtensionStore } from '../../../store/extension/extension.store';
 
 @Component({
   selector: 'syndesis-tech-extension-detail',
   templateUrl: 'tech-extension-detail.component.html'
 })
-export class TechExtensionDetailComponent implements OnInit {
-  constructor(private store: ExtensionStore) { }
+export class TechExtensionDetailComponent implements OnInit, OnDestroy {
+  extension: Extension;
+  loading: Observable<boolean>;
+  subscription: Subscription;
+  constructor(private store: ExtensionStore,
+              private router: Router,
+              private route: ActivatedRoute) {
+    this.loading = store.loading;
+               }
 
   ngOnInit() {
-    // WIP
+    this.subscription = this.store.resource.subscribe(extension => {
+      this.extension = extension;
+    });
+    this.route.paramMap.first(params => params.has('id')).subscribe(params => this.store.load(params.get('id')));
    }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
 }

--- a/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
+++ b/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Subscription';
 import { Extension } from '../../../model';
 import { ExtensionStore } from '../../../store/extension/extension.store';
 
@@ -9,24 +8,17 @@ import { ExtensionStore } from '../../../store/extension/extension.store';
   selector: 'syndesis-tech-extension-detail',
   templateUrl: 'tech-extension-detail.component.html'
 })
-export class TechExtensionDetailComponent implements OnInit, OnDestroy {
-  extension: Extension;
-  loading: Observable<boolean>;
-  subscription: Subscription;
-  constructor(private store: ExtensionStore,
+export class TechExtensionDetailComponent implements OnInit {
+  extension$: Observable<Extension>;
+  loading$: Observable<boolean>;
+  constructor(private extensionStore: ExtensionStore,
               private router: Router,
               private route: ActivatedRoute) {
-    this.loading = store.loading;
-               }
+    this.loading$ = this.extensionStore.loading;
+    this.extension$ = this.extensionStore.resource;
+  }
 
   ngOnInit() {
-    this.subscription = this.store.resource.subscribe(extension => {
-      this.extension = extension;
-    });
-    this.route.paramMap.first(params => params.has('id')).subscribe(params => this.store.load(params.get('id')));
+    this.route.paramMap.first(params => params.has('id')).subscribe(params => this.extensionStore.load(params.get('id')));
    }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
 }

--- a/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
+++ b/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
@@ -1,1 +1,142 @@
-<div>WIP - import</div>
+<div class="row toolbar-pf">
+  <div class="col-sm-12">
+    <div class="toolbar-pf-actions">
+      <div class="inline-block">
+        <ol class="breadcrumb no-bottom-margin">
+          <li>
+            <a [routerLink]="['/customizations']">
+              Customizations
+            </a>
+          </li>
+          <li>
+            <a [routerLink]="['..']">
+              Technical Extensions
+            </a>
+          </li>
+          <li class="active">
+            <strong>
+              Import Technical Extension
+            </strong>
+          </li>
+        </ol>
+      </div>
+      <div class="toolbar-pf-action-right">
+        <div class="toolbar-pf-action-right-alignment">
+          <button class="btn btn-default"
+                [routerLink]="['..']">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-12">
+    <p></p>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          Import Technical Extension
+        </h3>
+      </div>
+      <div class="panel-body">
+        <p>
+          To import a technical extension, it must be packaged as a .jar file. To update a technical extension in the breadcrumbs above,
+          click Technical Extensions and in the list of technical extensions, click Update for the appropriate technical
+          extension.
+        </p>
+        <ng-container *ngIf="error">
+          <div [class]="error.level" [innerHtml]="error.message">
+          </div>
+        </ng-container>
+        <dl class="dl-horizontal"
+            ng2FileDrop
+            [uploader]="uploader">
+          <dt>
+            Upload File
+          </dt>
+          <dd>
+            <div class="row">
+              <div class="col-md-6">
+                <input #fileSelect
+                       type="file"
+                       ng2FileSelect
+                       [uploader]="uploader">
+                <p class="help-block">Accepted file type: .jar</p>
+              </div>
+              <div class="col-md-6">
+                <div *ngIf="uploader.queue.length">
+                  <div *ngFor="let item of uploader.queue">
+                    <p *ngIf="!item.isUploaded">
+                      <span class="spinner spinner-lg spinner-inline"></span>
+                      {{ item.file.name }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </dd>
+        </dl>
+        <ng-container *ngIf="response">
+          <dl class="dl-horizontal">
+            <dt>
+              ID
+            </dt>
+            <dd>
+              {{ response.id }}
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              Name
+            </dt>
+            <dd>
+              {{ response.name }}
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              Description
+            </dt>
+            <dd>
+              {{ response.description }}
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              Steps
+            </dt>
+            <dd>
+              <div *ngFor="let action of response.actions">
+                <strong>
+                  {{ action.name }}
+                </strong>
+                 - {{ action.description }}
+              </div>
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt></dt>
+            <dd>
+              <button type="button"
+                      class="btn btn-primary"
+                      [disabled]="importing"
+                      (click)="doImport()">
+                <span *ngIf="importing"
+                      class="spinner spinner-sm spinner-inline"></span>
+                Import
+              </button>
+              <button *ngIf="!importing"
+                      type="button"
+                      class="btn btn-default"
+                      [routerLink]="['..']">
+                Cancel
+              </button>
+            </dd>
+          </dl>
+        </ng-container>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
+++ b/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
@@ -1,15 +1,111 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  FileUploader,
+  FileItem,
+  FileLikeObject,
+  FilterFunction,
+  FileUploaderOptions,
+  ParsedResponseHeaders
+} from 'ng2-file-upload-base/src';
+import { NotificationType } from 'patternfly-ng';
+import { Extension } from '../../../model';
 import { ExtensionStore } from '../../../store/extension/extension.store';
+import { NotificationService } from 'app/common/ui-patternfly/notification-service';
+
+interface FileError {
+  level: string;
+  message: string;
+}
 
 @Component({
   selector: 'syndesis-tech-extentions-import',
   templateUrl: 'tech-extension-import.component.html'
 })
+export class TechExtensionImportComponent {
 
-export class TechExtensionImportComponent implements OnInit {
-  constructor(private store: ExtensionStore) { }
+  uploader: FileUploader;
+  response: Extension = undefined;
+  error: FileError = undefined;
+  importing = false;
 
-  ngOnInit() {
-    // WIP
+  @ViewChild('fileSelect') fileSelect: ElementRef;
+
+  constructor(private store: ExtensionStore,
+              private notificationService: NotificationService,
+              private router: Router,
+              private route: ActivatedRoute) {
+    this.uploader = new FileUploader({
+      url: this.store.getUploadUrl(),
+      disableMultipart: false,
+      autoUpload: true,
+      filters: [
+        {
+          name: 'filename filter',
+          fn: (item: FileLikeObject, options: FileUploaderOptions) => {
+            if (!item.name.endsWith('.jar')) {
+              return false;
+            }
+            return true;
+          }
+        }
+      ]
+    });
+    this.uploader.onWhenAddingFileFailed = (item: FileLikeObject, filter: any, options: any): any => {
+      this.error = this.getGenericError();
+      this.fileSelect.nativeElement['value'] = '';
+      this.uploader.clearQueue();
+    };
+    this.uploader.onCompleteItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
+      this.error = undefined;
+      this.response = undefined;
+      let resp: any = {};
+      try {
+        resp = JSON.parse(response);
+      } catch (err) {
+        this.error = this.getGenericError();
+        return;
+      }
+      if (status === 200) {
+        this.response = <Extension> resp;
+        return;
+      }
+      this.error = {
+        level: 'alert alert-danger',
+        message: resp.userMsg || 'An unknown error has occurred'
+      };
+    };
+  }
+
+  getGenericError() {
+    return {
+        level: 'alert alert-danger',
+        message: '<strong>This is not a valid file type.</strong> Try again and specify a .jar file'
+      };
+  }
+
+  doImport() {
+    this.importing = true;
+    if (!this.response || !this.response.id) {
+      // safety net
+      this.response = undefined;
+      return;
+    }
+    this.store.importExtension(this.response.id).toPromise().then( value => {
+      this.notificationService.message(
+        NotificationType.SUCCESS,
+        'Imported!',
+        'Your technical extension has been imported',
+        false,
+        null,
+        []
+      );
+      this.router.navigate(['..', this.response.id], { relativeTo: this.route });
+    }).catch((reason: any) => {
+      this.error = {
+        level: 'alert alert-danger',
+        message: reason.userMsg || 'An unknown error has occurred'
+      };
+    });
   }
 }

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
@@ -1,14 +1,14 @@
 <div class="row">
   <div class="col-xs-12">
     <h1>Technical Extensions</h1>
-    <p>A technical extension defines one or more custom steps for use in integrations.  Find out more at <a>Syndesis Help</a></p>
+    <p>A technical extension defines one or more custom steps for use in integrations.  Find out more at <a><!-- TODO -->Syndesis Help</a></p>
   </div>
 </div>
 <div class="row tech-extensions-list">
   <div class="col-xs-12">
-    <syndesis-list-toolbar [items]="extensions"
+    <syndesis-list-toolbar [items]="extensions$"
                             [filterTags]="false"
-                            [filteredItems]="filteredExtensions"
+                            [filteredItems]="filteredExtensions$"
                             [viewTemplate]="viewTemplate">
       <ng-template #viewTemplate>
         <div class="toolbar-pf-action-right">
@@ -20,8 +20,8 @@
         </div>
       </ng-template>
     </syndesis-list-toolbar>
-    <syndesis-loading [loading]="loading | async">
-      <pfng-list [items]="filteredExtensions | async"
+    <syndesis-loading [loading]="loading$ | async">
+      <pfng-list [items]="filteredExtensions$ | async"
                 [config]="listConfig"
                 [itemTemplate]="itemTemplate"
                 [actionTemplate]="actionTemplate"

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
@@ -4,28 +4,28 @@
     <p>A technical extension defines one or more custom steps for use in integrations.  Find out more at <a>Syndesis Help</a></p>
   </div>
 </div>
-<div class="row">
+<div class="row tech-extensions-list">
   <div class="col-xs-12">
+    <syndesis-list-toolbar [items]="extensions"
+                            [filterTags]="false"
+                            [filteredItems]="filteredExtensions"
+                            [viewTemplate]="viewTemplate">
+      <ng-template #viewTemplate>
+        <div class="toolbar-pf-action-right">
+          <button type="button"
+                  class="btn btn-primary"
+                  [routerLink]="['/customizations/tech-extensions/import']">
+                  Import Technical Extension
+          </button>
+        </div>
+      </ng-template>
+    </syndesis-list-toolbar>
     <syndesis-loading [loading]="loading | async">
-      <syndesis-list-toolbar [items]="extensions"
-                             [filterTags]="false"
-                             [filteredItems]="filteredExtensions"
-                             [viewTemplate]="viewTemplate">
-        <ng-template #viewTemplate>
-          <div class="toolbar-pf-action-right">
-            <button type="button"
-                    class="btn btn-primary"
-                    [routerLink]="['/customizations/tech-extensions/import']">
-                    Import Technical Extension
-            </button>
-          </div>
-        </ng-template>
-
-      </syndesis-list-toolbar>
-      <pfng-list [items]="filteredExtensions"
+      <pfng-list [items]="filteredExtensions | async"
                 [config]="listConfig"
                 [itemTemplate]="itemTemplate"
-                [actionTemplate]="actionTemplate">
+                [actionTemplate]="actionTemplate"
+                (onClick)="handleClick($event)">
         <ng-template #itemTemplate
                     let-item="item"
                     let-index="index">

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.scss
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.scss
@@ -1,0 +1,5 @@
+:host ::ng-deep .toolbar-pf {
+    background: inherit;
+    border-bottom: none;
+    box-shadow: none;
+  }

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
@@ -19,16 +19,16 @@ import { Extensions, Extension } from '../../model';
   styleUrls: ['./tech-extensions-list.component.scss']
 })
 export class TechExtensionsListComponent implements OnInit {
-  extensions: Observable<Extensions>;
-  filteredExtensions: Subject<Extensions> = new BehaviorSubject(<Extensions>{});
-  loading: Observable<boolean>;
+  extensions$: Observable<Extensions>;
+  filteredExtensions$: Subject<Extensions> = new BehaviorSubject(<Extensions>{});
+  loading$: Observable<boolean>;
   listConfig: ListConfig;
 
   constructor(private store: ExtensionStore,
               private router: Router,
               private route: ActivatedRoute) {
-    this.extensions = this.store.list;
-    this.loading = this.store.loading;
+    this.extensions$ = this.store.list;
+    this.loading$ = this.store.loading;
     this.listConfig = {
       dblClick: false,
       multiSelect: false,

--- a/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
+++ b/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ExtensionStore } from '../../store/extension/extension.store';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -10,11 +11,12 @@ import {
   ListEvent,
   EmptyStateConfig,
 } from 'patternfly-ng';
-import { Extensions } from '../../model';
+import { Extensions, Extension } from '../../model';
 
 @Component({
   selector: 'syndesis-tech-extensions-list',
-  templateUrl: 'tech-extensions-list.component.html'
+  templateUrl: 'tech-extensions-list.component.html',
+  styleUrls: ['./tech-extensions-list.component.scss']
 })
 export class TechExtensionsListComponent implements OnInit {
   extensions: Observable<Extensions>;
@@ -22,7 +24,9 @@ export class TechExtensionsListComponent implements OnInit {
   loading: Observable<boolean>;
   listConfig: ListConfig;
 
-  constructor(private store: ExtensionStore) {
+  constructor(private store: ExtensionStore,
+              private router: Router,
+              private route: ActivatedRoute) {
     this.extensions = this.store.list;
     this.loading = this.store.loading;
     this.listConfig = {
@@ -47,6 +51,11 @@ export class TechExtensionsListComponent implements OnInit {
         } as ActionConfig
       } as EmptyStateConfig
     };
+  }
+
+  handleClick(event: any) {
+    const extension = event.item;
+    this.router.navigate([extension.id], { relativeTo: this.route });
   }
 
   ngOnInit() {

--- a/ui/src/app/integrations/list/list.component.scss
+++ b/ui/src/app/integrations/list/list.component.scss
@@ -1,17 +1,5 @@
 @import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
 .integrations.list {
-  color: #656565;
-  /*
-  /deep/ .list-pf {
-    .list-pf-item {
-      background: $color-pf-white;
-      cursor: pointer;
-      &:hover {
-        background: $color-pf-blue-50;
-      }
-    }
-  }
-  */
   .integration-icons {
     display: inline-table;
     min-width: 135px;

--- a/ui/src/app/integrations/list/list.component.scss
+++ b/ui/src/app/integrations/list/list.component.scss
@@ -1,6 +1,7 @@
 @import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
 .integrations.list {
   color: #656565;
+  /*
   /deep/ .list-pf {
     .list-pf-item {
       background: $color-pf-white;
@@ -10,6 +11,7 @@
       }
     }
   }
+  */
   .integration-icons {
     display: inline-table;
     min-width: 135px;

--- a/ui/src/app/store/extension/extension.service.ts
+++ b/ui/src/app/store/extension/extension.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-
+import { Observable } from 'rxjs/Observable';
 import { Http, Response, ResponseContentType } from '@angular/http';
 import { Restangular } from 'ngx-restangular';
 
@@ -16,7 +16,7 @@ export class ExtensionService extends RESTService<Extension, Extensions> {
     return this.restangularService.one().getRestangularUrl();
   }
 
-  public importExtension(id: string) {
+  public importExtension(id: string): Observable<Response> {
     const url = this.restangularService.one(id).one('install').getRestangularUrl();
     return this.http.post(url, {});
   }

--- a/ui/src/app/store/extension/extension.service.ts
+++ b/ui/src/app/store/extension/extension.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 
+import { Http, Response, ResponseContentType } from '@angular/http';
 import { Restangular } from 'ngx-restangular';
 
 import { RESTService } from '../entity/rest.service';
@@ -7,7 +8,16 @@ import { Extension, Extensions } from '../../model';
 
 @Injectable()
 export class ExtensionService extends RESTService<Extension, Extensions> {
-  constructor(restangular: Restangular) {
+  constructor(restangular: Restangular, private http: Http) {
     super(restangular.service('../v1beta1/extensions'), 'extension');
+  }
+
+  public getUploadUrl() {
+    return this.restangularService.one().getRestangularUrl();
+  }
+
+  public importExtension(id: string) {
+    const url = this.restangularService.one(id).one('install').getRestangularUrl();
+    return this.http.post(url, {});
   }
 }

--- a/ui/src/app/store/extension/extension.store.ts
+++ b/ui/src/app/store/extension/extension.store.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Response } from '@angular/http';
 import { ExtensionService } from './extension.service';
 import { Extension, Extensions, TypeFactory } from '../../model';
 import { AbstractStore } from '../entity/entity.store';
@@ -18,11 +20,11 @@ export class ExtensionStore extends AbstractStore<
     return 'Extension';
   }
 
-  public getUploadUrl() {
+  public getUploadUrl(): string {
     return this.service.getUploadUrl();
   }
 
-  public importExtension(id: string) {
+  public importExtension(id: string): Observable<Response> {
     return this.service.importExtension(id);
   }
 }

--- a/ui/src/app/store/extension/extension.store.ts
+++ b/ui/src/app/store/extension/extension.store.ts
@@ -17,4 +17,12 @@ export class ExtensionStore extends AbstractStore<
   protected get kind() {
     return 'Extension';
   }
+
+  public getUploadUrl() {
+    return this.service.getUploadUrl();
+  }
+
+  public importExtension(id: string) {
+    return this.service.importExtension(id);
+  }
 }

--- a/ui/src/scss/_overrides.scss
+++ b/ui/src/scss/_overrides.scss
@@ -84,6 +84,28 @@ body.cards-pf {
   }
 }
 
+// override the background that seems off with patternfly-ng's list
+.list-pf {
+  .list-pf-item {
+    background: $color-pf-white;
+    cursor: pointer;
+    &:hover {
+      background: $color-pf-blue-50;
+    }
+  }
+}
+
 .blank-slate-pf {
   background-color: inherit;
+}
+
+// override classes to help sort padding issues
+.no-bottom-margin {
+  margin-bottom: 0px;
+}
+
+// wrapper for toolbar-pf buttons where a breadcrumb is also used
+.toolbar-pf-action-right-alignment {
+  margin-top: 5px;
+  position: relative;
 }


### PR DESCRIPTION
Makes it possible to upload a tech extension via the UI and import it, fixes the list so it works properly, also adds some of the detail page.  Need to implement deleting and updating tech extensions, as well as fetch them via the step store (or somehow) in the integration editor.

Relates to #262 #263 
Fixes #264 

@lburgazzoli FYI...