### PR TITLE
The return of the checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run:
           name: Build UI
           command: |
-            ./app/build.sh --batch-mode --module ui --image-mode=docker | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --batch-mode --module ui --image-mode=docker | tee build_log.txt
       - store_artifacts:
           path: ./build_ui_log.txt
       - save_cache:
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Build Connectors
           command: |
-            ./app/build.sh --init --batch-mode --module connectors | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --init --batch-mode --module connectors | tee build_log.txt
       - <<: *save_junit
       - store_test_results:
           path: /workspace/junit
@@ -138,7 +138,7 @@ jobs:
       - run:
           name: Build Verifier
           command: |
-            ./app/build.sh --batch-mode --module verifier --image-mode=docker | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --batch-mode --module verifier --image-mode=docker | tee build_log.txt
       - <<: *save_junit
       - store_test_results:
           path: /workspace/junit
@@ -164,7 +164,7 @@ jobs:
       - run:
           name: Build Runtime
           command: |
-            ./app/build.sh --batch-mode --module runtime | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --batch-mode --module runtime | tee build_log.txt
       - <<: *save_junit
       - store_test_results:
           path: /workspace/junit
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Build S2I Builder image
           command: |
-            ./app/build.sh --batch-mode --module s2i --image-mode docker | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --batch-mode --module s2i --image-mode docker | tee build_log.txt
       - store_artifacts:
           path: build_log.txt
       - <<: *push_images
@@ -216,7 +216,7 @@ jobs:
       - run:
           name: Build Rest
           command: |
-            ./app/build.sh --batch-mode --module rest --image-mode docker | tee build_log.txt | grep -v " Download"
+            ./app/build.sh --batch-mode --module rest --image-mode docker | tee build_log.txt
           no_output_timeout: 20m
       - run:
           name: Collect API docs
@@ -259,7 +259,7 @@ jobs:
             if [ -n "${OPENSHIFT_TOKEN}" ]; then
               curl -fsSL https://github.com/openshift/origin/releases/download/v3.6.0/openshift-origin-client-tools-v3.6.0-c4dd4cf-linux-64bit.tar.gz | tar xz -C /usr/bin --strip-components 1
               oc login --server "${OPENSHIFT_SERVER}" --token "${OPENSHIFT_TOKEN}"
-              ./app/build.sh --batch-mode --mode system-test | tee test_log.txt | grep -v " Download"
+              ./app/build.sh --batch-mode --mode system-test | tee test_log.txt
             fi
       - store_artifacts:
           path: test_log.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ jobs:
           name: Build Rest
           command: |
             ./app/build.sh --batch-mode --module rest --image-mode docker | tee build_log.txt
-          no_output_timeout: 20m
       - run:
           name: Collect API docs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
           name: Build Rest
           command: |
             ./app/build.sh --batch-mode --module rest --image-mode docker | tee build_log.txt | grep -v " Download"
+          no_output_timeout: 20m
       - run:
           name: Collect API docs
           command: |

--- a/app/.mvn/jvm.config
+++ b/app/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx512m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication
+-Xmx1024m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -69,6 +69,8 @@
 		<basepom.test.fork-count>1</basepom.test.fork-count>
 		<basepom.failsafe.fork-count>1</basepom.failsafe.fork-count>
 		<basepom.failsafe.reuse-vm>true</basepom.failsafe.reuse-vm>
+        <!-- takes a really long time -->
+        <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
 
 		<!-- Plugin versions -->
 		<exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -404,6 +404,7 @@
 				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
+                    <inherited>false</inherited>
 					<configuration>
 						<header>license/syndesis-license.txt</header>
 						<skipExistingHeaders>true</skipExistingHeaders>

--- a/app/rest/connector-generator/pom.xml
+++ b/app/rest/connector-generator/pom.xml
@@ -42,11 +42,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.syndesis</groupId>
-      <artifactId>credential</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-parser</artifactId>
     </dependency>
@@ -57,8 +52,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>
@@ -72,11 +77,33 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- === Testing Dependencies ======================================================== -->
+
+    <!-- we need deployment.json from dao -->
+    <dependency>
+      <groupId>io.syndesis</groupId>
+      <artifactId>dao</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SupportedAuthenticationTypes.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SupportedAuthenticationTypes.java
@@ -30,7 +30,7 @@ enum SupportedAuthenticationTypes {
 
     final String label;
 
-    private final ConfigurationProperty.PropertyValue propertyValue;
+    private final transient ConfigurationProperty.PropertyValue propertyValue;
 
     private SupportedAuthenticationTypes(final String label) {
         this.label = label;

--- a/app/rest/pom.xml
+++ b/app/rest/pom.xml
@@ -36,7 +36,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <basepom.test.timeout>300</basepom.test.timeout>
-    <basepom.check.skip-all>true</basepom.check.skip-all>
     <basepom.test.timeout>150</basepom.test.timeout>
     <basepom.failsafe.timeout>0</basepom.failsafe.timeout>
     <basepom.compiler.fail-warnings>true</basepom.compiler.fail-warnings>
@@ -957,7 +956,6 @@
     <profile>
       <id>ci</id>
       <properties>
-        <basepom.check.skip-all>false</basepom.check.skip-all>
         <user.home>/home/jenkins</user.home>
         <fabric8.namespace>syndesis-ci</fabric8.namespace>
         <fabric8.mode>openshift</fabric8.mode>

--- a/app/rest/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
+++ b/app/rest/project-generator/src/main/java/io/syndesis/project/converter/ProjectGeneratorConfiguration.java
@@ -15,18 +15,25 @@
  */
 package io.syndesis.project.converter;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
 import io.syndesis.connector.catalog.ConnectorCatalog;
 import io.syndesis.dao.extension.ExtensionDataManager;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.project.converter.visitor.*;
+import io.syndesis.project.converter.visitor.DataMapperStepVisitor;
+import io.syndesis.project.converter.visitor.EndpointStepVisitor;
+import io.syndesis.project.converter.visitor.ExpressionFilterStepVisitor;
+import io.syndesis.project.converter.visitor.ExtensionStepVisitor;
+import io.syndesis.project.converter.visitor.RuleFilterStepVisitor;
+import io.syndesis.project.converter.visitor.StepVisitorFactory;
+import io.syndesis.project.converter.visitor.StepVisitorFactoryRegistry;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 
 @Configuration
 @EnableConfigurationProperties(ProjectGeneratorProperties.class)

--- a/app/rest/rest/pom.xml
+++ b/app/rest/rest/pom.xml
@@ -209,6 +209,16 @@
       <artifactId>kubernetes-model</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+
     <!-- === Testing Dependencies ======================================================== -->
 
     <dependency>
@@ -253,6 +263,12 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -169,12 +169,6 @@
       </build>
     </profile>
 
-    <profile>
-      <id>flash</id>
-      <properties>
-        <basepom.check.skip-all>false</basepom.check.skip-all>
-      </properties>
-    </profile>
   </profiles>
 </project>
 


### PR DESCRIPTION
Seems that we lost checks from being run, this reinstates the checks.

 - Makes the license plugin non-inheritable so its not run on modules, only on parent build.
 - We should rely on `basepom.check.skip-all` set from parent and the profile configuration there, not in individual modules
 -  fixes reported dependency checks/codestyle checks