### PR TITLE
feat(build): add cleanup to fabric8-maven-plugin

### DIFF
--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -212,6 +212,7 @@
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
         <configuration>
+          <cleanup>remove</cleanup>
           <generator>
             <config>
               <spring-boot>


### PR DESCRIPTION
This configures `cleanup` property of fabric8-maven-plugin to `remove`.

I was having issues deploying fresh versions to development environment
on minishift. Adding `cleanup` property seemed to have helped.