### PR TITLE
fix(rest): allow printable characters in filter value

### DIFF
--- a/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/util/FilterOptionsParser.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 
 public class FilterOptionsParser {
 
-    private static final Pattern VALID_QUERY_PATTERN = Pattern.compile("(?<property>\\w+)(?:(?<operation>(?:\\s*=\\s*))(?<value>\\w+))?");
+    private static final Pattern VALID_QUERY_PATTERN = Pattern.compile("(?<property>\\w+)(?:(?<operation>(?:\\s*=\\s*))(?<value>\\p{Print}+))?");
 
     private FilterOptionsParser() {
     }
@@ -57,7 +57,7 @@ public class FilterOptionsParser {
 
         private final Optional<String> value;
 
-        private Filter(String property, String operation, String value) {
+        /* default */ Filter(String property, String operation, String value) {
             this.property = property;
             this.operation = Optional.ofNullable(operation);
             this.value = Optional.ofNullable(value);

--- a/app/rest/rest/src/test/java/io/syndesis/rest/util/FilterOptionsParserTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/util/FilterOptionsParserTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FilterOptionsParserTest {
+
+    @Test
+    public void shouldParseFilterOptionsWithDash() {
+        final FilterOptionsParser.Filter expected = new FilterOptionsParser.Filter("connectorGroupId", "=", "swagger-connector-template");
+
+        assertThat(FilterOptionsParser.fromString("connectorGroupId=swagger-connector-template")).usingFieldByFieldElementComparator()
+            .containsOnly(expected);
+    }
+
+}


### PR DESCRIPTION
Changes the regular expression that determines if a given `query`
parameter for list filtering is a valid filter expression to include
printable values.

Fixes #724