### PR TITLE
fix: be explicit about Supplier type not to trigger a warning

### DIFF
--- a/runtime/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java
+++ b/runtime/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java
@@ -44,7 +44,7 @@ public class ChoiceHandler implements StepHandler<Choice> {
         final CamelContext context = routeBuilder.getContext();
         final ChoiceDefinition choice = route.choice();
 
-        List<Filter> filters = ObjectHelper.supplyIfEmpty(step.getFilters(), Collections::emptyList);
+        List<Filter> filters = ObjectHelper.supplyIfEmpty(step.getFilters(), Collections::<Filter>emptyList);
         for (Filter filter : filters) {
             Predicate predicate = JsonSimpleHelpers.getMandatorySimplePredicate(context, filter, filter.getExpression());
             ChoiceDefinition when = choice.when(predicate);
@@ -54,7 +54,7 @@ public class ChoiceHandler implements StepHandler<Choice> {
 
         Otherwise otherwiseStep = step.getOtherwise();
         if (otherwiseStep != null) {
-            List<Step> otherwiseSteps = ObjectHelper.supplyIfEmpty(otherwiseStep.getSteps(), Collections::emptyList);
+            List<Step> otherwiseSteps = ObjectHelper.supplyIfEmpty(otherwiseStep.getSteps(), Collections::<Step>emptyList);
             if (!otherwiseSteps.isEmpty()) {
                 route = routeBuilder.addSteps(choice.otherwise(), otherwiseSteps);
             }


### PR DESCRIPTION
Seems that the `javac` reports a warning if generics are not specified
(but could be inferred, which is odd).

```
[ERROR] [...]syndesis/runtime/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java:[47,58] incompatible types: inferred type does not conform to upper bound(s)
[ERROR]     inferred: java.util.List<? extends java.lang.Object>
[ERROR]     upper bound(s): java.util.List<io.syndesis.integration.model.steps.Filter>,java.lang.Object
[ERROR] [...]/syndesis/runtime/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java:[57,67] incompatible types: inferred type does not conform to upper bound(s)
```