### PR TITLE
 feat: Order actions in Swagger connector generator

### DIFF
--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerConnectorGenerator.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerConnectorGenerator.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.connector.generator.swagger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.parameters.SerializableParameter;
 import io.swagger.parser.SwaggerParser;
 import io.syndesis.connector.generator.ConnectorGenerator;
+import io.syndesis.connector.generator.util.ActionComparator;
 import io.syndesis.model.DataShape;
 import io.syndesis.model.action.Action;
 import io.syndesis.model.action.ActionDescriptor;
@@ -154,6 +156,7 @@ public class SwaggerConnectorGenerator extends ConnectorGenerator {
         final String connectorGav = connectorTemplate.getCamelConnectorGAV();
         final String connectorScheme = connectorTemplate.getCamelConnectorPrefix();
 
+        final List<ConnectorAction> actions = new ArrayList<>();
         int idx = 0;
         for (final Entry<String, Path> pathEntry : paths.entrySet()) {
             final Path path = pathEntry.getValue();
@@ -196,9 +199,12 @@ public class SwaggerConnectorGenerator extends ConnectorGenerator {
                     .descriptor(descriptor).tags(ofNullable(operation.getTags()).orElse(Collections.emptyList()))//
                     .build();
 
-                builder.addAction(action);
+                actions.add(action);
             }
         }
+
+        actions.sort(ActionComparator.INSTANCE);
+        builder.addAllActions(actions);
 
         if (idx != 0) {
             // we changed the Swagger specification by adding missing

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/util/ActionComparator.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/util/ActionComparator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.generator.util;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import io.syndesis.model.action.ConnectorAction;
+
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+public final class ActionComparator implements Comparator<ConnectorAction> {
+
+    public static final Comparator<ConnectorAction> INSTANCE = new ActionComparator();
+
+    private static final Comparator<String> BASE_COMPARATOR = Comparator.nullsLast(String::compareTo);
+
+    private ActionComparator() {
+        // use INSTANCE field
+    }
+
+    @Override
+    public int compare(final ConnectorAction left, final ConnectorAction right) {
+        final String leftTags = allTags(left);
+        final String rightTags = allTags(right);
+
+        final int base = BASE_COMPARATOR.compare(leftTags, rightTags);
+        if (base != 0) {
+            return base;
+        }
+
+        final String leftName = name(left);
+        final String rightName = name(right);
+
+        return BASE_COMPARATOR.compare(leftName, rightName);
+    }
+
+    private static String allTags(final ConnectorAction left) {
+        return trimToNull(left.getTags().stream().collect(Collectors.joining()));
+    }
+
+    private static String name(final ConnectorAction action) {
+        return trimToNull(action.getName());
+    }
+}

--- a/rest/connector-generator/src/test/java/io/syndesis/connector/generator/util/ActionComparatorTest.java
+++ b/rest/connector-generator/src/test/java/io/syndesis/connector/generator/util/ActionComparatorTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.generator.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.syndesis.model.action.ConnectorAction;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ActionComparatorTest {
+
+    @Test
+    public void shouldOrderActionsBasedOnTags() {
+        final ConnectorAction a = new ConnectorAction.Builder().addTag("a").build();
+        final ConnectorAction b = new ConnectorAction.Builder().addTag("b").build();
+        final ConnectorAction c = new ConnectorAction.Builder().addTag("c").build();
+        final ConnectorAction noTags = new ConnectorAction.Builder().build();
+
+        final List<ConnectorAction> actions = new ArrayList<>(Arrays.asList(c, noTags, a, b));
+
+        Collections.shuffle(actions);
+
+        actions.sort(ActionComparator.INSTANCE);
+
+        assertThat(actions).containsExactly(a, b, c, noTags);
+    }
+
+    @Test
+    public void shouldOrderActionsBasedOnTagsAndName() {
+        final ConnectorAction a = new ConnectorAction.Builder().name("a").addTag("a").build();
+        final ConnectorAction b = new ConnectorAction.Builder().name("b").addTag("b").build();
+        final ConnectorAction c = new ConnectorAction.Builder().name("c").addTag("b").build();
+        final ConnectorAction noTagsA = new ConnectorAction.Builder().name("a").build();
+        final ConnectorAction noTagsB = new ConnectorAction.Builder().name("b").build();
+        final ConnectorAction noTagsNoName = new ConnectorAction.Builder().build();
+
+        final List<ConnectorAction> actions = new ArrayList<>(Arrays.asList(c, noTagsA, a, noTagsB, b, noTagsNoName));
+
+        Collections.shuffle(actions);
+
+        actions.sort(ActionComparator.INSTANCE);
+
+        assertThat(actions).containsExactly(a, b, c, noTagsA, noTagsB, noTagsNoName);
+    }
+}


### PR DESCRIPTION
**Based on #495 please review that first**

Adds sorting to actions based on tags and then on names of actions. NULL
or empty tags/actions are placed last.

Fixes #105