### PR TITLE
Build the UI last

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
       </activation>
       <modules>
         <module>connectors</module>
-        <module>ui</module>
         <module>runtime</module>
         <module>rest</module>
         <module>s2i</module>
         <module>tests</module>
         <module>verifier</module>
+        <module>ui</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
As none of the Java modules require it to be built first and it takes forever to compile.