### PR TITLE
fix(ui): use values from configuredProperties in new connection wizard

### DIFF
--- a/app/ui/src/app/connections/common/configuration/configuration.service.ts
+++ b/app/ui/src/app/connections/common/configuration/configuration.service.ts
@@ -61,6 +61,13 @@ export class ConnectionConfigurationService {
     let props = {};
     if (connection.connector) {
       props = this.cloneObject(connection.connector.properties);
+      if (connection.connector.configuredProperties) {
+        Object.keys(connection.connector.configuredProperties).forEach(key => {
+          if (props[key]) {
+            props[key].value = connection.connector.configuredProperties[key];
+          }
+        });
+      }
       if (connection.configuredProperties) {
         Object.keys(connection.configuredProperties).forEach(key => {
           if (props[key]) {


### PR DESCRIPTION
We should use `configuredProperties` from Connector to setup the form to
create the new Connection. These still can be overridden with values
from `Connection.configuredProperties` if those are specified.

Fixes #999