### PR TITLE
Add some ignoreUsedDependencies that are needed in the build

### DIFF
--- a/app/core/pom.xml
+++ b/app/core/pom.xml
@@ -413,6 +413,7 @@
         <artifactId>duplicate-finder-maven-plugin</artifactId>
         <configuration>
           <ignoredClassPatterns>
+            <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</ignoredUnusedDeclaredDependency>
             <ignoredClassPattern>io.fabric8.kubernetes.client.*</ignoredClassPattern>
             <ignoredClassPattern>org.infinispan.*</ignoredClassPattern>
             <ignoredClassPattern>org.springframework.security.crypto.*</ignoredClassPattern>


### PR DESCRIPTION
Add some ignoreUsedDependencies that are needed in the build, and add a plugin repository statement for SNAPSHOTS because the syndesis-build-helper-maven-plugin is used and I'm getting errors when running mvn clean and it can't resolve the plugin.