### PR TITLE
fix(rest): use getter syntax for connector symmary

### DIFF
--- a/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -70,12 +70,12 @@ public interface Connector extends WithId<Connector>, WithActions<ConnectorActio
     @Override
     Map<String, ConfigurationProperty> getProperties();
 
+    Optional<ConnectorSummary> getSummary();
+
     OptionalInt getUses();
 
     default Optional<String> propertyTaggedWith(final String tag) {
         return propertyTaggedWith(getConfiguredProperties(), tag);
     }
-
-    Optional<ConnectorSummary> summary();
 
 }

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
@@ -15,22 +15,12 @@
  */
 package io.syndesis.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.awt.*;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Iterator;
-import java.util.Properties;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
 import io.syndesis.dao.icon.IconDataAccessObject;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.BufferedSource;
-import okio.Okio;
+import io.syndesis.model.ListResult;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.verifier.AlwaysOkVerifier;
+import io.syndesis.verifier.Verifier;
+
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,17 +31,22 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-
-import io.syndesis.model.ListResult;
-import io.syndesis.model.connection.Connector;
-import io.syndesis.verifier.AlwaysOkVerifier;
-import io.syndesis.verifier.Verifier;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import java.awt.Dimension;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Properties;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConnectorsITCase extends BaseITCase {
 

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -145,11 +145,11 @@ public class CustomConnectorITCase extends BaseITCase {
     public void shouldProvideSummaryForCustomConnectors() {
         final ResponseEntity<Connector> responseForCustomConnector = get("/api/v1/connectors/connector-from-template-1", Connector.class);
 
-        assertThat(responseForCustomConnector.getBody().summary()).isPresent();
+        assertThat(responseForCustomConnector.getBody().getSummary()).isPresent();
 
         final ResponseEntity<Connector> responseForNonCustomConnector = get("/api/v1/connectors/non-custom-connector", Connector.class);
 
-        assertThat(responseForNonCustomConnector.getBody().summary()).isNotPresent();
+        assertThat(responseForNonCustomConnector.getBody().getSummary()).isNotPresent();
     }
 
     private static ConnectorTemplate createConnectorTemplate(final String id, final String name) {


### PR DESCRIPTION
The Connector::summary method needs to be called getSummary in order to be serialized by Jackson to JSON.