### PR TITLE
fix(rest): provide actionsSummary instead of summary

### DIFF
--- a/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
+++ b/app/rest/model/src/main/java/io/syndesis/model/connection/Connector.java
@@ -19,15 +19,18 @@ import java.io.Serializable;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithDependencies;
 import io.syndesis.model.WithId;
 import io.syndesis.model.WithName;
 import io.syndesis.model.WithProperties;
+import io.syndesis.model.action.ActionsSummary;
 import io.syndesis.model.action.ConnectorAction;
 import io.syndesis.model.action.WithActions;
+
 import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
 @JsonDeserialize(builder = Connector.Builder.class)
@@ -67,7 +70,7 @@ public interface Connector extends WithId<Connector>, WithActions<ConnectorActio
 
     Optional<String> getConnectorFactory();
 
-    Optional<ConnectorSummary> getSummary();
+    Optional<ActionsSummary> getActionsSummary();
 
     OptionalInt getUses();
 

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorHandler.java
@@ -110,7 +110,7 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
 
         final ConnectorSummary summary = new ConnectorSummary.Builder().createFrom(connector).build();
 
-        return connector.builder().summary(summary).build();
+        return connector.builder().actionsSummary(summary.getActionsSummary()).build();
     }
 
     @Path("/{id}/actions")
@@ -153,7 +153,7 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
             .map(c -> {
                 final ConnectorSummary summary = new ConnectorSummary.Builder().createFrom(c).build();
 
-                return c.builder().summary(summary).build();
+                return c.builder().actionsSummary(summary.getActionsSummary()).build();
             })
             .collect(Collectors.toList());
 

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/connector/CustomConnectorITCase.java
@@ -191,11 +191,11 @@ public class CustomConnectorITCase extends BaseITCase {
     public void shouldProvideSummaryForCustomConnectors() {
         final ResponseEntity<Connector> responseForCustomConnector = get("/api/v1/connectors/connector-from-template-1", Connector.class);
 
-        assertThat(responseForCustomConnector.getBody().getSummary()).isPresent();
+        assertThat(responseForCustomConnector.getBody().getActionsSummary()).isPresent();
 
         final ResponseEntity<Connector> responseForNonCustomConnector = get("/api/v1/connectors/non-custom-connector", Connector.class);
 
-        assertThat(responseForNonCustomConnector.getBody().getSummary()).isNotPresent();
+        assertThat(responseForNonCustomConnector.getBody().getActionsSummary()).isNotPresent();
     }
 
     private MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon) {


### PR DESCRIPTION
This, somewhat crudely, replaces the `summary` property of a `Connector`
of type `ConnectorSummary` with `actionsSummary` property of type
`ActionSummary`.

Fixes #898
  