### PR TITLE
fix: install syndesis-parent POM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ node {
                         withYarn {
                             inside {
                                 checkout scm
+                                stage ('install parent') {
+                                    container('maven') {
+                                        sh "mvn -B -U -N install"
+                                    }
+                                }
                                 stage ('build connectors') {
                                     container('maven') {
                                         sh """


### PR DESCRIPTION
Seems that our builds are failing as the syndesis-parent POM cannot be
resolved. This adds a stage to install just the syndesis-parent POM in
the local Maven repository.