### PR TITLE
fix(ui): use values from configuredProperties

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
@@ -48,11 +48,11 @@ export class ApiConnectorInfoComponent implements OnInit {
     }
 
     if (this.apiConnectorData) {
-      const { name, description, properties, icon } = this.apiConnectorData;
+      const { name, description, configuredProperties, properties, icon } = this.apiConnectorData;
       this.apiConnectorDataForm.get('name').setValue(name);
       this.apiConnectorDataForm.get('description').setValue(description);
-      this.apiConnectorDataForm.get('host').setValue(properties.host.defaultValue);
-      this.apiConnectorDataForm.get('basePath').setValue(properties.basePath.defaultValue);
+      this.apiConnectorDataForm.get('host').setValue(configuredProperties.host || properties.host.defaultValue);
+      this.apiConnectorDataForm.get('basePath').setValue(configuredProperties.basePath || properties.basePath.defaultValue);
       this.icon = icon;
       this.isDirty = true;
     }


### PR DESCRIPTION
The current value of `host` and `basePath` properties is stored in
`configuredProperties` of the Connector, if the value there is not
present fall back to the `defaultValue` from `properties`

Fixes #999