### PR TITLE
chore(rest-swagger): add support for OAuth2

### DIFF
--- a/app/connectors/connectors/rest/rest-swagger-connector/src/main/java/io/syndesis/connector/swagger/AuthenticationType.java
+++ b/app/connectors/connectors/rest/rest-swagger-connector/src/main/java/io/syndesis/connector/swagger/AuthenticationType.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.swagger;
+
+public enum AuthenticationType {
+    none, oauth2
+}

--- a/app/connectors/connectors/rest/rest-swagger-connector/src/main/java/io/syndesis/connector/swagger/springboot/SwaggerConnectorConnectorConfigurationCommon.java
+++ b/app/connectors/connectors/rest/rest-swagger-connector/src/main/java/io/syndesis/connector/swagger/springboot/SwaggerConnectorConnectorConfigurationCommon.java
@@ -1,6 +1,7 @@
 package io.syndesis.connector.swagger.springboot;
 
 import javax.annotation.Generated;
+import io.syndesis.connector.swagger.AuthenticationType;
 
 /**
  * REST Swagger Connector
@@ -10,6 +11,11 @@ import javax.annotation.Generated;
 @Generated("org.apache.camel.maven.connector.SpringBootAutoConfigurationMojo")
 public class SwaggerConnectorConnectorConfigurationCommon {
 
+    /**
+     * API basePath for example /v2. Default is unset if set overrides the value
+     * present in Swagger specification.
+     */
+    private String basePath;
     /**
      * Scheme hostname and port to direct the HTTP requests to in the form of
      * https://hostname:port. Can be configured at the endpoint component or in
@@ -25,6 +31,16 @@ public class SwaggerConnectorConnectorConfigurationCommon {
      */
     private String operationId;
     private String specification;
+    private AuthenticationType authenticationType;
+    private String accessToken;
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(String basePath) {
+        this.basePath = basePath;
+    }
 
     public String getHost() {
         return host;
@@ -48,5 +64,21 @@ public class SwaggerConnectorConnectorConfigurationCommon {
 
     public void setSpecification(String specification) {
         this.specification = specification;
+    }
+
+    public AuthenticationType getAuthenticationType() {
+        return authenticationType;
+    }
+
+    public void setAuthenticationType(AuthenticationType authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 }

--- a/app/connectors/connectors/rest/rest-swagger-connector/src/main/resources/camel-connector-schema.json
+++ b/app/connectors/connectors/rest/rest-swagger-connector/src/main/resources/camel-connector-schema.json
@@ -16,6 +16,18 @@
     "version":"1.2-SNAPSHOT"
   },
   "componentProperties":{
+    "basePath":{
+      "kind":"property",
+      "displayName":"Base Path",
+      "group":"producer",
+      "label":"producer",
+      "required":false,
+      "type":"string",
+      "javaType":"java.lang.String",
+      "deprecated":false,
+      "secret":false,
+      "description":"API basePath for example \/v2. Default is unset if set overrides the value present in Swagger specification."
+    },
     "host":{
       "kind":"property",
       "displayName":"Host",
@@ -47,6 +59,24 @@
     "specification":{
       "kind":"property",
       "displayName":"Swagger specification",
+      "required":false,
+      "type":"string",
+      "javaType":"java.lang.String",
+      "deprecated":false,
+      "secret":false
+    },
+    "authenticationType":{
+      "kind":"property",
+      "displayName":"Authentication type",
+      "required":false,
+      "type":"object",
+      "javaType":"io.syndesis.connector.swagger.AuthenticationType",
+      "deprecated":false,
+      "secret":false
+    },
+    "accessToken":{
+      "kind":"property",
+      "displayName":"OAuth access token",
       "required":false,
       "type":"string",
       "javaType":"java.lang.String",

--- a/app/connectors/connectors/rest/rest-swagger-connector/src/main/resources/camel-connector.json
+++ b/app/connectors/connectors/rest/rest-swagger-connector/src/main/resources/camel-connector.json
@@ -14,7 +14,7 @@
   "pattern" : "From",
   "inputDataType" : "json",
   "outputDataType" : "json",
-  "componentOptions" : [ "host" ],
+  "componentOptions" : [ "host", "basePath" ],
   "endpointValues" : {
     "consumes" : "application/json"
   },
@@ -23,6 +23,20 @@
     "specification" : {
       "name" : "specification",
       "displayName" : "Swagger specification",
+      "kind" : "property",
+      "type" : "string",
+      "javaType" : "java.lang.String"
+    },
+    "authenticationType" : {
+      "name" : "authenticationType",
+      "displayName" : "Authentication type",
+      "kind" : "property",
+      "type" : "enum",
+      "javaType" : "io.syndesis.connector.swagger.AuthenticationType"
+    },
+    "accessToken" : {
+      "name" : "accessToken",
+      "displayName" : "OAuth access token",
       "kind" : "property",
       "type" : "string",
       "javaType" : "java.lang.String"

--- a/app/connectors/connectors/rest/rest-swagger-connector/src/test/java/io/syndesis/connector/swagger/SwaggerConnectorComponentTest.java
+++ b/app/connectors/connectors/rest/rest-swagger-connector/src/test/java/io/syndesis/connector/swagger/SwaggerConnectorComponentTest.java
@@ -77,4 +77,17 @@ public class SwaggerConnectorComponentTest {
             assertThat(restSwagger.getOperationId()).isEqualTo("addPet");
         });
     }
+
+    @Test
+    public void shouldSetOAuth2AuthorizationHeader() {
+        final SwaggerConnectorComponent component = new SwaggerConnectorComponent();
+
+        component.setAuthenticationType(AuthenticationType.oauth2);
+        component.setAccessToken("the-token");
+
+        final HashMap<String, Object> headers = new HashMap<>();
+        component.addAuthenticationHeadersTo(headers);
+
+        assertThat(headers).containsEntry("Authorization", "Bearer the-token");
+    }
 }


### PR DESCRIPTION
Adds support for setting the `Authorization` header for OAuth2
authentication. Also adds support for `basePath` component property.

Fixes #606