### PR TITLE
Allow OAuth bearer token authentication against the backend API

### DIFF
--- a/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -141,15 +141,3 @@
       type: ImageChange
 {{/WithDockerImages}}
     - type: ConfigChange
-{{#Restricted}}
-- apiVersion: v1
-  kind: ClusterRoleBinding
-  roleRef:
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: syndesis-oauth-client
-    namespace: ${OPENSHIFT_PROJECT}
-  userNames:
-  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
-{{/Restricted}}

--- a/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -121,7 +121,6 @@
             requests:
               memory: 20Mi
 {{#Restricted}}
-        serviceAccount: syndesis-oauth-client
         serviceAccountName: syndesis-oauth-client
 {{/Restricted}}
         volumes:

--- a/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -82,7 +82,10 @@
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            {{#Restricted}}- --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}{{/Restricted}}
+{{#Restricted}}
+            - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
+            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+{{/Restricted}}
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -117,6 +120,10 @@
               memory: 200Mi
             requests:
               memory: 20Mi
+{{#Restricted}}
+        serviceAccount: syndesis-oauth-client
+        serviceAccountName: syndesis-oauth-client
+{{/Restricted}}
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -134,3 +141,15 @@
       type: ImageChange
 {{/WithDockerImages}}
     - type: ConfigChange
+{{#Restricted}}
+- apiVersion: v1
+  kind: ClusterRoleBinding
+  roleRef:
+    name: system:auth-delegator
+  subjects:
+  - kind: ServiceAccount
+    name: syndesis-oauth-client
+    namespace: ${OPENSHIFT_PROJECT}
+  userNames:
+  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
+{{/Restricted}}

--- a/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -82,6 +82,7 @@
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
 {{#Restricted}}
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
             - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -744,7 +744,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -707,7 +707,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            
+
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -727,6 +727,7 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
+
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -743,6 +744,7 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -707,6 +707,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -629,7 +629,7 @@ objects:
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
-            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"*","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
 
           env:
           - name: OAUTH_COOKIE_SECRET
@@ -674,17 +674,6 @@ objects:
     triggers:
 
     - type: ConfigChange
-- apiVersion: v1
-  kind: ClusterRoleBinding
-  roleRef:
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: syndesis-oauth-client
-    namespace: ${OPENSHIFT_PROJECT}
-  userNames:
-  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
-
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -664,7 +664,6 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
-        serviceAccount: syndesis-oauth-client
         serviceAccountName: syndesis-oauth-client
 
         volumes:

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -629,6 +629,8 @@ objects:
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
+            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"*","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -662,6 +664,9 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
+        serviceAccount: syndesis-oauth-client
+        serviceAccountName: syndesis-oauth-client
+
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -669,6 +674,17 @@ objects:
     triggers:
 
     - type: ConfigChange
+- apiVersion: v1
+  kind: ClusterRoleBinding
+  roleRef:
+    name: system:auth-delegator
+  subjects:
+  - kind: ServiceAccount
+    name: syndesis-oauth-client
+    namespace: ${OPENSHIFT_PROJECT}
+  userNames:
+  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -628,6 +628,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
             - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
 

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -632,7 +632,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            
+
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -666,6 +666,7 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
+
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -673,6 +674,7 @@ objects:
     triggers:
 
     - type: ConfigChange
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -674,7 +674,6 @@ objects:
     triggers:
 
     - type: ConfigChange
-
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -632,6 +632,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -757,7 +757,6 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
-        serviceAccount: syndesis-oauth-client
         serviceAccountName: syndesis-oauth-client
 
         volumes:

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -722,7 +722,7 @@ objects:
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
-            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"*","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
 
           env:
           - name: OAUTH_COOKIE_SECRET
@@ -776,17 +776,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-- apiVersion: v1
-  kind: ClusterRoleBinding
-  roleRef:
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: syndesis-oauth-client
-    namespace: ${OPENSHIFT_PROJECT}
-  userNames:
-  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
-
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -722,6 +722,8 @@ objects:
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
+            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"*","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -755,6 +757,9 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
+        serviceAccount: syndesis-oauth-client
+        serviceAccountName: syndesis-oauth-client
+
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -771,6 +776,17 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+- apiVersion: v1
+  kind: ClusterRoleBinding
+  roleRef:
+    name: system:auth-delegator
+  subjects:
+  - kind: ServiceAccount
+    name: syndesis-oauth-client
+    namespace: ${OPENSHIFT_PROJECT}
+  userNames:
+  - system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -721,6 +721,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
             - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
             - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
 

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -776,7 +776,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -725,6 +725,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -725,7 +725,7 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            
+
           env:
           - name: OAUTH_COOKIE_SECRET
             valueFrom:
@@ -759,6 +759,7 @@ objects:
               memory: 200Mi
             requests:
               memory: 20Mi
+
         volumes:
         - name: syndesis-oauthproxy-tls
           secret:
@@ -775,6 +776,7 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/app/rest/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
+++ b/app/rest/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
@@ -68,17 +68,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter() throws Exception {
-        RequestHeaderAuthenticationFilter f = new RequestHeaderAuthenticationFilter() {
-            @Override
-            protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
-                final Object fromHeader = super.getPreAuthenticatedCredentials(request);
-                if (fromHeader == null) {
-                    return "<missing>";
-                }
-
-                return fromHeader;
-            }
-        };
+        RequestHeaderAuthenticationFilter f = new RequestHeaderAuthenticationFilter();
         f.setPrincipalRequestHeader("X-Forwarded-User");
         f.setCredentialsRequestHeader("X-Forwarded-Access-Token");
         f.setAuthenticationManager(authenticationManager());

--- a/app/rest/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
+++ b/app/rest/runtime/src/main/java/io/syndesis/runtime/SecurityConfiguration.java
@@ -68,7 +68,17 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     private RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter() throws Exception {
-        RequestHeaderAuthenticationFilter f = new RequestHeaderAuthenticationFilter();
+        RequestHeaderAuthenticationFilter f = new RequestHeaderAuthenticationFilter() {
+            @Override
+            protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+                final Object fromHeader = super.getPreAuthenticatedCredentials(request);
+                if (fromHeader == null) {
+                    return "<missing>";
+                }
+
+                return fromHeader;
+            }
+        };
         f.setPrincipalRequestHeader("X-Forwarded-User");
         f.setCredentialsRequestHeader("X-Forwarded-Access-Token");
         f.setAuthenticationManager(authenticationManager());

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -49,6 +49,12 @@ create_oauthclient() {
         "app/deploy/support/serviceaccount-as-oauthclient-restricted.yml" \
         "$tag" \
         "$use_local_resource"
+
+    local currentUser=$(oc whoami)
+    oc login -u system:admin
+    oc adm policy add-cluster-role-to-user system:auth-delegator -z syndesis-oauth-client
+    oc login -u $currentUser
+
 }
 
 create_and_apply_template() {


### PR DESCRIPTION
We need to allow non UI clients to access our backend APIs as for some of them it is cumbersome to use OAuth flow and Cookies. This is difficult for our IDE integration to do, for example.

oauth-proxy can be configured to also check if the `Authorization` header of the incoming request contains an OAuth bearer token and check if that token is valid to pass on the request to the API.

This configures oauth-proxy when running a _restricted_ variant of the templates to that end.

Caveat is that in this configuration oauth-proxy is not pasing the `X-Forwarded-Access-Token` header, and we will loose OpenShift OAuth token that we require (for some endpoints).

When `Authentication` with `null` credentials is passed on to the `PreAuthenticatedAuthenticationProvider` it fails to authenticate the request.

This adds a fixed credentials `"<missing>"` so that the authentication provider can authenticate and pass the request through.

The drawback of this is that the `Authentication` stored in the `SecurityContext` will not have access to OpenShift OAuth token (it will be `"<missing>"`), and there is no way of fixing that unless we modify oauth-proxy to include it for requests with Bearer token.