### PR TITLE
chore: add relativePath to pom.xmls

### DIFF
--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -22,6 +22,7 @@
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.syndesis</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -23,6 +23,7 @@
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.syndesis</groupId>

--- a/s2i/pom.xml
+++ b/s2i/pom.xml
@@ -24,6 +24,7 @@
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.syndesis</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -22,6 +22,7 @@
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.syndesis</groupId>

--- a/verifier/pom.xml
+++ b/verifier/pom.xml
@@ -23,6 +23,7 @@
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.syndesis</groupId>


### PR DESCRIPTION
We should have relativePath for syndesis-parent parent POM as it allows
Maven to find it when running a _resume-from_ (`-rf`) or building from
a submodule.