### PR TITLE
feat: Enable Prometheus metrics exporter in integration containers

### DIFF
--- a/app/s2i/src/main/docker/Dockerfile
+++ b/app/s2i/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fabric8/s2i-java:2.0.2
+FROM fabric8/s2i-java:2.1.0
 
 COPY m2 /tmp/artifacts/m2/
 


### PR DESCRIPTION
Upgrading the base image for Syndesis s2i images enabled the Promtheus JMX exporter javaagent by
default.