### PR TITLE
fix(actions-filter): only display relevant actions...

### DIFF
--- a/app/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
+++ b/app/rest/dao/src/main/resources/io/syndesis/dao/deployment.json
@@ -931,8 +931,8 @@
                     "deprecated": false,
                     "secret": false,
                     "componentProperty": false,
-                    "defaultValue": "queue",
-                    "description": "By default, the destination is a queue."
+                    "defaultValue": "topic",
+                    "description": "By default, the destination is a topic."
                   },
                   "persistent": {
                     "kind": "parameter",
@@ -1007,8 +1007,8 @@
                     "deprecated": false,
                     "secret": false,
                     "componentProperty": false,
-                    "defaultValue": "queue",
-                    "description": "By default, the destination is a queue."
+                    "defaultValue": "topic",
+                    "description": "By default, the destination is a topic."
                   },
                   "durableSubscriptionId": {
                     "kind": "parameter",
@@ -1095,8 +1095,8 @@
                     "deprecated": false,
                     "secret": false,
                     "componentProperty": false,
-                    "defaultValue": "queue",
-                    "description": "By default, the destination is a queue."
+                    "defaultValue": "topic",
+                    "description": "By default, the destination is a topic."
                   },
                   "messageSelector": {
                     "kind": "parameter",

--- a/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
@@ -102,30 +102,15 @@ export class IntegrationsSelectActionComponent extends FlowPage
     }
   }
 
-  // filters out actions that do not use the 'From' pattern
-  connectorStartActionsFilter(connector: Connector): Connector {
-    const filteredConnectorActions = connector.actions.filter(action => action.pattern === 'From');
-    connector.actions = filteredConnectorActions;
-    return connector;
-  }
-
-  // filters out actions that do not use the 'To' pattern
-  connectorFinishActionsFilter(connector: Connector): Connector {
-    const filteredConnectorActions = connector.actions.filter(action => action.pattern === 'To');
-    connector.actions = filteredConnectorActions;
-    return connector;
-  }
-
   ngOnInit() {
     // set a local var for current step
-    this.route.params.pluck<Params, string>('position').subscribe(value => this.currentStep = parseInt(value));
+    this.currentStep = +this.route.snapshot.paramMap.get('position')
 
     // if it's a start step
     if (this.currentStep === this.currentFlow.getFirstPosition()) {
       this.actions = this.connector
         .filter(connector => connector !== undefined)
-        .map(this.connectorStartActionsFilter)
-        .map(connector => connector.actions);
+        .switchMap(connector => [connector.actions.filter(action => action.pattern === 'From')]);
     }
 
     // if it's anything other than a start step
@@ -133,8 +118,7 @@ export class IntegrationsSelectActionComponent extends FlowPage
       && this.currentStep <= this.currentFlow.getLastPosition()) {
       this.actions = this.connector
         .filter(connector => connector !== undefined)
-        .map(this.connectorFinishActionsFilter)
-        .map(connector => connector.actions);
+        .switchMap(connector => [connector.actions.filter(action => action.pattern === 'To')]);
     }
 
     this.actionsSubscription = this.actions.subscribe(_ =>

--- a/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
@@ -103,17 +103,14 @@ export class IntegrationsSelectActionComponent extends FlowPage
   }
 
   ngOnInit() {
-    // set a local var for current step
     this.currentStep = +this.route.snapshot.paramMap.get('position');
 
-    // if it's a start step
     if (this.currentStep === this.currentFlow.getFirstPosition()) {
       this.actions = this.connector
         .filter(connector => connector !== undefined)
         .switchMap(connector => [connector.actions.filter(action => action.pattern === 'From')]);
     }
 
-    // if it's anything other than a start step
     if (this.currentStep > this.currentFlow.getFirstPosition()
       && this.currentStep <= this.currentFlow.getLastPosition()) {
       this.actions = this.connector

--- a/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integrations/edit-page/action-select/action-select.component.ts
@@ -104,7 +104,7 @@ export class IntegrationsSelectActionComponent extends FlowPage
 
   ngOnInit() {
     // set a local var for current step
-    this.currentStep = +this.route.snapshot.paramMap.get('position')
+    this.currentStep = +this.route.snapshot.paramMap.get('position');
 
     // if it's a start step
     if (this.currentStep === this.currentFlow.getFirstPosition()) {
@@ -128,13 +128,10 @@ export class IntegrationsSelectActionComponent extends FlowPage
       })
     );
 
-    this.routeSubscription = this.route.params
-      .pluck<Params, string>('position')
-      .map((position: string) => {
-        this.position = Number.parseInt(position);
-        this.loadActions();
-      })
-      .subscribe();
+    this.route.paramMap.subscribe(params => {
+      this.position = +params.get('position');
+      this.loadActions();
+    });
 
     /**
      * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.


### PR DESCRIPTION
... for start and subsequent steps in create integration flow.

Add hooks for filtering actions list in the integrations action select

This helps the following issues:
https://github.com/syndesisio/syndesis/issues/637
https://github.com/syndesisio/syndesis/issues/253