### PR TITLE
 connector extensions

### DIFF
--- a/app/connectors/connectors/twitter-connector/pom.xml
+++ b/app/connectors/connectors/twitter-connector/pom.xml
@@ -103,6 +103,7 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/app/core/model/src/main/java/io/syndesis/model/Kind.java
+++ b/app/core/model/src/main/java/io/syndesis/model/Kind.java
@@ -38,7 +38,7 @@ public enum Kind {
     EnvironmentType(io.syndesis.model.environment.EnvironmentType.class),
 
     Extension(io.syndesis.model.extension.Extension.class),
-    ExtensionAction(io.syndesis.model.action.ExtensionAction.class),
+    StepAction(io.syndesis.model.action.StepAction.class),
 
     Organization(io.syndesis.model.environment.Organization.class),
 

--- a/app/core/model/src/main/java/io/syndesis/model/Schema.java
+++ b/app/core/model/src/main/java/io/syndesis/model/Schema.java
@@ -20,5 +20,5 @@ package io.syndesis.model;
  */
 public class Schema {
     // changing this will reset all the DB data.
-    public static final String VERSION = "22";
+    public static final String VERSION = "23";
 }

--- a/app/core/model/src/main/java/io/syndesis/model/WithResourceId.java
+++ b/app/core/model/src/main/java/io/syndesis/model/WithResourceId.java
@@ -15,9 +15,30 @@
  */
 package io.syndesis.model;
 
-public interface WithId<T extends WithId<T>> extends WithResourceId, WithKind {
+import java.util.Optional;
 
-    @Override
-    T withId(String id);
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ * Non-generic superclass of {@link WithId}.
+ */
+public interface WithResourceId {
+
+    Optional<String> getId();
+
+    Object withId(String id);
+
+    default boolean idEquals(final String another) {
+        final Optional<String> id = getId();
+        if (id.isPresent()) {
+            return id.get().equals(another);
+        }
+
+        return false;
+    }
+
+    @JsonIgnore
+    default boolean hasId() {
+        return getId().isPresent();
+    }
 }

--- a/app/core/model/src/main/java/io/syndesis/model/action/Action.java
+++ b/app/core/model/src/main/java/io/syndesis/model/action/Action.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.syndesis.model.DataShape;
 import io.syndesis.model.Kind;
 import io.syndesis.model.WithConfigurationProperties;
+import io.syndesis.model.WithResourceId;
 import io.syndesis.model.WithKind;
 import io.syndesis.model.WithName;
 import io.syndesis.model.WithTags;
@@ -46,14 +47,14 @@ import io.syndesis.model.connection.ConfigurationProperty;
         value = ImmutableConnectorAction.class,
         name  = Action.TYPE_CONNECTOR),
     @JsonSubTypes.Type(
-        value = ImmutableExtensionAction.class,
-        name  = Action.TYPE_EXTENSION)
+        value = ImmutableStepAction.class,
+        name  = Action.TYPE_STEP)
 })
 @JsonPropertyOrder({ "id", "name", "description", "descriptor", "tags", "actionType" })
 @JsonIgnoreProperties(value = {"properties", "inputDataShape", "outputDataShape"}, allowGetters = true)
-public interface Action<D extends ActionDescriptor> extends WithKind, WithName, WithTags, WithConfigurationProperties, Serializable {
+public interface Action extends WithResourceId, WithKind, WithName, WithTags, WithConfigurationProperties, Serializable {
     String TYPE_CONNECTOR = "connector";
-    String TYPE_EXTENSION = "extension";
+    String TYPE_STEP = "step";
 
     enum Pattern { From, To }
 
@@ -66,7 +67,7 @@ public interface Action<D extends ActionDescriptor> extends WithKind, WithName, 
 
     String getDescription();
 
-    D getDescriptor();
+    ActionDescriptor getDescriptor();
 
     Pattern getPattern();
 

--- a/app/core/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
+++ b/app/core/model/src/main/java/io/syndesis/model/action/ConnectorAction.java
@@ -27,7 +27,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorAction.Builder.class)
 @SuppressWarnings("immutables")
-public interface ConnectorAction extends Action<ConnectorDescriptor>, WithId<ConnectorAction>, WithDependencies {
+public interface ConnectorAction extends Action, WithId<ConnectorAction>, WithDependencies {
 
     @Override
     @Value.Default
@@ -39,6 +39,9 @@ public interface ConnectorAction extends Action<ConnectorDescriptor>, WithId<Con
     default ConnectorAction withId(String id) {
         return new Builder().createFrom(this).id(id).build();
     }
+
+    @Override
+    ConnectorDescriptor getDescriptor();
 
     @Override
     default List<Dependency> getDependencies() {

--- a/app/core/model/src/main/java/io/syndesis/model/action/StepAction.java
+++ b/app/core/model/src/main/java/io/syndesis/model/action/StepAction.java
@@ -20,22 +20,25 @@ import io.syndesis.model.WithId;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(builder = ExtensionAction.Builder.class)
+@JsonDeserialize(builder = StepAction.Builder.class)
 @SuppressWarnings("immutables")
-public interface ExtensionAction extends Action<ExtensionDescriptor>, WithId<ExtensionAction> {
+public interface StepAction extends Action, WithId<StepAction> {
 
     @Override
     @Value.Default
     default String getActionType() {
-        return Action.TYPE_EXTENSION;
+        return Action.TYPE_STEP;
     }
 
     @Override
-    default ExtensionAction withId(String id) {
+    default StepAction withId(String id) {
         return new Builder().createFrom(this).id(id).build();
     }
 
-    class Builder extends ImmutableExtensionAction.Builder {
+    @Override
+    StepDescriptor getDescriptor();
+
+    class Builder extends ImmutableStepAction.Builder {
     }
 
 

--- a/app/core/model/src/main/java/io/syndesis/model/action/StepDescriptor.java
+++ b/app/core/model/src/main/java/io/syndesis/model/action/StepDescriptor.java
@@ -26,14 +26,14 @@ import io.syndesis.model.connection.ConfigurationProperty;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(builder = ExtensionDescriptor.Builder.class)
+@JsonDeserialize(builder = StepDescriptor.Builder.class)
 @SuppressWarnings("immutables")
-public interface ExtensionDescriptor extends ActionDescriptor, Serializable {
+public interface StepDescriptor extends ActionDescriptor, Serializable {
 
-    final class Builder extends ImmutableExtensionDescriptor.Builder {
+    final class Builder extends ImmutableStepDescriptor.Builder {
         // make ImmutableActionDefinition.Builder accessible
 
-        public ExtensionDescriptor.Builder withActionDefinitionStep(
+        public StepDescriptor.Builder withActionDefinitionStep(
             final String name,
             final String description,
             final Consumer<ActionDescriptorStep.Builder> stepConfigurator) {
@@ -49,9 +49,9 @@ public interface ExtensionDescriptor extends ActionDescriptor, Serializable {
             return this;
         }
 
-        public ExtensionDescriptor.Builder replaceConfigurationProperty(final String propertyName,
-                                                                        final Consumer<ConfigurationProperty.Builder> configurationPropertyConfigurator) {
-            final ExtensionDescriptor definition = build();
+        public StepDescriptor.Builder replaceConfigurationProperty(final String propertyName,
+                                                                   final Consumer<ConfigurationProperty.Builder> configurationPropertyConfigurator) {
+            final StepDescriptor definition = build();
             final List<ActionDescriptorStep> steps = definition.getPropertyDefinitionSteps();
 
             int stepIdx;
@@ -88,7 +88,7 @@ public interface ExtensionDescriptor extends ActionDescriptor, Serializable {
     }
 
 
-    ExtensionAction.Kind getKind();
+    StepAction.Kind getKind();
 
     String getEntrypoint();
 }

--- a/app/core/model/src/main/java/io/syndesis/model/action/WithActions.java
+++ b/app/core/model/src/main/java/io/syndesis/model/action/WithActions.java
@@ -17,15 +17,25 @@ package io.syndesis.model.action;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.syndesis.model.WithId;
 import io.syndesis.model.validation.AllValidations;
 
-public interface WithActions<T extends Action<? extends ActionDescriptor>> {
+public interface WithActions<T extends Action> {
 
     @NotNull(groups = AllValidations.class)
     List<T> getActions();
+
+    @JsonIgnore
+    default <S extends T> List<S> getActions(Class<S> clazz) {
+        return getActions().stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .collect(Collectors.toList());
+    }
 
     default Optional<T> findActionById(String actionId) {
         if (getActions() == null) {
@@ -34,8 +44,8 @@ public interface WithActions<T extends Action<? extends ActionDescriptor>> {
 
         return getActions().stream()
             .filter(WithId.class::isInstance)
-            .filter(action -> ((WithId)action).getId().isPresent())
-            .filter(action -> actionId.equals(((WithId)action).getId().get()))
+            .filter(action -> action.getId().isPresent())
+            .filter(action -> actionId.equals(action.getId().get()))
             .findFirst();
     }
 }

--- a/app/core/model/src/main/java/io/syndesis/model/extension/Extension.java
+++ b/app/core/model/src/main/java/io/syndesis/model/extension/Extension.java
@@ -18,20 +18,25 @@ package io.syndesis.model.extension;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.core.IndexedProperty;
 import io.syndesis.model.Kind;
-import io.syndesis.model.WithConfigurationProperties;
 import io.syndesis.model.WithDependencies;
 import io.syndesis.model.WithId;
 import io.syndesis.model.WithMetadata;
 import io.syndesis.model.WithName;
+import io.syndesis.model.WithProperties;
 import io.syndesis.model.WithTags;
-import io.syndesis.model.action.ExtensionAction;
+import io.syndesis.model.action.Action;
+import io.syndesis.model.action.ConnectorAction;
+import io.syndesis.model.action.StepAction;
 import io.syndesis.model.action.WithActions;
 import io.syndesis.model.validation.AllValidations;
 import io.syndesis.model.validation.NonBlockingValidations;
@@ -41,18 +46,23 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(builder = Extension.Builder.class)
 @NoDuplicateExtension(groups = NonBlockingValidations.class)
-@JsonPropertyOrder({"name", "description", "icon", "extensionId", "version", "tags", "actions", "dependencies", "schemaVersion"})
+@JsonPropertyOrder({"schemaVersion", "name", "description", "icon", "extensionId", "version", "tags", "actions", "dependencies"})
 @IndexedProperty.Multiple({
     @IndexedProperty("extensionId"),
     @IndexedProperty("status")
 })
 @SuppressWarnings("immutables")
-public interface Extension extends WithId<Extension>, WithActions<ExtensionAction>, WithName, WithTags, WithConfigurationProperties, WithDependencies, WithMetadata, Serializable {
+public interface Extension extends WithId<Extension>, WithActions<Action>, WithName, WithTags, WithProperties, WithDependencies, WithMetadata, Serializable {
 
     enum Status {
         Draft,
         Installed,
         Deleted
+    }
+
+    enum Type {
+        Steps,
+        Connectors
     }
 
     @Override
@@ -89,6 +99,21 @@ public interface Extension extends WithId<Extension>, WithActions<ExtensionActio
     Optional<Date> getLastUpdated();
 
     Optional<Date> getCreatedDate();
+
+    @NotNull(groups = AllValidations.class)
+    Type getExtensionType();
+
+    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    default List<StepAction> getStepActions() {
+        return getActions(StepAction.class);
+    }
+
+    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    default List<ConnectorAction> getConnectorActions() {
+        return getActions(ConnectorAction.class);
+    }
 
     @Override
     default Extension withId(String id) {

--- a/app/core/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
+++ b/app/core/model/src/main/java/io/syndesis/model/integration/SimpleStep.java
@@ -39,7 +39,7 @@ public interface SimpleStep extends Step {
     }
 
     @Override
-    Optional<Action<?>> getAction();
+    Optional<Action> getAction();
 
     @Override
     Optional<Connection> getConnection();

--- a/app/core/model/src/main/java/io/syndesis/model/integration/Step.java
+++ b/app/core/model/src/main/java/io/syndesis/model/integration/Step.java
@@ -37,7 +37,7 @@ public interface Step extends WithId<Step>, WithConfiguredProperties, WithDepend
         return Kind.Step;
     }
 
-    Optional<Action<?>> getAction();
+    Optional<Action> getAction();
 
     Optional<Connection> getConnection();
 

--- a/app/core/model/src/test/resources/io/syndesis/model/extension/syndesis-extension-definition.json
+++ b/app/core/model/src/test/resources/io/syndesis/model/extension/syndesis-extension-definition.json
@@ -6,7 +6,7 @@
   "version" : "1.0.0-SNAPSHOT",
   "tags" : [ ],
   "actions" : [ {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-bean-binding",
     "name" : "BeanBindingLogExtension",
     "description" : "A simple bean-binding based logging extension",
@@ -23,7 +23,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-function-1",
     "name" : "FunctionLogExtension1",
     "description" : "A simple function based logging extension (1)",
@@ -40,7 +40,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-function-2",
     "name" : "FunctionLogExtension2",
     "description" : "A simple function based logging extension (2)",
@@ -57,7 +57,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-boot-1",
     "name" : "BootLogExtension1",
     "description" : "A simple route-definition based logging extension (1)",
@@ -74,7 +74,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-boot-2",
     "name" : "BootLogExtension2",
     "description" : "A simple route-builder based logging extension (2)",
@@ -91,7 +91,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-boot-3",
     "name" : "BootLogExtension3",
     "description" : "A simple processor based logging extension (2)",
@@ -108,7 +108,7 @@
     },
     "tags" : [ ]
   }, {
-    "actionType" : "extension",
+    "actionType" : "step",
     "id" : "my-step",
     "name" : "StepLogExtension",
     "description" : "A simple step based logging extension",

--- a/app/extension/api/src/main/resources/syndesis/syndesis-extension-definition-schema.json
+++ b/app/extension/api/src/main/resources/syndesis/syndesis-extension-definition-schema.json
@@ -25,6 +25,13 @@
     "extensionId": {
       "type": "string"
     },
+    "extensionType": {
+      "type": "string",
+      "enum": [
+        "Steps",
+        "Connectors"
+      ]
+    },
     "version": {
       "type": "string"
     },
@@ -38,8 +45,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "id": "urn:jsonschema:io:syndesis:model:action:ExtensionAction",
-        "additionalProperties": false,
+        "id": "urn:jsonschema:io:syndesis:model:action:Action",
         "properties": {
           "id": {
             "type": "string"
@@ -52,20 +58,8 @@
           },
           "descriptor": {
             "type": "object",
-            "id": "urn:jsonschema:io:syndesis:model:action:ExtensionDescriptor",
-            "additionalProperties": false,
+            "id": "urn:jsonschema:io:syndesis:model:action:ActionDescriptor",
             "properties": {
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "STEP",
-                  "BEAN",
-                  "ENDPOINT"
-                ]
-              },
-              "entrypoint": {
-                "type": "string"
-              },
               "propertyDefinitionSteps": {
                 "type": "array",
                 "items": {
@@ -86,6 +80,9 @@
                         "id": "urn:jsonschema:io:syndesis:model:connection:ConfigurationProperty",
                         "additionalProperties": false,
                         "properties": {
+                          "displayName": {
+                            "type": "string"
+                          },
                           "description": {
                             "type": "string"
                           },
@@ -94,22 +91,6 @@
                           },
                           "required": {
                             "type": "boolean"
-                          },
-                          "enum": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "id": "urn:jsonschema:io:syndesis:model:connection:ConfigurationProperty:PropertyValue",
-                              "additionalProperties": false,
-                              "properties": {
-                                "label": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              }
-                            }
                           },
                           "group": {
                             "type": "string"
@@ -126,13 +107,25 @@
                           "deprecated": {
                             "type": "boolean"
                           },
+                          "enum": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "id": "urn:jsonschema:io:syndesis:model:connection:ConfigurationProperty:PropertyValue",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
                           "type": {
                             "type": "string"
                           },
                           "defaultValue": {
-                            "type": "string"
-                          },
-                          "displayName": {
                             "type": "string"
                           },
                           "tags": {
@@ -142,6 +135,12 @@
                             }
                           }
                         }
+                      }
+                    },
+                    "configuredProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     }
                   }
@@ -237,6 +236,12 @@
       "additionalProperties": {
         "type": "object",
         "$ref": "urn:jsonschema:io:syndesis:model:connection:ConfigurationProperty"
+      }
+    },
+    "configuredProperties": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
       }
     },
     "metadata": {

--- a/app/extension/converter/src/test/java/io/syndesis/extension/converter/ExtensionSchemaValidationTest.java
+++ b/app/extension/converter/src/test/java/io/syndesis/extension/converter/ExtensionSchemaValidationTest.java
@@ -27,8 +27,8 @@ import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import io.syndesis.core.Json;
 import io.syndesis.model.action.Action;
-import io.syndesis.model.action.ExtensionAction;
-import io.syndesis.model.action.ExtensionDescriptor;
+import io.syndesis.model.action.StepAction;
+import io.syndesis.model.action.StepDescriptor;
 import io.syndesis.model.extension.Extension;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class ExtensionSchemaValidationTest {
     }
 
     @Test
-    public void validateExtensionTest() throws ProcessingException {
+    public void validateStepExtensionTest() throws ProcessingException {
         String syndesisExtensionSchema = "/syndesis/syndesis-extension-definition-schema.json";
         JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:" + syndesisExtensionSchema);
         ExtensionConverter converter = new DefaultExtensionConverter();
@@ -62,15 +62,14 @@ public class ExtensionSchemaValidationTest {
             .uses(OptionalInt.empty())
             .version("1.0.0")
             .schemaVersion(ExtensionConverter.getCurrentSchemaVersion())
-            .addAction(new ExtensionAction.Builder()
+            .addAction(new StepAction.Builder()
                 .id("action-1")
                 .name("action-1-name")
                 .description("Action 1 Description")
-                .actionType("extension")
                 .pattern(Action.Pattern.From)
-                .descriptor(new ExtensionDescriptor.Builder()
+                .descriptor(new StepDescriptor.Builder()
                     .entrypoint("direct:hello")
-                    .kind(ExtensionAction.Kind.ENDPOINT)
+                    .kind(StepAction.Kind.ENDPOINT)
                     .build())
                 .build())
             .build();
@@ -95,6 +94,7 @@ public class ExtensionSchemaValidationTest {
                 .description("Description")
                 .version("1.0.0")
                 .schemaVersion("old-V0.1")
+                .extensionType(Extension.Type.Steps)
                 .build();
 
         JsonNode tree = converter.toPublicExtension(extension);

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -101,6 +101,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${maven.version}</version>
@@ -358,6 +363,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.List;
 
 import io.syndesis.model.Dependency;
-import io.syndesis.model.action.ExtensionAction;
-import io.syndesis.model.action.ExtensionDescriptor;
+import io.syndesis.model.action.StepAction;
+import io.syndesis.model.action.StepDescriptor;
 import io.syndesis.model.connection.Connection;
 import io.syndesis.model.extension.Extension;
 import io.syndesis.model.filter.FilterPredicate;
@@ -100,10 +100,10 @@ public class ProjectGeneratorTest extends ProjectGeneratorTestSupport {
                     .build())
                 .putConfiguredProperty("key-1", "val-1")
                 .putConfiguredProperty("key-2", "val-2")
-                .action(new ExtensionAction.Builder()
+                .action(new StepAction.Builder()
                     .id("my-extension-1-action-1")
-                    .descriptor(new ExtensionDescriptor.Builder()
-                        .kind(ExtensionAction.Kind.ENDPOINT)
+                    .descriptor(new StepDescriptor.Builder()
+                        .kind(StepAction.Kind.ENDPOINT)
                         .entrypoint("direct:extension")
                         .build()
                     ).build())
@@ -116,10 +116,10 @@ public class ProjectGeneratorTest extends ProjectGeneratorTestSupport {
                     .build())
                 .putConfiguredProperty("key-1", "val-1")
                 .putConfiguredProperty("key-2", "val-2")
-                .action(new ExtensionAction.Builder()
+                .action(new StepAction.Builder()
                     .id("my-extension-1-action-1")
-                    .descriptor(new ExtensionDescriptor.Builder()
-                        .kind(ExtensionAction.Kind.BEAN)
+                    .descriptor(new StepDescriptor.Builder()
+                        .kind(StepAction.Kind.BEAN)
                         .entrypoint("com.example.MyExtension::action")
                         .build()
                     ).build())
@@ -132,10 +132,10 @@ public class ProjectGeneratorTest extends ProjectGeneratorTestSupport {
                     .build())
                 .putConfiguredProperty("key-1", "val-1")
                 .putConfiguredProperty("key-2", "val-2")
-                .action(new ExtensionAction.Builder()
+                .action(new StepAction.Builder()
                     .id("my-extension-2-action-1")
-                    .descriptor(new ExtensionDescriptor.Builder()
-                        .kind(ExtensionAction.Kind.STEP)
+                    .descriptor(new StepDescriptor.Builder()
+                        .kind(StepAction.Kind.STEP)
                         .entrypoint("com.example.MyStep")
                         .build()
                     ).build())

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerate/integration.json
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerate/integration.json
@@ -100,7 +100,7 @@
           "propertyDefinitionSteps" : [ ]
         },
         "tags" : [ ],
-        "actionType" : "extension"
+        "actionType" : "step"
       },
       "stepKind" : "extension",
       "configuredProperties" : {
@@ -123,6 +123,7 @@
         } ],
         "id" : "my-extension-1",
         "properties" : { },
+        "configuredProperties" : { },
         "metadata" : { }
       },
       "dependencies" : [ ],
@@ -138,7 +139,7 @@
           "propertyDefinitionSteps" : [ ]
         },
         "tags" : [ ],
-        "actionType" : "extension"
+        "actionType" : "step"
       },
       "stepKind" : "extension",
       "configuredProperties" : {
@@ -152,6 +153,7 @@
         "dependencies" : [ ],
         "id" : "my-extension-2",
         "properties" : { },
+        "configuredProperties" : { },
         "metadata" : { }
       },
       "dependencies" : [ ],
@@ -167,7 +169,7 @@
           "propertyDefinitionSteps" : [ ]
         },
         "tags" : [ ],
-        "actionType" : "extension"
+        "actionType" : "step"
       },
       "stepKind" : "extension",
       "configuredProperties" : {
@@ -181,6 +183,7 @@
         "dependencies" : [ ],
         "id" : "my-extension-3",
         "properties" : { },
+        "configuredProperties" : { },
         "metadata" : { }
       },
       "dependencies" : [ ],

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
@@ -24,7 +24,7 @@ import io.syndesis.extension.api.SyndesisStepExtension;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 import io.syndesis.integration.runtime.IntegrationStepHandler;
 import io.syndesis.integration.runtime.util.StringHelpers;
-import io.syndesis.model.action.ExtensionAction;
+import io.syndesis.model.action.StepAction;
 import io.syndesis.model.integration.Step;
 import org.apache.camel.CamelContext;
 import org.apache.camel.TypeConverter;
@@ -39,7 +39,7 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
             return false;
         }
 
-        return step.getAction().filter(ExtensionAction.class::isInstance).isPresent();
+        return step.getAction().filter(StepAction.class::isInstance).isPresent();
     }
 
     @SuppressWarnings("PMD")
@@ -48,19 +48,19 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
         ObjectHelper.notNull(route, "route");
 
         // Model
-        final ExtensionAction action = step.getAction().filter(ExtensionAction.class::isInstance).map(ExtensionAction.class::cast).get();
+        final StepAction action = step.getAction().filter(StepAction.class::isInstance).map(StepAction.class::cast).get();
 
         // Camel
         final Map<String, String> properties = step.getConfiguredProperties();
         final CamelContext context = builder.getContext();
 
-        if (action.getDescriptor().getKind() == ExtensionAction.Kind.ENDPOINT) {
+        if (action.getDescriptor().getKind() == StepAction.Kind.ENDPOINT) {
             for (Map.Entry<String, String> entry: properties.entrySet()) {
                 route.setHeader(entry.getKey(), builder.constant(entry.getValue()));
             }
 
             route = route.to(action.getDescriptor().getEntrypoint());
-        } else if (action.getDescriptor().getKind() == ExtensionAction.Kind.BEAN) {
+        } else if (action.getDescriptor().getKind() == StepAction.Kind.BEAN) {
             String method = null;
             String function = action.getDescriptor().getEntrypoint();
             String options = null;
@@ -95,7 +95,7 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
             }
 
             route = route.to(uri);
-        } else if (action.getDescriptor().getKind() == ExtensionAction.Kind.STEP) {
+        } else if (action.getDescriptor().getKind() == StepAction.Kind.STEP) {
             final String target = action.getDescriptor().getEntrypoint();
             final TypeConverter converter = context.getTypeConverter();
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
@@ -24,8 +24,8 @@ import io.syndesis.extension.api.SyndesisStepExtension;
 import io.syndesis.integration.runtime.handlers.support.StepHandlerTestSupport;
 import io.syndesis.model.action.ConnectorAction;
 import io.syndesis.model.action.ConnectorDescriptor;
-import io.syndesis.model.action.ExtensionAction;
-import io.syndesis.model.action.ExtensionDescriptor;
+import io.syndesis.model.action.StepAction;
+import io.syndesis.model.action.StepDescriptor;
 import io.syndesis.model.integration.SimpleStep;
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -99,9 +99,9 @@ public class ExtensionStepHandlerTest extends StepHandlerTestSupport {
                     .build(),
                 new SimpleStep.Builder()
                     .stepKind("extension")
-                    .action(new ExtensionAction.Builder()
-                        .descriptor(new ExtensionDescriptor.Builder()
-                            .kind(ExtensionAction.Kind.ENDPOINT)
+                    .action(new StepAction.Builder()
+                        .descriptor(new StepDescriptor.Builder()
+                            .kind(StepAction.Kind.ENDPOINT)
                             .entrypoint("log:myLog")
                             .build())
                         .build())
@@ -163,9 +163,9 @@ public class ExtensionStepHandlerTest extends StepHandlerTestSupport {
                     .build(),
                 new SimpleStep.Builder()
                     .stepKind("extension")
-                    .action(new ExtensionAction.Builder()
-                        .descriptor(new ExtensionDescriptor.Builder()
-                            .kind(ExtensionAction.Kind.BEAN)
+                    .action(new StepAction.Builder()
+                        .descriptor(new StepDescriptor.Builder()
+                            .kind(StepAction.Kind.BEAN)
                             .entrypoint("io.syndesis.integration.runtime.handlers.ExtensionStepHandlerTest$MyExtension::action")
                             .build())
                         .build())
@@ -224,9 +224,9 @@ public class ExtensionStepHandlerTest extends StepHandlerTestSupport {
                     .build(),
                 new SimpleStep.Builder()
                     .stepKind("extension")
-                    .action(new ExtensionAction.Builder()
-                        .descriptor(new ExtensionDescriptor.Builder()
-                            .kind(ExtensionAction.Kind.STEP)
+                    .action(new StepAction.Builder()
+                        .descriptor(new StepDescriptor.Builder()
+                            .kind(StepAction.Kind.STEP)
                             .entrypoint("io.syndesis.integration.runtime.handlers.ExtensionStepHandlerTest$MyStepExtension")
                             .build())
                         .build())

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
@@ -19,8 +19,8 @@ import io.syndesis.extension.api.SyndesisStepExtension;
 import io.syndesis.integration.runtime.handlers.support.StepHandlerTestSupport;
 import io.syndesis.model.action.ConnectorAction;
 import io.syndesis.model.action.ConnectorDescriptor;
-import io.syndesis.model.action.ExtensionAction;
-import io.syndesis.model.action.ExtensionDescriptor;
+import io.syndesis.model.action.StepAction;
+import io.syndesis.model.action.StepDescriptor;
 import io.syndesis.model.integration.SimpleStep;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
@@ -84,9 +84,9 @@ public class LogsAndErrorsTest extends StepHandlerTestSupport {
                     new SimpleStep.Builder()
                             .id("s2")
                             .stepKind("extension")
-                            .action(new ExtensionAction.Builder()
-                                    .descriptor(new ExtensionDescriptor.Builder()
-                                            .kind(ExtensionAction.Kind.STEP)
+                            .action(new StepAction.Builder()
+                                    .descriptor(new StepDescriptor.Builder()
+                                            .kind(StepAction.Kind.STEP)
                                             .entrypoint(LogExtension.class.getName())
                                             .build())
                                     .build())
@@ -94,9 +94,9 @@ public class LogsAndErrorsTest extends StepHandlerTestSupport {
                     new SimpleStep.Builder()
                             .id("s3")
                             .stepKind("extension")
-                            .action(new ExtensionAction.Builder()
-                                    .descriptor(new ExtensionDescriptor.Builder()
-                                            .kind(ExtensionAction.Kind.STEP)
+                            .action(new StepAction.Builder()
+                                    .descriptor(new StepDescriptor.Builder()
+                                            .kind(StepAction.Kind.STEP)
                                             .entrypoint(ErrorExtension.class.getName())
                                             .build())
                                     .build())

--- a/app/rest/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
+++ b/app/rest/credential/src/main/java/io/syndesis/credential/CredentialProviderRegistry.java
@@ -59,8 +59,7 @@ final class CredentialProviderRegistry implements CredentialProviderLocator {
             if ("oauth2".equalsIgnoreCase(authentication.get())) {
                 socialProperties = new OAuth2ConnectorProperties(connector);
             } else {
-                throw new IllegalArgumentException(
-                    "Unsupported authentication type: " + authentication.get() + ", for connector: " + providerId);
+                socialProperties = new ConnectorSettings(connector);
             }
         } else {
             socialProperties = new ConnectorSettings(connector);

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/extension/ExtensionActivator.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/extension/ExtensionActivator.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.rest.v1.handler.extension;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import io.syndesis.dao.manager.DataManager;
+import io.syndesis.model.Dependency;
+import io.syndesis.model.Kind;
+import io.syndesis.model.WithConfigurationProperties;
+import io.syndesis.model.WithConfiguredProperties;
+import io.syndesis.model.WithName;
+import io.syndesis.model.action.ConnectorAction;
+import io.syndesis.model.connection.Connection;
+import io.syndesis.model.connection.Connector;
+import io.syndesis.model.extension.Extension;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExtensionActivator {
+
+    private final DataManager dataManager;
+
+    public ExtensionActivator(DataManager dataManager) {
+        this.dataManager = dataManager;
+    }
+
+    public void activateExtension(Extension extension) {
+        Date rightNow = new Date();
+
+        // Uninstall other active extensions
+        doDeleteInstalled(extension.getExtensionId());
+
+        updateConnectors(extension);
+
+        dataManager.update(new Extension.Builder().createFrom(extension)
+            .status(Extension.Status.Installed)
+            .lastUpdated(rightNow)
+            .build());
+    }
+
+    public void deleteExtension(Extension extension) {
+        if (extension.getStatus().isPresent() && extension.getStatus().get().equals(Extension.Status.Installed)) {
+            doDeleteRelatedObjects(extension);
+        }
+        doDelete(extension);
+    }
+
+    private void doDeleteInstalled(String logicalExtensionId) {
+        Set<String> ids = dataManager.fetchIdsByPropertyValue(Extension.class, "extensionId", logicalExtensionId);
+        for (String id : ids) {
+            Extension extension = dataManager.fetch(Extension.class, id);
+            if (extension.getStatus().isPresent() && extension.getStatus().get() == Extension.Status.Installed) {
+                doDelete(extension);
+            }
+        }
+    }
+
+    private void doDelete(Extension extension) {
+        Date rightNow = new Date();
+        dataManager.update(new Extension.Builder()
+            .createFrom(extension)
+            .status(Extension.Status.Deleted)
+            .lastUpdated(rightNow)
+            .build());
+    }
+
+    private void doDeleteRelatedObjects(Extension extension) {
+        Optional<Connector> connector = findAssociatedConnector(extension);
+        if (connector.isPresent()) {
+            List<Connection> connections = findAssociatedConnections(connector.get());
+            for (Connection connection : connections) {
+                if (connection.getId().isPresent()) {
+                    dataManager.delete(Connection.class, connection.getId().get());
+                }
+            }
+
+            if (connector.get().getId().isPresent()) {
+                dataManager.delete(Connector.class, connector.get().getId().get());
+            }
+        }
+    }
+
+    private void updateConnectors(Extension extension) {
+        if (extension.getConnectorActions().size() == 0) {
+            // No connector to create, but delete any previously created connector
+            doDeleteRelatedObjects(extension);
+            return;
+        }
+
+        Connector newConnector = toConnector(extension);
+
+        Optional<Connector> existingConnector = findAssociatedConnector(extension);
+        if (existingConnector.isPresent()) {
+            // Put already configured properties into new connector
+            newConnector = migrateOldConnectorData(existingConnector.get(), newConnector);
+            dataManager.update(newConnector);
+
+            List<Connection> existingConnections = findAssociatedConnections(existingConnector.get());
+            for (Connection connection : existingConnections) {
+                Connection newConnection = recreateConnection(connection, newConnector);
+                dataManager.update(newConnection);
+            }
+        } else {
+            dataManager.create(newConnector);
+        }
+    }
+
+    private Connection recreateConnection(Connection existingConnection, Connector newConnector) {
+        Optional<Connector> connectorToUse = existingConnection.getConnector().map(old -> newConnector);
+
+        Map<String, String> confProperties = new TreeMap<>(existingConnection.getConfiguredProperties());
+        confProperties.keySet().retainAll(newConnector.getProperties().keySet());
+
+        return new Connection.Builder()
+            .createFrom(existingConnection)
+            .connector(connectorToUse)
+            .configuredProperties(confProperties)
+            .build();
+    }
+
+    private Connector migrateOldConnectorData(Connector existingConnector, Connector newConnector) {
+        Map<String, String> propValues = new TreeMap<>(existingConnector.getConfiguredProperties());
+        propValues.keySet().retainAll(newConnector.getProperties().keySet());
+
+        if (!propValues.isEmpty()) {
+            return new Connector.Builder()
+                .createFrom(newConnector)
+                .putAllConfiguredProperties(propValues)
+                .build();
+        }
+        return newConnector;
+    }
+
+    private List<Connection> findAssociatedConnections(Connector connector) {
+        return dataManager.fetchAll(Connection.class).getItems().stream()
+            .filter(c -> connector.getId().equals(c.getConnectorId()))
+            .collect(Collectors.toList());
+    }
+
+    private Optional<Connector> findAssociatedConnector(Extension extension) {
+        return Optional.ofNullable(dataManager.fetch(Connector.class, getConnectorIdForExtension(extension)));
+    }
+
+    private Connector toConnector(Extension extension) {
+        List<ConnectorAction> connectorActions = extension.getActions(ConnectorAction.class);
+
+        return new Connector.Builder()
+            .createFrom((WithName) extension)
+            .createFrom((WithConfigurationProperties) extension)
+            .createFrom((WithConfiguredProperties) extension)
+            .kind(Kind.Connector)
+            .actions(connectorActions)
+            .description(extension.getDescription())
+            .icon(extension.getIcon())
+            .addDependency(new Dependency.Builder()
+                .id(extension.getExtensionId())
+                .type(Dependency.Type.EXTENSION)
+                .build())
+            .id(getConnectorIdForExtension(extension))
+            .build();
+    }
+
+    private String getConnectorIdForExtension(Extension extension) {
+        return "ext-" + extension.getExtensionId().replaceAll("[^a-zA-Z0-9]","-");
+    }
+
+
+}

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
@@ -247,7 +247,7 @@ public class ExtensionsITCase extends BaseITCase {
         assertThat(got1.getBody()).isEmpty();
 
         dataManager.create(new IntegrationDeployment.Builder()
-            .integrationId("integration-extension")
+            .integrationId("integration-extension-1")
             .version(1)
             .targetState(IntegrationDeploymentState.Active)
             .currentState(IntegrationDeploymentState.Active)
@@ -268,8 +268,8 @@ public class ExtensionsITCase extends BaseITCase {
 
         // Create a inactive integration that uses the extension
         dataManager.create(new IntegrationDeployment.Builder()
-            .integrationId("integration-extension")
-            .version(2)
+            .integrationId("integration-extension-2")
+            .version(1)
             .targetState(IntegrationDeploymentState.Undeployed)
             .currentState(IntegrationDeploymentState.Active)
             .createdDate(new Date())
@@ -292,10 +292,10 @@ public class ExtensionsITCase extends BaseITCase {
             new ParameterizedTypeReference<Set<ResourceIdentifier>>() {}, tokenRule.validToken(), HttpStatus.OK);
 
         assertThat(got2.getBody().size()).isEqualTo(1);
-        assertThat(got2.getBody()).allMatch(ri -> ri.getId().isPresent() && ri.getId().get().equals("integration-extension:1"));
+        assertThat(got2.getBody()).allMatch(ri -> ri.getId().isPresent() && ri.getId().get().equals("integration-extension-1"));
 
-        dataManager.delete(IntegrationDeployment.class, "integration-extension:1");
-        dataManager.delete(IntegrationDeployment.class, "integration-extension:2");
+        dataManager.delete(IntegrationDeployment.class, "integration-extension-1");
+        dataManager.delete(IntegrationDeployment.class, "integration-extension-2");
     }
 
     @Test
@@ -372,6 +372,7 @@ public class ExtensionsITCase extends BaseITCase {
                 .name("Extension " + prg)
                 .description("Extension Description " + prg)
                 .version("1.0")
+                .extensionType(Extension.Type.Steps)
                 .build();
 
             JsonNode extensionTree = ExtensionConverter.getDefault().toPublicExtension(extension);

--- a/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
+++ b/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
@@ -102,7 +102,7 @@ public class Application implements ApplicationRunner {
         for (final ModelData<?> model : modelList) {
             if (model.getKind() == Kind.Connector) {
                 final Connector connector = (Connector) model.getData();
-                for (final Action<?> action : connector.getActions()) {
+                for (final Action action : connector.getActions()) {
                     steps.add(
                         new SimpleStep.Builder()
                             .stepKind("endpoint")
@@ -144,7 +144,7 @@ public class Application implements ApplicationRunner {
                     Connector connector = Json.mapper().readValue(resource.getInputStream(), Connector.class);
 
                     if (connector != null) {
-                        for (final Action<?> action : connector.getActions()) {
+                        for (final Action action : connector.getActions()) {
                             steps.add(
                                 new SimpleStep.Builder()
                                     .stepKind("endpoint")

--- a/app/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
+++ b/app/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.html
@@ -32,7 +32,7 @@
         <div class="panel-heading">
           <h1 class="panel-title inline-block">
             {{ extension.name }}
-            <small>({{ extension.extensionId }})</small>
+            <small>(ID: {{ extension.extensionId }})</small>
           </h1>
           <div class="pull-right">
             <button type="button"
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="panel-body">
-          <h4>Overview</h4>
+          <h2 class="section-heading">Overview</h2>
           <dl class="dl-horizontal">
             <dt>
               Name
@@ -61,8 +61,33 @@
               {{ extension.description }}
             </dd>
           </dl>
-          <p></p>
-          <h4>Supported Steps</h4>
+          <dl class="dl-horizontal">
+            <dt>
+              Type
+            </dt>
+            <dd>
+              <ng-container *ngIf="extension.extensionType == 'Steps'; else typeDescConnector">
+                Step Extension
+              </ng-container>
+              <ng-template #typeDescConnector>
+                Connector Extension
+              </ng-template>
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              Last Update
+            </dt>
+            <dd>
+              {{ extension.lastUpdated | date : 'medium' }}
+            </dd>
+          </dl>
+          <ng-container *ngIf="extension.extensionType == 'Steps'; else supportedTypeConnector">
+            <h2 class="section-heading intermediate">Supported Steps</h2>
+          </ng-container>
+          <ng-template #supportedTypeConnector>
+            <h2 class="section-heading intermediate">Supported Actions</h2>
+          </ng-template>
           <div class="row">
             <div class="col-xs-1">
             </div>
@@ -76,8 +101,7 @@
             </div>
           </div>
           <ng-container *ngIf="integrations$ | async; let integrations">
-              <p></p>
-              <h4>Usage</h4>
+              <h2 class="section-heading intermediate">Usage</h2>
               <div class="row">
                 <div class="col-xs-1">
                 </div>

--- a/app/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.scss
+++ b/app/ui/src/app/customizations/tech-extensions/detail/tech-extension-detail.component.scss
@@ -2,3 +2,19 @@
   background: inherit;
   padding: 20px 15px;
 }
+
+h2.section-heading {
+  font-weight: bold;
+  font-size: 14px;
+  margin-left: 20px;
+  margin-bottom: 20px;
+}
+
+h2.section-heading.intermediate {
+  margin-top: 35px;
+}
+
+h1 small {
+  padding-left: 5px;
+  font-size: 85%;
+}

--- a/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
+++ b/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.html
@@ -64,7 +64,8 @@
           <div [class]="error.level" [innerHtml]="error.message">
           </div>
         </ng-container>
-        <dl class="dl-horizontal"
+
+        <dl class="dl-horizontal dl-file-uploader"
             ng2FileDrop
             [uploader]="uploader">
           <dt>
@@ -119,7 +120,25 @@
           </dl>
           <dl class="dl-horizontal">
             <dt>
-              Steps
+              Type
+            </dt>
+            <dd>
+              <ng-container *ngIf="response.extensionType == 'Steps'; else typeDescConnector">
+                Step Extension
+              </ng-container>
+              <ng-template #typeDescConnector>
+                Connector Extension
+              </ng-template>
+            </dd>
+          </dl>
+          <dl class="dl-horizontal">
+            <dt>
+              <ng-container *ngIf="response.extensionType == 'Steps'; else typeConnector">
+                Steps
+              </ng-container>
+              <ng-template #typeConnector>
+                Actions
+              </ng-template>
             </dt>
             <dd>
               <div *ngFor="let action of response.actions">

--- a/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.scss
+++ b/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.scss
@@ -2,3 +2,12 @@
   background: inherit;
   padding: 20px 15px;
 }
+
+h3 small {
+  padding-left: 5px;
+  font-size: 85%;
+}
+
+.dl-file-uploader {
+  margin-top: 35px;
+}

--- a/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
+++ b/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
@@ -65,7 +65,7 @@ export class TechExtensionImportComponent implements OnInit {
         header: 'Imported!',
         message: 'Your extension has been imported'
       });
-      const id = this.extensionId || this.response.id;
+      const id = this.response.id || this.extensionId;
       this.router.navigate(['/customizations/extensions', id], { relativeTo: this.route });
     }).catch((reason: any) => {
       this.error = {

--- a/app/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
+++ b/app/ui/src/app/customizations/tech-extensions/tech-extensions-list.component.html
@@ -38,6 +38,14 @@
               <div class="list-pf-description" text-overflow-pf>{{ item.description }}</div>
             </div>
             <div class="list-pf-additional-content">
+              <span>
+                <ng-container *ngIf="item.extensionType == 'Steps'; else typeDescConnector">
+                  Step Extension
+                </ng-container>
+                <ng-template #typeDescConnector>
+                  Connector Extension
+                </ng-template>
+              </span>
               <span *ngIf="item.uses">
                 Used by <span [innerHtml]="item.uses | i18nPlural: itemUseMapping"></span>
               </span>

--- a/app/ui/src/app/model.ts
+++ b/app/ui/src/app/model.ts
@@ -37,33 +37,16 @@ export interface Extension extends BaseEntity {
   extensionId: string;
   version: string;
   tags: Array<string>;
-  actions: Array<ExtensionAction>;
+  actions: Array<Action>;
   dependencies: Array<string>;
   status: 'Draft' | 'Installed' | 'Deleted';
   id: string;
+  schemaVersion: string;
   properties: {};
+  configuredProperties: {};
+  extensionType: string;
 }
 export type Extensions = Array<Extension>;
-
-export interface ExtensionAction extends BaseEntity {
-  id: string;
-  name: string;
-  description: string;
-  descriptor: ExtensionDescriptor;
-  tags: Array<string>;
-  actionType: string;
-  pattern: 'From' | 'To';
-}
-export type ExtensionActions = Array<ExtensionAction>;
-
-export interface ExtensionDescriptor extends BaseEntity {
-  kind: 'STEP' | 'BEAN' | 'ENDPOINT';
-  entrypoint: string;
-  propertyDefinitionSteps: Array<ActionDescriptorStep>;
-  inputDataShape: DataShape;
-  outputDataShape: DataShape;
-}
-export type ExtensionDescriptors = Array<ExtensionDescriptor>;
 
 export interface Action extends BaseEntity {
   actionType: string;
@@ -422,28 +405,6 @@ class TypeFactoryClass {
       status: undefined,
       id: undefined,
       properties: undefined
-    };
-  }
-
-  createExtensionAction() {
-    return <ExtensionAction>{
-      id: undefined,
-      name: undefined,
-      description: undefined,
-      descriptor: undefined,
-      tags: undefined,
-      actionType: undefined,
-      pattern: undefined
-    };
-  }
-
-  createExtensionDescriptor() {
-    return <ExtensionDescriptor>{
-      kind: undefined,
-      entrypoint: undefined,
-      propertyDefinitionSteps: undefined,
-      inputDataShape: undefined,
-      outputDataShape: undefined
     };
   }
 

--- a/app/ui/src/app/store/step/step.store.ts
+++ b/app/ui/src/app/store/step/step.store.ts
@@ -192,18 +192,20 @@ export class StepStore {
     const allSteps = [];
     for ( const extension of extensions ) {
       for ( const action of extension.actions) {
-        const properties = action.descriptor.propertyDefinitionSteps.reduce((acc, current) => {
-          return { ...acc, ...current.properties };
-        }, {});
-        allSteps.push({
-          name: action.name,
-          description: action.description,
-          stepKind: 'extension',
-          properties: properties,
-          extension: extension,
-          action: action,
-          configuredProperties: undefined,
-        });
+        if (action.actionType == 'step') {
+          const properties = action.descriptor.propertyDefinitionSteps.reduce((acc, current) => {
+            return {...acc, ...current.properties};
+          }, {});
+          allSteps.push({
+            name: action.name,
+            description: action.description,
+            stepKind: 'extension',
+            properties: properties,
+            extension: extension,
+            action: action,
+            configuredProperties: undefined,
+          });
+        }
       }
     }
     return this.steps.concat(allSteps).sort((a, b) => a.name.localeCompare(b.name));

--- a/project/proposals/181-tech-extension.adoc
+++ b/project/proposals/181-tech-extension.adoc
@@ -302,12 +302,12 @@ public interface Descriptor {
         value = ImmutableConnectorAction.class,
         name  = Action.TYPE_CONNECTOR),
     @JsonSubTypes.Type(
-        value = ImmutableExtensionAction.class,
+        value = ImmutableStepAction.class,
         name  = Action.TYPE_EXTENSION)
 })
 public interface Action<D extends Descriptor> {
     String TYPE_CONNECTOR = "connector";
-    String TYPE_EXTENSION = "extension";
+    String TYPE_STEP = "step";
 
     /**
      * Only used as marker purpose
@@ -342,7 +342,7 @@ public interface ExtensionAction extends Action<ExtensionDescriptor> {
         return Action.TYPE_EXTENSION;
     }
 
-    class Builder extends ImmutableExtensionAction.Builder {
+    class Builder extends ImmutableStepAction.Builder {
     }
 }
 


### PR DESCRIPTION
Fixes #1041 by allowing extensions to contain connectors and steps.
Fixes #1055 
Fixes #1057 
Fixes #1042 

Notes:
- `ExtensionAction` has been renamed to `StepAction`, so extensions can contain `StepAction` or `ConnectorAction`.
- `Action` is no longer generic, to avoid chaining.
- I've extended the maven plugin to generate inspections (type specification) for any kind of extension actions.
- An extension activator manages the lifecycle of resources created from an extension (`Connector`, `Connection`).
- UI updated according to #806 