### PR TITLE
Loosing JSON schema properties and upgrade HTTP client

### DIFF
--- a/app/connectors/connector-verifier/pom.xml
+++ b/app/connectors/connector-verifier/pom.xml
@@ -48,6 +48,36 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/connectors/connector-verifier/src/main/java/io/syndesis/verifier/api/SyndesisMetadata.java
+++ b/app/connectors/connector-verifier/src/main/java/io/syndesis/verifier/api/SyndesisMetadata.java
@@ -21,6 +21,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import io.syndesis.verifier.api.support.SyndesisMetadataConverter;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(converter = SyndesisMetadataConverter.class)
 public final class SyndesisMetadata<T> {
 
     public final T inputSchema;
@@ -33,8 +38,7 @@ public final class SyndesisMetadata<T> {
      */
     public final Map<String, List<PropertyPair>> properties;
 
-    public SyndesisMetadata(final Map<String, List<PropertyPair>> properties, final T inputSchema,
-                            final T outputSchema) {
+    public SyndesisMetadata(final Map<String, List<PropertyPair>> properties, final T inputSchema, final T outputSchema) {
         this.properties = properties;
         this.inputSchema = inputSchema;
         this.outputSchema = outputSchema;
@@ -45,6 +49,10 @@ public final class SyndesisMetadata<T> {
                 Collections.sort(propertyPairs, Comparator.comparing(PropertyPair::getDisplayValue));
             }
         }
+    }
+
+    public boolean isNull() {
+        return inputSchema == null && outputSchema == null && (properties == null || properties.isEmpty());
     }
 
 }

--- a/app/connectors/connector-verifier/src/main/java/io/syndesis/verifier/api/support/SyndesisMetadataConverter.java
+++ b/app/connectors/connector-verifier/src/main/java/io/syndesis/verifier/api/support/SyndesisMetadataConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.api.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.syndesis.verifier.api.SyndesisMetadata;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.Converter;
+
+public class SyndesisMetadataConverter implements Converter<SyndesisMetadata<?>, Map<String, Object>> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public Map<String, Object> convert(final SyndesisMetadata<?> value) {
+        if (value == null || value.isNull()) {
+            return null;
+        }
+
+        final Map<String, Object> converted = new HashMap<>();
+
+        converted.put("properties", value.properties);
+        converted.put("inputSchema", MAPPER.valueToTree(value.inputSchema));
+        converted.put("outputSchema", MAPPER.valueToTree(value.outputSchema));
+
+        return converted;
+    }
+
+    @Override
+    public JavaType getInputType(final TypeFactory typeFactory) {
+        return typeFactory.constructMapLikeType(HashMap.class, String.class, Object.class);
+    }
+
+    @Override
+    public JavaType getOutputType(final TypeFactory typeFactory) {
+        return typeFactory.constructMapLikeType(HashMap.class, String.class, Object.class);
+    }
+
+}

--- a/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/SyndesisMetadataTest.java
+++ b/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/SyndesisMetadataTest.java
@@ -22,12 +22,13 @@ import java.util.Map;
 
 import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class SyndesisMetadataTest {
 
@@ -48,7 +49,7 @@ public class SyndesisMetadataTest {
 
         final String json = mapper.writeValueAsString(syndesisMetadata);
 
-        JSONAssert.assertEquals(
+        assertEquals(
             "{\"outputSchema\":{\"type\":\"object\",\"title\":\"output\"},\"inputSchema\":{\"type\":\"object\",\"title\":\"input\"},\"properties\":{\"aProperty\":[{\"displayValue\":\"label\",\"value\":\"value\"}]}}",
             json, JSONCompareMode.STRICT);
     }

--- a/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/SyndesisMetadataTest.java
+++ b/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/SyndesisMetadataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.api;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+public class SyndesisMetadataTest {
+
+    @Test
+    public void shouldSerializeWithObjectSchema() throws JsonProcessingException, JSONException {
+        final Map<String, List<PropertyPair>> properties = new HashMap<>();
+        properties.put("aProperty", Collections.singletonList(new PropertyPair("value", "label")));
+
+        final ObjectSchema inputSchema = new ObjectSchema();
+        inputSchema.setTitle("input");
+
+        final ObjectSchema outputSchema = new ObjectSchema();
+        outputSchema.setTitle("output");
+
+        final SyndesisMetadata<ObjectSchema> syndesisMetadata = new SyndesisMetadata<>(properties, inputSchema, outputSchema);
+
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final String json = mapper.writeValueAsString(syndesisMetadata);
+
+        JSONAssert.assertEquals(
+            "{\"outputSchema\":{\"type\":\"object\",\"title\":\"output\"},\"inputSchema\":{\"type\":\"object\",\"title\":\"input\"},\"properties\":{\"aProperty\":[{\"displayValue\":\"label\",\"value\":\"value\"}]}}",
+            json, JSONCompareMode.STRICT);
+    }
+}

--- a/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/support/SyndesisMetadataConverterTest.java
+++ b/app/connectors/connector-verifier/src/test/java/io/syndesis/verifier/api/support/SyndesisMetadataConverterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.verifier.api.support;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+
+import io.syndesis.verifier.api.SyndesisMetadata;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+public class SyndesisMetadataConverterTest {
+
+    @Test
+    public void shouldContainAllFieldsOfSyndesisMetadata() {
+        final SyndesisMetadataConverter converter = new SyndesisMetadataConverter();
+
+        final PodamFactory podam = new PodamFactoryImpl();
+
+        final SyndesisMetadata<?> metadata = podam.manufacturePojo(SyndesisMetadata.class, String.class);
+
+        final Map<String, Object> converted = converter.convert(metadata);
+
+        final String[] fields = Arrays.stream(SyndesisMetadata.class.getDeclaredFields()).map(Field::getName)
+            .filter(field -> !"$jacocoData".equals(field)).toArray(String[]::new);
+
+        assertThat(converted).as("The converted map doesn't contain exactly the fields that the SyndesisMetadata object contains")
+            .containsOnlyKeys(fields);
+    }
+}

--- a/app/connectors/connectors/sql/sql-common/pom.xml
+++ b/app/connectors/connectors/sql/sql-common/pom.xml
@@ -55,8 +55,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <version>0.0.20131108.vaadin1</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/app/connectors/connectors/sql/sql-common/src/main/java/io/syndesis/connector/sql/stored/JSONBeanUtil.java
+++ b/app/connectors/connectors/sql/sql-common/src/main/java/io/syndesis/connector/sql/stored/JSONBeanUtil.java
@@ -63,7 +63,11 @@ public class JSONBeanUtil {
         final JSONObject obj = new JSONObject();
         for (String key : map.keySet()) {
             if (! key.startsWith("#")) {  //don't include Camel stats
-                obj.put(key, map.get(key));
+                try {
+                    obj.put(key, map.get(key));
+                } catch (JSONException e) {
+                    throw new IllegalStateException(e);
+                }
             }
         }
         return obj.toString();

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -995,6 +995,18 @@
         <version>${atlasmap.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>uk.co.jemos.podam</groupId>
+        <artifactId>podam</artifactId>
+        <version>7.1.0.RELEASE</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.vaadin.external.google</groupId>
+        <artifactId>android-json</artifactId>
+        <version>0.0.20131108.vaadin1</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>

--- a/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/support/RegexBasedMasqueradeReaderTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/support/RegexBasedMasqueradeReaderTest.java
@@ -21,10 +21,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author roland

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/LogsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/LogsITCase.java
@@ -19,10 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.ResponseEntity;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -103,8 +103,7 @@ export class BasicFilterComponent implements OnChanges {
     this.integrationSupport
       .getFilterOptions(dataShape)
       .toPromise()
-      .then((resp: any) => {
-        const body = JSON.parse(resp['_body']);
+      .then((body: any) => {
         const ops = body.ops;
         const paths = body.paths;
         initializeForm(ops, paths);

--- a/app/verifier/pom.xml
+++ b/app/verifier/pom.xml
@@ -333,6 +333,19 @@
       <artifactId>javax.el</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
+++ b/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
@@ -39,10 +39,10 @@ import org.json.JSONException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class SqlMetadataAdapterTest {
 
@@ -121,7 +121,7 @@ public class SqlMetadataAdapterTest {
         SyndesisMetadata<JsonSchema> syndesisMetaData2 = adapter.adapt("sql-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_metadata.json"), StandardCharsets.UTF_8);
         String actualMetadata = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
-        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
 
     }
 
@@ -141,18 +141,18 @@ public class SqlMetadataAdapterTest {
         ObjectMapper mapper = new ObjectMapper();
         String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8);
         String actualListOfProcedures = (mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData));
-        JSONAssert.assertEquals(expectedListOfProcedures, actualListOfProcedures, JSONCompareMode.STRICT);
+        assertEquals(expectedListOfProcedures, actualListOfProcedures, JSONCompareMode.STRICT);
 
         parameters.put(SqlMetadataAdapter.PATTERN, SqlMetadataAdapter.FROM_PATTERN);
         String expectedListOfStartProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8);
         String actualListOfStartProcedures = (mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData));
-        JSONAssert.assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures, JSONCompareMode.STRICT);
+        assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures, JSONCompareMode.STRICT);
 
         parameters.put("procedureName", "DEMO_ADD");
         SyndesisMetadata<JsonSchema> syndesisMetaData2 = adapter.adapt("sql-stored-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/demo_add_metadata.json"), StandardCharsets.UTF_8);
         String actualMetadata = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
-        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
 
     }
 }

--- a/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
+++ b/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
@@ -35,12 +35,14 @@ import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
 import io.syndesis.verifier.api.SyndesisMetadata;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertEquals;
 
 public class SqlMetadataAdapterTest {
 
@@ -103,7 +105,7 @@ public class SqlMetadataAdapterTest {
     }
 
     @Test
-    public void adaptForSqlTest() throws IOException {
+    public void adaptForSqlTest() throws IOException, JSONException {
 
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension();
         Map<String,Object> parameters = new HashMap<>();
@@ -119,12 +121,12 @@ public class SqlMetadataAdapterTest {
         SyndesisMetadata<JsonSchema> syndesisMetaData2 = adapter.adapt("sql-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_metadata.json"), StandardCharsets.UTF_8);
         String actualMetadata = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata);
+        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
 
     }
 
     @Test
-    public void adaptForSqlStoredTest() throws IOException {
+    public void adaptForSqlStoredTest() throws IOException, JSONException {
 
         SqlStoredConnectorMetaDataExtension ext = new SqlStoredConnectorMetaDataExtension();
         Map<String,Object> parameters = new HashMap<>();
@@ -139,18 +141,18 @@ public class SqlMetadataAdapterTest {
         ObjectMapper mapper = new ObjectMapper();
         String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8);
         String actualListOfProcedures = (mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData));
-        assertEquals(expectedListOfProcedures, actualListOfProcedures);
+        JSONAssert.assertEquals(expectedListOfProcedures, actualListOfProcedures, JSONCompareMode.STRICT);
 
         parameters.put(SqlMetadataAdapter.PATTERN, SqlMetadataAdapter.FROM_PATTERN);
         String expectedListOfStartProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8);
         String actualListOfStartProcedures = (mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData));
-        assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures);
+        JSONAssert.assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures, JSONCompareMode.STRICT);
 
         parameters.put("procedureName", "DEMO_ADD");
         SyndesisMetadata<JsonSchema> syndesisMetaData2 = adapter.adapt("sql-stored-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/demo_add_metadata.json"), StandardCharsets.UTF_8);
         String actualMetadata = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata);
+        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
 
     }
 }

--- a/app/verifier/src/test/resources/sql/demo_add_metadata.json
+++ b/app/verifier/src/test/resources/sql/demo_add_metadata.json
@@ -2,6 +2,7 @@
   "inputSchema" : {
     "$schema" : "http://json-schema.org/schema#",
     "title" : "DEMO_ADD_IN",
+    "type": "object",
     "properties" : {
       "A" : {
         "type" : "integer",
@@ -16,6 +17,7 @@
   "outputSchema" : {
     "$schema" : "http://json-schema.org/schema#",
     "title" : "DEMO_ADD_OUT",
+    "type": "object",
     "properties" : {
       "C" : {
         "type" : "integer",

--- a/app/verifier/src/test/resources/sql/name_sql_metadata.json
+++ b/app/verifier/src/test/resources/sql/name_sql_metadata.json
@@ -2,6 +2,7 @@
   "inputSchema" : {
     "$schema" : "http://json-schema.org/schema#",
     "title" : "SQL_PARAM_IN",
+    "type": "object",
     "properties" : {
       "id" : {
         "type" : "integer",
@@ -12,6 +13,7 @@
   "outputSchema" : {
     "$schema" : "http://json-schema.org/schema#",
     "title" : "SQL_PARAM_OUT",
+    "type": "object",
     "properties" : {
       "ID" : {
         "type" : "integer",


### PR DESCRIPTION
When serializing `SyndesisMetadata<ObjectSchema>` `type` property of
the schema (i.e. `"type": "object") is lost.

This workarounds it by converting `SyndesisMetadata` to a
`Map<String, Object>` before serialization so that property is not lost.

Probably has something to do with generics and the way JAX-RS support
for Jackson insists on using the method return type as the type of
object to serialize.

Seems that we missed a spot when migrating from restangular, now we
receive parsed JSON response body directly instead of in the `_body`
property.

Also cleans up unused imports.

Fixes #1295 