### PR TITLE
chore(rest): adds `uses` counter to Connector

### DIFF
--- a/app/rest/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
+++ b/app/rest/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
@@ -142,7 +142,7 @@ public class DataManager implements DataAccessObjectRegistry {
     }
 
     @SuppressWarnings("unchecked")
-    public final <T extends WithId<T>> ListResult<T> fetchAll(Class<T> model) {
+    public <T extends WithId<T>> ListResult<T> fetchAll(Class<T> model) {
         return fetchAll(model, noOperators());
     }
 

--- a/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -18,6 +18,7 @@ package io.syndesis.model.connection;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
@@ -52,6 +53,8 @@ public interface Connector extends WithId<Connector>, WithActions<ConnectorActio
 
     @Override
     Map<String, String> getConfiguredProperties();
+
+    OptionalInt getUses();
 
     default Builder builder() {
         return new Builder().createFrom(this);

--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveFilterer.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/ReflectiveFilterer.java
@@ -21,7 +21,6 @@ import io.syndesis.rest.v1.util.PredicateFilter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/CustomConnectorHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/CustomConnectorHandler.java
@@ -15,17 +15,6 @@
  */
 package io.syndesis.rest.v1.handler.connection;
 
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -45,6 +34,17 @@ import io.syndesis.rest.v1.operations.SortOptionsFromQueryParams;
 import io.syndesis.rest.v1.util.PredicateFilter;
 
 import org.springframework.context.ApplicationContext;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
 @Api(tags = {"custom-connector", "connector-template"})
 public final class CustomConnectorHandler extends BaseConnectorGeneratorHandler {

--- a/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
@@ -22,27 +22,32 @@ import io.syndesis.inspector.Inspectors;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.rest.v1.state.ClientSideState;
 import io.syndesis.verifier.Verifier;
+
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Okio;
+
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
+
+import java.awt.Dimension;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import java.awt.*;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Iterator;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,19 +64,18 @@ public class ConnectorHandlerTest {
 
     private static final Verifier NO_VERIFIER = null;
 
-    private final DataManager dataManager = mock(DataManager.class);
-
     private final ApplicationContext applicationContext = mock(ApplicationContext.class);
+
+    private final DataManager dataManager = mock(DataManager.class);
 
     private final ConnectorHandler handler = new ConnectorHandler(dataManager, NO_VERIFIER, NO_CREDENTIALS, NO_INSPECTORS, NO_STATE,
         NO_ENCRYPTION_COMPONENT, applicationContext);
 
     @Test
     public void connectorIconShouldHaveCorrectContentType() throws IOException {
-        try (MockWebServer mockWebServer = new MockWebServer()) {
+        try (MockWebServer mockWebServer = new MockWebServer(); final Buffer resultBuffer = new Buffer()) {
             mockWebServer.start();
 
-            final Buffer resultBuffer = new Buffer();
             resultBuffer.writeAll(Okio.source(getClass().getResourceAsStream("test-image.png")));
 
             mockWebServer.enqueue(new MockResponse().setHeader(CONTENT_TYPE, "image/png").setBody(resultBuffer));

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -15,8 +15,6 @@
  */
 package io.syndesis.runtime.connector;
 
-import java.util.List;
-
 import io.syndesis.connector.generator.ActionsSummary;
 import io.syndesis.connector.generator.ConnectorGenerator;
 import io.syndesis.connector.generator.ConnectorSummary;


### PR DESCRIPTION
This adds a uses counter to Connector that counts the number of integrations that make use of a particular connector.

This in turn means that endpoints for getting and listing connectors need to load all integrations

Fixes #666