### PR TITLE
Fix: better swagger upload form validation

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -21,7 +21,7 @@
   <p>
     <strong>Choose how you want to create your connector?</strong>
   </p>
-  <form class="syn-form syn-form--swagger-upload" (ngSubmit)="onSubmit(swaggerForm)" #swaggerForm="ngForm" novalidate>
+  <form class="syn-form syn-form--swagger-upload" (ngSubmit)="onSubmit(swaggerForm, uploadFileOption.checked)" #swaggerForm="ngForm" novalidate>
     <fieldset class="syn-form__body">
       <div class="syn-form-input-list syn-form-input-list--horizontal">
         <label class="syn-form-input-list__option">
@@ -52,7 +52,7 @@
     <fieldset class="syn-form__buttons">
       <syndesis-button type="submit"
         [loading]="apiConnectorState.loading"
-        [disabled]="(!uploadFileOption.checked && swaggerForm.invalid) || (uploadFileOption.checked && !swaggerFileList)">
+        [disabled]="(!uploadFileOption.checked && !swaggerFileUrlInput.value) || (uploadFileOption.checked && !swaggerFileList)">
         Next
       </syndesis-button>
     </fieldset>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
@@ -44,14 +44,14 @@ export class ApiConnectorSwaggerUploadComponent {
     }
   }
 
-  onSubmit({ valid }): void {
+  onSubmit({ valid }, attachFile: boolean): void {
     if ((this.swaggerFileUrl && valid) || this.swaggerFileList) {
       const validateSwaggerRequest = {
         connectorTemplateId: 'swagger-connector-template',
         configuredProperties: {
           specification: this.swaggerFileUrl
         },
-        file: this.swaggerFileList && this.swaggerFileList[0]
+        file: attachFile && this.swaggerFileList && this.swaggerFileList[0]
       };
 
       this.request.next(validateSwaggerRequest);


### PR DESCRIPTION
Introduces a fix for resetting the form state upon switching between options, so the button remains disabled when the user selects a new choice but no information has been introduced.