### PR TITLE
fix(project-generator): Filter step skips an index

### DIFF
--- a/app/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/FilterStepVisitor.java
+++ b/app/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/FilterStepVisitor.java
@@ -29,11 +29,13 @@ public abstract class FilterStepVisitor implements StepVisitor {
     @Override
     public Collection<io.syndesis.integration.model.steps.Step> visit(StepVisitorContext stepContext) {
         Step step = stepContext.getStep();
+        StepVisitorContext currentContext = stepContext;
         if (step instanceof FilterStep && step.getStepKind().equals(getStepKind())) {
             Filter filter = createFilter((FilterStep) step);
             List<io.syndesis.integration.model.steps.Step> steps = new ArrayList<>();
             while (stepContext.hasNext()) {
-                steps.addAll(visit(stepContext.next()));
+                currentContext = currentContext.next();
+                steps.addAll(visit(currentContext));
             }
             filter.setSteps(steps);
             return Collections.singletonList(filter);
@@ -43,7 +45,7 @@ public abstract class FilterStepVisitor implements StepVisitor {
         StepVisitorFactory<?> factory = generatorContext.getVisitorFactoryRegistry().get(stepContext.getStep().getStepKind());
         StepVisitor visitor = factory.create();
 
-        return visitor.visit(stepContext);
+        return visitor.visit(currentContext);
     }
 
     private Filter createFilter(FilterStep s) {


### PR DESCRIPTION
When generating `syndesis.yaml` it's important that the index of the
step is in line with the generated `application.properties` in
`/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationSupport.java`

In the case when the filter step is followed by two or more steps the
nested steps are created with the same context, and thus share the same
index.

This tracks the context that needs to be used to maintain the index.

Fixes #888