### PR TITLE
Ui assembly

### DIFF
--- a/app/ui/src/assembly/unix-dist.xml
+++ b/app/ui/src/assembly/unix-dist.xml
@@ -1,45 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (C) 2016 Red Hat, Inc.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+     Copyright 2005-2016 Red Hat, Inc.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
 -->
 <assembly>
-
     <id>dist</id>
-
     <formats>
         <format>tar.gz</format>
-        <format>zip</format>
     </formats>
     <includeBaseDirectory>False</includeBaseDirectory>
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/dist</directory>
-            <outputDirectory>/srv</outputDirectory>
+            <outputDirectory>/</outputDirectory>
             <includes>
                 <include>**</include>
             </includes>
             <fileMode>0644</fileMode>
         </fileSet>
-        <fileSet>
-            <directory>${project.basedir}</directory>
-            <outputDirectory>/etc/</outputDirectory>
-            <includes>
-                <include>Caddyfile</include>
-            </includes>
-            <fileMode>0644</fileMode>
-        </fileSet>
-
     </fileSets>
 </assembly>

--- a/app/ui/src/assembly/unix-dist.xml
+++ b/app/ui/src/assembly/unix-dist.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+   Copyright (C) 2016 Red Hat, Inc.
 
-     Copyright 2005-2016 Red Hat, Inc.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-     Red Hat licenses this file to you under the Apache License, version
-     2.0 (the "License"); you may not use this file except in compliance
-     with the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
 
-        http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-     implied.  See the License for the specific language governing
-     permissions and limitations under the License.
-
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 -->
 <assembly>
     <id>dist</id>


### PR DESCRIPTION
Changes for the purposes of prod builds

- Maven assembly to only build .tar.gz
- Strip the original directory structure required for Caddy (not needed for nginx) 
- Copy license from parent pom