### PR TITLE
fix(openshift): look at `availableReplicas` instead of `readyReplicas`

### DIFF
--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -125,13 +125,13 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         DeploymentConfig dc = openShiftClient.deploymentConfigs().withName(sName).get();
 
         int allReplicas = 0;
-        int readyReplicas = 0;
+        int availableReplicas = 0;
         if (dc != null && dc.getStatus() != null) {
             DeploymentConfigStatus status = dc.getStatus();
             allReplicas = nullSafe(status.getReplicas());
-            readyReplicas = nullSafe(status.getReadyReplicas());
+            availableReplicas = nullSafe(status.getAvailableReplicas());
         }
-        return desiredReplicas == allReplicas && desiredReplicas == readyReplicas;
+        return desiredReplicas == allReplicas && desiredReplicas == availableReplicas;
     }
 
     @Override


### PR DESCRIPTION
Seems that we should be looking at `availableReplicas` instead of
`readyReplicas` to determine if the integration pod is running.

Looking at kubernetes reference[1] seems more appropriate for our use
case.

Tested on minishift with integration pod that was happy to run and a
integration that was not so happy to run, seems to reflect what we want
to achieve.

Fixes #625

[1] https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#deploymentstatus-v1beta2-apps