### PR TITLE
fix: Disable API connector delete button if API connector is in use by any integrations

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-list.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-list.component.html
@@ -50,7 +50,7 @@
           <ng-template #actionTemplate
                        let-item="item"
                        let-index="index">
-            <button type="button" class="btn btn-default">Delete</button>
+            <button type="button" [disabled]="item.uses > 0" class="btn btn-default">Delete</button>
           </ng-template>
         </pfng-list>
 


### PR DESCRIPTION
Fixes #847