### PR TITLE
fix(salesforce): access external id for upsert from endpoint URI

### DIFF
--- a/app/connectors/connectors/salesforce/salesforce-common/src/main/java/io/syndesis/connector/salesforce/UpdatingSalesforceConnector.java
+++ b/app/connectors/connectors/salesforce/salesforce-common/src/main/java/io/syndesis/connector/salesforce/UpdatingSalesforceConnector.java
@@ -20,7 +20,7 @@ public abstract class UpdatingSalesforceConnector extends SalesforceConnector {
     protected UpdatingSalesforceConnector(final String componentName, final String componentScheme, final Class<?> componentClass) {
         super(componentName, componentScheme, componentClass);
 
-        setBeforeProducer(new AdaptObjectForUpdateProcessor(getOptions()));
+        setBeforeProducer(new AdaptObjectForUpdateProcessor());
     }
 
 }


### PR DESCRIPTION
Since connector options don't include endpoint parameters we need to
fetch the external id property name from the endpoint URI in the
exchange. Otherwise we would end up using the default (Id) field as
external property identifier.