### PR TITLE
fix(amq-connection): ensure required fields are filled before enablin…

### DIFF
--- a/app/ui/src/app/connections/create-page/configure-fields/configure-fields.component.ts
+++ b/app/ui/src/app/connections/create-page/configure-fields/configure-fields.component.ts
@@ -46,6 +46,8 @@ export class ConnectionsConfigureFieldsComponent
         this.connection.configuredProperties = data;
       }
     );
+
+    this.current.formGroup = (this.hasCredentials) ? null : this.formGroup;
   }
 
   ngOnDestroy() {

--- a/app/ui/src/app/connections/create-page/create-page.component.html
+++ b/app/ui/src/app/connections/create-page/create-page.component.html
@@ -14,7 +14,7 @@
           <li class="active"><strong>Create Connection</strong></li>
         </ol>
       </div>
-      <div class="toolbar-pf-action-right">
+      <div *ngIf="current.loaded" class="toolbar-pf-action-right">
         <button class="btn btn-default"
                 (click)="cancel()">Cancel
         </button> &nbsp;
@@ -24,7 +24,7 @@
           <i class="fa fa-chevron-left"></i> Back
         </button>
         <button class="btn btn-primary"
-                *ngIf="getCurrentPage() === 'configure-fields'"
+                *ngIf="showNextButton()"
                 (click)="goForward()"
                 [disabled]="!canContinue()">
           Next <i class="fa fa-chevron-right"></i>

--- a/app/ui/src/app/connections/create-page/create-page.component.ts
+++ b/app/ui/src/app/connections/create-page/create-page.component.ts
@@ -16,7 +16,7 @@ const category = getCategory('Connections');
 })
 export class ConnectionsCreatePage implements OnInit, OnDestroy {
   constructor(
-    private current: CurrentConnectionService,
+    public current: CurrentConnectionService,
     private route: ActivatedRoute,
     private router: Router,
     private nav: NavigationService
@@ -43,7 +43,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
       case 'connection-basics':
         return this.connection.name && this.connection.connector;
       case 'configure-fields':
-      // TODO validate form
+        return this.current.formGroup && this.current.formGroup.valid;
       case 'review':
       // TODO is this ever going to be false?
       default:
@@ -66,6 +66,8 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
     switch (page) {
       case 'connection-basics':
         return false;
+      case 'configure-fields':
+        return !this.current.hasCredentials();
       default:
         return true;
     }

--- a/app/ui/src/app/connections/create-page/current-connection.ts
+++ b/app/ui/src/app/connections/create-page/current-connection.ts
@@ -1,4 +1,5 @@
 import { Injectable, EventEmitter } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
 
@@ -23,6 +24,7 @@ export class CurrentConnectionService {
   private _connection: Connection;
   private _credentials: any;
   private _oauthStatus: any;
+  private _formGroup: FormGroup;
   private subscription: Subscription;
 
   constructor(
@@ -34,6 +36,7 @@ export class CurrentConnectionService {
     this._credentials = undefined;
     this._oauthStatus = undefined;
     this._connection = undefined;
+    this._formGroup = undefined;
     this._loaded = false;
     this.subscription = this.events.subscribe((event: ConnectionEvent) =>
       this.handleEvent(event)
@@ -132,6 +135,14 @@ export class CurrentConnectionService {
 
   get connection(): Connection {
     return this._connection;
+  }
+
+  get formGroup(): FormGroup {
+    return this._formGroup;
+  }
+
+  set formGroup(formGroup: FormGroup) {
+    this._formGroup = formGroup;
   }
 
   set connection(connection: Connection) {


### PR DESCRIPTION
…g "next" btn in configure-fields step.

expose formGroup on the "current" object so we can disable "next" btn when form is invalid
only show action toolbar once view loading has completed
hide the "next" btn when configuring a connection that uses oauth

Incremental step towards https://github.com/syndesisio/syndesis/issues/637 and should also help https://github.com/syndesisio/syndesis/issues/282