### PR TITLE
refactor: add default discriminator values to Action subclasses

### DIFF
--- a/rest/model/src/main/java/io/syndesis/model/action/Action.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/Action.java
@@ -38,7 +38,7 @@ import io.syndesis.model.connection.ConfigurationProperty;
 
 @JsonTypeInfo(
     use      = JsonTypeInfo.Id.NAME,
-    include  = JsonTypeInfo.As.PROPERTY,
+    include  = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "actionType"
 )
 @JsonSubTypes({

--- a/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
@@ -23,6 +23,13 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = ConnectorAction.Builder.class)
 @SuppressWarnings("immutables")
 public interface ConnectorAction extends Action<ConnectorDescriptor>, WithId<ConnectorAction> {
+
+    @Override
+    @Value.Default
+    default String getActionType() {
+        return Action.TYPE_CONNECTOR;
+    }
+
     @Override
     default ConnectorAction withId(String id) {
         return new Builder().createFrom(this).id(id).build();

--- a/rest/model/src/main/java/io/syndesis/model/action/ExtensionAction.java
+++ b/rest/model/src/main/java/io/syndesis/model/action/ExtensionAction.java
@@ -23,6 +23,13 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = ExtensionAction.Builder.class)
 @SuppressWarnings("immutables")
 public interface ExtensionAction extends Action<ExtensionDescriptor>, WithId<ExtensionAction> {
+
+    @Override
+    @Value.Default
+    default String getActionType() {
+        return Action.TYPE_EXTENSION;
+    }
+
     @Override
     default ExtensionAction withId(String id) {
         return new Builder().createFrom(this).id(id).build();


### PR DESCRIPTION
We're missing `actionType` when Jackson deserializes Action's from JSON
the correct class instances are created but tye `actionType` remains to
be `null`. This adds default value for `actionType` property.

Fixes #482