### PR TITLE
feature: enable debugging in -dev templates

### DIFF
--- a/app/build.sh
+++ b/app/build.sh
@@ -78,6 +78,11 @@ With "--minishift" Minishift can be initialized and installed with Syndesis
     --watch                   Watch startup of pods
 -i  --image-mode <mode>       Which templates to install: "docker" for plain images, "openshift" for image streams
                               (default: "openshift")
+
+With "--dev" common development tasks are simplified
+
+    --debug <name>           Setup a port forwarding to <name> pod (example: rest)
+
 Examples:
 
 * Build only backend modules, fast               build.sh --backend --flash
@@ -86,6 +91,7 @@ Examples:
 * Build only the rest and verifier image         build.sh --module rest,verifier --image-mode s2i
 * Build for system test                          build.sh --system-test
 * Start Minishift afresh                         build.sh --minishift --full-reset --install --watch
+* Setup debug port forward for rest pod          build.sh --dev --debug rest
 
 EOT
 }
@@ -610,6 +616,18 @@ run_minishift() {
     fi
 }
 
+dev_tasks() {
+    if [ $(hasflag --debug) ]; then
+        local name=$(readopt --debug)
+        if [ -z "${name}" ]; then
+            name="rest"
+        fi
+
+        local pod=$(oc get -o name pod -l component=syndesis-${name})
+        oc port-forward ${pod//*\//} 5005:5005
+    fi
+}
+
 # ============================================================================
 # Main loop
 
@@ -639,6 +657,12 @@ if [ -n "$(hasflag --system-test)" ]; then
     exit 0
 fi
 
+# Developer helper tasks
+if [ -n "$(hasflag --dev)" ]; then
+    dev_tasks
+    exit 0
+fi
+
 # Check for the mode to use
 mode=$(readopt --mode)
 if [ -z "${mode}" ]; then
@@ -662,6 +686,10 @@ case $mode in
         ;;
     "minishift")
         run_minishift
+        exit 0
+        ;;
+    "dev")
+        dev_tasks
         exit 0
         ;;
     **)

--- a/app/deploy/generator/04-syndesis-rest.yml.mustache
+++ b/app/deploy/generator/04-syndesis-rest.yml.mustache
@@ -93,7 +93,10 @@
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
-{{^WithDockerImages}}
+{{#Debug}}
+          - name: JAVA_DEBUG
+            value: "true"
+{{/Debug}}{{^WithDockerImages}}
           image: ' '
 {{/WithDockerImages}}{{#WithDockerImages}}
           image: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Syndesis.Rest }}:{{ Tags.Syndesis }}

--- a/app/deploy/generator/04-syndesis-verifier.yml.mustache
+++ b/app/deploy/generator/04-syndesis-verifier.yml.mustache
@@ -48,7 +48,10 @@
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
-{{^WithDockerImages}}
+{{#Debug}}
+          - name: JAVA_DEBUG
+            value: "true"
+{{/Debug}}{{^WithDockerImages}}
           image: ' '
 {{/WithDockerImages}}{{#WithDockerImages}}
           image: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Syndesis.Verifier }}:{{ Tags.Syndesis }}

--- a/app/deploy/generator/run.sh
+++ b/app/deploy/generator/run.sh
@@ -21,7 +21,7 @@ echo "$MESSAGE" > ${targetdir}/syndesis.yml
 go run syndesis-template.go $* --name=syndesis >> ${targetdir}/syndesis.yml
 
 echo "$MESSAGE" > ${targetdir}/syndesis-dev.yml
-go run syndesis-template.go $* --name=syndesis-dev --with-docker-images --allow-localhost >> ${targetdir}/syndesis-dev.yml
+go run syndesis-template.go $* --name=syndesis-dev --with-docker-images --allow-localhost --debug >> ${targetdir}/syndesis-dev.yml
 
 echo "$MESSAGE" > ${targetdir}/syndesis-restricted.yml
 go run syndesis-template.go $* --name=syndesis-restricted --restricted >> ${targetdir}/syndesis-restricted.yml
@@ -30,7 +30,7 @@ echo "$MESSAGE" > ${targetdir}/syndesis-ephemeral-restricted.yml
 go run syndesis-template.go $* --name=syndesis-ephemeral-restricted --ephemeral --restricted >> ${targetdir}/syndesis-ephemeral-restricted.yml
 
 echo "$MESSAGE" > ${targetdir}/syndesis-dev-restricted.yml
-go run syndesis-template.go $* --name=syndesis-dev-restricted --restricted --with-docker-images --allow-localhost >> ${targetdir}/syndesis-dev-restricted.yml
+go run syndesis-template.go $* --name=syndesis-dev-restricted --restricted --with-docker-images --allow-localhost --debug >> ${targetdir}/syndesis-dev-restricted.yml
 
 echo "$MESSAGE" > ${targetdir}/syndesis-ci.yml
 go run syndesis-template.go $* --name=syndesis-ci --probeless >> ${targetdir}/syndesis-ci.yml

--- a/app/deploy/generator/syndesis-template.go
+++ b/app/deploy/generator/syndesis-template.go
@@ -83,6 +83,7 @@ type Context struct {
 	Registry                      string
 	Images                        images
 	Tags                          tags
+	Debug						  bool
 }
 
 // TODO: Could be added from a local configuration file
@@ -160,6 +161,7 @@ func init() {
 	flags.StringVar(&context.Tags.Atlasmap, "atlasmap-tag", "latest", "Atlasmap image to use")
 	flags.BoolVar(&context.Productized, "product", false, "Generate product templates?")
 	flags.StringVar(&context.Registry, "registry", "docker.io", "Registry to use for imagestreams")
+	flags.BoolVar(&context.Debug, "debug", false, "Enable debug support")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -741,6 +741,8 @@ objects:
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          - name: JAVA_DEBUG
+            value: "true"
           image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
@@ -883,6 +885,8 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
+          - name: JAVA_DEBUG
+            value: "true"
           image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -745,6 +745,8 @@ objects:
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          - name: JAVA_DEBUG
+            value: "true"
           image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
@@ -887,6 +889,8 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
+          - name: JAVA_DEBUG
+            value: "true"
           image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This sets the environment variable `JAVA_DEBUG` to `true` for
`syndesis-rest` and `syndesis-verifier` pods in `syndesis-dev-*.yml`
templates.

With that environment variable set the Java process is launched with
remote debugging enabled and debugger interface on port `5005`.

Next one can port forward that port via

     oc port-forward syndesis-rest-... 5005:5005

and use the debugger to connect to `localhost:5005`.