### PR TITLE
refactor(tools): sprinkle `eval $(minishift oc-env)`

### DIFF
--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -170,6 +170,7 @@ order_modules() {
 }
 
 kill_pods() {
+    eval $(minishift oc-env)
     for pod in $@; do
         if [ "${POD_MODULES/$pod/}" != "${POD_MODULES}" ]; then
             echo "Killing pods "$(oc get pod -o name | grep "syndesis-$pod")

--- a/tools/bin/commands/dev
+++ b/tools/bin/commands/dev
@@ -17,6 +17,7 @@ dev::run() {
             name="rest"
         fi
 
+        eval $(minishift oc-env)
         local pod=$(oc get -o name pod -l component=syndesis-${name})
         oc port-forward ${pod//*\//} 5005:5005
     fi

--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -50,6 +50,8 @@ minishift::run() {
         minishift start ${show_logs_arg:- }--memory ${memory:-4912} --cpus ${cpus:-2} --disk-size ${disksize:-20GB} --openshift-version ${openshift_version:-v3.6.0}
     fi
 
+    eval $(minishift oc-env)
+
     local project=$(readopt --project -p)
     if [ -n "${project}" ]; then
         # Delete project if existing


### PR DESCRIPTION
Adds `eval $(minishift oc-env)` to few scripts that are used in
development so we can have the `oc` binary at the same version as the
OpenShift running on minishfit. Another plus is that we don't need to
install `oc` binary separately to startup minishift via `syndesis
minishift --install`