### PR TITLE
fix: display connection name instead of id

### DIFF
--- a/app/ui/src/app/integrations/detail-page/detail.component.html
+++ b/app/ui/src/app/integrations/detail-page/detail.component.html
@@ -59,7 +59,7 @@
                         <img class="connection-icon"
                              src="../../../assets/icons/{{ step.connection.connectorId }}.integration.png">
                       </div>
-                      <div>{{ step.connection.connectorId | capitalize }}</div>
+                      <div>{{ step.connection.name | capitalize }}</div>
                     </div>
                   </ng-container>
                   <ng-container *ngSwitchDefault>


### PR DESCRIPTION
Now looks like:
![screenshot-2017-12-5 syndesis 2](https://user-images.githubusercontent.com/1306050/33604870-d9ff0326-d9b7-11e7-97fe-0cd346ecb754.png)


Fixes #609 
