### PR TITLE
Simplify /info endpoint for custom connectors

### DIFF
--- a/project/proposals/119-custom-connectors.md
+++ b/project/proposals/119-custom-connectors.md
@@ -150,23 +150,99 @@ Accept: application/json
 }
 
 HTTP/1.1 200 OK
-Content-Length: 2
 
 {
-  "name": "Swagger Petstore",
-  "description": "This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on irc.freenode.net, #swagger. For this sample, you can use the api key special-key to test the authorization filters.",
-  "icon": "data:image/svg+xml;utf8,<svg ...",
+  "name": "Petstore",
+  "description": "Petstore API connector",
   "properties": {
-    "host": "http://petstore.swagger.io",
-    "basePath": "/v2"
-    "authentication": [
-      {
-        "type": "oauth2",
-        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog"
-      }
-    ]
-  }
-  "errors" : []
+    "accessToken": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "OAuth Access token",
+      "displayName": "OAuth Access token",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": false,
+      "secret": true,
+      "type": "string",
+      "tags": [
+        "oauth-access-token"
+      ],
+      "enum": []
+    },
+    "accessTokenUrl": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "URL to fetch the OAuth Access token",
+      "displayName": "OAuth Access token URL",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": false,
+      "secret": false,
+      "type": "string",
+      "tags": [
+        "oauth-access-token-url"
+      ],
+      "enum": []
+    },
+    "authenticationType": {
+      "componentProperty": true,
+      "defaultValue": "oauth2",
+      "deprecated": false,
+      "description": "Type of authentication used to connect to the API",
+      "displayName": "Authentication Type",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": false,
+      "secret": false,
+      "type": "string",
+      "tags": [
+        "authentication-type"
+      ],
+      "enum": [
+        {
+          "label": "OAuth 2.0",
+          "value": "oauth2"
+        }
+      ]
+    },
+    "basePath": {
+        //...
+    },
+    "clientId": {
+        //...
+    },
+    "clientSecret": {
+        //...
+    },
+    "host": {
+        //...
+    },
+    "operationId": {
+        //...
+    },
+    "specification": {
+        //...
+    }
+  },
+  "actionsSummary": {
+    "actionCountByTags": {
+      "store": 4,
+      "user": 8,
+      "pet": 8
+    },
+    "totalActions": 20
+  },
+  "warnings": [
+  ],
+  "errors": [
+  ]
 }
 ```
 

--- a/project/proposals/119-custom-connectors.md
+++ b/project/proposals/119-custom-connectors.md
@@ -31,7 +31,6 @@ New API endpoints for defining custom connectors:
 | --------- | ---- | ----------- |
 | GET       | /api/**{version}**/custom/connectors | Returns a list of known connector templates |
 | GET       | /api/**{version}**/custom/connectors/**{id}** | Returns a specific connector template identified by the given **id** |
-| POST      | /api/**{version}**/custom/connectors/**{id}**/validation | Validate new custom connector properties and return suggested properties in addition to validation result |
 | POST      | /api/**{version}**/custom/connectors/**{id}**/info | Provides information like proposed name, icon and description for new connector |
 | POST      | /api/**{version}**/custom/connectors/**{id}**| Create a new custom connector |
 
@@ -120,48 +119,24 @@ Based on the connector template property `specification`, tagged with `upload`, 
 
 The user opts to specify the Swagger specification via URL of the specification, but mistakenly selects the URL of the HTML document instead of the specification, the UI can perform validation before proceeding by invoking:
 
+
 ```http
-POST /api/v1/custom/connectors/swagger-connector-template/validation
+POST /api/v1/custom/connectors/swagger-connector-template/info
 Content-Type: application/json
 Accept: application/json
 
 {
-  "configuredProperties": {
-    "specification": "http://petstore.swagger.io/index.html"
-  }
+  "errors" : [
+    {
+      "property": "specification",
+      "error": "ValidSpecification",
+      "message": "Given specification is not readable"
+    }
+  ]
 }
-
-HTTP/1.1 400 Bad Request
-Content-Type: application/json
-[
-  {
-    "property": "specification",
-    "error": "ValidSpecification",
-    "message": "Given specification is not readable"
-  }
-]
 ```
 
-The user provides the correct URL, now the response is positive:
-
-```http
-POST /api/v1/custom/connectors/swagger-connector-template/validation
-Content-Type: application/json
-Accept: application/json
-
-{
-  "configuredProperties": {
-    "specification": "http://petstore.swagger.io/v2/swagger.json"
-  }
-}
-
-HTTP/1.1 200 OK
-Content-Length: 2
-
-[]
-```
-
-After validating the specification information about it can be retrieved:
+The user provides the correct URL, now the response is positive and information fetched from the specification is returned:
 
 ```http
 POST /api/v1/custom/connectors/swagger-connector-template/info
@@ -175,37 +150,27 @@ Accept: application/json
 }
 
 HTTP/1.1 200 OK
-Content-Type: application/json
+Content-Length: 2
 
 {
   "name": "Swagger Petstore",
   "description": "This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on irc.freenode.net, #swagger. For this sample, you can use the api key special-key to test the authorization filters.",
   "icon": "data:image/svg+xml;utf8,<svg ...",
-  "host": "http://petstore.swagger.io",
-  "basePath": "/v2",
-  "authentication": [
-    {
-      "type": "oauth2",
-      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog"
-    },
-    {
-      "type" : "apiKey"
-    }
-  ],
-  "actions": [
-    {
-      "groupName": "pet",
-      "description": "Everything about your Pets",
-      "actions": [
-        { "name": "POST /pet", "description": "Add a new pet to the store" },
-        ...
-      ]
-    }
-  ]
+  "properties": {
+    "host": "http://petstore.swagger.io",
+    "basePath": "/v2"
+    "authentication": [
+      {
+        "type": "oauth2",
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog"
+      }
+    ]
+  }
+  "errors" : []
 }
 ```
 
-With that the user can opt to change some of the date, here the user opted to change the name of the new connector from the suggested *"Swagger Petstore"* to *"Petstore API"*, and the new connector can be created:
+With that the user can opt to change some of the data, here the user opted to change the name of the new connector from the suggested *"Swagger Petstore"* to *"Petstore API"*, and the new connector can be created:
 
 ```http
 POST /api/v1/custom/connectors/swagger-connector-template

--- a/rest/connector-generator/pom.xml
+++ b/rest/connector-generator/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>jackson-json-reference-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+
     <!-- === Testing Dependencies ======================================================== -->
 
     <dependency>

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ActionsSummary.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ActionsSummary.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.generator;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = ActionsSummary.Builder.class)
+@SuppressWarnings("immutables")
+public interface ActionsSummary {
+
+    final class Builder extends ImmutableActionsSummary.Builder {
+        // make ImmutableActionsSummary.Builder accessible
+    }
+
+    Map<String, Integer> getActionCountByTags();
+
+    int getTotalActions();
+}

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ConnectorGenerator.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ConnectorGenerator.java
@@ -30,7 +30,7 @@ public abstract class ConnectorGenerator {
 
     public abstract Connector generate(ConnectorTemplate connectorTemplate, ConnectorSettings connectorSettings);
 
-    public abstract Connector info(ConnectorTemplate connectorTemplate, ConnectorSettings connectorSettings);
+    public abstract ConnectorSummary info(ConnectorTemplate connectorTemplate, ConnectorSettings connectorSettings);
 
     protected final Connector baseConnectorFrom(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
         final Set<String> properties = connectorTemplate.getProperties().keySet();

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ConnectorSummary.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/ConnectorSummary.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.generator;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.model.Violation;
+import io.syndesis.model.WithConfigurationProperties;
+import io.syndesis.model.WithName;
+import io.syndesis.model.WithProperties;
+import io.syndesis.model.connection.Connector;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = ConnectorSummary.Builder.class)
+@SuppressWarnings("immutables")
+public interface ConnectorSummary extends WithName, WithConfigurationProperties {
+
+    final class Builder extends ImmutableConnectorSummary.Builder {
+        // make ImmutableConnectorSummary.Builder accessible
+
+        public Builder createFrom(final Connector connector) {
+            return new Builder().createFrom((WithProperties) connector)//
+                .name(connector.getName())//
+                .description(connector.getDescription())//
+                .icon(connector.getIcon());
+        }
+
+    }
+
+    ActionsSummary getActionsSummary();
+
+    String getDescription();
+
+    List<Violation> getErrors();
+
+    String getIcon();
+
+    List<Violation> getWarnings();
+}

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/package-info.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@ImmutablesStyle
+package io.syndesis.connector.generator;
+
+import io.syndesis.core.immutable.ImmutablesStyle;

--- a/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerConnectorGenerator.java
+++ b/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerConnectorGenerator.java
@@ -37,6 +37,7 @@ import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.parameters.SerializableParameter;
 import io.swagger.parser.SwaggerParser;
 import io.syndesis.connector.generator.ConnectorGenerator;
+import io.syndesis.connector.generator.ConnectorSummary;
 import io.syndesis.connector.generator.util.ActionComparator;
 import io.syndesis.model.DataShape;
 import io.syndesis.model.action.Action;
@@ -73,8 +74,10 @@ public class SwaggerConnectorGenerator extends ConnectorGenerator {
     }
 
     @Override
-    public Connector info(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
-        return basicConnector(connectorTemplate, connectorSettings);
+    public ConnectorSummary info(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
+        final Connector connector = basicConnector(connectorTemplate, connectorSettings);
+
+        return new ConnectorSummary.Builder().createFrom(connector).build();
     }
 
     /* default */ Connector basicConnector(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {

--- a/rest/model/src/main/java/io/syndesis/model/Violation.java
+++ b/rest/model/src/main/java/io/syndesis/model/Violation.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.rest.v1.operations;
+package io.syndesis.model;
 
 import java.lang.annotation.Annotation;
 

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandler.java
@@ -15,9 +15,6 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
-import java.util.Collections;
-import java.util.List;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -25,12 +22,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorSettings;
-import io.syndesis.rest.v1.operations.Violation;
 
 import org.springframework.context.ApplicationContext;
 
@@ -53,17 +47,4 @@ public final class ConnectorSettingsHandler extends BaseConnectorGeneratorHandle
         return withGeneratorAndTemplate(templateId, (generator, template) -> generator.info(template, connectorSettings));
     }
 
-    @POST
-    @Path("/validation")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation("Validates a new Connector based on the ConnectorTemplate identified by the provided `connector-template-id` and the data given in `connectorSettings`")
-    @ApiResponses({//
-        @ApiResponse(code = 204, message = "All validations pass"), //
-        @ApiResponse(code = 400, message = "Found violations in validation", responseContainer = "Set", response = Violation.class)//
-    })
-    public List<Violation> validate(final ConnectorSettings connectorSettings) {
-        // intentionally left blank
-        return Collections.emptyList();
-    }
 }

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandler.java
@@ -22,8 +22,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import io.swagger.annotations.ApiOperation;
+import io.syndesis.connector.generator.ConnectorSummary;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorSettings;
 
 import org.springframework.context.ApplicationContext;
@@ -42,8 +42,8 @@ public final class ConnectorSettingsHandler extends BaseConnectorGeneratorHandle
     @Path("/info")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation("Creates a new Connector based on the ConnectorTemplate identified by the provided `connector-template-id` and the data given in `connectorSettings`")
-    public Connector info(final ConnectorSettings connectorSettings) {
+    @ApiOperation("Provides a summary of the connector as it would be built using a ConnectorTemplate identified by the provided `connector-template-id` and the data given in `connectorSettings`")
+    public ConnectorSummary info(final ConnectorSettings connectorSettings) {
         return withGeneratorAndTemplate(templateId, (generator, template) -> generator.info(template, connectorSettings));
     }
 

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ConstraintViolationExceptionMapper.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/exception/ConstraintViolationExceptionMapper.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import io.syndesis.rest.v1.operations.Violation;
+import io.syndesis.model.Violation;
 
 import org.springframework.stereotype.Component;
 

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/extension/ExtensionHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/extension/ExtensionHandler.java
@@ -34,7 +34,7 @@ import io.syndesis.rest.v1.handler.BaseHandler;
 import io.syndesis.rest.v1.operations.Deleter;
 import io.syndesis.rest.v1.operations.Getter;
 import io.syndesis.rest.v1.operations.Lister;
-import io.syndesis.rest.v1.operations.Violation;
+import io.syndesis.model.Violation;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationSupportHandler.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationSupportHandler.java
@@ -41,7 +41,6 @@ import javax.ws.rs.core.SecurityContext;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 

--- a/rest/rest/src/main/java/io/syndesis/rest/v1/operations/Validating.java
+++ b/rest/rest/src/main/java/io/syndesis/rest/v1/operations/Validating.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.syndesis.model.Violation;
 import io.syndesis.model.WithId;
 import io.syndesis.model.validation.AllValidations;
 

--- a/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandlerTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandlerTest.java
@@ -16,8 +16,8 @@
 package io.syndesis.rest.v1.handler.connection;
 
 import io.syndesis.connector.generator.ConnectorGenerator;
+import io.syndesis.connector.generator.ConnectorSummary;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorSettings;
 import io.syndesis.model.connection.ConnectorTemplate;
 
@@ -42,15 +42,15 @@ public class ConnectorSettingsHandlerTest {
 
         final ConnectorTemplate template = new ConnectorTemplate.Builder().build();
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().build();
-        final Connector connector = new Connector.Builder().build();
+        final ConnectorSummary preparedSummary = new ConnectorSummary.Builder().build();
 
         when(dataManager.fetch(ConnectorTemplate.class, "connector-template")).thenReturn(template);
         when(applicationContext.getBean("connector-template", ConnectorGenerator.class)).thenReturn(connectorGenerator);
-        when(connectorGenerator.info(same(template), same(connectorSettings))).thenReturn(connector);
+        when(connectorGenerator.info(same(template), same(connectorSettings))).thenReturn(preparedSummary);
 
-        final Connector connectorInfo = handler.info(connectorSettings);
+        final ConnectorSummary info = handler.info(connectorSettings);
 
-        assertThat(connectorInfo).isSameAs(connector);
+        assertThat(info).isSameAs(preparedSummary);
     }
 
 }

--- a/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandlerTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorSettingsHandlerTest.java
@@ -15,14 +15,11 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
-import java.util.List;
-
 import io.syndesis.connector.generator.ConnectorGenerator;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorSettings;
 import io.syndesis.model.connection.ConnectorTemplate;
-import io.syndesis.rest.v1.operations.Violation;
 
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -56,14 +53,4 @@ public class ConnectorSettingsHandlerTest {
         assertThat(connectorInfo).isSameAs(connector);
     }
 
-    @Test
-    public void shouldValidateConnectorSettings() {
-        final ConnectorSettingsHandler handler = new ConnectorSettingsHandler("connector-template", dataManager, applicationContext);
-
-        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().build();
-
-        final List<Violation> violations = handler.validate(connectorSettings);
-
-        assertThat(violations).isEmpty();
-    }
 }

--- a/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorTemplateHandlerTest.java
+++ b/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorTemplateHandlerTest.java
@@ -21,13 +21,14 @@ import java.util.Map;
 import javax.persistence.EntityNotFoundException;
 
 import io.syndesis.connector.generator.ConnectorGenerator;
+import io.syndesis.connector.generator.ConnectorSummary;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.action.ConnectorAction;
 import io.syndesis.model.connection.ConfigurationProperty;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorGroup;
-import io.syndesis.model.connection.ConnectorTemplate;
 import io.syndesis.model.connection.ConnectorSettings;
+import io.syndesis.model.connection.ConnectorTemplate;
 
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -63,27 +64,22 @@ public class ConnectorTemplateHandlerTest {
         final ConnectorAction action = new ConnectorAction.Builder().name("action").build();
 
         when(dataManager.fetch(ConnectorTemplate.class, "connector-template-id")).thenReturn(connectorTemplate);
-        when(dataManager.create(any(Connector.class)))
-            .thenAnswer(invocation -> invocation.getArgumentAt(0, Connector.class));
+        when(dataManager.create(any(Connector.class))).thenAnswer(invocation -> invocation.getArgumentAt(0, Connector.class));
 
-        when(applicationContext.getBean("connector-template-id", ConnectorGenerator.class))
-            .thenReturn(new ConnectorGenerator() {
-                @Override
-                public Connector generate(final ConnectorTemplate connectorTemplate,
-                    final ConnectorSettings connectorSettings) {
-                    return new Connector.Builder().createFrom(baseConnectorFrom(connectorTemplate, connectorSettings))
-                        .addAction(action).build();
-                }
+        when(applicationContext.getBean("connector-template-id", ConnectorGenerator.class)).thenReturn(new ConnectorGenerator() {
+            @Override
+            public Connector generate(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
+                return new Connector.Builder().createFrom(baseConnectorFrom(connectorTemplate, connectorSettings)).addAction(action)
+                    .build();
+            }
 
-                @Override
-                public Connector info(final ConnectorTemplate connectorTemplate,
-                    final ConnectorSettings connectorSettings) {
-                    return null;
-                }
-            });
+            @Override
+            public ConnectorSummary info(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
+                return null;
+            }
+        });
 
-        final Connector created = new ConnectorTemplateHandler(dataManager, applicationContext).create(
-            "connector-template-id",
+        final Connector created = new ConnectorTemplateHandler(dataManager, applicationContext).create("connector-template-id",
             new ConnectorSettings.Builder()//
                 .name("new connector")//
                 .description("new connector description")//

--- a/rest/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/ConnectionsITCase.java
@@ -18,8 +18,8 @@ package io.syndesis.runtime;
 import java.util.List;
 import java.util.UUID;
 
+import io.syndesis.model.Violation;
 import io.syndesis.model.connection.Connection;
-import io.syndesis.rest.v1.operations.Violation;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
@@ -17,10 +17,11 @@ package io.syndesis.runtime;
 
 import io.syndesis.model.ListResult;
 import io.syndesis.model.ResourceIdentifier;
+import io.syndesis.model.Violation;
 import io.syndesis.model.extension.Extension;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.SimpleStep;
-import io.syndesis.rest.v1.operations.Violation;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.springframework.core.ParameterizedTypeReference;

--- a/rest/runtime/src/test/java/io/syndesis/runtime/IntegrationsITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/IntegrationsITCase.java
@@ -16,9 +16,11 @@
 package io.syndesis.runtime;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import io.syndesis.model.Violation;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.rest.v1.handler.exception.RestError;
-import io.syndesis.rest.v1.operations.Violation;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;

--- a/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -19,16 +19,14 @@ import java.util.List;
 
 import io.syndesis.connector.generator.ConnectorGenerator;
 import io.syndesis.model.connection.Connector;
-import io.syndesis.model.connection.ConnectorTemplate;
 import io.syndesis.model.connection.ConnectorSettings;
-import io.syndesis.rest.v1.operations.Violation;
+import io.syndesis.model.connection.ConnectorTemplate;
 import io.syndesis.runtime.BaseITCase;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -51,14 +49,12 @@ public class CustomConnectorITCase extends BaseITCase {
         public static final ConnectorGenerator testGenerator() {
             return new ConnectorGenerator() {
                 @Override
-                public Connector generate(final ConnectorTemplate connectorTemplate,
-                    final ConnectorSettings connectorSettings) {
+                public Connector generate(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
                     return baseConnectorFrom(connectorTemplate, connectorSettings);
                 }
 
                 @Override
-                public Connector info(final ConnectorTemplate connectorTemplate,
-                    final ConnectorSettings connectorSettings) {
+                public Connector info(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
                     return baseConnectorFrom(connectorTemplate, connectorSettings);
                 }
             };
@@ -79,8 +75,7 @@ public class CustomConnectorITCase extends BaseITCase {
     public void shouldCreateNewCustomConnectors() {
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().build();
 
-        final ResponseEntity<Connector> response = post("/api/v1/custom/connectors/connector-template", connectorSettings,
-            Connector.class);
+        final ResponseEntity<Connector> response = post("/api/v1/custom/connectors/connector-template", connectorSettings, Connector.class);
 
         final Connector created = response.getBody();
         assertThat(created).isNotNull();
@@ -89,8 +84,7 @@ public class CustomConnectorITCase extends BaseITCase {
 
     @Test
     public void shouldOfferConnectorTemplates() {
-        final ResponseEntity<ConnectorTemplateResultList> response = get("/api/v1/custom/connectors",
-            ConnectorTemplateResultList.class);
+        final ResponseEntity<ConnectorTemplateResultList> response = get("/api/v1/custom/connectors", ConnectorTemplateResultList.class);
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().items).contains(template);
@@ -100,31 +94,18 @@ public class CustomConnectorITCase extends BaseITCase {
     public void shouldOfferCustomConnectorInfo() {
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().build();
 
-        final ResponseEntity<Connector> response = post("/api/v1/custom/connectors/connector-template/info",
-            connectorSettings, Connector.class);
+        final ResponseEntity<Connector> response = post("/api/v1/custom/connectors/connector-template/info", connectorSettings,
+            Connector.class);
 
         assertThat(response.getBody()).isNotNull();
     }
 
     @Test
     public void shouldOfferSingleConnectorTemplateById() {
-        final ResponseEntity<ConnectorTemplate> response = get("/api/v1/custom/connectors/connector-template",
-            ConnectorTemplate.class);
+        final ResponseEntity<ConnectorTemplate> response = get("/api/v1/custom/connectors/connector-template", ConnectorTemplate.class);
 
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody()).isEqualTo(template);
-    }
-
-    @Test
-    public void shouldValidateCustomConnectors() {
-        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().build();
-
-        final ResponseEntity<List<Violation>> response = post("/api/v1/custom/connectors/connector-template/validation",
-            connectorSettings, new ParameterizedTypeReference<List<Violation>>() {
-                // defining type parameters
-            });
-
-        assertThat(response.getBody()).isNotNull().isEmpty();
     }
 
     private static ConnectorTemplate createConnectorTemplate() {


### PR DESCRIPTION
**Based on #495 and #500 please review that first**

This removes `/api/v1/custom/connectors/{id}/validation` endpoint and changes the response from `/api/v1/custom/connectors/{id}/info` to be a bit simpler and in the same time to contain errors and warnings.

//cc @deeleman 