### PR TITLE
fix(openshift): turn off incremental build

### DIFF
--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -243,7 +243,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
               .withType("Source")
               .withNewSourceStrategy()
                 .withNewFrom().withKind("ImageStreamTag").withName(builderStreamTag).withNamespace(imageStreamNamespace).endFrom()
-                .withIncremental(true)
+                .withIncremental(false)
                 // TODO: This environment setup needs to be externalized into application.properties
                 // https://github.com/syndesisio/syndesis-rest/issues/682
                 .withEnv(new EnvVar("MAVEN_OPTS", config.getMavenOptions(), null))


### PR DESCRIPTION
Seems that turning of incremental build helps with having a working
integration pod build the second time it's invoked. Lets start with this
and see if we can optimize it better in the future.

Fixes #761