### PR TITLE
fix(salesforce): Use connector component scheme for enrich

### DIFF
--- a/app/connectors/connectors/salesforce/salesforce-common/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnector.java
+++ b/app/connectors/connectors/salesforce/salesforce-common/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnector.java
@@ -40,7 +40,7 @@ public abstract class SalesforceStreamingConnector extends DefaultConnectorCompo
         options.put(SalesforceEndpointConfig.SOBJECT_QUERY, query);
         options.remove(SalesforceEndpointConfig.SOBJECT_NAME);
 
-        final String salesforceComponent = getComponentName() + "-component";
+        final String salesforceComponent = getComponentScheme();
 
         if (!topicName.endsWith("_delete")) {
             final Enricher enricher = new Enricher(


### PR DESCRIPTION
Changes the enrich endpoint URI to
`DefaultConnectorComponent::getComponentScheme()`  from
`DefaultConnectorComponent::getComponentName() + "-component"`.

With this the enrich step is using the correct scheme in the
endpoint URI, to fetch the affected Salesforce object the
notification was received for.

Fixes #884