### PR TITLE
fix(ui): Make error icon not show up as ellipse

### DIFF
--- a/app/ui/src/app/common/validation/validation-error.component.scss
+++ b/app/ui/src/app/common/validation/validation-error.component.scss
@@ -10,6 +10,7 @@
   &__icon {
     display: block;
     width: 24px;
+    height: 24px;
     line-height: 18px;
     margin-right: 1em;
     border: 3px solid $color-pf-red-200;


### PR DESCRIPTION
Sets the fixed height for error icon block so it doesn't expand with the
content to form an ellipse.

Before:
![screenshot-2018-1-8 syndesis - development 1](https://user-images.githubusercontent.com/1306050/34668626-8c36fcf8-f46e-11e7-9ab3-dd612aa5a1ac.png)

After:
![screenshot-2018-1-8 syndesis - development](https://user-images.githubusercontent.com/1306050/34668621-8625fd64-f46e-11e7-8f79-78abb09dd211.png)


