### PR TITLE
(chore) remove dependency on camel-core from rest

### DIFF
--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -40,16 +40,20 @@
         </dependency>
 
         <dependency>
-            <groupId>io.syndesis</groupId>
-            <artifactId>extension-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Test -->
+
+        <!-- The extension-api module is needed only for tests -->
+        <!-- Transitive dependency on camel-core must be removed if moving this in compile scope -->
+        <dependency>
+            <groupId>io.syndesis</groupId>
+            <artifactId>extension-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/app/rest/rest/pom.xml
+++ b/app/rest/rest/pom.xml
@@ -161,6 +161,14 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-multipart-provider</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -246,7 +254,7 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
-    
+
     <!-- ===================================================================================== -->
 
     <!-- Atlasmap Data Mapper Services -->
@@ -338,6 +346,8 @@
             <ignoredUnusedDeclaredDependency>io.syndesis:controllers</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>io.syndesis:openshift</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>io.syndesis.integration:integration-project-generator</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.sun.xml.bind:jaxb-impl</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.sun.xml.bind:jaxb-core</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredUsedUndeclaredDependencies>
             <!-- if declared complains about being unused -->


### PR DESCRIPTION
@rhuss this should be sufficient.. I don't see camel anymore in rest/runtime `dependency:tree`