### PR TITLE
fix(rest): adds support for multipart upload of specification

### DIFF
--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -18,7 +18,6 @@ package io.syndesis.connector.generator.swagger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -26,7 +25,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
 

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Path("/connectors")
 @Api(value = "connectors")

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/ConnectorsITCase.java
@@ -31,7 +31,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 import java.awt.Dimension;
 import java.io.IOException;

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -15,6 +15,10 @@
  */
 package io.syndesis.runtime.connector;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
 import io.syndesis.connector.generator.ConnectorGenerator;
 import io.syndesis.model.action.ActionsSummary;
 import io.syndesis.model.connection.ConfigurationProperty;
@@ -38,8 +42,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-
-import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -135,6 +137,41 @@ public class CustomConnectorITCase extends BaseITCase {
     }
 
     @Test
+    public void shouldCreateNewCustomConnectorsFromMultipartWithIcon() {
+        final ResponseEntity<Connector> response = post("/api/v1/connectors/custom",
+            multipartBody(
+                new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID)
+                    .putConfiguredProperty("specification", "here-be-specification").build(),
+                getClass().getResourceAsStream("/io/syndesis/runtime/test-image.png")),
+            Connector.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
+
+        final Connector created = response.getBody();
+        assertThat(created).isNotNull();
+        assertThat(created.getDescription()).isEqualTo("test-description");
+        assertThat(dataManager.fetch(Connector.class, response.getBody().getId().get())).isNotNull();
+        assertThat(created.getIcon()).startsWith("db:");
+        final Icon icon = dataManager.fetch(Icon.class, created.getIcon().substring(3));
+        assertThat(icon.getMediaType()).isEqualTo(MediaType.IMAGE_PNG_VALUE);
+    }
+
+    @Test
+    public void shouldCreateNewCustomConnectorsFromMultipartWithSpecificationAndIcon() {
+        final ResponseEntity<Connector> response = post("/api/v1/connectors/custom",
+            multipartBody(new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build(),
+                getClass().getResourceAsStream("/io/syndesis/runtime/test-image.png"),
+                new ByteArrayInputStream("here-be-specification".getBytes(StandardCharsets.US_ASCII))),
+            Connector.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
+
+        final Connector created = response.getBody();
+        assertThat(created).isNotNull();
+        assertThat(created.getDescription()).isEqualTo("test-description");
+        assertThat(dataManager.fetch(Connector.class, response.getBody().getId().get())).isNotNull();
+        assertThat(created.getIcon()).startsWith("db:");
+        final Icon icon = dataManager.fetch(Icon.class, created.getIcon().substring(3));
+        assertThat(icon.getMediaType()).isEqualTo(MediaType.IMAGE_PNG_VALUE);
+    }
+
+    @Test
     public void shouldOfferCustomConnectorInfo() {
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build();
 
@@ -161,46 +198,31 @@ public class CustomConnectorITCase extends BaseITCase {
         assertThat(responseForNonCustomConnector.getBody().getSummary()).isNotPresent();
     }
 
+    private MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon) {
+        final LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
+        multipartData.add("connectorSettings", connectorSettings);
+        multipartData.add("icon", new InputStreamResource(icon));
+        return multipartData;
+    }
+
+    private MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon,
+        final InputStream specification) {
+        final MultiValueMap<String, Object> multipartData = multipartBody(connectorSettings, icon);
+        multipartData.add("specification", new InputStreamResource(specification));
+
+        return multipartData;
+    }
+
+    private HttpHeaders multipartHeaders() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        return headers;
+    }
+
     private static ConnectorTemplate createConnectorTemplate(final String id, final String name) {
         return new ConnectorTemplate.Builder()//
             .id(id)//
             .name(name)//
             .build();
-    }
-
-    @Test
-    public void shouldCreateNewCustomConnectorsFromMultipartWithIcon() {
-        ResponseEntity<Connector> response = post(
-            "/api/v1/connectors/custom",
-            multipartBody(
-                new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build(),
-                getClass().getResourceAsStream("/io/syndesis/runtime/test-image.png")
-            ),
-            Connector.class,
-            tokenRule.validToken(),
-            HttpStatus.OK,
-            multipartHeaders()
-        );
-
-        final Connector created = response.getBody();
-        assertThat(created).isNotNull();
-        assertThat(created.getDescription()).isEqualTo("test-description");
-        assertThat(dataManager.fetch(Connector.class, response.getBody().getId().get())).isNotNull();
-        assertThat(created.getIcon()).startsWith("db:");
-        Icon icon = dataManager.fetch(Icon.class, created.getIcon().substring(3));
-        assertThat(icon.getMediaType()).isEqualTo(MediaType.IMAGE_PNG_VALUE);
-    }
-
-    private HttpHeaders multipartHeaders() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        return headers;
-    }
-
-    private MultiValueMap<String, Object> multipartBody(ConnectorSettings connectorSettings, InputStream is) {
-        LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
-        multipartData.add("connectorSettings", connectorSettings);
-        multipartData.add("icon", new InputStreamResource(is));
-        return multipartData;
     }
 }

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -26,10 +26,8 @@ import io.syndesis.model.connection.ConnectorTemplate;
 import io.syndesis.model.icon.Icon;
 import io.syndesis.runtime.BaseITCase;
 
-import okio.Okio;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.InputStreamResource;
@@ -41,7 +39,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomSwaggerConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomSwaggerConnectorITCase.java
@@ -21,19 +21,15 @@ import io.syndesis.model.Violation;
 import io.syndesis.model.action.ActionsSummary;
 import io.syndesis.model.connection.ConfigurationProperty;
 import io.syndesis.model.connection.Connector;
-import io.syndesis.model.connection.ConnectorGroup;
 import io.syndesis.model.connection.ConnectorSettings;
 import io.syndesis.model.connection.ConnectorSummary;
 import io.syndesis.model.connection.ConnectorTemplate;
-import io.syndesis.model.icon.Icon;
 import io.syndesis.runtime.BaseITCase;
 import okio.Okio;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -85,6 +81,19 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
     }
 
     @Test
+    public void shouldCreateCustomConnectorInfoForUploadedSwagger() throws IOException {
+        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build();
+
+        final ResponseEntity<Connector> response = post("/api/v1/connectors/custom",
+            multipartBodyForInfo(connectorSettings, getClass().getResourceAsStream("/io/syndesis/runtime/test-swagger.json")),
+            Connector.class, tokenRule.validToken(), HttpStatus.OK, multipartHeaders());
+
+        final Connector got = response.getBody();
+
+        assertThat(got).isNotNull();
+    }
+
+    @Test
     public void shouldOfferCustomConnectorInfoForUploadedSwagger() throws IOException {
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build();
 
@@ -119,7 +128,7 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
     private MultiValueMap<String, Object> multipartBodyForInfo(ConnectorSettings connectorSettings, InputStream is) throws IOException {
         LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
         multipartData.add("connectorSettings", connectorSettings);
-        multipartData.add("swaggerSpecification", Okio.buffer(Okio.source(is)).readUtf8());
+        multipartData.add("specification", Okio.buffer(Okio.source(is)).readUtf8());
         return multipartData;
     }
 }


### PR DESCRIPTION
This adds support for uploading specification in a mime part of a
multipart upload for the `POST /connectors/custom` endpoint. Also
renames `swaggerSpecification` part to just `specification` to keep it
in line with the `ConnectorSettings` naming.