### PR TITLE
Update build command and bump node version to align with development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
-    <node.version>v6.11.5</node.version>
+    <node.version>v8.9.1</node.version>
     <yarn.version>v1.2.1</yarn.version>
 
     <jackson.version>2.8.10</jackson.version>

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "start": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js",
     "start:prod": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js --aot --prod",
     "start:minishift": "./scripts/minishift-setup.sh && yarn ng serve --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}')",
-    "build:ci": "yarn ng build --aot --prod --progress=false",
+    "build:ci": "npm rebuild && yarn ng build --aot --prod --progress=false",
     "lint": "yarn ng lint --format stylish",
     "lint:fix": "yarn ng lint --fix",
     "test": "yarn ng test --sourcemaps=false",

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -81,15 +81,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>angular-cli install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>install --no-optional -g @angular/cli</arguments>
-            </configuration>
-          </execution>
-          <execution>
             <id>yarn install</id>
             <goals>
               <goal>yarn</goal>
@@ -113,7 +104,7 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
-              <arguments>ng build --aot --prod --progress=false</arguments>
+              <arguments>build:ci</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Using 6.x means we have to do `npm rebuild` whenever we rebuild the whole repo.  Since we're using 8.x for dev we should align to this.  And no need to install angular-cli globally, can just use the existing `build:ci` task for this.