### PR TITLE
refactor(rest): set uses to 0 if not used

### DIFF
--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -206,14 +206,10 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
             .collect(Collectors.groupingBy(String::toString, Collectors.counting()));
 
         return connectors.stream().map(c -> {
-            final Long uses = connectorUsage.get(c.getId().get());
-            if (uses != null) {
-                return new Connector.Builder()//
-                    .createFrom(c)//
-                    .uses(uses.intValue()).build();
-            }
-
-            return c;
+            final int uses = connectorUsage.getOrDefault(c.getId().get(), 0L).intValue();
+            return (Connector) new Connector.Builder()//
+                .createFrom(c)//
+                .uses(uses).build();
         }).collect(Collectors.toList());
     }
 }

--- a/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/connection/ConnectorHandlerTest.java
@@ -141,7 +141,7 @@ public class ConnectorHandlerTest {
 
         final List<Connector> augmented = handler.augmentedWithUsage(Arrays.asList(connector1, connector2, connector3));
 
-        assertThat(augmented).contains(usedConnector(connector1, 1), usedConnector(connector2, 2), connector3);
+        assertThat(augmented).contains(usedConnector(connector1, 1), usedConnector(connector2, 2), usedConnector(connector3, 0));
     }
 
     private static ConnectorAction newActionBy(final Connector connector) {


### PR DESCRIPTION
With #666 the `uses` property would not be set on a Connector if the
Connector was not used by any Integration. This changes that to set it
to `0` if it's unused to make it simpler for the UI to use the property.