### PR TITLE
fix: Look at right side of DataShape (input/output)

### DIFF
--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -467,7 +467,15 @@ export class CurrentFlow {
     return JSON.parse(JSON.stringify(this.integration));
   }
 
-  fetchDataShapeFor(step: Step, output = true): Promise<any> {
+  fetchInputDataShapeFor(step: Step): Promise<any> {
+    return this.fetchDataShapeFor(step, false);
+  }
+
+  fetchOutputDataShapeFor(step: Step): Promise<any> {
+    return this.fetchDataShapeFor(step, true);
+  }
+
+  private fetchDataShapeFor(step: Step, output = true): Promise<any> {
     return new Promise(resolve => {
       // extension step must be always carrying full data shape
       if (step.stepKind === 'extension') {

--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -95,8 +95,8 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     for (const pair of this.currentFlow.getPreviousStepsWithDataShape(this.position)) {
       if (this.isSupportedDataShape(pair.step.action.descriptor.outputDataShape)) {
         this.addInitializationTask();
-        this.currentFlow.fetchDataShapeFor(pair.step, false).then(dataShape => {
-          this.addDocument(pair.step.id, pair.index, dataShape, true);
+        this.currentFlow.fetchOutputDataShapeFor(pair.step).then(dataShape => {
+          this.addSourceDocument(pair.step.id, pair.index, dataShape);
           this.removeInitializationTask();
         })
         .catch(response => this.cfg.errorService.error(
@@ -114,8 +114,8 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     }
     if (targetPair) {
       this.addInitializationTask();
-      this.currentFlow.fetchDataShapeFor(targetPair.step, true).then(dataShape => {
-        this.addDocument(targetPair.step.id, targetPair.index, dataShape, false);
+      this.currentFlow.fetchInputDataShapeFor(targetPair.step).then(dataShape => {
+        this.addTargetDocument(targetPair.step.id, targetPair.index, dataShape);
         this.removeInitializationTask();
       })
       .catch(response => this.cfg.errorService.error(
@@ -237,6 +237,14 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
             .indexOf(dataShape.kind) > -1;
   }
 
+  private addSourceDocument(documentId: string, index: number, dataShape: DataShape): boolean {
+    return this.addDocument(documentId, index, dataShape, true);
+  }
+
+  private addTargetDocument(documentId: string, index: number, dataShape: DataShape): boolean {
+    return this.addDocument(documentId, index, dataShape, false);
+  }
+
   private addDocument(
     documentId: string,
     index: number,
@@ -281,7 +289,7 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     }
 
     initModel.id = documentId;
-    initModel.name = 'Step ' + index + ' - '
+    initModel.name = 'Step ' + (index + 1) + ' - '
         + (dataShape.name ? dataShape.name : dataShape.type);
     initModel.description = dataShape.description;
     initModel.isSource = isSource;

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -138,10 +138,10 @@ export class IntegrationStepConfigureComponent extends FlowPage implements OnIni
     }
     const prevStep = this.currentFlow.getPreviousStepWithDataShape(this.position);
     const nextStep = this.currentFlow.getSubsequentStepWithDataShape(this.position);
-    this.currentFlow.fetchDataShapeFor(prevStep, true)
+    this.currentFlow.fetchOutputDataShapeFor(prevStep)
       .then(inDataShape => {
         this.inputDataShape = inDataShape;
-        this.currentFlow.fetchDataShapeFor(nextStep, false)
+        this.currentFlow.fetchInputDataShapeFor(nextStep)
           .then(outDataShape => {
             this.outputDataShape = outDataShape;
           })


### PR DESCRIPTION
Follow up for #1135, fixed bugs to look at output DataShape for the previous steps and input DataShape for the subsequent steps, with tiny cleanup. Also fixed to display 1-based step index while internal index is 0-based.