### PR TITLE
Add an additional plugin repository needed in the build and additional dependency ignores.

### DIFF
--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -60,6 +60,18 @@
       <url>https://jcenter.bintray.com</url>
     </pluginRepository>
 
+    <pluginRepository>
+      <id>sonatype-snapshot</id>
+      <name>Sonatype snapshot repository</name>
+      <url>https://oss.sonatype.org/service/local/repositories/snapshots/content</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+
   </pluginRepositories>
 
   <build>

--- a/app/runtime/pom.xml
+++ b/app/runtime/pom.xml
@@ -67,6 +67,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-api</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.google.auto.service:auto-service</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/app/verifier/pom.xml
+++ b/app/verifier/pom.xml
@@ -325,6 +325,10 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>io.syndesis:sql-common</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>junit:junit</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>commons-io:commons-io</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.assertj:assertj-core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.paypal.springboot:resteasy-spring-boot-starter</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-web:</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-undertow</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Add some ignoreUsedDependencies that are needed in the build, and add a plugin repository statement for SNAPSHOTS because the syndesis-build-helper-maven-plugin is used and I'm getting errors when running mvn clean and it can't resolve the plugin.