### PR TITLE
chore(image-generator): add support for connector templates

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -440,10 +440,9 @@
 							<exclude>**/.gitkeep</exclude>
 							<exclude>**/*.webapp</exclude>
 							<exclude>**/browserconfig.xml</exclude>
-							<exclude>connectors/connectors/**/springboot/*Configuration.java
-							</exclude> <!-- auto generated without headers -->
-							<exclude>connectors/connectors/**/springboot/*Common.java
-							</exclude> <!-- auto generated without headers -->
+							<exclude>connectors/connectors/**/springboot/*Configuration.java</exclude><!-- auto generated without headers -->
+							<exclude>connectors/connectors/**/springboot/*Common.java </exclude><!-- auto generated without headers -->
+							<exclude>rest/syndesis-builder-image-generator/image/**</exclude><!-- auto generated without headers -->
 						</excludes>
 					</configuration>
 					<dependencies>

--- a/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
+++ b/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
@@ -38,8 +38,11 @@ import io.syndesis.dao.init.ReadApiClientData;
 import io.syndesis.dao.manager.DaoConfiguration;
 import io.syndesis.model.Kind;
 import io.syndesis.model.action.Action;
+import io.syndesis.model.action.ConnectorAction;
+import io.syndesis.model.action.ConnectorDescriptor;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.connection.Connector;
+import io.syndesis.model.connection.ConnectorTemplate;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.SimpleStep;
 import io.syndesis.model.integration.Step;
@@ -103,6 +106,24 @@ public class Application implements ApplicationRunner {
                             .build()
                     );
                 }
+            }
+
+            if (model.getKind() == Kind.ConnectorTemplate) {
+                final ConnectorTemplate template = (ConnectorTemplate) model.getData();
+                steps.add(
+                    new SimpleStep.Builder()
+                        .stepKind("endpoint")
+                        .connection(new Connection.Builder()
+                            .connectorId("connector-" + template.getId())
+                            .build())
+                        .action(new ConnectorAction.Builder()
+                            .descriptor(new ConnectorDescriptor.Builder()
+                                .camelConnectorGAV(template.getCamelConnectorGAV())
+                                .camelConnectorPrefix(template.getCamelConnectorPrefix())
+                                .build())
+                            .build())
+                        .build()
+                );
             }
         }
 


### PR DESCRIPTION
We need to add artifacts for connectors that can be generated from
connector templates. This generates an ad hoc action and adds a step
with it to the integration being stubbed for the project generator in
order to accomplish that.