### PR TITLE
fix(rest): AWS connector dependency

### DIFF
--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -186,17 +186,7 @@
           <!-- ==== AWS S3 ==== -->
           <dependency>
             <groupId>io.syndesis</groupId>
-            <artifactId>aws-s3-copy-object-connector</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>io.syndesis</groupId>
-            <artifactId>aws-s3-get-object-connector</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>io.syndesis</groupId>
-            <artifactId>aws-s3-polling-bucket-connector</artifactId>
+            <artifactId>aws-s3-connector</artifactId>
             <version>${project.version}</version>
           </dependency>
           <!-- ==== REST Swagger ==== -->


### PR DESCRIPTION
We seem to be referencing AWS connector GAVs before refactor in #1163.