### PR TITLE
fix: use proper GAV for REST Swagger connector

### DIFF
--- a/app/rest/connector-generator/src/test/resources/swagger/concur.connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/concur.connector.json
@@ -162,7 +162,7 @@
   },
   "actions": [
     {
-      "id": "io.syndesis:swagger-connector:@syndesis-connectors.version@:_id_:operation-0",
+      "id": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@:_id_:operation-0",
       "connectorId": "concur-quick-expense",
       "name": "Get all quick expenses",
       "description": "Returns all quick expenses owned by the user.",
@@ -172,7 +172,7 @@
         "Resources"
       ],
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis-connectors.version@",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -240,7 +240,7 @@
       }
     },
     {
-      "id": "io.syndesis:swagger-connector:@syndesis-connectors.version@:_id_:operation-1",
+      "id": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@:_id_:operation-1",
       "connectorId": "concur-quick-expense",
       "name": "Create a new quick expense",
       "description": "Creates a new quick expense.",
@@ -250,7 +250,7 @@
         "Resources"
       ],
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis-connectors.version@",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -295,7 +295,7 @@
       }
     },
     {
-      "id": "io.syndesis:swagger-connector:@syndesis-connectors.version@:_id_:operation-2",
+      "id": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@:_id_:operation-2",
       "connectorId": "concur-quick-expense",
       "name": "Get a single quick expense by ID",
       "description": "Returns a quick expenses by ID.",
@@ -305,7 +305,7 @@
         "Resources"
       ],
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis-connectors.version@",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -361,7 +361,7 @@
       }
     },
     {
-      "id": "io.syndesis:swagger-connector:@syndesis-connectors.version@:_id_:operation-3",
+      "id": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@:_id_:operation-3",
       "connectorId": "concur-quick-expense",
       "name": "Update a quick expense by ID",
       "description": "Updates the QuickExpense specified in the URL.  Only the fields provided in the supplied object will be updated, missing fields will not be altered.",
@@ -371,7 +371,7 @@
         "Resources"
       ],
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis-connectors.version@",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -428,11 +428,11 @@
       }
     },
     {
-      "id": "io.syndesis:swagger-connector:@syndesis-connectors.version@:_id_:operation-4",
+      "id": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@:_id_:operation-4",
       "connectorId": "concur-quick-expense",
       "name": "Delete a quick expense by ID",
       "description": "Deletes the specified quick expense.",
-      "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis-connectors.version@",
+      "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis-connectors.version@",
       "camelConnectorPrefix": "swagger-operation",
       "pattern": "To",
       "actionType": "connector",

--- a/app/rest/connector-generator/src/test/resources/swagger/petstore.connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/petstore.connector.json
@@ -162,11 +162,11 @@
   },
   "actions": [
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:updatePet",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:updatePet",
       "name": "PUT /pet",
       "description": "Update an existing pet",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -206,11 +206,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:addPet",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:addPet",
       "name": "POST /pet",
       "description": "Add a new pet to the store",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -250,11 +250,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:findPetsByStatus",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:findPetsByStatus",
       "name": "Finds Pets by status",
       "description": "Multiple status values can be provided with comma separated strings",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -308,11 +308,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:findPetsByTags",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:findPetsByTags",
       "name": "Finds Pets by tags",
       "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -366,11 +366,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:getPetById",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:getPetById",
       "name": "Find pet by ID",
       "description": "Returns a single pet",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -424,11 +424,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:updatePetWithForm",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:updatePetWithForm",
       "name": "POST /pet/{petId}",
       "description": "Updates a pet in the store with form data",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -509,11 +509,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:deletePet",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:deletePet",
       "name": "DELETE /pet/{petId}",
       "description": "Deletes a pet",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -579,11 +579,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:uploadFile",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:uploadFile",
       "name": "POST /pet/{petId}/uploadImage",
       "description": "uploads an image",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -665,11 +665,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:getInventory",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:getInventory",
       "name": "Returns pet inventories by status",
       "description": "Returns a map of status codes to quantities",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -709,11 +709,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:placeOrder",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:placeOrder",
       "name": "POST /store/order",
       "description": "Place an order for a pet",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -754,11 +754,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:getOrderById",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:getOrderById",
       "name": "Find purchase order by ID",
       "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -812,11 +812,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:deleteOrder",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:deleteOrder",
       "name": "Delete purchase order by ID",
       "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -869,11 +869,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:createUser",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:createUser",
       "name": "Create user",
       "description": "This can only be done by the logged in user.",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -913,11 +913,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:createUsersWithArrayInput",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:createUsersWithArrayInput",
       "name": "POST /user/createWithArray",
       "description": "Creates list of users with given input array",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -957,11 +957,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:createUsersWithListInput",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:createUsersWithListInput",
       "name": "POST /user/createWithList",
       "description": "Creates list of users with given input array",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -1001,11 +1001,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:loginUser",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:loginUser",
       "name": "GET /user/login",
       "description": "Logs user into the system",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1072,11 +1072,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:logoutUser",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:logoutUser",
       "name": "GET /user/logout",
       "description": "Logs out current logged in user session",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1115,11 +1115,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:getUserByName",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:getUserByName",
       "name": "GET /user/{username}",
       "description": "Get user by user name",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1173,11 +1173,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:updateUser",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:updateUser",
       "name": "Updated user",
       "description": "This can only be done by the logged in user.",
       "descriptor": {
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -1231,7 +1231,7 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:deleteUser",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:deleteUser",
       "name": "Delete user",
       "description": "This can only be done by the logged in user.",
       "descriptor": {

--- a/app/rest/connector-generator/src/test/resources/swagger/reverb.connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/reverb.connector.json
@@ -188,11 +188,11 @@
   },
   "actions": [
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-63",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-63",
       "name": "GET /articles",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -300,12 +300,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-7",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-7",
       "name": "Full taxonomy tree of categories including middle categories",
       "description": "Full taxonomy tree of categories including middle categories",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -346,11 +346,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-5",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-5",
       "name": "GET /categories/flat",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -391,12 +391,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-6",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-6",
       "name": "Get category details",
       "description": "Get category details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -450,12 +450,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-8",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-8",
       "name": "Get subcategory details",
       "description": "Get subcategory details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -522,12 +522,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-4",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-4",
       "name": "List of supported product categories",
       "description": "List of supported product categories",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -568,11 +568,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-70",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-70",
       "name": "GET /comparison_shopping_pages/{id}",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -626,12 +626,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-71",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-71",
       "name": "Return new or used listings for a comparison shopping page",
       "description": "Return new or used listings for a comparison shopping page",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -738,12 +738,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-68",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-68",
       "name": "Returns a set of comparison shopping pages based on the current params",
       "description": "Returns a set of comparison shopping pages based on the current params",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -784,12 +784,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-69",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-69",
       "name": "Show comparison shopping page",
       "description": "Show comparison shopping page",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -858,12 +858,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-72",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-72",
       "name": "View reviews of a comparison shopping page",
       "description": "View reviews of a comparison shopping page",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -917,12 +917,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-39",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-39",
       "name": "Make an offer to the other participant in the conversation",
       "description": "Make an offer to the other participant in the conversation",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -977,12 +977,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-40",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-40",
       "name": "Make an offer to the other participant in the conversation",
       "description": "Make an offer to the other participant in the conversation",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -1037,12 +1037,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-153",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-153",
       "name": "Retrieve a list of country codes with corresponding subregions",
       "description": "Retrieve a list of country codes with corresponding subregions",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1083,11 +1083,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-38",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-38",
       "name": "GET /curated_sets/{slug}",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1141,12 +1141,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-74",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-74",
       "name": "List of supported display currencies for browsing listings",
       "description": "List of supported display currencies for browsing listings",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1187,12 +1187,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-73",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-73",
       "name": "List of supported listing currencies for shops",
       "description": "List of supported listing currencies for shops",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1233,12 +1233,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-48",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-48",
       "name": "Feedback details",
       "description": "Feedback details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1292,12 +1292,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-9",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-9",
       "name": "Get results from a handpicked collection",
       "description": "Get results from a handpicked collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1810,12 +1810,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-67",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-67",
       "name": "List of supported product conditions",
       "description": "List of supported product conditions",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -1856,12 +1856,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-19",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-19",
       "name": "All listings including used, handmade, and brand new",
       "description": "All listings including used, handmade, and brand new",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -2361,12 +2361,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-18",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-18",
       "name": "Bump a listing",
       "description": "Bump a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -2433,12 +2433,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-11",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-11",
       "name": "Create a listing",
       "description": "Create a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -2480,12 +2480,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-24",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-24",
       "name": "Create a review for a listing",
       "description": "Create a review for a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -2539,12 +2539,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-10",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-10",
       "name": "Default search of listings includes only used & handmade. Add a filter to view all listings or use the /listings/all endpoint.",
       "description": "Default search of listings includes only used & handmade. Add a filter to view all listings or use the /listings/all endpoint.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3045,12 +3045,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-22",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-22",
       "name": "Delete a draft listing. Cannot be used on non-drafts.",
       "description": "Delete a draft listing. Cannot be used on non-drafts.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3104,12 +3104,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-15",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-15",
       "name": "Delete an image from a listing",
       "description": "Delete an image from a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3176,12 +3176,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-26",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-26",
       "name": "Edit listing.",
       "description": "Edit listing.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3235,12 +3235,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-16",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-16",
       "name": "Find a product bundle attached to a listing",
       "description": "Find a product bundle attached to a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3308,12 +3308,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-25",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-25",
       "name": "Flag a listing for inappropriate content or fraud",
       "description": "Flag a listing for inappropriate content or fraud",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -3368,12 +3368,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-28",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-28",
       "name": "Individual facets",
       "description": "Individual facets",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3414,12 +3414,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-20",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-20",
       "name": "Listing details",
       "description": "Listing details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3473,12 +3473,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-27",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-27",
       "name": "Listing details",
       "description": "Listing details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3532,12 +3532,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-29",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-29",
       "name": "Make an offer to the seller of a listing",
       "description": "Make an offer to the seller of a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -3592,12 +3592,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-30",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-30",
       "name": "Returns the latest negotiation for the requesting user given a listing id",
       "description": "Returns the latest negotiation for the requesting user given a listing id",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3651,12 +3651,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-13",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-13",
       "name": "See all sales that include a listing.",
       "description": "See all sales that include a listing.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3710,12 +3710,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-12",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-12",
       "name": "Start a conversation with a seller",
       "description": "Start a conversation with a seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -3770,12 +3770,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-21",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-21",
       "name": "Update a listing",
       "description": "Update a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -3830,12 +3830,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-17",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-17",
       "name": "View available bump tiers and stats for a listing",
       "description": "View available bump tiers and stats for a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3889,12 +3889,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-23",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-23",
       "name": "View reviews of a listing",
       "description": "View reviews of a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -3948,12 +3948,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-14",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-14",
       "name": "View the images associated with a particular listing",
       "description": "View the images associated with a particular listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4007,12 +4007,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-106",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-106",
       "name": "Accept an offer",
       "description": "Accept an offer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -4067,12 +4067,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-111",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-111",
       "name": "Add a listing to your wishlist",
       "description": "Add a listing to your wishlist",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4126,12 +4126,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-108",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-108",
       "name": "Counter an offer",
       "description": "Counter an offer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -4186,12 +4186,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-146",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-146",
       "name": "Create a new address in your address book",
       "description": "Create a new address in your address book",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4232,11 +4232,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-97",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-97",
       "name": "DELETE /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4290,11 +4290,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-128",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-128",
       "name": "DELETE /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4348,12 +4348,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-109",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-109",
       "name": "Decline an offer",
       "description": "Decline an offer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4407,12 +4407,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-129",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-129",
       "name": "Delete a follow",
       "description": "Delete a follow",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4466,12 +4466,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-148",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-148",
       "name": "Delete an existing address in your address book",
       "description": "Delete an existing address in your address book",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4525,12 +4525,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-101",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-101",
       "name": "Display conversation details with messages in natural time order (oldest to newest)",
       "description": "Display conversation details with messages in natural time order (oldest to newest)",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4584,12 +4584,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-91",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-91",
       "name": "End a listing",
       "description": "End a listing",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -4644,12 +4644,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-138",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-138",
       "name": "Follow a brand",
       "description": "Follow a brand",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4703,12 +4703,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-116",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-116",
       "name": "Follow a category",
       "description": "Follow a category",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4762,12 +4762,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-135",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-135",
       "name": "Follow a collection",
       "description": "Follow a collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4821,12 +4821,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-122",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-122",
       "name": "Follow a handpicked collection",
       "description": "Follow a handpicked collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4880,12 +4880,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-131",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-131",
       "name": "Follow a search",
       "description": "Follow a search",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -4927,12 +4927,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-125",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-125",
       "name": "Follow a shop",
       "description": "Follow a shop",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -4986,12 +4986,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-119",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-119",
       "name": "Follow a subcategory",
       "description": "Follow a subcategory",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5058,12 +5058,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-137",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-137",
       "name": "Follow status for a brand",
       "description": "Follow status for a brand",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5117,12 +5117,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-115",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-115",
       "name": "Follow status for a category",
       "description": "Follow status for a category",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5176,12 +5176,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-134",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-134",
       "name": "Follow status for a collection",
       "description": "Follow status for a collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5235,12 +5235,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-121",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-121",
       "name": "Follow status for a handpicked collection",
       "description": "Follow status for a handpicked collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5294,12 +5294,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-130",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-130",
       "name": "Follow status for a search",
       "description": "Follow status for a search",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5340,12 +5340,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-124",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-124",
       "name": "Follow status for a shop",
       "description": "Follow status for a shop",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5399,12 +5399,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-118",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-118",
       "name": "Follow status for a subcategory",
       "description": "Follow status for a subcategory",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5471,12 +5471,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-105",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-105",
       "name": "Get a list of active negotiations as a buyer",
       "description": "Get a list of active negotiations as a buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5556,12 +5556,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-90",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-90",
       "name": "Get a list of active negotiations as a seller",
       "description": "Get a list of active negotiations as a seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5641,12 +5641,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-149",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-149",
       "name": "Get a list of payouts",
       "description": "Get a list of payouts",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5687,12 +5687,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-94",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-94",
       "name": "Get a list of refund requests as a seller",
       "description": "Get a list of refund requests as a seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5733,12 +5733,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-110",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-110",
       "name": "Get a list of wishlisted items",
       "description": "Get a list of wishlisted items",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5779,12 +5779,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-98",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-98",
       "name": "Get a list of your conversations",
       "description": "Get a list of your conversations",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5892,12 +5892,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-113",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-113",
       "name": "Get a list of your lists (wishlist, watch list, etc)",
       "description": "Get a list of your lists (wishlist, watch list, etc)",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5938,12 +5938,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-143",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-143",
       "name": "Get a list of your recently viewed listings.",
       "description": "Get a list of your recently viewed listings.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -5984,12 +5984,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-151",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-151",
       "name": "Get account details",
       "description": "Get account details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6030,12 +6030,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-76",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-76",
       "name": "Get all seller orders, newest first.",
       "description": "Get all seller orders, newest first.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6171,12 +6171,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-140",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-140",
       "name": "Get listings from your feed",
       "description": "Get listings from your feed",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6217,12 +6217,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-107",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-107",
       "name": "Get offer details",
       "description": "Get offer details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6276,12 +6276,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-93",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-93",
       "name": "Get payment",
       "description": "Get payment",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6335,12 +6335,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-92",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-92",
       "name": "Get payments",
       "description": "Get payments",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6490,12 +6490,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-79",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-79",
       "name": "Get seller orders awaiting shipment, newest first.",
       "description": "Get seller orders awaiting shipment, newest first.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6631,12 +6631,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-78",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-78",
       "name": "Get unpaid seller orders, newest first.",
       "description": "Get unpaid seller orders, newest first.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6772,12 +6772,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-144",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-144",
       "name": "Get your actionable status counts",
       "description": "Get your actionable status counts",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6818,12 +6818,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-77",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-77",
       "name": "Initiate a refund for a sold order",
       "description": "Initiate a refund for a sold order",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6877,12 +6877,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-75",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-75",
       "name": "List of orders that need feedback",
       "description": "List of orders that need feedback",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6923,12 +6923,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-104",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-104",
       "name": "List of received feedback",
       "description": "List of received feedback",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -6969,12 +6969,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-103",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-103",
       "name": "List of sent feedback",
       "description": "List of sent feedback",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7015,12 +7015,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-102",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-102",
       "name": "Mark a conversation read/unread",
       "description": "Mark a conversation read/unread",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -7075,12 +7075,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-82",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-82",
       "name": "Marks an order as picked up",
       "description": "Marks an order as picked up",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -7135,12 +7135,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-87",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-87",
       "name": "Marks an order as received by the buyer",
       "description": "Marks an order as received by the buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7194,12 +7194,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-81",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-81",
       "name": "Marks an order as shipped",
       "description": "Marks an order as shipped",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -7254,11 +7254,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-96",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-96",
       "name": "POST /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7312,11 +7312,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-127",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-127",
       "name": "POST /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7370,12 +7370,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-150",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-150",
       "name": "Read the line items of a payout",
       "description": "Read the line items of a payout",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7429,12 +7429,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-112",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-112",
       "name": "Remove a listing from your wishlist",
       "description": "Remove a listing from your wishlist",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7488,12 +7488,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-88",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-88",
       "name": "Retrieve a list of live listings for the seller. To search all listings specify state=all",
       "description": "Retrieve a list of live listings for the seller. To search all listings specify state=all",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -7982,12 +7982,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-89",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-89",
       "name": "Retrieve a list your draft listings",
       "description": "Retrieve a list your draft listings",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8448,12 +8448,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-132",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-132",
       "name": "Returns a user's ArticleCategoryFollows",
       "description": "Returns a user's ArticleCategoryFollows",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8494,12 +8494,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-84",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-84",
       "name": "Returns all orders, newest first.",
       "description": "Returns all orders, newest first.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8540,12 +8540,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-86",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-86",
       "name": "Returns order details for a buyer",
       "description": "Returns order details for a buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8599,12 +8599,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-80",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-80",
       "name": "Returns order details for a seller",
       "description": "Returns order details for a seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8658,12 +8658,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-85",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-85",
       "name": "Returns unpaid orders, newest first.",
       "description": "Returns unpaid orders, newest first.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8704,12 +8704,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-145",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-145",
       "name": "See all addresses in your address book",
       "description": "See all addresses in your address book",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8750,12 +8750,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-83",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-83",
       "name": "See previous orders from buyer",
       "description": "See previous orders from buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8809,12 +8809,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-114",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-114",
       "name": "See what the user is following",
       "description": "See what the user is following",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -8855,12 +8855,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-100",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-100",
       "name": "Send a message",
       "description": "Send a message",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -8915,12 +8915,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-133",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-133",
       "name": "Set a user's ArticleCategoryFollows",
       "description": "Set a user's ArticleCategoryFollows",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -8962,12 +8962,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-99",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-99",
       "name": "Start a conversation",
       "description": "Start a conversation",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -9009,12 +9009,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-139",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-139",
       "name": "Unfollow a brand",
       "description": "Unfollow a brand",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9068,12 +9068,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-117",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-117",
       "name": "Unfollow a category",
       "description": "Unfollow a category",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9127,12 +9127,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-136",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-136",
       "name": "Unfollow a collection",
       "description": "Unfollow a collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9186,12 +9186,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-123",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-123",
       "name": "Unfollow a handpicked collection",
       "description": "Unfollow a handpicked collection",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9245,12 +9245,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-126",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-126",
       "name": "Unfollow a shop",
       "description": "Unfollow a shop",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9304,12 +9304,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-120",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-120",
       "name": "Unfollow a subcategory",
       "description": "Unfollow a subcategory",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9376,12 +9376,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-95",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-95",
       "name": "Update a refund request for a sold order",
       "description": "Update a refund request for a sold order",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9435,12 +9435,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-152",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-152",
       "name": "Update account details",
       "description": "Update account details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -9482,12 +9482,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-147",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-147",
       "name": "Update an existing address in your address book",
       "description": "Update an existing address in your address book",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9541,12 +9541,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-141",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-141",
       "name": "get your feed",
       "description": "get your feed",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9587,12 +9587,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-142",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-142",
       "name": "get your feed customization options",
       "description": "get your feed customization options",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9633,12 +9633,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-3",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-3",
       "name": "Add feedback about an order's buyer",
       "description": "Add feedback about an order's buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9692,12 +9692,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-1",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-1",
       "name": "Add feedback about an order's seller",
       "description": "Add feedback about an order's seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9751,12 +9751,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-2",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-2",
       "name": "Feedback details for an order's buyer",
       "description": "Feedback details for an order's buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9810,12 +9810,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-0",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-0",
       "name": "Feedback details for an order's seller",
       "description": "Feedback details for an order's seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9869,12 +9869,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-66",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-66",
       "name": "Get list of payment methods",
       "description": "Get list of payment methods",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9915,12 +9915,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-43",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-43",
       "name": "Get a list of paginated transactions for a price guide.",
       "description": "Get a list of paginated transactions for a price guide.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -9987,12 +9987,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-44",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-44",
       "name": "Get a summary of transactions for a given price guide",
       "description": "Get a summary of transactions for a given price guide",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10072,12 +10072,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-42",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-42",
       "name": "Retrieve a Price Guide",
       "description": "Retrieve a Price Guide",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10131,12 +10131,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-41",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-41",
       "name": "Search the Price Guide",
       "description": "Search the Price Guide",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10191,12 +10191,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-57",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-57",
       "name": "Create a review for a product",
       "description": "Create a review for a product",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10250,12 +10250,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-55",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-55",
       "name": "Update a review",
       "description": "Update a review",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -10310,12 +10310,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-54",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-54",
       "name": "View a review",
       "description": "View a review",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10369,12 +10369,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-56",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-56",
       "name": "View reviews of a product",
       "description": "View reviews of a product",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10428,12 +10428,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-61",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-61",
       "name": "Add listings to a sale",
       "description": "Add listings to a sale",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10487,11 +10487,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-59",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-59",
       "name": "GET /sales/{slug}",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10545,12 +10545,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-62",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-62",
       "name": "Remove a listing from a sale",
       "description": "Remove a listing from a sale",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10604,12 +10604,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-58",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-58",
       "name": "View upcoming and live Reverb official sales.",
       "description": "View upcoming and live Reverb official sales.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10650,12 +10650,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-60",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-60",
       "name": "View your created sales.",
       "description": "View your created sales.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10696,11 +10696,11 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-64",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-64",
       "name": "GET /shipping/regions",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10741,12 +10741,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-65",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-65",
       "name": "List of supported shipping providers",
       "description": "List of supported shipping providers",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10787,12 +10787,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-37",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-37",
       "name": "Disable vacation mode. All listings will be re-enabled.",
       "description": "Disable vacation mode. All listings will be re-enabled.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10833,12 +10833,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-36",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-36",
       "name": "Enable vacation mode. All listings will be unavailable until vacation mode is turned off.",
       "description": "Enable vacation mode. All listings will be unavailable until vacation mode is turned off.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10879,12 +10879,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-33",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-33",
       "name": "Get accepted payment methods",
       "description": "Get accepted payment methods",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10925,12 +10925,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-31",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-31",
       "name": "Get your own shop details",
       "description": "Get your own shop details",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -10971,12 +10971,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-34",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-34",
       "name": "List of supported product conditions",
       "description": "List of supported product conditions",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11017,12 +11017,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-35",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-35",
       "name": "Returns shop vacation status",
       "description": "Returns shop vacation status",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11063,12 +11063,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-32",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-32",
       "name": "Update your shop profile",
       "description": "Update your shop profile",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -11110,12 +11110,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-49",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-49",
       "name": "Get details on a shop.",
       "description": "Get details on a shop.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11183,12 +11183,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-50",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-50",
       "name": "Get seller's feedback",
       "description": "Get seller's feedback",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11242,12 +11242,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-52",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-52",
       "name": "Get seller's feedback as a buyer",
       "description": "Get seller's feedback as a buyer",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11301,12 +11301,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-51",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-51",
       "name": "Get seller's feedback as a seller",
       "description": "Get seller's feedback as a seller",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11360,12 +11360,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-53",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-53",
       "name": "List of shipping profiles for your shop",
       "description": "List of shipping profiles for your shop",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11419,12 +11419,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-45",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-45",
       "name": "A list of wanted items by the user",
       "description": "A list of wanted items by the user",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11465,12 +11465,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-46",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-46",
       "name": "Mark an item wanted. Returns 200 on success or 422 on failure.",
       "description": "Mark an item wanted. Returns 200 on success or 422 on failure.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11524,12 +11524,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-47",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-47",
       "name": "Unmark an item wanted.",
       "description": "Unmark an item wanted.",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11583,12 +11583,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-156",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-156",
       "name": "Get details of a webhook registration",
       "description": "Get details of a webhook registration",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11642,12 +11642,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-154",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-154",
       "name": "Get webhook registrations",
       "description": "Get webhook registrations",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"
@@ -11688,12 +11688,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-155",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-155",
       "name": "Register a webhook",
       "description": "Register a webhook",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "json-schema",
@@ -11735,12 +11735,12 @@
       "pattern": "To"
     },
     {
-      "id": "io.syndesis:swagger-connector:1.2-SNAPSHOT:_id_:operation-157",
+      "id": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT:_id_:operation-157",
       "name": "Remove a webhook",
       "description": "Remove a webhook",
       "descriptor": {
         "connectorId": "-L-YhI-g7RhzbrJYbheI",
-        "camelConnectorGAV": "io.syndesis:swagger-connector:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis:rest-swagger-connector:1.2-SNAPSHOT",
         "camelConnectorPrefix": "swagger-operation",
         "inputDataShape": {
           "kind": "none"

--- a/app/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/app/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -1409,7 +1409,7 @@
       "name": "Swagger API Connector",
       "description": "Swagger API Connector",
       "icon": "fa-link",
-      "camelConnectorGAV": "io.syndesis:swagger-connector:@syndesis.version@",
+      "camelConnectorGAV": "io.syndesis:rest-swagger-connector:@syndesis.version@",
       "camelConnectorPrefix": "swagger-operation",
       "properties": {
         "specification": {


### PR DESCRIPTION
Missed this when refactoring, the GAV for REST Swagger connector points
to a wrong artifact.