### PR TITLE
Added support for custom headers, response types and params to to ApiHttpService

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector.service.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.service.ts
@@ -63,7 +63,7 @@ export class ApiConnectorService {
     const connector = this.sanitizeCustomConnectorRequest(rawConnector);
 
     if (icon) {
-      return apiHttpService.upload({ icon }, { connector }, 'PUT');
+      return apiHttpService.upload({ icon }, { connector }, { method: 'PUT' });
     } else {
       return apiHttpService.put(connector);
     }

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { StringMap, FileMap } from '@syndesis/ui/platform';
-import { ApiResponse, ApiEndpoint, ApiRequestProgress } from './api.models';
+import { ApiResponse, ApiEndpoint, ApiRequestProgress, ApiRequestOptions, ApiUploadOptions } from './api.models';
 
 @Injectable()
 export abstract class ApiHttpService {
@@ -45,40 +45,44 @@ export abstract class ApiHttpService {
   /**
    * Sends a GET request to the selected API endpoint URL.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
+   * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract get<T>(endpoint: string | any[]): Observable<T>;
+  abstract get<T>(endpoint: string | any[], options?: ApiRequestOptions|any): Observable<T>;
 
   /**
    * Sends a POST request containing the given body to the selected API endpoint URL.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
    * @param body Request body. Can be any type.
+   * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract post<T>(endpoint: string | any[], body: any): Observable<T>;
+  abstract post<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
 
   /**
    * Sends a PUT request containing the given body to the selected API endpoint URL.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
    * @param body Request body. Can be any type.
+   * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract put<T>(endpoint: string | any[], body: any): Observable<T>;
+  abstract put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
 
   /**
    * Sends a DELETE request to the selected API endpoint URL.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
+   * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract delete<T>(endpoint: string | any[]): Observable<T>;
+  abstract delete<T>(endpoint: string | any[], options?: ApiRequestOptions|any): Observable<T>;
 
   /**
    * Sends a multipart message wrapped by a POST/PUT request to the API, allowing one or several file uploads along with JSON objects.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
    * @param fileMap Hash library containing key/value pairs of named files.
    * @param body Request body. Can be any type.
-   * @param verb Optional. Allows for selecting a particular request verb between POST and PUT. Defaults to POST.
+   * @param options Optional. Allows for adding additional metadata to the request, such as custom headers or response types, methods, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract upload<T>(endpoint: string | any[], fileMap?: FileMap, body?: StringMap<any>, verb?: 'POST'|'PUT'): Observable<T>;
+  abstract upload<T>(endpoint: string | any[], fileMap?: FileMap, body?: StringMap<any>, options?: ApiUploadOptions): Observable<T>;
 }

--- a/app/ui/src/app/platform/types/api/api.models.ts
+++ b/app/ui/src/app/platform/types/api/api.models.ts
@@ -1,7 +1,9 @@
+import { HttpHeaders } from '@angular/common/http';
 import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { StringMap, FileMap } from '@syndesis/ui/platform';
+import { HttpParams } from '@angular/common/http/src/params';
 
 export declare type Endpoints = StringMap<string>;
 
@@ -27,13 +29,24 @@ export interface ApiResponse extends ApiErrors {
   kind?: string;
 }
 
+export interface ApiRequestOptions {
+  headers?: HttpHeaders;
+  params?: HttpParams;
+  responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
+  withCredentials?: boolean;
+}
+
+export interface ApiUploadOptions extends ApiRequestOptions {
+  method?: 'POST' | 'PUT';
+}
+
 export interface ApiEndpoint {
   url: string;
-  get<T>(): Observable<T>;
-  post<T>(payload: any): Observable<T>;
-  put<T>(payload: any): Observable<T>;
-  delete<T>(payload?: any): Observable<T>;
-  upload<T>(fileMap?: FileMap, body?: StringMap<any>, verb?: 'POST'|'PUT'): Observable<T>;
+  get<T>(options?: ApiRequestOptions): Observable<T>;
+  post<T>(body: any, options?: ApiRequestOptions): Observable<T>;
+  put<T>(body: any, options?: ApiRequestOptions): Observable<T>;
+  delete<T>(body?: any, options?: ApiRequestOptions): Observable<T>;
+  upload<T>(fileMap?: FileMap, body?: StringMap<any>, options?: ApiUploadOptions): Observable<T>;
 }
 
 export interface ApiRequestProgress {


### PR DESCRIPTION
This is a WIP to double check if, despite TypeScript requirements for type inference, we can define our own custom `HttpHeaders`, URL params and response types.

In a nutshell, the request methods from `ApiHttpService` now support a new `options` parameter in its signature that represents an object whose properties match the options parameters of the `HttpClient` class  in Angular. Basically we can now define an options object like this (see Angular's official API docs for more insights on `HttpHeaders` and `HttpParams` - all object properties are optional):

```
{
  headers?: HttpHeaders;
  params?: HttpParams;
  responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
  withCredentials?: boolean;
}
```

 and pass it on to `ApiHttpService` calls like this:

```typescript
apiHttpService
  .setApiEndpoint('/export.zip?id=foo&id=bar')
  .get<Blob>({ responseType: 'blob' });
```

You can also leverage the direct method interface:

```typescript

apiHttpService.get<Blob>('/export.zip?id=foo&id=bar', { responseType: 'blob' });
```