### PR TITLE
chore(rest): make RESTeasy version consistent

### DIFF
--- a/app/rest/pom.xml
+++ b/app/rest/pom.xml
@@ -492,6 +492,18 @@
 
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-servlet-initializer</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-spring</artifactId>
+        <version>${resteasy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jackson2-provider</artifactId>
         <version>${resteasy.version}</version>
       </dependency>


### PR DESCRIPTION
We need to declare RESTeasy dependencies we use, otherwise dependency
versions declared in Spring BOMs will be used, and those might differ
from the ones we want to use.