### PR TITLE
fix(project-generator): include configured properties from action descriptor in endpoint properties

### DIFF
--- a/app/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/ConnectorStepVisitor.java
+++ b/app/rest/project-generator/src/main/java/io/syndesis/project/converter/visitor/ConnectorStepVisitor.java
@@ -29,6 +29,7 @@ import io.syndesis.dao.manager.DataManager;
 import io.syndesis.model.Split;
 import io.syndesis.model.WithConfigurationProperties;
 import io.syndesis.model.action.ConnectorAction;
+import io.syndesis.model.action.ConnectorDescriptor;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.integration.Step;
@@ -158,6 +159,10 @@ public class ConnectorStepVisitor implements StepVisitor {
                 .filter(Predicates.or(connector::isSecret, action::isSecret))
                 .forEach(e -> e.setValue(String.format("{{%s-%d.%s}}", componentScheme, visitorContext.getIndex(), e.getKey())));
         }
+
+        // any configuredProperties on action descriptor are considered
+        final ConnectorDescriptor descriptor = action.getDescriptor();
+        properties.putAll(descriptor.getConfiguredProperties());
 
         if (hasComponentProperties(configuredProperties, connector, action)) {
             return new io.syndesis.integration.model.steps.Endpoint(String.format("%s-%d", componentScheme, visitorContext.getIndex()), Map.class.cast(properties));


### PR DESCRIPTION
Swagger custom API connectors set endpoint property `operationId` in the
action descriptor's configuredProperties, these need to be included in
the properties of the endpoint created by the project generator.

Fixes #1000