### PR TITLE
feat: New API HTTP Client for UI with composable REST interface

### DIFF
--- a/app/ui/src/app/app.module.ts
+++ b/app/ui/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { TourNgxBootstrapModule } from 'ngx-tour-ngx-bootstrap';
 import { NotificationModule } from 'patternfly-ng';
 import { DataMapperModule } from '@atlasmap/atlasmap.data.mapper';
 
+import { CoreModule } from './core';
 import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app.routing';
@@ -82,6 +83,7 @@ export function mapperRestangularProvider(
     FormsModule,
     ReactiveFormsModule,
     HttpModule,
+    CoreModule.forRoot(),
     DynamicFormsCoreModule.forRoot(),
     RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
     TabsModule.forRoot(),

--- a/app/ui/src/app/core/core.module.ts
+++ b/app/ui/src/app/core/core.module.ts
@@ -20,10 +20,10 @@ export class CoreModule {
       ngModule: CoreModule,
       providers: [
         SYNDESIS_PROVIDERS.ApiHttpProviderService,
-
-        { provide: ApiHttpService, useClass: SYNDESIS_PROVIDERS.ApiHttpProviderService },
-
-        { provide: Window, useValue: window }
+        {
+          provide: ApiHttpService,
+          useClass: SYNDESIS_PROVIDERS.ApiHttpProviderService
+        },
       ]},
     ];
   }

--- a/app/ui/src/app/core/core.module.ts
+++ b/app/ui/src/app/core/core.module.ts
@@ -1,0 +1,30 @@
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+
+import { ApiHttpService } from '@syndesis/ui/platform';
+import * as SYNDESIS_PROVIDERS from './providers';
+
+@NgModule({
+  imports: [CommonModule, HttpClientModule],
+})
+export class CoreModule {
+  constructor(@Optional() @SkipSelf() parentModule: CoreModule) {
+    if (parentModule) {
+      throw new Error('Syndesis CoreModule is already loaded. Import it in the AppModule only');
+    }
+  }
+
+  static forRoot(): Array<ModuleWithProviders> {
+    return [{
+      ngModule: CoreModule,
+      providers: [
+        SYNDESIS_PROVIDERS.ApiHttpProviderService,
+
+        { provide: ApiHttpService, useClass: SYNDESIS_PROVIDERS.ApiHttpProviderService },
+
+        { provide: Window, useValue: window }
+      ]},
+    ];
+  }
+}

--- a/app/ui/src/app/core/index.ts
+++ b/app/ui/src/app/core/index.ts
@@ -1,0 +1,1 @@
+export * from './core.module';

--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -1,12 +1,15 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpRequest, HttpEventType } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 
-import { ApiHttpService, ApiEndpoint, StringMap } from '@syndesis/ui/platform';
+import { ApiHttpService, ApiEndpoint, ApiRequestProgress, StringMap } from '@syndesis/ui/platform';
 import { ConfigService } from '@syndesis/ui/config.service';
+import { HttpProgressEvent, HttpResponse } from '@angular/common/http/src/response';
 
 @Injectable()
 export class ApiHttpProviderService extends ApiHttpService {
+  private uploadProgressSubject = new Subject<ApiRequestProgress>();
   private apiBaseHost: string;
   private apiChildEndpoints: StringMap<string>;
 
@@ -68,6 +71,59 @@ export class ApiHttpProviderService extends ApiHttpService {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
     return this.httpClient.delete<T>(url);
+  }
+
+  get uploadProgressEvent$(): Observable<ApiRequestProgress> {
+    return this.uploadProgressSubject.asObservable();
+  }
+
+  upload<T>(endpoint: string | any[], fileList?: FileList, body?: StringMap<any>): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = new HttpHeaders().set('Content-Type', 'multipart/form-data');
+
+    const formData = new FormData();
+    for (let i = 0; i < fileList.length; i++) {
+      formData.append(fileList.item(i).name, fileList.item(i));
+    }
+
+    if (body) {
+      for (const key in body) {
+        if (body.hasOwnProperty(key)) {
+          formData.append(key, body[key]);
+        }
+      }
+    }
+
+    const request = new HttpRequest('POST', url, formData, { headers, reportProgress: true });
+
+    return this.httpClient.request(request)
+      .do(requestEvent => {
+        if (requestEvent.type === HttpEventType.UploadProgress) {
+          this.emitProgressEvent(requestEvent);
+        }
+        return requestEvent;
+      })
+      .filter(requestEvent => requestEvent.type === HttpEventType.Response)
+      .map(requestEvent => requestEvent as HttpResponse<T>)
+      .map(requestEvent => requestEvent.body);
+  }
+
+  private emitProgressEvent(httpProgressEvent?: HttpProgressEvent): void {
+    let progress: ApiRequestProgress;
+
+    if (httpProgressEvent) {
+      progress = {
+        percentage: Math.round(100 * httpProgressEvent.loaded / httpProgressEvent.total),
+        bytesLoaded: httpProgressEvent.loaded,
+        bytesTotal: httpProgressEvent.total,
+        isComplete: httpProgressEvent.loaded == httpProgressEvent.total
+      };
+    } else {
+      progress = { isComplete: false, percentage: 0 };
+    }
+
+    this.uploadProgressSubject.next(progress);
   }
 
   private deconstructEndpointParams(endpoint: string | any[]): { endpointKey: string; endpointParams: any[]; } {

--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -41,7 +41,7 @@ export class ApiHttpProviderService extends ApiHttpService {
       url,
       get: <T>() => this.get<T>(url),
       post: <T>(body: any) => this.post<T>([endpointKey, ...endpointParams], body),
-      put: <T>(body: any) => this.post<T>([endpointKey, ...endpointParams], body),
+      put: <T>(body: any) => this.put<T>([endpointKey, ...endpointParams], body),
       delete: <T>() => this.delete<T>(url)
     };
   }

--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpRequest, HttpEventType } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpRequest, HttpEventType, HttpProgressEvent, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { ApiHttpService, ApiEndpoint, ApiRequestProgress, StringMap } from '@syndesis/ui/platform';
 import { ConfigService } from '@syndesis/ui/config.service';
-import { HttpProgressEvent, HttpResponse } from '@angular/common/http/src/response';
 
 @Injectable()
 export class ApiHttpProviderService extends ApiHttpService {

--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+
+import { ApiHttpService, ApiEndpoint, StringMap } from '@syndesis/ui/platform';
+import { ConfigService } from '@syndesis/ui/config.service';
+
+@Injectable()
+export class ApiHttpProviderService extends ApiHttpService {
+  private apiBaseHost: string;
+  private apiChildEndpoints: StringMap<string>;
+
+  constructor(private httpClient: HttpClient, private configService: ConfigService) {
+    super();
+
+    const { apiBase, apiEndpoint, apiChildEndpoints } = this.configService.getSettings();
+    this.apiBaseHost = `${apiBase}${apiEndpoint}`;
+    this.apiChildEndpoints = apiChildEndpoints;
+  }
+
+  getEndpointUrl(endpointKey: string, ...endpointParams: any[]): string {
+    let url = this.apiChildEndpoints[endpointKey] || endpointKey;
+
+    if (endpointParams && endpointParams.length == 1 && endpointParams[0] === Object(endpointParams[0])) {
+      url = this.replaceNameMatches(url, endpointParams[0]);
+    } else if (endpointParams && endpointParams.length >= 1) {
+      url = this.replaceIndexMatches(url, endpointParams);
+    }
+
+    if (!url.startsWith('http')) {
+      url = `${this.apiBaseHost}${url}`;
+    }
+
+    return url;
+  }
+
+  setEndpointUrl(endpointKey: string, ...endpointParams: any[]): ApiEndpoint {
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+
+    return {
+      url,
+      get: <T>() => this.get<T>(url),
+      post: <T>(body: any) => this.post<T>([endpointKey, ...endpointParams], body),
+      put: <T>(body: any) => this.post<T>([endpointKey, ...endpointParams], body),
+      delete: <T>() => this.delete<T>(url)
+    };
+  }
+
+  get<T>(endpoint: string | any[]): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    return this.httpClient.get<T>(url);
+  }
+
+  post<T>(endpoint: string | any[], body?: any): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    return this.httpClient.post<T>(url, body);
+  }
+
+  put<T>(endpoint: string | any[], body: any): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    return this.httpClient.put<T>(url, body);
+  }
+
+  delete<T>(endpoint: string | any[]): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    return this.httpClient.delete<T>(url);
+  }
+
+  private deconstructEndpointParams(endpoint: string | any[]): { endpointKey: string; endpointParams: any[]; } {
+    let endpointKey, endpointParams = [];
+    if (Array.isArray(endpoint) && endpoint.length >= 1) {
+      endpointKey = endpoint[0];
+      endpointParams = endpoint.slice(1);
+    } else {
+      endpointKey = endpoint;
+    }
+
+    return { endpointKey, endpointParams };
+  }
+
+  private replaceNameMatches(endpointTemplate: string, paramsMap: StringMap<any>): string {
+    return endpointTemplate.replace(/\{(\D*?)\}/g, (fullMatch, ...matchGroups) => {
+      return paramsMap[matchGroups[0].trim()];
+    });
+  }
+
+  private replaceIndexMatches(endpointTemplate: string, ...params: any[]): string {
+    if (Array.isArray(params) && params.length > 0) {
+      return endpointTemplate.replace(/\{(\d*?)\}/g, (fullMatch, ...matchGroups) => {
+        const index = parseInt(matchGroups[0], 10);
+        return params[index];
+      });
+    } else if (params && params.toString() !== '') {
+      return endpointTemplate.replace(/\{(\d*?)\}/g, params.toString());
+    }
+
+    return endpointTemplate;
+  }
+}

--- a/app/ui/src/app/core/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/core/providers/api-http-provider.service.ts
@@ -45,7 +45,10 @@ export class ApiHttpProviderService extends ApiHttpService {
       get: <T>() => this.get<T>(url),
       post: <T>(body: any) => this.post<T>([endpointKey, ...endpointParams], body),
       put: <T>(body: any) => this.put<T>([endpointKey, ...endpointParams], body),
-      delete: <T>() => this.delete<T>(url)
+      delete: <T>() => this.delete<T>(url),
+      upload: <T>(fileList?: FileList, body?: StringMap<any>) => {
+        return this.upload<T>([endpointKey, ...endpointParams], fileList, body);
+      }
     };
   }
 

--- a/app/ui/src/app/core/providers/index.ts
+++ b/app/ui/src/app/core/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './api-http-provider.service';

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
+import { StringMap } from './../platform.models';
 import { ApiResponse, ApiEndpoint, ApiRequestProgress } from './api.models';
 
 @Injectable()
 export abstract class ApiHttpService {
-  //TODO: abstract progressEvent$: Observable<ApiRequestProgress>;
+  abstract uploadProgressEvent$: Observable<ApiRequestProgress>;
 
   abstract getEndpointUrl(endpointKey: string, ...endpointParams: any[]): string;
 
@@ -19,5 +20,5 @@ export abstract class ApiHttpService {
 
   abstract delete<T>(endpoint: string | any[]): Observable<T>;
 
-  //TODO: abstract upload<T>(endpoint: string | any[], body?: any): Observable<T>;
+  abstract upload<T>(endpoint: string | any[], fileList?: FileList, body?: StringMap<any>): Observable<T>;
 }

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { ApiResponse, ApiEndpoint, ApiRequestProgress } from './api.models';
+
+@Injectable()
+export abstract class ApiHttpService {
+  //TODO: abstract progressEvent$: Observable<ApiRequestProgress>;
+
+  abstract getEndpointUrl(endpointKey: string, ...endpointParams: any[]): string;
+
+  abstract setEndpointUrl(endpointKey: string, ...endpointParams: any[]): ApiEndpoint;
+
+  abstract get<T>(endpoint: string | any[]): Observable<T>;
+
+  abstract post<T>(endpoint: string | any[], body: any): Observable<T>;
+
+  abstract put<T>(endpoint: string | any[], body: any): Observable<T>;
+
+  abstract delete<T>(endpoint: string | any[]): Observable<T>;
+
+  //TODO: abstract upload<T>(endpoint: string | any[], body?: any): Observable<T>;
+}

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-import { StringMap } from './../platform.models';
+import { StringMap } from '@syndesis/ui/platform';
 import { ApiResponse, ApiEndpoint, ApiRequestProgress } from './api.models';
 
 @Injectable()

--- a/app/ui/src/app/platform/types/api/api.models.ts
+++ b/app/ui/src/app/platform/types/api/api.models.ts
@@ -1,5 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 
+import { StringMap } from '@syndesis/ui/platform';
+
 export interface ApiErrorMessage {
   userMessage: string;
   developerMessage: string;
@@ -24,7 +26,7 @@ export interface ApiEndpoint {
   post<T>(payload: any): Observable<T>;
   put<T>(payload: any): Observable<T>;
   delete<T>(payload?: any): Observable<T>;
-  //TODO upload<T>(file?: File, payload?: any): Observable<T>;
+  upload<T>(fileList?: FileList, body?: StringMap<any>): Observable<T>;
 }
 
 export interface ApiRequestProgress {

--- a/app/ui/src/app/platform/types/api/api.models.ts
+++ b/app/ui/src/app/platform/types/api/api.models.ts
@@ -1,0 +1,35 @@
+import { Observable } from 'rxjs/Observable';
+
+export interface ApiErrorMessage {
+  userMessage: string;
+  developerMessage: string;
+}
+
+export interface ApiErrors {
+  errors?: {
+    status: number;
+    statusText: string;
+    messages: Array<ApiErrorMessage>;
+  };
+}
+
+export interface ApiResponse extends ApiErrors {
+  readonly id?: string;
+  kind?: string;
+}
+
+export interface ApiEndpoint {
+  url: string;
+  get<T>(): Observable<T>;
+  post<T>(payload: any): Observable<T>;
+  put<T>(payload: any): Observable<T>;
+  delete<T>(payload?: any): Observable<T>;
+  //TODO upload<T>(file?: File, payload?: any): Observable<T>;
+}
+
+export interface ApiRequestProgress {
+  percentage: number;
+  bytesLoaded: number;
+  bytesPending: number;
+  isComplete: boolean;
+}

--- a/app/ui/src/app/platform/types/api/api.models.ts
+++ b/app/ui/src/app/platform/types/api/api.models.ts
@@ -29,7 +29,7 @@ export interface ApiEndpoint {
 
 export interface ApiRequestProgress {
   percentage: number;
-  bytesLoaded: number;
-  bytesPending: number;
   isComplete: boolean;
+  bytesLoaded?: number;
+  bytesTotal?: number;
 }

--- a/app/ui/src/app/platform/types/api/index.ts
+++ b/app/ui/src/app/platform/types/api/index.ts
@@ -1,0 +1,2 @@
+export * from './api-http.service';
+export * from './api.models';

--- a/app/ui/src/app/platform/types/index.ts
+++ b/app/ui/src/app/platform/types/index.ts
@@ -1,3 +1,4 @@
+export * from './api';
 export * from './metadata';
 export * from './platform.models';
 export * from './platform.reducer';

--- a/app/ui/src/config.json.minishift
+++ b/app/ui/src/config.json.minishift
@@ -2,6 +2,10 @@
   "commment":"This config should for testing against a minishift using the syndesis-dev application templates.",
   "apiBase": "https://syndesis.192.168.64.2.xip.io",
   "apiEndpoint": "/api/v1",
+  "apiChildEndpoints": {
+    "submitCustomConnectorInfo": "/connectors/custom/info",
+    "submitCustomConnector": "/connectors/custom"
+  },
   "mapperEndpoint": "/mapper/v1",
   "branding": {
     "logoWhiteBg": "assets/images/syndesis-logo-svg-white.svg",

--- a/app/ui/src/config.json.staging
+++ b/app/ui/src/config.json.staging
@@ -2,6 +2,10 @@
   "commment":"This config should for testing against a minishift using the syndesis-dev application templates.",
   "apiBase": "https://syndesis-staging.b6ff.rh-idev.openshiftapps.com",
   "apiEndpoint": "/api/v1",
+  "apiChildEndpoints": {
+    "submitCustomConnectorInfo": "/connectors/custom/info",
+    "submitCustomConnector": "/connectors/custom"
+  },
   "mapperEndpoint": "/mapper/v1",
   "branding": {
     "logoWhiteBg": "assets/images/syndesis-logo-svg-white.svg",


### PR DESCRIPTION
Fixes #834 

Please refer to the linked issue for a comprehensive explanation on the rationale for this new class. This new internal service is designed for sending Http calls straight to our REST API through a more intuitive and flexible interface, allowing for replacing Restangular in the Api Connectors implementation or even on any other feature module in the future.

Please pay special attention to the new config nodes created at the config files. Ideally, we should go porting all URLs hardcoded in services and components to a centralized location and those files seem the right place until we come up with a more approppiate solution.

This PR welcomes `CoreModule` into our project, which is the module of choice for service providers, according to the official Angular recommendations for avoiding duplicated dependency instances in our injector.

[EDIT]; The Http service now implements multipart upload functionalities and upload progress events.