### PR TITLE
Add json ignore properties for unmarshalling to work

### DIFF
--- a/app/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
@@ -18,6 +18,7 @@ package io.syndesis.model.action;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.integration.support.Strings;
 import io.syndesis.model.Dependency;
@@ -28,6 +29,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorAction.Builder.class)
 @SuppressWarnings("immutables")
+@JsonIgnoreProperties(value = {"dependencies"}, allowGetters = true)
 public interface ConnectorAction extends Action<ConnectorDescriptor>, WithId<ConnectorAction>, WithDependencies {
 
     @Override

--- a/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithDependencies;
@@ -32,6 +33,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = Connector.Builder.class)
 @SuppressWarnings("immutables")
+@JsonIgnoreProperties(value = {"dependencies"}, allowGetters = true)
 public interface Connector extends WithId<Connector>, WithActions<ConnectorAction>, WithName, WithProperties, WithDependencies, Serializable {
 
     class Builder extends ImmutableConnector.Builder implements WithPropertiesBuilder<Builder> {

--- a/app/rest/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
@@ -38,6 +39,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = Extension.Builder.class)
 @NoDuplicateExtension(groups = NonBlockingValidations.class)
 @JsonPropertyOrder({ "name", "description", "icon", "extensionId", "version", "tags", "actions", "dependencies"})
+@JsonIgnoreProperties(value = {"dependencies"}, allowGetters = true)
 @SuppressWarnings("immutables")
 public interface Extension extends WithId<Extension>, WithActions<ExtensionAction>, WithName, WithTags, WithConfigurationProperties, WithDependencies, Serializable {
 

--- a/app/rest/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.syndesis.model.Kind;
@@ -44,6 +45,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
+@JsonIgnoreProperties(value = {"usedConnectorIds", "isInactive"}, allowGetters = true)
 @UniqueProperty(value = "name", groups = UniquenessRequired.class)
 @SuppressWarnings("immutables")
 public interface Integration extends WithId<Integration>, WithTags, WithName, Serializable {

--- a/app/rest/model/src/main/java/io/syndesis/model/integration/Step.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/integration/Step.java
@@ -18,6 +18,7 @@ package io.syndesis.model.integration;
 import java.io.Serializable;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithConfiguredProperties;
@@ -28,6 +29,7 @@ import io.syndesis.model.connection.Connection;
 import io.syndesis.model.extension.Extension;
 
 @JsonDeserialize(using = StepDeserializer.class)
+@JsonIgnoreProperties(value = {"dependencies"}, allowGetters = true)
 public interface Step extends WithId<Step>, WithConfiguredProperties, WithDependencies, Serializable {
 
     @Override


### PR DESCRIPTION
Unmarshalling of json payload was causing com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "...." ,therefor I excluded these fields.