### PR TITLE
fix: commit auto-generated files and ignore their licenses

### DIFF
--- a/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorAutoConfiguration.java
+++ b/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorConfiguration.java
+++ b/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorConfigurationCommon.java
+++ b/connectors/connectors/day-trade/day-trade-get-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradeGetConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorAutoConfiguration.java
+++ b/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorConfiguration.java
+++ b/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorConfigurationCommon.java
+++ b/connectors/connectors/day-trade/day-trade-place-connector/src/main/java/io/syndesis/connector/daytrade/springboot/DayTradePlaceConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.daytrade.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorAutoConfiguration.java
+++ b/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorConfiguration.java
+++ b/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorConfigurationCommon.java
+++ b/connectors/connectors/http/http-get-connector/src/main/java/io/syndesis/connector/http/springboot/HttpGetConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorAutoConfiguration.java
+++ b/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorConfiguration.java
+++ b/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorConfigurationCommon.java
+++ b/connectors/connectors/http/http-post-connector/src/main/java/io/syndesis/connector/http/springboot/HttpPostConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.http.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorAutoConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorConfigurationCommon.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-publish-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQPublishConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorAutoConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorConfigurationCommon.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-request-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRequestConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorAutoConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorConfigurationCommon.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-respond-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQRespondConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorAutoConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorConfiguration.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorConfigurationCommon.java
+++ b/connectors/connectors/jms/activemq-connectors/activemq-subscribe-connector/src/main/java/io/syndesis/connector/jms/springboot/ActiveMQSubscribeConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.jms.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-create-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceCreateSObjectConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceDeleteSObjectWithIdConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceGetSObjectWithIdConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-on-create-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnCreateConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-on-delete-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnDeleteConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-on-update-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceOnUpdateConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-update-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpdateSObjectConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-contact-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertContactConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorAutoConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorConfiguration.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorConfigurationCommon.java
+++ b/connectors/connectors/salesforce/salesforce-upsert-sobject-connector/src/main/java/io/syndesis/connector/salesforce/springboot/SalesforceUpsertSObjectConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.salesforce.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorAutoConfiguration.java
+++ b/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorConfiguration.java
+++ b/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorConfigurationCommon.java
+++ b/connectors/connectors/sql/sql-stored-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredConnectorConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorAutoConfiguration.java
+++ b/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorConfiguration.java
+++ b/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorConfigurationCommon.java
+++ b/connectors/connectors/sql/sql-stored-start-connector/src/main/java/io/syndesis/connector/sql/stored/springboot/SqlStoredStartConnectorConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.sql.stored.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorAutoConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorConfigurationCommon.java
+++ b/connectors/connectors/trade-insight/trade-insight-buy-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightBuyConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorAutoConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorConfigurationCommon.java
+++ b/connectors/connectors/trade-insight/trade-insight-sell-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightSellConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorAutoConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorConfiguration.java
+++ b/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorConfigurationCommon.java
+++ b/connectors/connectors/trade-insight/trade-insight-top-connector/src/main/java/io/syndesis/connector/tradeinsight/springboot/TradeInsightTopConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.tradeinsight.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorAutoConfiguration.java
+++ b/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.twitter.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorConfiguration.java
+++ b/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.twitter.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorConfigurationCommon.java
+++ b/connectors/connectors/twitter/twitter-mention-connector/src/main/java/io/syndesis/connector/twitter/springboot/TwitterMentionConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.connector.twitter.springboot;
 
 import javax.annotation.Generated;

--- a/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorAutoConfiguration.java
+++ b/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorAutoConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.search.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorConfiguration.java
+++ b/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.search.springboot;
 
 import java.util.HashMap;

--- a/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorConfigurationCommon.java
+++ b/connectors/connectors/twitter/twitter-search-connector/src/main/java/io/syndesis/search/springboot/TwitterSearchConnectorConfigurationCommon.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.syndesis.search.springboot;
 
 import javax.annotation.Generated;

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,8 @@ limitations under the License.</inlineHeader>
               <exclude>**/.gitkeep</exclude>
               <exclude>**/*.webapp</exclude>
               <exclude>**/browserconfig.xml</exclude>
+              <exclude>connectors/connectors/**/springboot/*Configuration.java</exclude> <!-- auto generated without headers -->
+              <exclude>connectors/connectors/**/springboot/*Common.java</exclude> <!-- auto generated without headers -->
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
Each time we generate the spring-boot auto configuration Java classes we
loose headers, there is an option to add headers in but the header
content is hardcoded within the connectors Maven plugin.

This commits auto generated Java classes without headers and removes
license headers check for them.