### PR TITLE
chore(rest): add REST Swagger connector to syndesis-build-helper

### DIFF
--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -211,6 +211,12 @@
             <artifactId>aws-s3-polling-bucket-connector</artifactId>
             <version>${syndesis-connectors.version}</version>
           </dependency>
+          <!-- ==== REST Swagger ==== -->
+          <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>rest-swagger-connector</artifactId>
+            <version>${syndesis-connectors.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
 


### PR DESCRIPTION
This adds the REST Swagger connector as a dependency of the syndesis-build-helper Maven plugin when invoked in runtime module to generate the `/META-INF/camel/camel-meta.json` that includes it.