### PR TITLE
Add Explicit version to spring-aop dependency, otherwise Eclipse plug…

### DIFF
--- a/app/rest/pom.xml
+++ b/app/rest/pom.xml
@@ -373,6 +373,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
+        <version>${spring.version}</version>
         <exclusions>
           <exclusion>
             <groupId>aopalliance</groupId>


### PR DESCRIPTION
…in won't work