### PR TITLE
feat(rest): Enable filtering of lists through REST API

### DIFF
--- a/app/rest/dao/src/main/resources/io/syndesis/dao/demo-data.json
+++ b/app/rest/dao/src/main/resources/io/syndesis/dao/demo-data.json
@@ -1218,6 +1218,7 @@
       "description": "Day Trade API connector",
       "icon": "fa-usd",
       "configuredProperties": {},
+      "connectorGroupId": "trade",
       "properties": {
         "host": {
           "kind": "property",
@@ -1449,6 +1450,7 @@
       "name": "Trade Insight",
       "description": "Trade Insight API connector",
       "icon": "fa-usd",
+      "connectorGroupId": "trade",
       "configuredProperties": {},
       "properties": {
         "host": {

--- a/app/rest/rest/pom.xml
+++ b/app/rest/rest/pom.xml
@@ -198,6 +198,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
@@ -15,8 +15,9 @@
  */
 package io.syndesis.rest.util;
 
-import io.syndesis.integration.support.Strings;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -32,8 +33,12 @@ public class FilterOptionsParser {
     }
 
     public static List<Filter> fromString(String query) {
+        if (StringUtils.isBlank(query)) {
+            return Collections.emptyList();
+        }
+
         return Stream.of(query.split(","))
-            .filter(Strings::isNotEmpty)
+            .filter(StringUtils::isNotBlank)
             .flatMap(q -> {
                 Matcher m = VALID_QUERY_PATTERN.matcher(q);
                 if (!m.matches()) {

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.util;
+
+import io.syndesis.integration.support.Strings;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FilterOptionsParser {
+
+    private static final Pattern VALID_QUERY_PATTERN = Pattern.compile("(?<property>\\w+)(?:(?<operation>(?:\\s*=\\s*))(?<value>\\w+))?");
+
+    private FilterOptionsParser() {
+    }
+
+    public static List<Filter> fromString(String query) {
+        return Stream.of(query.split(","))
+            .filter(Strings::isNotEmpty)
+            .flatMap(q -> {
+                Matcher m = VALID_QUERY_PATTERN.matcher(q);
+                if (!m.matches()) {
+                    return Stream.empty();
+                }
+                return Stream.of(
+                    new Filter(m.group("property"), m.group("operation"), m.group("value"))
+                );
+            }).collect(Collectors.toList());
+    }
+
+    public static class Filter {
+        private final String property;
+
+        private final Optional<String> operation;
+
+        private final Optional<String> value;
+
+        private Filter(String property, String operation, String value) {
+            this.property = property;
+            this.operation = Optional.ofNullable(operation);
+            this.value = Optional.ofNullable(value);
+        }
+
+        public String getProperty() {
+            return property;
+        }
+
+        public Optional<String> getOperation() {
+            return operation;
+        }
+
+        public Optional<String> getValue() {
+            return value;
+        }
+    }
+
+}

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectionUtils.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectionUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.util;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+public class ReflectionUtils {
+    private ReflectionUtils() {
+    }
+
+    static Method getGetMethodOfType(Class<?> clazz, String fieldName, Class<?>... types) {
+        // Check direct:
+        Method ret = extractMethod(clazz, fieldName, types);
+        if (ret != null) {
+            return ret;
+        }
+
+        // Check interfaces :
+        for (Class<?> intf : clazz.getInterfaces()) {
+            ret = extractMethod(intf, fieldName, types);
+            if (ret != null) {
+                return ret;
+            }
+        }
+
+        // Check parent:
+        Class<?> superClass = clazz.getSuperclass();
+        return superClass != null ? getGetMethodOfType(superClass, fieldName, types) : null;
+    }
+
+    static Method extractMethod(Class<?> clazz, String fieldName, Class<?>... types) {
+        try {
+            Method method = clazz.getDeclaredMethod("get" + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
+            Class<?> returnType = method.getReturnType();
+            for (Class<?> type : types) {
+                if (returnType.isAssignableFrom(type)) {
+                    return method;
+                }
+            }
+            return null;
+        } catch (NoSuchMethodException exp) {
+            return null;
+        }
+    }
+}

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveFilterer.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveFilterer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.util;
+
+import io.syndesis.model.ListResult;
+import io.syndesis.rest.v1.util.PredicateFilter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class ReflectiveFilterer<T> implements Function<ListResult<T>, ListResult<T>> {
+
+    private final List<PredicateFilter<T>> predicateFilters;
+
+    public ReflectiveFilterer(Class<T> modelClass, List<FilterOptionsParser.Filter> filters) {
+        predicateFilters = new ArrayList<>(filters.size());
+        for (FilterOptionsParser.Filter f : filters) {
+            String op = f.getOperation().orElseThrow(
+                () -> new IllegalArgumentException("Missing filter operation")
+            );
+
+            switch (op) {
+                case "=":
+                    String value = f.getValue().orElseThrow(
+                        () -> new IllegalArgumentException("Missing value in equality filter")
+                    );
+                    predicateFilters.add(equalityFilter(modelClass, f.getProperty(), value));
+                    break;
+                default:
+                    throw new IllegalArgumentException(String.format("Unknown filter operation %s", op));
+            }
+        }
+    }
+
+    @Override
+    public ListResult<T> apply(ListResult<T> result) {
+        for (PredicateFilter<T> pf : predicateFilters) {
+            result = pf.apply(result);
+        }
+        return result;
+    }
+
+    private PredicateFilter<T> equalityFilter(final Class<T> modelClass, final String property, final String value) {
+        Method stringGetMethod = ReflectionUtils.getGetMethodOfType(modelClass, property, String.class);
+        if (stringGetMethod != null) {
+            return new PredicateFilter<>(o -> {
+                try {
+                    return value.equals(stringGetMethod.invoke(o));
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new IllegalArgumentException("Cannot extract String value from " + stringGetMethod + " for object " + o, e);
+                }
+            });
+        }
+        Method optionalStringGetMethod = ReflectionUtils.getGetMethodOfType(modelClass, property, Optional.class);
+        if (optionalStringGetMethod != null) {
+            return new PredicateFilter<>(o -> {
+                try {
+                    return Optional.ofNullable(value).equals(optionalStringGetMethod.invoke(o));
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new IllegalArgumentException("Cannot extract String value from " + optionalStringGetMethod + " for object " + o, e);
+                }
+            });
+        }
+        throw new IllegalArgumentException(String.format("Cannot find field %s in %s as String field", property, modelClass.getName()));
+    }
+}

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveSorter.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveSorter.java
@@ -20,16 +20,12 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Function;
 
 import io.syndesis.model.ListResult;
 
 /**
  * Generic comparator which sorts based on fields. Fields are retrieved by reflections
- *
- * @author roland
- * @since 13/12/16
  */
 public class ReflectiveSorter<T> implements Function<ListResult<T>, ListResult<T>>, Comparator<T> {
 
@@ -74,7 +70,7 @@ public class ReflectiveSorter<T> implements Function<ListResult<T>, ListResult<T
     }
 
     private Comparator<T> getStringComparator(Class<T> modelClass, String fieldName) {
-        Method stringGetMethod = getGetMethodOfType(modelClass, fieldName, String.class);
+        Method stringGetMethod = ReflectionUtils.getGetMethodOfType(modelClass, fieldName, String.class);
         if (stringGetMethod != null) {
             return Comparator.comparing(k -> {
                 try {
@@ -88,7 +84,7 @@ public class ReflectiveSorter<T> implements Function<ListResult<T>, ListResult<T
     }
 
     private Comparator<T> getIntComparator(Class<T> modelClass, String fieldName) {
-        Method intGetMethod = getGetMethodOfType(modelClass, fieldName, int.class, Integer.class);
+        Method intGetMethod = ReflectionUtils.getGetMethodOfType(modelClass, fieldName, int.class, Integer.class);
         if (intGetMethod != null) {
             return Comparator.comparingInt(k -> {
                         try {
@@ -101,41 +97,6 @@ public class ReflectiveSorter<T> implements Function<ListResult<T>, ListResult<T
         return null;
     }
 
-
-    private Method getGetMethodOfType(Class<?> clazz, String fieldName, Class<?> ... types) {
-        // Check direct:
-        Method ret = extractMethod(clazz, fieldName, types);
-        if (ret != null) {
-            return ret;
-        }
-
-        // Check interfaces :
-        for (Class<?> intf : clazz.getInterfaces()) {
-            ret = extractMethod(intf, fieldName, types);
-            if (ret != null) {
-                return ret;
-            }
-        }
-
-        // Check parent:
-        Class<?> superClass = clazz.getSuperclass();
-        return superClass != null ? getGetMethodOfType(superClass, fieldName, types) : null;
-    }
-
-    private Method extractMethod(Class<?> clazz, String fieldName, Class<?>... types) {
-        try {
-            Method method = clazz.getDeclaredMethod("get" + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
-            Class<?> returnType = method.getReturnType();
-            for (Class<?> type : types) {
-                if (returnType.isAssignableFrom(type)) {
-                    return method;
-                }
-            }
-            return null;
-        } catch (NoSuchMethodException exp) {
-            return null;
-        }
-    }
 
     @Override
     public int compare(T o1, T o2) {

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/SortOptions.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/SortOptions.java
@@ -15,10 +15,6 @@
  */
 package io.syndesis.rest.util;
 
-/**
- * @author roland
- * @since 14/12/16
- */
 public interface SortOptions {
 
     String getSortField();

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/FilterOptionsFromQueryParams.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/FilterOptionsFromQueryParams.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.operations;
+
+import io.syndesis.rest.util.FilterOptionsParser;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+public class FilterOptionsFromQueryParams {
+
+    private final List<FilterOptionsParser.Filter> queryFilters;
+
+    FilterOptionsFromQueryParams(UriInfo uri) {
+        MultivaluedMap<String, String> queryParams = uri.getQueryParameters();
+        String query = queryParams.getFirst("query");
+        this.queryFilters = FilterOptionsParser.fromString(query);
+    }
+
+    public List<FilterOptionsParser.Filter> getFilters() {
+        return queryFilters;
+    }
+
+}

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/Lister.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/Lister.java
@@ -25,6 +25,7 @@ import io.syndesis.dao.manager.WithDataManager;
 import io.syndesis.model.ListResult;
 import io.syndesis.model.WithId;
 import io.syndesis.rest.util.PaginationFilter;
+import io.syndesis.rest.util.ReflectiveFilterer;
 import io.syndesis.rest.util.ReflectiveSorter;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -43,13 +44,16 @@ public interface Lister<T extends WithId<T>> extends Resource, WithDataManager {
         @ApiImplicitParam(
             name = "page", value = "Page number to return", paramType = "query", dataType = "integer", defaultValue = "1"),
         @ApiImplicitParam(
-            name = "per_page", value = "Number of records per page", paramType = "query", dataType = "integer", defaultValue = "20")
+            name = "per_page", value = "Number of records per page", paramType = "query", dataType = "integer", defaultValue = "20"),
+        @ApiImplicitParam(
+            name = "query", value = "The search query to filter results on", paramType = "query", dataType = "string"),
 
     })
     default ListResult<T> list(@Context UriInfo uriInfo) {
         Class<T> clazz = resourceKind().getModelClass();
         return getDataManager().fetchAll(
             clazz,
+            new ReflectiveFilterer<>(clazz, new FilterOptionsFromQueryParams(uriInfo).getFilters()),
             new ReflectiveSorter<>(clazz, new SortOptionsFromQueryParams(uriInfo)),
             new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo))
         );

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/SortOptionsFromQueryParams.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/operations/SortOptionsFromQueryParams.java
@@ -22,11 +22,6 @@ import javax.ws.rs.core.UriInfo;
 
 import io.syndesis.rest.util.SortOptions;
 
-
-/**
- * @author roland
- * @since 14/12/16
- */
 public class SortOptionsFromQueryParams implements SortOptions {
 
     private final String sortField;

--- a/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
@@ -107,4 +107,5 @@ public class ConnectorHandlerTest {
             }
         }
     }
+
 }

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
@@ -104,4 +104,15 @@ public class ConnectorsITCase extends BaseITCase {
         assertThat(result.getErrors()).isNotEmpty();
     }
 
+    @Test
+    public void filterConnectorList() {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Class<ListResult<Connector>> type = (Class) ListResult.class;
+        ResponseEntity<ListResult<Connector>> response = get("/api/v1/connectors?query=connectorGroupId=trade", type);
+        assertThat(response.getStatusCode()).as("component list status code").isEqualTo(HttpStatus.OK);
+        ListResult<Connector> result = response.getBody();
+        assertThat(result.getTotalCount()).as("connectors total").isEqualTo(2);
+        assertThat(result.getItems().size()).as("connector list").isEqualTo(2);
+    }
+
 }

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -54,12 +54,6 @@ public class CustomConnectorITCase extends BaseITCase {
 
     private final ConnectorTemplate template = createConnectorTemplate(TEMPLATE_ID, "connector template");
 
-    public static class ConnectorResultList {
-        public List<Connector> items;
-
-        public int totalCount;
-    }
-
     @Configuration
     public static class TestConfiguration {
         private static final ActionsSummary ACTIONS_SUMMARY = new ActionsSummary.Builder().totalActions(5).putActionCountByTag("foo", 3)
@@ -127,22 +121,6 @@ public class CustomConnectorITCase extends BaseITCase {
         assertThat(created).isNotNull();
         assertThat(created.getDescription()).isEqualTo("test-description");
         assertThat(dataManager.fetch(Connector.class, response.getBody().getId().get())).isNotNull();
-    }
-
-    @Test
-    public void shouldListCustomConnectorsGeneratedFromFirstTemplate() {
-        final ResponseEntity<ConnectorResultList> response = get("/api/v1/connectors/custom?templateId=" + TEMPLATE_ID,
-            ConnectorResultList.class);
-
-        assertThat(response.getBody().items).containsOnly(connector1, connector2);
-    }
-
-    @Test
-    public void shouldListCustomConnectorsGeneratedFromSecondTemplate() {
-        final ResponseEntity<ConnectorResultList> response = get("/api/v1/connectors/custom?templateId=" + SECOND_TEMPLATE_ID,
-            ConnectorResultList.class);
-
-        assertThat(response.getBody().items).containsOnly(connector3);
     }
 
     @Test

--- a/app/runtime/model/src/main/java/io/syndesis/integration/support/Strings.java
+++ b/app/runtime/model/src/main/java/io/syndesis/integration/support/Strings.java
@@ -21,4 +21,7 @@ public class Strings {
         return value == null || value.length() == 0 || value.trim().length() == 0;
     }
 
+    public static boolean isNotEmpty(String value) {
+        return !isEmpty(value);
+    }
 }

--- a/project/proposals/119-custom-connectors.md
+++ b/project/proposals/119-custom-connectors.md
@@ -42,13 +42,13 @@ properties.
 
 New API endpoints for defining custom connectors:
 
-| HTTP Verb | Path                                                             | Description                                                                           |
-| --------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| GET       | /api/**{version}**/connector-templates                           | Returns a list of known connector templates                                           |
-| GET       | /api/**{version}**/connector-templates/**{templateId}**          | Returns a specific connector template identified by the given **templateId**          |
-| POST      | /api/**{version}**/connectors/custom/info                        | Provides information like proposed name, icon and description for new connector       | 
-| POST      | /api/**{version}**/connectors/custom/                            | Create a new custom connector                                                         |
-| GET       | /api/**{version}**/connectors/custom?templateId=**{templateId}** | Lists all connectors that were created from a template identified with **templateId** |
+| HTTP Verb | Path                                                                    | Description                                                                           |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| GET       | /api/**{version}**/connector-templates                                  | Returns a list of known connector templates                                           |
+| GET       | /api/**{version}**/connector-templates/**{templateId}**                 | Returns a specific connector template identified by the given **templateId**          |
+| POST      | /api/**{version}**/connectors/custom/info                               | Provides information like proposed name, icon and description for new connector       |
+| POST      | /api/**{version}**/connectors/custom                                    | Create a new custom connector                                                         |
+| GET       | /api/**{version}**/connectors?query=connectorGroupId%3D**{templateId}** | Lists all connectors that were created from a template identified with **templateId** |
 
 ### New custom connector based on Swagger specification example
 


### PR DESCRIPTION
This enables generic filtering via the REST API, especially important for custom connector listing.

Fixes #660.