### PR TITLE
(feat) add support for a duration form control

### DIFF
--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.component.html
@@ -1,0 +1,41 @@
+<form class="form-inline duration-input">
+  <div class="input-group">
+    <input class="form-control duration-input__input"
+           [attr.accept]="model.accept"
+           [attr.autoComplete]="model.autoComplete"
+           [attr.list]="model.listId"
+           [attr.max]="model.max"
+           [attr.min]="model.min"
+           [attr.multiple]="model.multiple"
+           [attr.step]="model.step"
+           [attr.tabindex]="model.tabIndex"
+           [attr.id]="fieldId"
+           [autofocus]="model.autoFocus"
+           [dynamicId]="bindId && model.id"
+           [(ngModel)]="baseValue"
+           [ngModelOptions]="{standalone: true}"
+           [tooltip]="model.hint"
+           [ngClass]="model.cls.element.control"
+           [pattern]="model.pattern"
+           [placeholder]="model.placeholder"
+           [readonly]="model.readOnly"
+           [required]="model.required"
+           [spellcheck]="model.spellCheck"
+           [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+           type="number"
+           (blur)="inputBlurTriggered($event)"
+           (change)="inputChangeTriggered($event)"
+           (focus)="inputFocusTriggered($event)" />
+  </div>
+  <div class="input-group">
+    <select class="duration-input__select"
+            [(ngModel)]="duration"
+            [ngModelOptions]="{standalone: true}"
+            (blur)="selectBlurTriggered($event)"
+            (change)="selectChangeTriggered($event)"
+            (focus)="selectFocusTriggered($event)">
+      <option value="" disabled>Choose a time unit</option>
+      <option *ngFor="let duration of durations" [ngValue]="duration">{{ duration.label }}</option>
+    </select>
+  </div>
+</form>

--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
@@ -1,0 +1,118 @@
+import { Component,
+  Input,
+  Output,
+  OnInit,
+  EventEmitter } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { DynamicFormControlModel, DynamicFormControlEvent } from '@ng-dynamic-forms/core';
+
+@Component({
+  selector: 'syndesis-duration-control',
+  templateUrl: './duration-form-control.component.html'
+})
+export class DurationFormControlComponent implements OnInit {
+  @Input() group: FormGroup;
+  @Input() model: any;
+  @Input() fieldId: string;
+  @Input() bindId: boolean;
+
+  @Output() blur = new EventEmitter<any>();
+  @Output() change = new EventEmitter<any>();
+  @Output() focus = new EventEmitter<any>();
+
+  baseValue: number;
+  duration: { value: number, label: string };
+  modelId: string;
+
+  durations = [
+    {
+      value: 1,
+      label: 'Milliseconds'
+    },
+    {
+      value: 1000,
+      label: 'Seconds'
+    },
+    {
+      value: 60000,
+      label: 'Minutes'
+    },
+    {
+      value: 3600000,
+      label: 'Hours'
+    },
+    {
+      value: 86400000,
+      label: 'Days'
+    }
+  ];
+
+  calculateDuration() {
+    return this.baseValue * (this.duration ? this.duration.value : 1);
+  }
+
+  updateFormGroup() {
+    const value = this.calculateDuration();
+    this.model.valueUpdates.next(value);
+    this.group.value[this.modelId] = value;
+  }
+
+  getEvent($event: any, type: string): DynamicFormControlEvent {
+    return {
+      $event,
+      context: undefined,
+      control: undefined,
+      group: this.group,
+      model: this.model,
+      type
+    } as DynamicFormControlEvent;
+  }
+
+  selectBlurTriggered($event) {
+    this.updateFormGroup();
+    this.blur.emit(this.getEvent($event, 'blur'));
+  }
+
+  selectChangeTriggered($event) {
+    this.updateFormGroup();
+    this.change.emit(this.getEvent($event, 'change'));
+  }
+
+  selectFocusTriggered($event) {
+    this.updateFormGroup();
+    this.focus.emit(this.getEvent($event, 'focus'));
+  }
+
+  inputBlurTriggered($event) {
+    this.updateFormGroup();
+    this.blur.emit(this.getEvent($event, 'blur'));
+  }
+
+  inputChangeTriggered($event) {
+    this.updateFormGroup();
+    this.change.emit(this.getEvent($event, 'change'));
+  }
+
+  inputFocusTriggered($event) {
+    this.updateFormGroup();
+    this.focus.emit(this.getEvent($event, 'focus'));
+  }
+
+  ngOnInit() {
+    this.modelId = this.model.id;
+    const value = +this.model.value || 0;
+    if (!value) {
+      return;
+    }
+    let duration;
+    for (const _duration of this.durations) {
+      if ( value / _duration.value > 1 ) {
+        duration = _duration;
+      } else {
+        break;
+      }
+    }
+    this.baseValue = value / duration.value;
+    this.duration = duration;
+  }
+}

--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.model.ts
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.model.ts
@@ -1,0 +1,10 @@
+import { DynamicInputModel, DynamicInputModelConfig, ClsConfig } from '@ng-dynamic-forms/core';
+
+export class DurationInputModel extends DynamicInputModel {
+
+  constructor(config: DynamicInputModelConfig, layout?: ClsConfig) {
+    super(config, layout);
+    this.inputType = 'duration';
+  }
+
+}

--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -117,50 +117,67 @@
       <div *ngSwitchCase="4"
            [class.input-group]="model.prefix || model.suffix">
 
-        <div *ngIf="model.prefix"
-             class="input-group-addon"
-             [innerHTML]="model.prefix"></div>
+        <ng-container [ngSwitch]="model.inputType">
+          <ng-container *ngSwitchCase="'duration'">
+            <syndesis-duration-control [group]="group"
+                                       [model]="model"
+                                       [fieldId]="fieldHash"
+                                       [bindId]="bindId"
+                                       (blur)="onFocusChange($event)"
+                                       (change)="onValueChange($event)"
+                                       (focus)="onFocusChange($event)">
+            </syndesis-duration-control>
+          </ng-container>
+          <ng-container *ngSwitchDefault>
 
-        <input class="form-control"
-               [attr.accept]="model.accept"
-               [attr.autoComplete]="model.autoComplete"
-               [attr.list]="model.listId"
-               [attr.max]="model.max"
-               [attr.min]="model.min"
-               [attr.multiple]="model.multiple"
-               [attr.step]="model.step"
-               [attr.tabindex]="model.tabIndex"
-               [attr.id]="fieldHash"
-               [autofocus]="model.autoFocus"
-               [dynamicId]="bindId && model.id"
-               [formControlName]="model.id"
-               [maxlength]="model.maxLength"
-               [minlength]="model.minLength"
-               [name]="model.name"
-               [tooltip]="model.hint"
-               [ngClass]="model.cls.element.control"
-               [pattern]="model.pattern"
-               [placeholder]="model.placeholder"
-               [readonly]="model.readOnly"
-               [required]="model.required"
-               [spellcheck]="model.spellCheck"
-               [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
-               [type]="model.inputType"
-               (blur)="onFocusChange($event)"
-               (change)="onValueChange($event)"
-               (focus)="onFocusChange($event)" />
+            <div *ngIf="model.prefix"
+                class="input-group-addon"
+                [innerHTML]="model.prefix"></div>
 
-        <div *ngIf="model.suffix"
-             class="input-group-addon"
-             [innerHTML]="model.suffix"></div>
+            <input class="form-control"
+                  [attr.accept]="model.accept"
+                  [attr.autoComplete]="model.autoComplete"
+                  [attr.list]="model.listId"
+                  [attr.max]="model.max"
+                  [attr.min]="model.min"
+                  [attr.multiple]="model.multiple"
+                  [attr.step]="model.step"
+                  [attr.tabindex]="model.tabIndex"
+                  [attr.id]="fieldHash"
+                  [autofocus]="model.autoFocus"
+                  [dynamicId]="bindId && model.id"
+                  [formControlName]="model.id"
+                  [maxlength]="model.maxLength"
+                  [minlength]="model.minLength"
+                  [name]="model.name"
+                  [tooltip]="model.hint"
+                  [ngClass]="model.cls.element.control"
+                  [pattern]="model.pattern"
+                  [placeholder]="model.placeholder"
+                  [readonly]="model.readOnly"
+                  [required]="model.required"
+                  [spellcheck]="model.spellCheck"
+                  [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
+                  [type]="model.inputType"
+                  (blur)="onFocusChange($event)"
+                  (change)="onValueChange($event)"
+                  (focus)="onFocusChange($event)" />
 
-        <datalist *ngIf="model.list"
-                  [id]="model.listId">
+            <div *ngIf="model.suffix"
+                class="input-group-addon"
+                [innerHTML]="model.suffix"></div>
 
-          <option *ngFor="let option of model.list"
-                  [value]="option">
+            <datalist *ngIf="model.list"
+                      [id]="model.listId">
 
-        </datalist>
+              <option *ngFor="let option of model.list"
+                      [value]="option">
+
+            </datalist>
+
+          </ng-container>
+
+        </ng-container>
 
       </div>
 

--- a/app/ui/src/app/common/ui-patternfly/ui-patternfly.module.ts
+++ b/app/ui/src/app/common/ui-patternfly/ui-patternfly.module.ts
@@ -1,17 +1,19 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TextMaskModule } from 'angular2-text-mask';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TooltipModule } from 'ngx-bootstrap';
 import { ToolbarModule, CardModule, ListModule } from 'patternfly-ng';
 import { SyndesisFormComponent } from './syndesis-form-control.component';
+import { DurationFormControlComponent } from './duration-form-control.component';
 import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
 
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     ReactiveFormsModule,
     TextMaskModule,
     DynamicFormsCoreModule,
@@ -19,13 +21,15 @@ import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
     RouterModule,
     ToolbarModule,
     CardModule,
-    ListModule
+    ListModule,
   ],
   declarations: [
     SyndesisFormComponent,
+    DurationFormControlComponent,
     ListToolbarComponent
   ],
   exports: [
+    DurationFormControlComponent,
     DynamicFormsCoreModule,
     SyndesisFormComponent,
     ListToolbarComponent,

--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FormFactoryService, ConfigurationProperty, ConfiguredConfigurationProperty } from '@syndesis/ui/platform';
+import { DurationInputModel } from '@syndesis/ui/common/ui-patternfly/duration-form-control.model';
 import {
   DynamicFormControlModel,
   DynamicCheckboxModel,
@@ -10,6 +11,7 @@ import {
 
 @Injectable()
 export class FormFactoryProviderService extends FormFactoryService {
+
   constructor() {
     super();
   }
@@ -23,12 +25,12 @@ export class FormFactoryProviderService extends FormFactoryService {
     values: any = {},
     controls: Array<string> = ['*']
   ): DynamicFormControlModel[] {
-    const answer = <DynamicFormControlModel[]>[];
+    const answer = [] as Array<DynamicFormControlModel>;
     for (const key in properties) {
       if (!properties.hasOwnProperty(key)) {
         continue;
       }
-      const field = <ConfiguredConfigurationProperty>properties[key];
+      const field = properties[key] as ConfiguredConfigurationProperty;
       const value = values[key];
       let formField: any;
       const validators = field.required ? { required: null } : {};
@@ -55,103 +57,21 @@ export class FormFactoryProviderService extends FormFactoryService {
           break;
       }
       // then use the appropriate ng2 dynamic forms constructor
-      if (type === 'checkbox') {
-        formField = new DynamicCheckboxModel(
-          {
-            id: key,
-            label: field.displayName || key,
-            hint: field.description,
-            value: value || field.value || field.defaultValue
-          },
-          {
-            element: {
-              control: 'element-control checkbox'
-            },
-            grid: {
-              control: 'col-sm-offset-3 col-sm-9',
-              label: ''
-            }
-          }
-        );
-      } else if (type === 'textarea') {
-        formField = new DynamicTextAreaModel(
-          {
-            id: key,
-            label: field.displayName || key,
-            value: value || field.value || field.defaultValue,
-            hint: field.description,
-            required: field.required,
-            rows: field.rows,
-            cols: field.cols,
-            validators: validators,
-            errorMessages: errorMessages
-          },
-          {
-            element: {
-              label: 'control-label'
-            },
-            grid: {
-              control: 'col-sm-9',
-              label: 'col-sm-3'
-            }
-          }
-        );
-      } else if (type === 'select') {
-        formField = new DynamicSelectModel(
-          {
-            id: key,
-            multiple: false,
-            label: field.displayName || key,
-            value: value || field.defaultValue || field.enum[0].value,
-            hint: field.description,
-            required: field.required,
-            validators: validators,
-            errorMessages: errorMessages,
-            options: field.enum
-          },
-          {
-            element: {
-              label: 'control-label'
-            },
-            grid: {
-              control: 'col-sm-9',
-              label: 'col-sm-3'
-            }
-          }
-        );
-      } else {
-        if (field.secret) {
-          type = 'password';
-        }
-        formField = new DynamicInputModel(
-          {
-            id: key,
-            label: type === 'hidden' ? null : field.displayName || key,
-            inputType: type,
-            value: value || field.value || field.defaultValue,
-            hint: field.description,
-            list: field.enum
-              ? (<Array<any>>field.enum).map(val => {
-                  if (typeof val === 'string') {
-                    return val;
-                  }
-                  return val['value'];
-                })
-              : undefined,
-            required: type === 'hidden' ? undefined : field.required,
-            validators: type === 'hidden' ? undefined : validators,
-            errorMessages: errorMessages
-          },
-          {
-            element: {
-              label: 'control-label'
-            },
-            grid: {
-              control: 'col-sm-9',
-              label: 'col-sm-3'
-            }
-          }
-        );
+      switch (type) {
+        case 'duration':
+          formField = this.createDuration(key, field, value);
+          break;
+        case 'checkbox':
+          formField = this.createCheckbox(key, field, value);
+          break;
+        case 'textarea':
+          formField = this.createTextArea(key, field, value, validators, errorMessages);
+          break;
+        case 'select':
+          formField = this.createSelect(key, field, value, validators, errorMessages);
+          break;
+        default:
+          formField = this.createInput(key, field, value, type,  validators, errorMessages);
       }
 
       if (formField) {
@@ -176,5 +96,136 @@ export class FormFactoryProviderService extends FormFactoryService {
       return aIndex - bIndex;
     });
     return answer;
+  }
+
+  private createDuration(key: string,
+                         field: ConfiguredConfigurationProperty,
+                         value: any): any {
+    return new DurationInputModel({
+      id: key,
+      label: field.displayName || key,
+      inputType: 'duration',
+      value: value || field.value || field.defaultValue,
+      hint: field.description,
+      required: field.required,
+    }, {
+        element: {
+          label: 'control-label'
+        },
+        grid: {
+          control: 'col-sm-9',
+          label: 'col-sm-3'
+        }
+      });
+  }
+
+  private createInput(
+                      key: string,
+                      field: ConfiguredConfigurationProperty,
+                      value: any,
+                      type: string,
+                      validators: {},
+                      errorMessages: {}) {
+    if (field.secret) {
+      type = 'password';
+    }
+    return new DynamicInputModel({
+      id: key,
+      label: type === 'hidden' ? null : field.displayName || key,
+      inputType: type,
+      value: value || field.value || field.defaultValue,
+      hint: field.description,
+      list: field.enum
+        ? (<Array<any>>field.enum).map(val => {
+          if (typeof val === 'string') {
+            return val;
+          }
+          return val['value'];
+        })
+        : undefined,
+      required: type === 'hidden' ? undefined : field.required,
+      validators: type === 'hidden' ? undefined : validators,
+      errorMessages: errorMessages
+    }, {
+        element: {
+          label: 'control-label'
+        },
+        grid: {
+          control: 'col-sm-9',
+          label: 'col-sm-3'
+        }
+      });
+  }
+
+  private createSelect(key: string,
+                       field: ConfiguredConfigurationProperty,
+                       value: any,
+                       validators: {},
+                       errorMessages: {}) {
+    return new DynamicSelectModel({
+      id: key,
+      multiple: false,
+      label: field.displayName || key,
+      value: value || field.defaultValue || field.enum[0].value,
+      hint: field.description,
+      required: field.required,
+      validators: validators,
+      errorMessages: errorMessages,
+      options: field.enum
+    }, {
+        element: {
+          label: 'control-label'
+        },
+        grid: {
+          control: 'col-sm-9',
+          label: 'col-sm-3'
+        }
+      });
+  }
+
+  private createTextArea(key: string,
+                         field: ConfiguredConfigurationProperty,
+                         value: any,
+                         validators: {},
+                         errorMessages: {}) {
+    return new DynamicTextAreaModel({
+      id: key,
+      label: field.displayName || key,
+      value: value || field.value || field.defaultValue,
+      hint: field.description,
+      required: field.required,
+      rows: field.rows,
+      cols: field.cols,
+      validators: validators,
+      errorMessages: errorMessages
+    }, {
+        element: {
+          label: 'control-label'
+        },
+        grid: {
+          control: 'col-sm-9',
+          label: 'col-sm-3'
+        }
+      });
+  }
+
+  private createCheckbox(key: string,
+                         field: ConfiguredConfigurationProperty,
+                         value: any
+  ) {
+    return new DynamicCheckboxModel({
+      id: key,
+      label: field.displayName || key,
+      hint: field.description,
+      value: value || field.value || field.defaultValue
+    }, {
+        element: {
+          control: 'element-control checkbox'
+        },
+        grid: {
+          control: 'col-sm-offset-3 col-sm-9',
+          label: ''
+        }
+      });
   }
 }


### PR DESCRIPTION
![download](https://user-images.githubusercontent.com/351660/35632902-f44f9dea-0675-11e8-8a47-c834f4cf3dc7.png)

@KurtStam FYI, note you'll want to update the `description` attribute on that field now that the user can select a time unit, currently it refers to milliseconds.

fixes #717 

Marked WIP as there's currently an override that forces this particular field to be a duration, can take that out when the connector can set `duration` for relevant fields that require this control.