### PR TITLE
Labels, consistant icon sizing and OAuth settings icon for API connectors

### DIFF
--- a/app/ui/src/app/connections/detail-page/info.component.ts
+++ b/app/ui/src/app/connections/detail-page/info.component.ts
@@ -13,7 +13,7 @@ import { ConnectionConfigurationService } from '../common/configuration/configur
     <h1>
       <dl class="dl-horizontal">
         <dt>
-          <img [src]="connection | synIconPath" width="46">
+          <img class="syn-icon-medium" [src]="connection | synIconPath">
         </dt>
         <dd>
           <syndesis-editable-text [value]="connection.name"

--- a/app/ui/src/app/connections/list/list.component.html
+++ b/app/ui/src/app/connections/list/list.component.html
@@ -88,7 +88,7 @@
               <!-- Card Icon -->
               <div class="card-pf-top-element">
                 <span class="card-pf-icon-large image-icon">
-                <img [src]="connection | synIconPath">
+                <img class="syn-icon-medium" [src]="connection | synIconPath">
               </span>
               </div>
 

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
@@ -19,7 +19,7 @@
       </div>
 
       <div class="syn-form-row syn-form-row--oauth" *ngIf="authSetupForm.value.authenticationType == 'oauth2'">
-        <label class="syn-form-row__label" for="authorizationEndpoint">Authentication URL</label>
+        <label class="syn-form-row__label" for="authorizationEndpoint">Authorization URL</label>
         <input class="syn-form-row__input"
           [class.syn-submitted]="form.submitted"
           type="text"
@@ -27,7 +27,7 @@
       </div>
       
       <div class="syn-form-row syn-form-row--oauth" *ngIf="authSetupForm.value.authenticationType == 'oauth2'">
-        <label class="syn-form-row__label" for="tokenEndpoint">Authorization URL</label>
+        <label class="syn-form-row__label" for="tokenEndpoint">Access Token URL</label>
         <input class="syn-form-row__input"
           [class.syn-submitted]="form.submitted"
           type="text"

--- a/app/ui/src/app/customizations/api-connector/api-connector-detail/api-connector-detail.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-detail/api-connector-detail.component.html
@@ -30,7 +30,7 @@
       <div class="card-pf card-pf-view">
         <div class="card-pf-body">
           <div class="card-pf-top-element text-center">
-            <img [src]="apiConnectorData | synIconPath:true" width="100"/>
+            <img class="syn-icon-large" [src]="apiConnectorData | synIconPath:true"/>
           </div>
           <h2 class="card-pf-title text-center">
             {{ apiConnectorData.name || 'N/A' }}

--- a/app/ui/src/app/dashboard/connections.component.html
+++ b/app/ui/src/app/dashboard/connections.component.html
@@ -32,7 +32,7 @@
 
               <div class="card-pf-top-element">
                 <span class="card-pf-icon-large image-icon">
-                <img [src]="connection | synIconPath">
+                <img class="syn-icon-medium" [src]="connection | synIconPath">
               </span>
               </div>
 

--- a/app/ui/src/app/integrations/detail-page/detail.component.html
+++ b/app/ui/src/app/integrations/detail-page/detail.component.html
@@ -56,7 +56,7 @@
                          title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
                       <div [class]="'step-line ' + getStepLineClass(index)"></div>
                       <div class="icon">
-                        <img class="connection-icon" [src]="step.connection | synIconPath">
+                        <img class="syn-icon-small" [src]="step.connection | synIconPath">
                       </div>
                       <div>{{ step.connection.name | capitalize }}</div>
                     </div>

--- a/app/ui/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -19,7 +19,7 @@
        container="body">
       <i [class]="getIconClass()"
          *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
-      <img class="connection-icon"
+      <img class="syn-icon-small"
            *ngIf="step.stepKind === 'endpoint' && step.connection"
            [src]="step.connection | synIconPath">
     </p>

--- a/app/ui/src/app/integrations/list/list.component.html
+++ b/app/ui/src/app/integrations/list/list.component.html
@@ -16,11 +16,11 @@
                  let-index="index">
       <div class="list-pf-left integration-icons">
         <span *ngIf="getStart(integration).connection; let connection">
-          <img [src]="connection | synIconPath" width="40">
+          <img class="syn-icon-small" [src]="connection | synIconPath">
         </span>
         <span class="fa fa-angle-right"></span>
         <span *ngIf="getFinish(integration).connection; let connection">
-          <img [src]="connection | synIconPath" width="40">
+          <img  class="syn-icon-small" [src]="connection | synIconPath">
         </span>
       </div>
       <div class="list-pf-content-wrapper">

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
@@ -34,7 +34,8 @@
         </div>
         <div class="list-pf-content list-pf-content-flex">
           <div class="list-pf-left">
-            <span class="fa {{ item.client.icon }} list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
+            <img *ngIf="!item.client.icon.startsWith('fa-')" class="syn-icon-medium list-pf-icon list-pf-icon-bordered list-pf-icon-small" [src]="item.client | synIconPath">
+            <span *ngIf="item.client.icon.startsWith('fa-')" class="fa {{ item.client.icon }} list-pf-icon list-pf-icon-bordered list-pf-icon-small"></span>
           </div>
           <div class="list-pf-content-wrapper">
             <div class="list-pf-main-content">

--- a/app/ui/src/scss/_common.scss
+++ b/app/ui/src/scss/_common.scss
@@ -43,3 +43,21 @@ a.disabled {
 .syn-preventclick {
   @include preventclick;
 }
+
+@mixin syn-icon-box($size) {
+  max-height: $size;
+  max-width: $size;
+}
+
+.syn-icon-large {
+  @include syn-icon-box(100px);
+}
+
+.syn-icon-medium {
+  @include syn-icon-box(46px);
+  padding: 3px;
+}
+
+.syn-icon-small {
+  @include syn-icon-box(24px);
+}


### PR DESCRIPTION
Sets labes for OAuth as in the documentation, defines three new CSS clases (syn-icon-[large|medium|small]) and uses those instead of width/height img attributes, and adds API connector icon to OAuth settings list.