### PR TITLE
fix(connectors): removes refactored salesforce-model dependency

### DIFF
--- a/app/connectors/connectors/salesforce/salesforce-delete-sobject-connector/pom.xml
+++ b/app/connectors/connectors/salesforce/salesforce-delete-sobject-connector/pom.xml
@@ -76,12 +76,6 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>salesforce-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/app/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/pom.xml
+++ b/app/connectors/connectors/salesforce/salesforce-delete-sobject-with-id-connector/pom.xml
@@ -75,12 +75,6 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>salesforce-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/app/connectors/connectors/salesforce/salesforce-get-sobject-connector/pom.xml
+++ b/app/connectors/connectors/salesforce/salesforce-get-sobject-connector/pom.xml
@@ -76,12 +76,6 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>salesforce-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/app/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/pom.xml
+++ b/app/connectors/connectors/salesforce/salesforce-get-sobject-with-id-connector/pom.xml
@@ -76,12 +76,6 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>salesforce-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
In the Salesforce connector refactor (#817) renamed dependency `salesforce-model` (replaced by `salesforce-common`) was left behind in some of the connector POMs. This removes those.