### PR TITLE
fix(syndesis install): Support installation of productised templates

### DIFF
--- a/app/deploy/generator/syndesis-template.go
+++ b/app/deploy/generator/syndesis-template.go
@@ -162,7 +162,7 @@ func install(cmd *cobra.Command, args []string) {
 		if err := mergo.MergeWithOverwrite(&context, productContext); err != nil {
 			log.Fatal("Cannot merge in product image names")
 		}
-		context.Name = context.Name + "-" + context.Tags.Syndesis
+		context.Name = context.Name + "-fuse-ignite-" + context.Tags.Syndesis
 	}
 
 	files, err := ioutil.ReadDir("./")

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -75,11 +75,26 @@ create_and_apply_template() {
         "$tag" \
         "$use_local_resource"
 
-    oc new-app $template \
+    oc new-app $(get_template_name $template $tag) \
       -p ROUTE_HOSTNAME="${route}" \
       -p OPENSHIFT_MASTER="$(oc whoami --show-server)" \
       -p OPENSHIFT_PROJECT="$(oc project -q)" \
       -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client)
+}
+
+# Try first a template with the tag as combination
+get_template_name() {
+    local template=$1
+    local tag=${2:-}
+    if [ -n "$tag" ]; then
+        local candidate="$template-$tag"
+        $(oc get template $candidate >/dev/null 2>&1)
+        if [ $? -eq 0 ]; then
+          echo $candidate
+          return
+        fi
+    fi
+    echo $template
 }
 
 create_openshift_resource() {

--- a/tools/bin/install-syndesis
+++ b/tools/bin/install-syndesis
@@ -82,15 +82,30 @@ create_and_apply_template() {
         "$tag" \
         "$use_local_resource"
 
-    oc new-app $template \
+    oc new-app $(get_template_name $template $tag) \
       -p ROUTE_HOSTNAME="${route}" \
       -p OPENSHIFT_MASTER="$(oc whoami --show-server)" \
       -p OPENSHIFT_PROJECT="$(oc project -q)" \
       -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client)
 }
 
+# Try first a template with the tag as combination
+get_template_name() {
+    local template=$1
+    local tag=${2:-}
+    if [ -n "$tag" ]; then
+        local candidate="$template-$tag"
+        $(oc get template $candidate >/dev/null 2>&1)
+        if [ $? -eq 0 ]; then
+          echo $candidate
+          return
+        fi
+    fi
+    echo $template
+}
+
 create_openshift_resource() {
-    local resource=${1:-}
+    local resource=${1}
     local tag=${2:-}
     local use_local_resource=${3:-}
 
@@ -110,7 +125,6 @@ create_openshift_resource() {
 
 wait_for_syndesis_to_be_ready() {
     # Wait a bit to start image fetching
-    # Patch imagestreams from "DockerImage" to "ImageStreamTag"
     oc get pods -w &
     watch_pid=$!
     for dc in "syndesis-rest" "syndesis-ui" "syndesis-verifier"; do


### PR DESCRIPTION
Productised templates use a different name, as they include also the
tag in the name (so that multiple template version can coexist
and a provisioning script can decide which of the templates to apply).

BTW, this might be also a good solution in general, too allow more
smooth upgrads.