### PR TITLE
fix(rest): use buffered streams for icon upload

### DIFF
--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorIconHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectorIconHandler.java
@@ -82,36 +82,38 @@ public final class ConnectorIconHandler extends BaseHandler {
                 throw new IllegalArgumentException("Can't find a valid 'icon' part in the multipart request");
             }
 
-            MediaType mediaType = filePart.getMediaType();
-            if (!mediaType.getType().equals("image")) {
-                // URLConnection.guessContentTypeFromStream resets the stream after inspecting the media type so
-                // can continue to be used, rather than being consumed.
-                String guessedMediaType = URLConnection.guessContentTypeFromStream(new BufferedInputStream(result));
-                if (!guessedMediaType.startsWith("image/")) {
-                    throw new IllegalArgumentException("Invalid file contents for an image");
+            try (BufferedInputStream iconStream = new BufferedInputStream(result)) {
+                MediaType mediaType = filePart.getMediaType();
+                if (!mediaType.getType().equals("image")) {
+                    // URLConnection.guessContentTypeFromStream resets the stream after inspecting the media type so
+                    // can continue to be used, rather than being consumed.
+                    String guessedMediaType = URLConnection.guessContentTypeFromStream(iconStream);
+                    if (!guessedMediaType.startsWith("image/")) {
+                        throw new IllegalArgumentException("Invalid file contents for an image");
+                    }
+                    mediaType = MediaType.valueOf(guessedMediaType);
                 }
-                mediaType = MediaType.valueOf(guessedMediaType);
+
+                Icon.Builder iconBuilder = new Icon.Builder()
+                    .mediaType(mediaType.toString());
+
+                Icon icon;
+                String connectorIcon = connector.getIcon();
+                if (connectorIcon != null && connectorIcon.startsWith("db:")) {
+                    String connectorIconId = connectorIcon.substring(3);
+                    iconBuilder.id(connectorIconId);
+                    icon = iconBuilder.build();
+                    getDataManager().update(icon);
+                } else {
+                    icon = getDataManager().create(iconBuilder.build());
+                }
+
+                iconDao.write(icon.getId().get(), iconStream);
+
+                Connector updatedConnector = new Connector.Builder().createFrom(connector).icon("db:" + icon.getId().get()).build();
+                getDataManager().update(updatedConnector);
+                return updatedConnector;
             }
-
-            Icon.Builder iconBuilder = new Icon.Builder()
-                .mediaType(mediaType.toString());
-
-            Icon icon;
-            String connectorIcon = connector.getIcon();
-            if (connectorIcon != null && connectorIcon.startsWith("db:")) {
-                String connectorIconId = connectorIcon.substring(3);
-                iconBuilder.id(connectorIconId);
-                icon = iconBuilder.build();
-                getDataManager().update(icon);
-            } else {
-                icon = getDataManager().create(iconBuilder.build());
-            }
-
-            iconDao.write(icon.getId().get(), result);
-
-            Connector updatedConnector = new Connector.Builder().createFrom(connector).icon("db:" + icon.getId().get()).build();
-            getDataManager().update(updatedConnector);
-            return updatedConnector;
         } catch (IOException e) {
             throw new IllegalArgumentException("Error while reading multipart request", e);
         }


### PR DESCRIPTION
When reading the submitted icon stream we should be used the buffered
stream that was reset to the initial position, otherwise we just store
the icon data after first 1024 bytes (or the length of the buffer in
BufferInputStream).