### PR TITLE
TechExt added fallback behavior for not optimized queries

### DIFF
--- a/app/core/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/app/core/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -40,7 +40,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = Extension.Builder.class)
 @NoDuplicateExtension(groups = NonBlockingValidations.class)
 @JsonPropertyOrder({ "name", "description", "icon", "extensionId", "version", "tags", "actions", "dependencies"})
-@UniqueProperty(value = "extensionId", groups = UniquenessRequired.class)
 @SuppressWarnings("immutables")
 public interface Extension extends WithId<Extension>, WithActions<ExtensionAction>, WithName, WithTags, WithConfigurationProperties, WithDependencies, Serializable {
 


### PR DESCRIPTION
fixes #1075

Currently Tech Extension behavior is broken.

The reason for that is that commit https://github.com/syndesisio/syndesis/commit/8fa6e4f6c23daef46d8590a1f3d04c63269d40e2 introduces a new optimized SQL query based on indexes.

The problem with that commit is that it indexes only properties that are annotated as `@UniqueProperty`.
When a query that should use non indexed properties is used, the code log the problem as a WARNING but it also throws a blocking exception, breaking previous behavior.

That commit also introduced a UNIQUE constraint on a field in Extension model that is not correct, since that field is only part of the primary key, and it breaks update functionality.

Current PR introduces a fallback logic to the old behevior, in case of not indexed properties, without reverting the code able to handle optimized queries.

**This might not the final fix, but it'd be useful to get it merge, so to restore Tech Ext functionality in the meanwhile.**

Also if the previous commit endedup in TP3, we broke Tech Ext behavior in that version.