### PR TITLE
fix: Add a means to control the order of form elements via an external 'controls' array

### DIFF
--- a/app/ui/src/app/common/forms.service.ts
+++ b/app/ui/src/app/common/forms.service.ts
@@ -22,7 +22,8 @@ export class FormFactoryService {
       | Map<string, ConfigurationProperty>
       | Map<string, any>
       | {},
-    values: any = {}
+    values: any = {},
+    controls: Array<string> = ['*']
   ): DynamicFormControlModel[] {
     const answer = <DynamicFormControlModel[]>[];
     for (const key in properties) {
@@ -159,6 +160,23 @@ export class FormFactoryService {
         answer.push(formField);
       }
     }
+    // guard against missing wildcard
+    if (controls.find(val => val === '*') === undefined) {
+      controls.push('*');
+    }
+    // sort the form based on the controls array
+    const wildcardIndex = controls.findIndex(val => val === '*');
+    answer.sort((a, b) => {
+      let aIndex = controls.findIndex(val => val === a.id);
+      if (aIndex === -1) {
+        aIndex = wildcardIndex;
+      }
+      let bIndex = controls.findIndex(val => val === b.id);
+      if (bIndex === -1) {
+        bIndex = wildcardIndex;
+      }
+      return aIndex - bIndex;
+    });
     return answer;
   }
 }

--- a/app/ui/src/app/connections/common/configuration/configuration.service.ts
+++ b/app/ui/src/app/connections/common/configuration/configuration.service.ts
@@ -38,7 +38,15 @@ export class ConnectionConfigurationService {
     readOnly: boolean
   ): DynamicFormControlModel[] {
     const config = this.getFormConfig(connection);
-    const formModel = this.formFactory.createFormModel(config);
+    let controls = ['*'];
+    // TODO temporary client-side hack to tweak form ordering
+    switch (connection.connectorId) {
+      case 'activemq':
+        controls = ['brokerUrl', 'username', 'password', 'clientId', 'skipCertificateCheck', 'brokerCertificate', 'clientCertificate'];
+        break;
+      default:
+    }
+    const formModel = this.formFactory.createFormModel(config, undefined, controls);
     formModel
       .filter(model => model instanceof DynamicInputModel)
       .forEach(model => ((<DynamicInputModel>model).readOnly = readOnly));


### PR DESCRIPTION
fixes #886 

Also adds a client-side tweak for now that at least organizes the broker connection configuration page a little better.