### PR TITLE
Fix reference to dev workflow pages

### DIFF
--- a/doc/sdh/index.adoc
+++ b/doc/sdh/index.adoc
@@ -17,4 +17,4 @@ include::introduction.adoc[]
 
 include::build/syndesis.adoc[]
 include::process/process.adoc[]
-include::process/workflow.adoc[]
+include::workflow/workflow.adoc[]


### PR DESCRIPTION
Little type preventing a bunch of information showing up in the developer handbook.