### PR TITLE
chore(checks): Let's exclude UI from Codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - app/ui/**
+


### PR DESCRIPTION
In order for Codacy to pickup them the configuration files need to be in the root of the repository.

I'm not 100% sure about `syndesis-policy` dependency and what happens if it goes out of sync with `ruleset.xml`.

Would be cool to get feedback if this breaks anyone's workflow.

Fixes #1112 