### PR TITLE
fix(s2i): Ensure Jolokia is serving over https

### DIFF
--- a/app/s2i/src/main/docker/Dockerfile
+++ b/app/s2i/src/main/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM fabric8/s2i-java:2.1.0
 
+ENV AB_JOLOKIA_HTTPS="true"
+
 COPY m2 /tmp/artifacts/m2/
 
 COPY settings.xml /tmp/settings.xml


### PR DESCRIPTION
Since the move to latest java-s2i base image, Jolokia was no longer serving over https by default.
This re-enables it so the OpenShift JVM console works again.