### PR TITLE
feature(API connectors): File browser now allows for thumb preview when in create mode.

### DIFF
--- a/app/ui/src/app/common/icon-path.pipe.ts
+++ b/app/ui/src/app/common/icon-path.pipe.ts
@@ -26,16 +26,8 @@ export class IconPathPipe implements PipeTransform {
 
   transform(connection: IconConnection, isConnector?: boolean): SafeUrl | null {
     if (connection && connection.icon instanceof File) {
-      const promise = new Promise<SafeUrl>(resolve => {
-        const file = connection.icon as File;
-        const fileReader = new FileReader();
-
-        fileReader.onload = event => resolve(this.toSafeUrl(event.target['result']));
-        fileReader.readAsDataURL(file);
-      });
-
-      const asyncPipe = new AsyncPipe(this.changeDetectorRef);
-      return asyncPipe.transform<SafeUrl>(promise);
+      const tempIconBlobPath = URL.createObjectURL(connection.icon);
+      return this.toSafeUrl(tempIconBlobPath);
 
     } else if (connection && typeof (connection.icon) === 'string') {
       // TODO: Streamline this assignation block once we manage to create a common model

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
@@ -18,7 +18,10 @@
         <label class="syn-form-row__label" for="connectorName">Connector Icon</label>
         <div class="syn-form-column syn-form-filebrowser">
           <span class="syn-form-filebrowser__default-file">
-            <i class="fa fa-times"></i>
+            <i class="fa fa-upload" *ngIf="(createMode && !iconFile) || !createMode"></i>
+            <img *ngIf="createMode && iconFile"
+              class="syn-form-filebrowser__preview"
+              [src]="{ icon: iconFile } | synIconPath">
           </span>
           <input class="syn-form-filebrowser__input" type="file" name="connectorIcon" (change)="onChange($event)">
         </div>

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
@@ -20,5 +20,18 @@
       }
     }
   }
+}
 
+.syn-form-filebrowser {
+  &__default-file {
+    overflow: hidden;
+  }
+
+  &__preview {
+    display: block;
+    min-width: 50px;
+    max-height: 50px;
+    margin-left: 50%;
+    transform: translateX(-50%);
+  }
 }

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
@@ -16,8 +16,7 @@ export class ApiConnectorInfoComponent implements OnInit {
   createMode: boolean;
   apiConnectorDataForm: FormGroup;
   editControlKey: string;
-  icon: string; // TODO - Replace default thumb by image if any. Wrap in square container
-  private iconFile: File;
+  iconFile: File;
   private isDirty: boolean;
 
   constructor(
@@ -48,12 +47,11 @@ export class ApiConnectorInfoComponent implements OnInit {
     }
 
     if (this.apiConnectorData) {
-      const { name, description, configuredProperties, properties, icon } = this.apiConnectorData;
+      const { name, description, configuredProperties, properties } = this.apiConnectorData;
       this.apiConnectorDataForm.get('name').setValue(name);
       this.apiConnectorDataForm.get('description').setValue(description);
       this.apiConnectorDataForm.get('host').setValue(configuredProperties.host || properties.host.defaultValue);
       this.apiConnectorDataForm.get('basePath').setValue(configuredProperties.basePath || properties.basePath.defaultValue);
-      this.icon = icon;
       this.isDirty = true;
     }
   }

--- a/app/ui/src/app/customizations/api-connector/api-connector.actions.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.actions.ts
@@ -71,8 +71,8 @@ export class ApiConnectorActions {
     return new ApiConnectorUpdateFail(payload);
   }
 
-  static updateComplete(payload: CustomConnectorRequest): ApiConnectorUpdateComplete {
-    return new ApiConnectorUpdateComplete(payload);
+  static updateComplete(): ApiConnectorUpdateComplete {
+    return new ApiConnectorUpdateComplete();
   }
 
   static delete(payload: string): ApiConnectorDelete {
@@ -158,8 +158,6 @@ export class ApiConnectorUpdate implements Action {
 
 export class ApiConnectorUpdateComplete implements Action {
   readonly type = ApiConnectorActions.UPDATE_COMPLETE;
-
-  constructor(public payload: CustomConnectorRequest) { }
 }
 
 export class ApiConnectorUpdateFail implements Action {

--- a/app/ui/src/app/customizations/api-connector/api-connector.effects.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.effects.ts
@@ -9,6 +9,7 @@ import {
   ApiConnectorValidateSwagger,
   ApiConnectorCreate,
   ApiConnectorCreateComplete,
+  ApiConnectorUpdate,
   ApiConnectorDelete,
   ApiConnectorDeleteComplete
 } from './api-connector.actions';
@@ -19,6 +20,7 @@ export class ApiConnectorEffects {
   fetchApiConnectors$: Observable<Action> = this.actions$
     .ofType(
     ApiConnectorActions.FETCH,
+    ApiConnectorActions.UPDATE_FAIL,
     ApiConnectorActions.DELETE_FAIL
     )
     .mergeMap(() =>
@@ -59,20 +61,24 @@ export class ApiConnectorEffects {
 
   @Effect()
   updateCustomConnector$: Observable<Action> = this.actions$
-    .ofType<ApiConnectorCreate>(ApiConnectorActions.UPDATE)
-    .mergeMap(action =>
-      this.apiConnectorService
+    .ofType<ApiConnectorUpdate>(ApiConnectorActions.UPDATE)
+    .mergeMap((action: ApiConnectorUpdate) => {
+      const hasUpdatedIcon = !!action.payload.iconFile;
+      return this.apiConnectorService
         .updateCustomConnector(action.payload)
-        .map(response => ({ type: ApiConnectorActions.UPDATE_COMPLETE }))
+        .map(response => ({ type: ApiConnectorActions.UPDATE_COMPLETE, payload: hasUpdatedIcon }))
         .catch(error => Observable.of({
           type: ApiConnectorActions.UPDATE_FAIL,
           payload: error
-        }))
-    );
+        }));
+    });
 
   @Effect()
   refreshApiConnectors$: Observable<Action> = this.actions$
-    .ofType<ApiConnectorCreateComplete>(ApiConnectorActions.CREATE_COMPLETE)
+    .ofType(
+      ApiConnectorActions.CREATE_COMPLETE,
+      ApiConnectorActions.UPDATE_COMPLETE
+    )
     .switchMap(() => Observable.of(ApiConnectorActions.fetch()));
 
   @Effect()


### PR DESCRIPTION
Fixes #1080 

In edit mode the thumbnail is not updated, since the image will be uploaded as soon as it is selected by the end user so no preview features are required.

When creating a new connector, the preview is enabled though, since the image will not be uploaded until the user submits the form. 

The icon preview area will crop and center the icon whenever its size exceeds the allocated size for that.

Since there is still no support for fetching icons after validating the swagger file, the cross icon has been replaced by an upload icon.

The following links allow for seeing an actual recoding of the implementation:

- https://app.hyfy.io/v/abuHAYOMw7n/
- https://app.hyfy.io/v/abuHAYOMw7n/
