### PR TITLE
fix: Connector descriptors with update to 1.2-SNAPSHOT

### DIFF
--- a/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -733,7 +733,7 @@
           "displayName": "Password",
           "group": "security",
           "label": "common,security",
-          "required": true,
+          "required": false,
           "type": "string",
           "javaType": "java.lang.String",
           "tags":[],
@@ -745,8 +745,7 @@
         "schema": {
           "kind": "property",
           "displayName": "Schema",
-          "group": "producer",
-          "label": "common",
+          "group": "common",
           "required": false,
           "type": "string",
           "javaType": "java.lang.String",
@@ -760,8 +759,7 @@
         "catalog": {
           "kind": "property",
           "displayName": "Catalog",
-          "group": "producer",
-          "label": "common",
+          "group": "common",
           "required": false,
           "type": "string",
           "javaType": "java.lang.String",
@@ -794,15 +792,15 @@
               "description": "Select the Stored Procedure",
               "properties": {
                 "procedureName": {
-                  "kind": "path",
+                  "kind": "property",
+                  "group": "common",
                   "displayName": "Procedure Name",
-                  "group": "producer",
-                  "required": true,
+                  "required": false,
                   "type": "string",
                   "javaType": "java.lang.String",
                   "tags":[],
                   "deprecated": false,
-                  "secret": false,
+                  "secret": true,
                   "componentProperty": false,
                   "description": "Name of the Store Procedure"
                 },

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -42,7 +42,7 @@
     <basepom.compiler.fail-warnings>true</basepom.compiler.fail-warnings>
     <dep.plugin.compiler.version>3.7.0</dep.plugin.compiler.version>
 
-    <syndesis-connectors.version>0.5.8</syndesis-connectors.version>
+    <syndesis-connectors.version>1.2-SNAPSHOT</syndesis-connectors.version>
     <syndesis-integration-runtime.version>${project.version}</syndesis-integration-runtime.version>
 
     <assertj-core.version>3.6.2</assertj-core.version>

--- a/s2i/src/main/docker/project/pom.xml
+++ b/s2i/src/main/docker/project/pom.xml
@@ -49,67 +49,67 @@
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>twitter-mention-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>twitter-search-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-create-sobject-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-delete-sobject-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-delete-sobject-with-id-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-get-sobject-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-get-sobject-with-id-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-update-sobject-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-upsert-sobject-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-on-create-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-on-update-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>salesforce-on-delete-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis</groupId>
       <artifactId>sql-stored-connector</artifactId>
-      <version>0.5.8</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
 
     <!-- extensions used in this integration -->


### PR DESCRIPTION
Fixes the DeploymentDescriptorIT test to look for properties also within
connector properties. Updates `deployment.json` to match connector JSON
schema in 1.2-SNAPSHOT.

**Updates connectors version to 1.2-SNAPSHOT. With this it will be
difficult to run on minishift as -SNAPSHOT version cannot be resolved
from any Maven repository (we don't publish -SNAPSHOTs), and if merged
without the upgrade to 1.2-SNAPSHOT the test will fail as the connector
JSON schema differs in 0.5.8 vs 1.2-SNAPSHOT.**

Fixes #476