### PR TITLE
chore(1.2.x): Include AMQ deployment in templates

### DIFF
--- a/app/deploy/generator/04-amq-example.yml.mustache
+++ b/app/deploy/generator/04-amq-example.yml.mustache
@@ -1,0 +1,90 @@
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange

--- a/app/deploy/support/syndesis-amq.yml
+++ b/app/deploy/support/syndesis-amq.yml
@@ -14,7 +14,7 @@ metadata:
     openshift.io/provider-display-name: syndesis.io
     tags: messaging,amq,jboss
   name: amq63-basic
-  parameters:
+parameters:
   - description: The name for the application.
     displayName: Application Name
     name: APPLICATION_NAME
@@ -40,14 +40,6 @@ metadata:
     from: '[a-zA-Z0-9]{8}'
     generate: expression
     name: MQ_PASSWORD
-  - description: Namespace in which the ImageStreams for Red Hat Middleware images are
-      installed. These ImageStreams are normally installed in the openshift namespace.
-      You should only need to modify this if you've installed the ImageStreams in a
-      different namespace/project.
-    displayName: ImageStream Namespace
-    name: IMAGE_STREAM_NAMESPACE
-    required: true
-    value: fuse-ignite
 objects:
 - apiVersion: v1
   kind: ImageStream
@@ -60,10 +52,10 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.2
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
       importPolicy:
         scheduled: true
-      name: "1.2"
+      name: "1.3"
 - apiVersion: v1
   kind: Service
   metadata:
@@ -74,8 +66,12 @@ objects:
     name: ${APPLICATION_NAME}-amq-tcp
   spec:
     ports:
-    - port: 61616
+    - name: openwire
+      port: 61616
       targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
 - apiVersion: v1
@@ -121,6 +117,9 @@ objects:
           - containerPort: 61616
             name: tcp
             protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
           readinessProbe:
             exec:
               command:
@@ -135,6 +134,6 @@ objects:
         - ${APPLICATION_NAME}-amq
         from:
           kind: ImageStreamTag
-          name: jboss-amq-63:1.2
+          name: jboss-amq-63:1.3
       type: ImageChange
     - type: ConfigChange

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -321,6 +321,96 @@ objects:
        }
       }
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: syndesis-atlasmap

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -242,6 +242,96 @@ objects:
        }
       }
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: syndesis-atlasmap

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -246,6 +246,96 @@ objects:
        }
       }
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: syndesis-atlasmap

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -326,6 +326,96 @@ objects:
        }
       }
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: syndesis-atlasmap

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -330,6 +330,96 @@ objects:
        }
       }
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jboss-amq-63
+    labels:
+      app: syndesis
+      component: amq
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.3
+      importPolicy:
+        scheduled: true
+      name: "1.3"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+    labels:
+      application: broker
+    name: broker-amq-tcp
+  spec:
+    ports:
+    - name: openwire
+      port: 61616
+      targetPort: 61616
+    - name: stomp
+      port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: broker-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: broker
+    name: broker-amq
+  spec:
+    replicas: 0
+    selector:
+      deploymentConfig: broker-amq
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: broker
+          deploymentConfig: broker-amq
+        name: broker-amq
+      spec:
+        containers:
+        - env:
+          - name: AMQ_USER
+            value: amq
+          - name: AMQ_PASSWORD
+            value: topSecret
+          - name: AMQ_TRANSPORTS
+            value: openwire,stomp
+          image: jboss-amq-63
+          imagePullPolicy: Always
+          name: broker-amq
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 61616
+            name: tcp
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/amq/bin/readinessProbe.sh
+        terminationGracePeriodSeconds: 60
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - broker-amq
+        from:
+          kind: ImageStreamTag
+          name: jboss-amq-63:1.3
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: syndesis-atlasmap


### PR DESCRIPTION
This PR adds AMQ broker to a default deployment with replica count set to 0. Also I've upgraded AMQ image tag to `1.3`. There's hardcoded username and password for broker to keep it simple.

It's part of example scenario from https://github.com/syndesisio/syndesis/issues/1324