### PR TITLE
fix: static typing restored for Integration instance object

### DIFF
--- a/app/ui/src/app/store/integration/integration.store.ts
+++ b/app/ui/src/app/store/integration/integration.store.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { IntegrationService } from './integration.service';
-import { Integrations, Integration, TypeFactory } from '../../model';
+import { Observable } from 'rxjs/Observable';
 
+import { Integrations, Integration, TypeFactory } from '@syndesis/ui/model';
+
+import { IntegrationService } from './integration.service';
 import { AbstractStore } from '../entity/entity.store';
 import { EventsService } from '../entity/events.service';
 
@@ -22,16 +24,14 @@ export class IntegrationStore extends AbstractStore<
     return 'Integration';
   }
 
-  public activate(i: Integration) {
-    const _i = JSON.parse(JSON.stringify(i));
-    _i.desiredStatus = 'Active';
-    return this.update(_i);
+  public activate(integration: Integration): Observable<Integration> {
+    integration.desiredStatus = 'Active';
+    return this.update(integration);
   }
 
-  public deactivate(i: Integration) {
-    const _i = JSON.parse(JSON.stringify(i));
-    _i.desiredStatus = 'Inactive';
-    return this.update(_i);
+  public deactivate(integration: Integration): Observable<Integration> {
+    integration.desiredStatus = 'Inactive';
+    return this.update(integration);
   }
 
   newInstance(): Integration {


### PR DESCRIPTION
Not bound to any particular issue, but just a quick fix for some methods that broke statical typing in the Integration "store".

Details: The statement `JSON.parse(JSON.stringify(i))` turned the`Integration` instance object input into a non-typed literal object (typed as `any`). That's why the compiler and the CI never complained when `integration.desiredStatus` was populated with a non valid value ('Activated' instead of the allowed primitive string `Active`).

TypeScript is a huge safety net when it comes to ensure that function payloads are consistent and testable... unless static typing is removed from the picture. Let's commit to ensure consistent typing at all times ;)

