### PR TITLE
fix: flaky test in SQL start connector

### DIFF
--- a/app/connectors/connectors/sql/sql-start-connector/src/test/java/io/syndesis/connector/sql/SqlStartConnectorComponentTest.java
+++ b/app/connectors/connectors/sql/sql-start-connector/src/test/java/io/syndesis/connector/sql/SqlStartConnectorComponentTest.java
@@ -91,7 +91,7 @@ public class SqlStartConnectorComponentTest {
             context.addRoutes(new RouteBuilder() {
                 @Override
                 public void configure() throws Exception {
-                    from("sql-start-connector:SELECT * FROM NAME")
+                    from("sql-start-connector:SELECT * FROM NAME ORDER BY id")
                     .process(new Processor() {
                         @Override
                         public void process(Exchange exchange)


### PR DESCRIPTION
By not specifiying ORDER BY, the order of the rows in the result from
the SQL statement needs not be deterministic as the assert requires it
to be.