### PR TITLE
refactor(synesis): Split up monolythic script into commands

### DIFF
--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# All modules, in the right build order
+ALL_MODULES="connectors verifier runtime rest s2i ui tests"
+POD_MODULES="verifier rest ui"
+MODULES=(
+  "ui"
+  "connectors"
+  "runtime:connectors"
+  "verifier:connectors"
+  "rest:connectors runtime"
+  "s2i:rest runtime connectors"
+  "tests:connectors runtime rest s2i"
+)
+
+build::description() {
+    echo "Build Syndesis"
+}
+
+build::usage() {
+    cat <<EOT
+-b  --backend                 Build only backend modules (rest, verifier, runtime, connectors)
+    --images                  Build only modules with Docker images (ui, rest, verifier, s2i)
+-m  --module <m1>,<m2>, ..    Build modules
+                              Modules: ui, rest, connectors, s2i, verifier, runtime
+-d  --dependencies            Build also all project the specified module depends on
+    --init                    Install top-level parent pom, too. Only needed when used with -m
+    --skip-tests              Skip unit and system test execution
+    --skip-checks             Disable all checks
+-f  --flash                   Skip checks and tests execution (fastest mode)
+-i  --image-mode  <mode>      <mode> can be
+                              - "none"      : No images are build (default)
+                              - "openshift" : Build for OpenShift image streams
+                              - "docker"    : Build against a plain Docker daemon
+                              - "auto"      : Automatically detect whether to use "s2i" or "docker"
+    --docker                  == --image-mode docker
+    --openshift               == --image-mode openshift
+-p  --project <project>       Specifies the project to create images in when using '--images s2i'
+-k  --kill-pods               Kill pods after the image has been created.
+                              Useful when building with image-mode docker
+-c  --clean                   Run clean builds (mvn clean)
+-b  --batch-mode              Run mvn in batch mode
+EOT
+
+}
+
+build::run() {
+    call_maven "$(maven_args)"
+}
+
+maven_args() {
+    local project=${1:-}
+    local args=""
+
+    if [ -n "$(hasflag --flash -f)" ]; then
+        args="$args -Pflash"
+    fi
+
+    if [ -n "$(hasflag --skip-tests)" ]; then
+        args="$args -DskipTests"
+    fi
+
+    if [ -n "$(hasflag --skip-checks)" ]; then
+        args="$args -Pskip-checks"
+    fi
+
+    if [ -n "$(hasflag --batch-mode -b)" ]; then
+        args="$args --batch-mode"
+    fi
+
+    local image_mode="$(readopt --image-mode -i)"
+    if [ -z "${image_mode}" ]; then
+      if [ $(hasflag --docker) ]; then
+          image_mode="docker"
+      elif [ $(hasflag --openshift --s2i) ]; then
+          image_mode="openshift"
+      fi
+    fi
+    if [ "${image_mode}" != "none" ]; then
+        if [ -n "$(hasflag --images)" ] || [ -n "${image_mode}" ]; then
+            #Build images
+            args="$args -Pimage"
+            if [ -n "${image_mode}" ]; then
+                if [ "${image_mode}" == "openshift" ] || [ "${image_mode}" == "s2i" ]; then
+                    args="$args -Dfabric8.mode=openshift"
+                elif [ "${image_mode}" == "docker" ]; then
+                    args="$args -Dfabric8.mode=kubernetes"
+                elif [ "${image_mode}" != "auto" ]; then
+                    echo "ERROR: Invalid --image-mode ${image_mode}. Only 'none', 'openshift', 'docker' or 'auto' supported".
+                    exit 1
+                fi
+            fi
+        fi
+    fi
+
+    if [ -z "$project" ]; then
+        project="$(readopt --project -p)"
+    fi
+    if [ -n "${project}" ]; then
+        args="$args -Dfabric8.namespace=${project}"
+    fi
+
+    if [ -n "$(hasflag --clean -c)" ]; then
+        args="$args clean"
+    fi
+
+    local goals="$(readopt --goals)"
+    if [ -n "${goals}" ]; then
+        args="$args ${goals//,/ }"
+    else
+        args="$args install"
+    fi
+
+    echo $args
+}
+
+extract_modules() {
+    local modules=""
+
+    if [ "$(hasflag --backend -b)" ]; then
+        modules="$modules connectors runtime rest verifier"
+    fi
+
+    if [ "$(hasflag --images)" ]; then
+        modules="$modules ui rest verifier s2i"
+    fi
+
+    local arg_modules=$(readopt --module -m);
+    if [ -n "${arg_modules}" ]; then
+        modules="$modules ${arg_modules//,/ }"
+    fi
+
+    if [ "$(hasflag --dependencies -d)" ]; then
+        local extra_modules=""
+        for module in $modules; do
+            for m in "${MODULES[@]}"; do
+              local k=${m%%:*}
+              if [ "$module" == $k ]; then
+                  local v=${m#*:}
+                  extra_modules="${extra_modules} $v"
+              fi
+            done
+        done
+        modules="$modules $extra_modules"
+    fi
+    if [ -z "$modules" ]; then
+      return
+    fi
+    # Unique modules
+    local unique_modules=$(echo $modules | xargs -n 1 | sort -u | xargs | awk '$1=$1')
+    echo $(order_modules "$unique_modules")
+}
+
+order_modules() {
+    # Fix order
+    local modules="$1"
+    # All modules in the proper order
+    local ret=$ALL_MODULES
+    for cm in "${MODULES[@]}"; do
+      local check_module=${cm%%:*}
+      # Check if $check_module is in the module list
+      if [ -n "${modules##*${check_module}*}" ]; then
+        # No, so remove it from the return value
+        ret=${ret//$check_module/}
+      fi
+    done
+
+    # Normalize return value
+    echo $ret | awk '$1=$1'
+}
+
+kill_pods() {
+    for pod in $@; do
+        if [ "${POD_MODULES/$pod/}" != "${POD_MODULES}" ]; then
+            echo "Killing pods "$(oc get pod -o name | grep "syndesis-$pod")
+            oc get pod -o name | grep "syndesis-$pod" | xargs oc delete
+        fi
+    done
+}
+
+call_maven() {
+    local args=$1
+    local maven_modules=$(extract_modules)
+    check_error $maven_modules
+    cd $(appdir)
+    if [ -z "${maven_modules}" ]; then
+        echo "=============================================================================="
+        echo "./mvnw $args"
+        echo "=============================================================================="
+        ./mvnw $args
+        if [ $(hasflag --kill-pods --kill-pod -k) ]; then
+          kill_pods $POD_MODULES
+        fi
+    else
+      echo "Modules: $maven_modules"
+      if [ $(hasflag --init) ]; then
+        echo "=============================================================================="
+        echo "./mvnw -N install"
+        ./mvnw -N install
+      fi
+      for module in $maven_modules; do
+        echo "=============================================================================="
+        echo "./mvnw $args -f $module"
+        echo "=============================================================================="
+        ./mvnw -f $module $args
+        if [ $(hasflag --kill-pods --kill-pod -k) ]; then
+            kill_pods $module
+        fi
+      done
+    fi
+}

--- a/tools/bin/commands/dev
+++ b/tools/bin/commands/dev
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+dev::description() {
+    echo "Developer tools"
+}
+
+dev::usage() {
+    cat <<EOT
+    --debug <name>            Setup a port forwarding to <name> pod (example: rest)
+EOT
+}
+
+dev::run() {
+    if [ $(hasflag --debug) ]; then
+        local name=$(readopt --debug)
+        if [ -z "${name}" ]; then
+            name="rest"
+        fi
+
+        local pod=$(oc get -o name pod -l component=syndesis-${name})
+        oc port-forward ${pod//*\//} 5005:5005
+    fi
+}

--- a/tools/bin/commands/doc
+++ b/tools/bin/commands/doc
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+doc::description() {
+    echo "Generate Syndesis Developer Handbook"
+}
+
+doc::usage() {
+    cat <<EOT
+
+
+EOT
+}
+
+doc::run() {
+     echo "doc"
+
+}

--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+minishift::description() {
+    echo "Initialize and manage a Minishift developer environment"
+}
+
+minishift::usage() {
+    cat <<EOT
+    --reset                   Reset the minishift installation with 'minishift delete && minishift start'.
+    --full-reset              Full reset by 'minishift stop && rm -rf ~/.minishift && minishift start'
+    --memory <mem>            How much memory to use when doing a reset. Default: 4GB
+    --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: 2
+    --disk-size <size>        How many disk space to use when doing a reset. Default: 20GB
+    --install                 Install templates into a running Minishift.
+-p  --project                 Install into this project. Delete this project if already existing
+    --watch                   Watch startup of pods
+-i  --image-mode <mode>       Which templates to install: "docker" for plain images, "openshift" for image streams
+                              (default: "openshift")
+EOT
+}
+
+minishift::run() {
+    if [ $(hasflag --full-reset) ] || [ $(hasflag --reset) ]; then
+        # Only warning if minishift is not installed
+        minishift delete --clear-cache --force
+        if [ $(hasflag --full-reset) ] && [ -d ~/.minishift ]; then
+            rm -rf ~/.minishift
+        fi
+        local memory=$(readopt --memory)
+        local cpus=$(readopt --cpus)
+        local disksize=$(readopt --disk-size)
+        minishift start --show-libmachine-logs=true --memory ${memory:-4912} --cpus ${cpus:-2} --disk-size ${disksize:-20GB}
+    fi
+
+    local project=$(readopt --project -p)
+    if [ -n "${project}" ]; then
+        # Delete project if existing
+        if oc get project "${project}" >/dev/null 2>&1 ; then
+            echo "Deleting project ${project}"
+            oc delete project "${project}"
+        fi
+        echo "Creating project ${project}"
+        for i in {1..10}; do
+            if oc new-project "${project}" >/dev/null 2>&1 ; then
+              break
+            fi
+            echo "Project still exist. Waiting 10s ..."
+            sleep 10
+        done
+        oc project "${project}"
+    fi
+
+    local image_mode=$(readopt --image-mode -i)
+    local template="syndesis-restricted"
+    if [ "$image_mode" == "openshift" ]; then
+        template="syndesis-restricted"
+    elif [ "$image_mode" == "docker" ]; then
+        template="syndesis-dev-restricted"
+    fi
+    if [ $(hasflag --install) ]; then
+        basedir=$(appdir)
+        check_error "$basedir"
+        oc create -f ${basedir}/deploy/support/serviceaccount-as-oauthclient-restricted.yml
+        oc create -f ${basedir}/deploy/${template}.yml
+        oc new-app ${template} \
+          -p ROUTE_HOSTNAME=syndesis.$(minishift ip).nip.io \
+          -p OPENSHIFT_MASTER=$(oc whoami --show-server) \
+          -p OPENSHIFT_PROJECT=$(oc project -q) \
+          -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client)
+    fi
+    if [ $(hasflag --watch) ]; then
+        exec watch oc get pods
+    fi
+}

--- a/tools/bin/commands/system-test
+++ b/tools/bin/commands/system-test
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+system-test::description() {
+    echo "Run system tests"
+}
+
+system-test::usage() {
+    cat - <<EOT
+    --project <project>       The test project to use
+    --token <token>           Token for connecting to the server
+    --server <url>            OpenShift Server url to use for the tests. If not given, use the currently connected
+                              server
+    --pool <project>          If no project is given use, a pooling mechanism. This pool has to be created
+                              before with --create-pool
+    --test-id <id>            Id to identify the test run
+    --create-pool <prefix>    Create project pool for system-tests with all projects with the given prefix
+    --list-pool               Show all locks for the pool
+    --release-project <t-id>  Release project for given test id (or all if no test id is given)
+EOT
+}
+
+system-test::run() {
+    local server=$(readopt --server)
+    local pool=$(readopt --pool)
+    if [ -z "${pool}" ]; then
+        pool="syndesis-ci"
+    fi
+    if [ -n "${server:-}" ]; then
+        local token=$(readopt --token)
+        if [ -z "${token:-}" ]; then
+            echo "--server provided for sytem tests but no --token for credentials"
+            exit 1
+        fi
+        local log
+        log=$(oc login --server $server --token $token)
+        if [ $? -ne 0 ]; then
+           echo bla
+           echo $log
+           exit 1
+        fi
+    fi
+
+    local lock_prefix=$(readopt --create-pool)
+    if [ -n "${lock_prefix}" ]; then
+        create_pool $lock_prefix
+    elif [ -n "$(hasflag --list-pool)" ]; then
+        list_pool "$pool"
+    elif [ -n "$(hasflag --release-project)" ]; then
+        release_project "$pool" "$(readopt --test-id)"
+    else
+        test_build $pool
+    fi
+}
+
+# ======================================================
+# Testing functions
+
+base64_decode_option() {
+    set +e
+    for opt in -D -d; do
+        echo "Y2hpbGk=" | base64 $opt >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            echo $opt
+            set -e
+            return
+        fi
+    done
+    set -e
+    echo "ERROR: Neither base64 -d nor base64 -D works"
+}
+
+find_secret() {
+    local project=$1
+    local service_account=$2
+    oc get sa $service_account -n $project -o yaml | grep "${service_account}-token-" | awk -F ": " '{print $2}'
+}
+
+read_token() {
+    local secret=$1
+    local project=$2
+    base64_opt=$(base64_decode_option)
+    check_error $base64_opt
+    oc get secret $secret -n $project -o yaml | grep token: | awk -F ": " '{print $2}' | base64 $base64_opt
+}
+
+read_token_of_sa() {
+    local project=$1
+    local service_account=$2
+    local secret=$(find_secret $project $service_account)
+    local token=$(read_token $secret $project)
+    echo $token
+}
+
+# Create a lock for all projects with the given prefix
+create_pool() {
+    local prefix=$1
+    local service_account="default"
+    local pool=$(readopt --pool)
+
+    if [ -z "$pool" ]; then
+        pool="syndesis-ci"
+    fi
+
+    for p in $(oc get projects | grep $prefix | awk -F " " '{print $1}'); do
+        echo "Creating a secret lock for project $p"
+        local secret=$(find_secret $p "default")
+        echo "Found secret: $secret"
+        local token=$(read_token_of_sa $p $service_account)
+        echo "Found token: $token"
+        oc delete secret project-lock-$p -n $pool_project || true
+        oc create secret generic project-lock-$p --from-literal=token=$token -n $pool_project
+        oc annotate secret project-lock-$p syndesis.io/lock-for-project=$p -n $pool_project
+        oc annotate secret project-lock-$p syndesis.io/allocated-by="" -n $pool_project
+
+        oc adm policy add-role-to-user edit system:serviceaccount:$p:$service_account -n $p
+        oc adm policy add-role-to-user system:image-puller system:serviceaccount:$p:$service_account -n $p
+        oc adm policy add-role-to-user system:image-builder system:serviceaccount:$p:$service_account -n $p
+    done
+}
+
+# Gets the current OpenShift user token.
+current_token() {
+    echo $(oc whoami -t)
+}
+
+# Get the current OpenShift server
+current_server() {
+    echo $(oc whoami --show-server)
+}
+
+# Lock functions (secret lock strategy)
+
+# Displays the data of the lock. A project lock is a secret that contains the following:
+# 1. annotations:
+#    i)  syndesis.io/lock-for-project: The project that this lock corresponds to.
+#    ii) syndesis.io/allocated-by:     The owner of the lock.
+# 2. data:
+#    i)  connection information for the project (token)
+project_lock_data() {
+    local secret=$1
+    local pool=$2
+    oc get $secret -n $pool -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}}~{{.metadata.resourceVersion}}~{{index .metadata.annotations "syndesis.io/allocated-by"}}{{"\n"}}'
+}
+
+# Extract test id used for system tests
+calc_test_id() {
+    local test_id=$(readopt --test-id)
+
+    if [ -z "${test_id}" ]; then
+      if [ -n "${JOB_NAME:-}" ]; then
+          # Jenkins Job
+          test_id="${JOB_NAME:-}${BUILD_NUMBER:-}"
+      elif [ -n "${CIRCLE_JOB:-}" ]; then
+          # Circle CI Job
+          test_id="${CIRCLE_JOB:-}${CIRCLE_BUILD_NUM:-}"
+      else
+          test_id="cli"
+      fi
+    fi
+    echo $test_id
+}
+
+
+#
+# Obtains a project lock. (See above).
+lock_project() {
+    local test_id=$1
+    local pool=$2
+    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
+        local status=$(project_lock_data "$lock" "$pool")
+        local project=$(echo $status | awk -F "~" '{print $1}')
+        local version=$(echo $status | awk -F "~" '{print $2}')
+        local allocator=$(echo $status | awk -F "~" '{print $3}')
+
+        if [ "${test_id}" == "${allocator}" ]; then
+           # Already occupied by the given test ID. No actionr required
+           echo $project;
+           return
+        fi
+
+        # Lock is free
+        if [ -z "$allocator" ]; then
+            oc annotate $lock syndesis.io/allocated-by=$test_id --resource-version=$version --overwrite -n $pool > /dev/null
+            local newstatus=$(project_lock_data "$lock" "$pool")
+            local newallocator=$(echo $newstatus | awk -F "~" '{print $3}')
+            if [ "$newallocator" == "$test_id" ]; then
+                echo $project
+                return
+            fi
+        fi
+    done
+
+    # Nothing found, empty return value
+}
+
+check_project_status() {
+    local pool=$1
+    # Checking active status of pool project
+    local pool_status=$(oc get projects | grep $pool | awk -F " " '{print $2}')
+    if [ "$pool_status" != "Active" ]; then
+        echo "ERROR: No active project $pool: $pool_status"
+        exit 1
+    fi
+}
+
+get_free_pool_project() {
+
+    # The pool project. See below.
+    local pool=$(readopt --pool)
+
+    # Calculate the test ID used for locking
+    local test_id=$(calc_test_id)
+
+    # The calculated project to use
+    local project
+    echo "Trying to allocate project for: $test_id" >&2
+
+    # Project holding secrets for all projects used for testing.
+    # These secrets are updated with locks to reflect the current
+    # status of all parallel running tests
+    if [ -z "$pool" ]; then
+        pool="syndesis-ci"
+    fi
+
+    # Is the poo project active ?
+    check_error $(check_project_status $pool)
+
+    echo "Using pool: $pool" >&2
+
+    # Get the lock for the given (or calculated) test_id. Retry 10 times if every projects
+    # is locked
+    local project=$(lock_project "$test_id" "$pool")
+    if [ -z "$project" ]; then
+        for r in {1..10}; do
+            project=$(lock_project "$test_id" "$pool_project")
+            if [ -n "${project}" ]; then
+                break
+            fi
+            echo "Couldn't obtain lock for a single project. Retrying in 1 minute." >&2
+            sleep 1m
+        done
+    fi
+
+    if [ -n "$project" ]; then
+        echo "Obtained project $project" >&2
+        echo $project
+    else
+        echo "ERROR: Failed to allocate project. Exiting."
+    fi
+}
+
+project_lock_name() {
+    local secret_name=$1
+    local pool=$2
+    if [ -n "${secret}" ]; then
+      oc get secret $secret_name -n $pool -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}}{{"\n"}}'
+    fi
+}
+
+release_project_lock() {
+    local lock=$1
+    local pool_project=$2
+    oc annotate $lock syndesis.io/allocated-by="" --overwrite -n $pool_project > /dev/null
+}
+
+list_pool() {
+    local pool=$1
+    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
+        local status=$(project_lock_data "$lock" "$pool")
+        local project=$(echo $status | awk -F "~" '{print $1}')
+        local version=$(echo $status | awk -F "~" '{print $2}')
+        local allocator=$(echo $status | awk -F "~" '{print $3}')
+
+        echo -e "$project:\t${allocator:----}"
+    done
+}
+
+release_project() {
+    local pool=$1
+    local test_id=$2
+
+    oc project $pool
+    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
+        local status=$(project_lock_data "$lock" "$pool")
+        local project=$(echo $status | awk -F "~" '{print $1}')
+        local version=$(echo $status | awk -F "~" '{print $2}')
+        local allocator=$(echo $status | awk -F "~" '{print $3}')
+
+        if [ -z "${test_id:-}" ] || [ "${test_id}" == "${allocator:-}" ]; then
+          echo "Releasing $lock"
+          release_project_lock $lock $pool
+        fi
+    done
+}
+
+test_build() {
+    source "$(basedir)/commands/build"
+
+    echo "Running build for system tests"
+    local pool=$1
+    # Test project given directly
+    local project=$(readopt --project)
+    if [ -z "$project" ]; then
+        project=$(get_free_pool_project)
+        check_error $project
+        local test_id=$(calc_test_id)
+        trap "release_project "$pool" "$test_id"" EXIT
+    fi
+
+    oc project $project
+    local maven_args=$(maven_args $project)
+    check_error $maven_args
+    maven_args="-Psystem-tests -Pimages -Dfabric8.mode=openshift $maven_args"
+    call_maven "$maven_args"
+}

--- a/tools/bin/syndesis
+++ b/tools/bin/syndesis
@@ -181,7 +181,7 @@ function run {
     fi
 
 
-    if [ -z "${command}" ]; then
+    if [ -z "${command:-}" ]; then
         # Try to detect command
         for cand in "$(ls $cmd_dir)"; do
             if [ -f "$cmd_dir/$cand" ] && [ $(hasflag --$cand) ]; then
@@ -191,12 +191,12 @@ function run {
         done
     fi
 
-    if [ x"$command" == xhelp ] || [ $(hasflag --help -h) ]; then
+    if [ "${command:-}" == "help" ] || [ $(hasflag --help -h) ]; then
         display_help $command
         exit 0
     fi
 
-    if [ -z "${command}" ]; then
+    if [ -z "${command:-}" ]; then
         command="build"
     fi
 

--- a/tools/bin/syndesis
+++ b/tools/bin/syndesis
@@ -163,7 +163,7 @@ function run {
     local first_arg=${1:-}
     local cmd_dir="$(basedir)/commands"
     local command
-    if [ -n "${first_arg}" ] && [ "${first_arg//^\-/}" == "${first_arg}" ]; then
+    if [ -n "${first_arg}" ] && [[ ${first_arg} != -* ]]; then
         command="$first_arg"
         if [ ! -f "$cmd_dir/$command" ]; then
             echo

--- a/tools/bin/syndesis
+++ b/tools/bin/syndesis
@@ -16,86 +16,33 @@ set -eu
 # Save global script args
 ARGS="$@"
 
-# All modules, in the right build order
-ALL_MODULES="connectors verifier runtime rest s2i ui tests"
-POD_MODULES="verifier rest ui"
-MODULES=(
-  "ui"
-  "connectors"
-  "runtime:connectors"
-  "verifier:connectors"
-  "rest:connectors runtime"
-  "s2i:rest runtime connectors"
-  "tests:connectors runtime rest s2i"
-)
-
 # Display a help message.
 display_help() {
+    local command="${1:-}"
+    local cmd_dir="$(basedir)/commands"
     cat - <<EOT
-Build Syndesis
+Syndesis Developer Tool
+EOT
+    if [ -z "${command}" ]; then
+        cat <<EOT
 
-Usage: build.sh [... options ...]
+Usage: syndesis <command> [... options ...]
 
-and the following options:
+with the following commands
 
--b  --backend                 Build only backend modules (rest, verifier, runtime, connectors)
-    --images                  Build only modules with Docker images (ui, rest, verifier, s2i)
--m  --module <m1>,<m2>, ..    Build modules
-                              Modules: ui, rest, connectors, s2i, verifier, runtime
--d  --dependencies            Build also all project the specified module depends on
-    --init                    Install top-level parent pom, too. Only needed when used with -m
+EOT
+        for cmd in $(ls $cmd_dir); do
+          source $cmd_dir/$cmd
+          printf "   %-15s  %s\n" $cmd "$($cmd::description)"
+        done
+        cat - <<EOT
 
-    --skip-tests              Skip unit and system test execution
-    --skip-checks             Disable all checks
--f  --flash                   Skip checks and tests execution (fastest mode)
+The following global options are available:
 
--i  --image-mode  <mode>      <mode> can be
-                              - "none"      : No images are build (default)
-                              - "openshift" : Build for OpenShift image streams
-                              - "docker"    : Build against a plain Docker daemon
-                              - "auto"      : Automatically detect whether to use "s2i" or "docker"
-    --docker                  == --image-mode docker
-    --openshift               == --image-mode openshift
-
--p  --project <project>       Specifies the project to create images in when using '--images s2i'
--k  --kill-pods               Kill pods after the image has been created.
-                              Useful when building with image-mode docker
-
--c  --clean                   Run clean builds (mvn clean)
--b  --batch-mode              Run mvn in batch mode
 -r  --rebase                  Fetch origin/master and try a rebase
-
 -h  --help                    Display this help message
 
-With "--system-test" the system tests are triggered which know these additional options:
-
-    --project <project>       The test project to use
-    --token <token>           Token for connecting to the server
-    --server <url>            OpenShift Server url to use for the tests. If not given, use the currently connected
-                              server
-    --pool <project>          If no project is given use, a pooling mechanism. This pool has to be created
-                              before with --create-pool
-    --test-id <id>            Id to identify the test run
-    --create-pool <prefix>    Create project pool for system-tests with all projects with the given prefix
-    --list-pool               Show all locks for the pool
-    --release-project <t-id>  Release project for given test id (or all if no test id is given)
-
-With "--minishift" Minishift can be initialized and installed with Syndesis
-
-    --reset                   Reset the minishift installation with 'minishift delete && minishift start'.
-    --full-reset              Full reset by 'minishift stop && rm -rf ~/.minishift && minishift start'
-    --memory <mem>            How much memory to use when doing a reset. Default: 4GB
-    --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: 2
-    --disk-size <size>        How many disk space to use when doing a reset. Default: 20GB
-    --install                 Install templates into a running Minishift.
--p  --project                 Install into this project. Delete this project if already existing
-    --watch                   Watch startup of pods
--i  --image-mode <mode>       Which templates to install: "docker" for plain images, "openshift" for image streams
-                              (default: "openshift")
-
-With "--dev" common development tasks are simplified
-
-    --debug <name>            Setup a port forwarding to <name> pod (example: rest)
+Call "syndesis <module> --help" for module specific options
 
 Examples:
 
@@ -106,8 +53,17 @@ Examples:
 * Build for system test                          build.sh --system-test
 * Start Minishift afresh                         build.sh --minishift --full-reset --install --watch
 * Setup debug port forward for rest pod          build.sh --dev --debug rest
+EOT
+    else
+        cat <<EOT
+
+Usage: syndesis $command [... options ...]
 
 EOT
+        source $cmd_dir/$command
+        echo "Options for $command:"
+        echo -e "$($command::usage)"
+    fi
 }
 
 # Dir where this script is located
@@ -186,7 +142,6 @@ check_error() {
 
 # ======================================================
 # Git update functions
-
 git_rebase_upstream() {
   echo "git fetch upstream master"
   git fetch upstream master
@@ -204,595 +159,54 @@ git_rebase_upstream() {
   fi
 }
 
-# ======================================================
-# Testing functions
-
-base64_decode_option() {
-    set +e
-    for opt in -D -d; do
-        echo "Y2hpbGk=" | base64 $opt >/dev/null 2>&1
-        if [ $? -eq 0 ]; then
-            echo $opt
-            set -e
-            return
-        fi
-    done
-    set -e
-    echo "ERROR: Neither base64 -d nor base64 -D works"
-}
-
-find_secret() {
-    local project=$1
-    local service_account=$2
-    oc get sa $service_account -n $project -o yaml | grep "${service_account}-token-" | awk -F ": " '{print $2}'
-}
-
-read_token() {
-    local secret=$1
-    local project=$2
-    base64_opt=$(base64_decode_option)
-    check_error $base64_opt
-    oc get secret $secret -n $project -o yaml | grep token: | awk -F ": " '{print $2}' | base64 $base64_opt
-}
-
-read_token_of_sa() {
-    local project=$1
-    local service_account=$2
-    local secret=$(find_secret $project $service_account)
-    local token=$(read_token $secret $project)
-    echo $token
-}
-
-# Create a lock for all projects with the given prefix
-create_pool() {
-    local prefix=$1
-    local service_account="default"
-    local pool=$(readopt --pool)
-
-    if [ -z "$pool" ]; then
-        pool="syndesis-ci"
-    fi
-
-    for p in $(oc get projects | grep $prefix | awk -F " " '{print $1}'); do
-        echo "Creating a secret lock for project $p"
-        local secret=$(find_secret $p "default")
-        echo "Found secret: $secret"
-        local token=$(read_token_of_sa $p $service_account)
-        echo "Found token: $token"
-        oc delete secret project-lock-$p -n $pool_project || true
-        oc create secret generic project-lock-$p --from-literal=token=$token -n $pool_project
-        oc annotate secret project-lock-$p syndesis.io/lock-for-project=$p -n $pool_project
-        oc annotate secret project-lock-$p syndesis.io/allocated-by="" -n $pool_project
-
-        oc adm policy add-role-to-user edit system:serviceaccount:$p:$service_account -n $p
-        oc adm policy add-role-to-user system:image-puller system:serviceaccount:$p:$service_account -n $p
-        oc adm policy add-role-to-user system:image-builder system:serviceaccount:$p:$service_account -n $p
-    done
-}
-
-# Gets the current OpenShift user token.
-current_token() {
-    echo $(oc whoami -t)
-}
-
-# Get the current OpenShift server
-current_server() {
-    echo $(oc whoami --show-server)
-}
-
-# Lock functions (secret lock strategy)
-
-# Displays the data of the lock. A project lock is a secret that contains the following:
-# 1. annotations:
-#    i)  syndesis.io/lock-for-project: The project that this lock corresponds to.
-#    ii) syndesis.io/allocated-by:     The owner of the lock.
-# 2. data:
-#    i)  connection information for the project (token)
-project_lock_data() {
-    local secret=$1
-    local pool=$2
-    oc get $secret -n $pool -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}}~{{.metadata.resourceVersion}}~{{index .metadata.annotations "syndesis.io/allocated-by"}}{{"\n"}}'
-}
-
-# Extract test id used for system tests
-calc_test_id() {
-    local test_id=$(readopt --test-id)
-
-    if [ -z "${test_id}" ]; then
-      if [ -n "${JOB_NAME:-}" ]; then
-          # Jenkins Job
-          test_id="${JOB_NAME:-}${BUILD_NUMBER:-}"
-      elif [ -n "${CIRCLE_JOB:-}" ]; then
-          # Circle CI Job
-          test_id="${CIRCLE_JOB:-}${CIRCLE_BUILD_NUM:-}"
-      else
-          test_id="cli"
-      fi
-    fi
-    echo $test_id
-}
-
-
-#
-# Obtains a project lock. (See above).
-lock_project() {
-    local test_id=$1
-    local pool=$2
-    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
-        local status=$(project_lock_data "$lock" "$pool")
-        local project=$(echo $status | awk -F "~" '{print $1}')
-        local version=$(echo $status | awk -F "~" '{print $2}')
-        local allocator=$(echo $status | awk -F "~" '{print $3}')
-
-        if [ "${test_id}" == "${allocator}" ]; then
-           # Already occupied by the given test ID. No actionr required
-           echo $project;
-           return
-        fi
-
-        # Lock is free
-        if [ -z "$allocator" ]; then
-            oc annotate $lock syndesis.io/allocated-by=$test_id --resource-version=$version --overwrite -n $pool > /dev/null
-            local newstatus=$(project_lock_data "$lock" "$pool")
-            local newallocator=$(echo $newstatus | awk -F "~" '{print $3}')
-            if [ "$newallocator" == "$test_id" ]; then
-                echo $project
-                return
-            fi
-        fi
-    done
-
-    # Nothing found, empty return value
-}
-
-check_project_status() {
-    local pool=$1
-    # Checking active status of pool project
-    local pool_status=$(oc get projects | grep $pool | awk -F " " '{print $2}')
-    if [ "$pool_status" != "Active" ]; then
-        echo "ERROR: No active project $pool: $pool_status"
-        exit 1
-    fi
-}
-
-get_free_pool_project() {
-
-    # The pool project. See below.
-    local pool=$(readopt --pool)
-
-    # Calculate the test ID used for locking
-    local test_id=$(calc_test_id)
-
-    # The calculated project to use
-    local project
-    echo "Trying to allocate project for: $test_id" >&2
-
-    # Project holding secrets for all projects used for testing.
-    # These secrets are updated with locks to reflect the current
-    # status of all parallel running tests
-    if [ -z "$pool" ]; then
-        pool="syndesis-ci"
-    fi
-
-    # Is the poo project active ?
-    check_error $(check_project_status $pool)
-
-    echo "Using pool: $pool" >&2
-
-    # Get the lock for the given (or calculated) test_id. Retry 10 times if every projects
-    # is locked
-    local project=$(lock_project "$test_id" "$pool")
-    if [ -z "$project" ]; then
-        for r in {1..10}; do
-            project=$(lock_project "$test_id" "$pool_project")
-            if [ -n "${project}" ]; then
-                break
-            fi
-            echo "Couldn't obtain lock for a single project. Retrying in 1 minute." >&2
-            sleep 1m
-        done
-    fi
-
-    if [ -n "$project" ]; then
-        echo "Obtained project $project" >&2
-        echo $project
-    else
-        echo "ERROR: Failed to allocate project. Exiting."
-    fi
-}
-
-project_lock_name() {
-    local secret_name=$1
-    local pool=$2
-    if [ -n "${secret}" ]; then
-      oc get secret $secret_name -n $pool -o go-template='{{index .metadata.annotations "syndesis.io/lock-for-project"}}{{"\n"}}'
-    fi
-}
-
-release_project_lock() {
-    local lock=$1
-    local pool_project=$2
-    oc annotate $lock syndesis.io/allocated-by="" --overwrite -n $pool_project > /dev/null
-}
-
-list_pool() {
-    local pool=$1
-    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
-        local status=$(project_lock_data "$lock" "$pool")
-        local project=$(echo $status | awk -F "~" '{print $1}')
-        local version=$(echo $status | awk -F "~" '{print $2}')
-        local allocator=$(echo $status | awk -F "~" '{print $3}')
-
-        echo -e "$project:\t${allocator:----}"
-    done
-}
-
-release_project() {
-    local pool=$1
-    local test_id=$2
-
-    oc project $pool
-    for lock in $(oc get secret -o name -n $pool | grep "project-lock-" ); do
-        local status=$(project_lock_data "$lock" "$pool")
-        local project=$(echo $status | awk -F "~" '{print $1}')
-        local version=$(echo $status | awk -F "~" '{print $2}')
-        local allocator=$(echo $status | awk -F "~" '{print $3}')
-
-        if [ -z "${test_id:-}" ] || [ "${test_id}" == "${allocator:-}" ]; then
-          echo "Releasing $lock"
-          release_project_lock $lock $pool
-        fi
-    done
-}
-
-# ======================================================
-# OpenShift helper functions
-
-kill_pods() {
-    for pod in $@; do
-        if [ "${POD_MODULES/$pod/}" != "${POD_MODULES}" ]; then
-            echo "Killing pods "$(oc get pod -o name | grep "syndesis-$pod")
-            oc get pod -o name | grep "syndesis-$pod" | xargs oc delete
-        fi
-    done
-}
-
-# ======================================================
-# Build functions
-
-extract_modules() {
-    local modules=""
-
-    if [ "$(hasflag --backend -b)" ]; then
-        modules="$modules connectors runtime rest verifier"
-    fi
-
-    if [ "$(hasflag --images)" ]; then
-        modules="$modules ui rest verifier s2i"
-    fi
-
-    local arg_modules=$(readopt --module -m);
-    if [ -n "${arg_modules}" ]; then
-        modules="$modules ${arg_modules//,/ }"
-    fi
-
-    if [ "$(hasflag --dependencies -d)" ]; then
-        local extra_modules=""
-        for module in $modules; do
-            for m in "${MODULES[@]}"; do
-              local k=${m%%:*}
-              if [ "$module" == $k ]; then
-                  local v=${m#*:}
-                  extra_modules="${extra_modules} $v"
-              fi
-            done
-        done
-        modules="$modules $extra_modules"
-    fi
-    if [ -z "$modules" ]; then
-      return
-    fi
-    # Unique modules
-    local unique_modules=$(echo $modules | xargs -n 1 | sort -u | xargs | awk '$1=$1')
-    echo $(order_modules "$unique_modules")
-}
-
-order_modules() {
-    # Fix order
-    local modules="$1"
-    # All modules in the proper order
-    local ret=$ALL_MODULES
-    for cm in "${MODULES[@]}"; do
-      local check_module=${cm%%:*}
-      # Check if $check_module is in the module list
-      if [ -n "${modules##*${check_module}*}" ]; then
-        # No, so remove it from the return value
-        ret=${ret//$check_module/}
-      fi
-    done
-
-    # Normalize return value
-    echo $ret | awk '$1=$1'
-}
-
-join_comma() {
-    local IFS=","
-    echo "$*"
-}
-
-get_maven_args() {
-    local project=${1:-}
-    local args=""
-
-    if [ -n "$(hasflag --flash -f)" ]; then
-        args="$args -Pflash"
-    fi
-
-    if [ -n "$(hasflag --skip-tests)" ]; then
-        args="$args -DskipTests"
-    fi
-
-    if [ -n "$(hasflag --skip-checks)" ]; then
-        args="$args -Pskip-checks"
-    fi
-
-    if [ -n "$(hasflag --batch-mode -b)" ]; then
-        args="$args --batch-mode"
-    fi
-
-    local image_mode="$(readopt --image-mode -i)"
-    if [ -z "${image_mode}" ]; then
-      if [ $(hasflag --docker) ]; then
-          image_mode="docker"
-      elif [ $(hasflag --openshift --s2i) ]; then
-          image_mode="openshift"
-      fi
-    fi
-    if [ "${image_mode}" != "none" ]; then
-        if [ -n "$(hasflag --images)" ] || [ -n "${image_mode}" ]; then
-            #Build images
-            args="$args -Pimage"
-            if [ -n "${image_mode}" ]; then
-                if [ "${image_mode}" == "openshift" ] || [ "${image_mode}" == "s2i" ]; then
-                    args="$args -Dfabric8.mode=openshift"
-                elif [ "${image_mode}" == "docker" ]; then
-                    args="$args -Dfabric8.mode=kubernetes"
-                elif [ "${image_mode}" != "auto" ]; then
-                    echo "ERROR: Invalid --image-mode ${image_mode}. Only 'none', 'openshift', 'docker' or 'auto' supported".
-                    exit 1
-                fi
-            fi
-        fi
-    fi
-
-    if [ -z "$project" ]; then
-        project="$(readopt --project -p)"
-    fi
-    if [ -n "${project}" ]; then
-        args="$args -Dfabric8.namespace=${project}"
-    fi
-
-    if [ -n "$(hasflag --clean -c)" ]; then
-        args="$args clean"
-    fi
-
-    local goals="$(readopt --goals)"
-    if [ -n "${goals}" ]; then
-        args="$args ${goals//,/ }"
-    else
-        args="$args install"
-    fi
-
-    echo $args
-}
-
-run_mvnw() {
-    local args=$1
-    local maven_modules=$(extract_modules)
-    check_error $maven_modules
-    cd $(appdir)
-    if [ -z "${maven_modules}" ]; then
-        echo "=============================================================================="
-        echo "./mvnw $args"
-        echo "=============================================================================="
-        ./mvnw $args
-        if [ $(hasflag --kill-pods --kill-pod -k) ]; then
-          kill_pods $POD_MODULES
-        fi
-    else
-      echo "Modules: $maven_modules"
-      if [ $(hasflag --init) ]; then
-        echo "=============================================================================="
-        echo "./mvnw -N install"
-        ./mvnw -N install
-      fi
-      for module in $maven_modules; do
-        echo "=============================================================================="
-        echo "./mvnw $args -f $module"
-        echo "=============================================================================="
-        ./mvnw -f $module $args
-        if [ $(hasflag --kill-pods --kill-pod -k) ]; then
-            kill_pods $module
-        fi
-      done
-    fi
-}
-
-run_build() {
-    run_mvnw "$(get_maven_args)"
-}
-
-run_system_test() {
-    local server=$(readopt --server)
-    local pool=$(readopt --pool)
-    if [ -z "${pool}" ]; then
-        pool="syndesis-ci"
-    fi
-    if [ -n "${server:-}" ]; then
-        local token=$(readopt --token)
-        if [ -z "${token:-}" ]; then
-            echo "--server provided for sytem tests but no --token for credentials"
+function run {
+    local first_arg=${1:-}
+    local cmd_dir="$(basedir)/commands"
+    local command
+    if [ -n "${first_arg}" ] && [ "${first_arg//^\-/}" == "${first_arg}" ]; then
+        command="$first_arg"
+        if [ ! -f "$cmd_dir/$command" ]; then
+            echo
+            echo ">>>> Unknown command '$command'"
+            echo
+            display_help
             exit 1
         fi
-        local log
-        log=$(oc login --server $server --token $token)
-        if [ $? -ne 0 ]; then
-           echo bla
-           echo $log
-           exit 1
-        fi
     fi
 
-    local lock_prefix=$(readopt --create-pool)
-    if [ -n "${lock_prefix}" ]; then
-        create_pool $lock_prefix
-    elif [ -n "$(hasflag --list-pool)" ]; then
-        list_pool "$pool"
-    elif [ -n "$(hasflag --release-project)" ]; then
-        release_project "$pool" "$(readopt --test-id)"
-    else
-       run_test_build $pool
-    fi
-}
-
-run_test_build() {
-    local pool=$1
-    # Test project given directly
-    local project=$(readopt --project)
-    if [ -z "$project" ]; then
-        project=$(get_free_pool_project)
-        check_error $project
-        local test_id=$(calc_test_id)
-        trap "release_project "$pool" "$test_id"" EXIT
+    # Check for the mode (backwards compatibility)
+    mode=$(readopt --mode)
+    if [ -n "${mode}" ]; then
+      command="${mode}"
     fi
 
-    oc project $project
-    local maven_args=$(get_maven_args $project)
-    check_error $maven_args
-    maven_args="-Psystem-tests -Pimages -Dfabric8.mode=openshift $maven_args"
-    run_mvnw "$maven_args"
-}
 
-run_minishift() {
-    if [ $(hasflag --full-reset) ] || [ $(hasflag --reset) ]; then
-        # Only warning if minishift is not installed
-        minishift delete --clear-cache --force
-        if [ $(hasflag --full-reset) ] && [ -d ~/.minishift ]; then
-            rm -rf ~/.minishift
-        fi
-        local memory=$(readopt --memory)
-        local cpus=$(readopt --cpus)
-        local disksize=$(readopt --disk-size)
-        minishift start --show-libmachine-logs=true --memory ${memory:-4912} --cpus ${cpus:-2} --disk-size ${disksize:-20GB}
-    fi
-
-    local project=$(readopt --project -p)
-    if [ -n "${project}" ]; then
-        # Delete project if existing
-        if oc get project "${project}" >/dev/null 2>&1 ; then
-            echo "Deleting project ${project}"
-            oc delete project "${project}"
-        fi
-        echo "Creating project ${project}"
-        for i in {1..10}; do
-            if oc new-project "${project}" >/dev/null 2>&1 ; then
-              break
+    if [ -z "${command}" ]; then
+        # Try to detect command
+        for cand in "$(ls $cmd_dir)"; do
+            if [ -f "$cmd_dir/$cand" ] && [ $(hasflag --$cand) ]; then
+                command=$cand
+                break
             fi
-            echo "Project still exist. Waiting 10s ..."
-            sleep 10
         done
-        oc project "${project}"
     fi
 
-    local image_mode=$(readopt --image-mode -i)
-    local template="syndesis-restricted"
-    if [ "$image_mode" == "openshift" ]; then
-        template="syndesis-restricted"
-    elif [ "$image_mode" == "docker" ]; then
-        template="syndesis-dev-restricted"
+    if [ x"$command" == xhelp ] || [ $(hasflag --help -h) ]; then
+        display_help $command
+        exit 0
     fi
-    if [ $(hasflag --install) ]; then
-        basedir=$(appdir)
-        check_error "$basedir"
-        oc create -f ${basedir}/deploy/support/serviceaccount-as-oauthclient-restricted.yml
-        oc create -f ${basedir}/deploy/${template}.yml
-        oc new-app ${template} \
-          -p ROUTE_HOSTNAME=syndesis.$(minishift ip).nip.io \
-          -p OPENSHIFT_MASTER=$(oc whoami --show-server) \
-          -p OPENSHIFT_PROJECT=$(oc project -q) \
-          -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client)
+
+    if [ -z "${command}" ]; then
+        command="build"
     fi
-    if [ $(hasflag --watch) ]; then
-        exec watch oc get pods
+
+    # Git rebase if requested
+    if [ $(hasflag --rebase -r) ]; then
+        git_rebase_upstream
     fi
+
+    source "$cmd_dir/$command"
+    eval "${command}::run"
 }
 
-dev_tasks() {
-    if [ $(hasflag --debug) ]; then
-        local name=$(readopt --debug)
-        if [ -z "${name}" ]; then
-            name="rest"
-        fi
-
-        local pod=$(oc get -o name pod -l component=syndesis-${name})
-        oc port-forward ${pod//*\//} 5005:5005
-    fi
-}
-
-# ============================================================================
-# Main loop
-
-if [ -n "$(hasflag --help -h)" ]; then
-    display_help
-    exit 0
-fi
-
-if [ -n "$(hasflag --rebase -r)" ]; then
-    git_rebase_upstream
-fi
-
-# RUn minishift tasks
-if [ -n "$(hasflag --minishift)" ]; then
-    run_minishift
-    exit 0
-fi
-
-# Run system tests
-if [ -n "$(hasflag --system-test)" ]; then
-    run_system_test
-    exit 0
-fi
-
-# Developer helper tasks
-if [ -n "$(hasflag --dev)" ]; then
-    dev_tasks
-    exit 0
-fi
-
-# Check for the mode to use
-mode=$(readopt --mode)
-if [ -z "${mode}" ]; then
-    mode="build"
-fi
-
-case $mode in
-    "build")
-        run_build
-        exit 0
-        ;;
-    "system-test")
-        run_system_test
-        exit 0
-        ;;
-    "minishift")
-        run_minishift
-        exit 0
-        ;;
-    "dev")
-        dev_tasks
-        exit 0
-        ;;
-    **)
-        echo "Invalid mode '$mode'. Known modes: build, system-test"
-        exit 1
-esac
+run $@


### PR DESCRIPTION
Each command is now moved into an own scripts from `commands/`.
Also support for `syndesis <command>` has been added, but old syntax
still works.

Re-organized help message to be be more context sensitive and hence
shorter normally:

syndesis -h ---> global usage
syndesis build -h --> only build relevant options