### PR TITLE
Adding a syndesis git sub command that gives us some interesting git info about what’s changed in the project.

### DIFF
--- a/tools/bin/commands/git
+++ b/tools/bin/commands/git
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+git::description() {
+    echo "Git tools"
+}
+
+git::usage() {
+    cat <<EOT
+    has_app_module_changed <module>     prints true if the module has changed relative to master
+    touched_pl                          prints the list of /app modules uncommitted changes
+EOT
+}
+
+git::has_app_module_changed() {
+    modules="$@"
+
+    local changed=`\
+        git diff origin/master --numstat | cut -f 3 \
+        | grep "app/" | cut -c 5- \
+        | cut -d / -f 1 \
+        | awk 'NF' | sort | uniq \
+    `
+    for var in $changed; do
+        for m in $modules; do
+          if [ "$var" = "$m" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+    echo 'false'
+}
+
+git::touched_pl() {
+    cd `appdir` 
+    git status -s | cut -c 4- | grep / | grep -v '\.\.' | cut -d / -f 1 | awk 'NF' | sort | uniq | paste -s -d"," -
+}
+
+git::run() {
+
+    local command="$1"
+    shift
+
+    case $command in
+        has_app_module_changed) 
+            git::has_app_module_changed $*
+            ;;
+        touched_pl)
+            git::touched_pl $*
+            ;;        
+        *)
+            git::usage
+            ;;
+    esac
+}

--- a/tools/bin/syndesis
+++ b/tools/bin/syndesis
@@ -188,6 +188,7 @@ git_rebase_upstream() {
 
 function run {
     local first_arg=${1:-}
+    shift
     local cmd_dir="$(basedir)/commands"
     local command
     if [ -n "${first_arg}" ] && [[ ${first_arg} != -* ]]; then
@@ -243,7 +244,7 @@ function run {
 
     source "$cmd_dir/$command"
 
-    eval "${command}::run"
+    eval "${command}::run $*"
 }
 
 if [ $(hasflag --verbose) ]; then


### PR DESCRIPTION
Adding some handy commands that may becom more useful.. for example you could do something like:

`mvn clean install -Dfabric8.mode=kubernetes -P image -P flash -pl $(syndesis git touched_pl),runtime $*`

to basically have maven rebuild changed module and deploy them for quick manual testing.

Was also thinking of seeing if we can skip building of modules in circleci if they have not been modified.  thats what `syndesis git has_app_module_changed runtime` would be for.
