### PR TITLE
Refactor, using an immutable object for Json (de)serialization

### DIFF
--- a/app/connectors/connectors-maven-plugin/src/main/java/io/syndesis/maven/connectors/GenerateConnectorInspectionsMojo.java
+++ b/app/connectors/connectors-maven-plugin/src/main/java/io/syndesis/maven/connectors/GenerateConnectorInspectionsMojo.java
@@ -101,7 +101,7 @@ public class GenerateConnectorInspectionsMojo extends AbstractMojo {
                 }
 
                 for (File file: files) {
-                    final Connector connector = Json.mapper().readValue(file, Connector.class);
+                    final Connector connector = Json.reader().forType(Connector.class).readValue(file);
                     final List<ConnectorAction> actions = new ArrayList<>();
 
                     for (ConnectorAction action : connector.getActions()) {
@@ -128,7 +128,7 @@ public class GenerateConnectorInspectionsMojo extends AbstractMojo {
                     }
 
                     if (!actions.isEmpty()) {
-                        Json.mapper().writeValue(
+                        Json.writer().writeValue(
                             file,
                             new Connector.Builder()
                                 .createFrom(connector)

--- a/app/core/core/src/main/java/io/syndesis/core/Json.java
+++ b/app/core/core/src/main/java/io/syndesis/core/Json.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
@@ -28,27 +30,56 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
  */
 public final class Json {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-        .registerModules(new Jdk8Module())
-        .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
-        .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+    private static final ObjectMapper OBJECT_MAPPER;
+    private static final ObjectWriter OBJECT_WRITER;
+    private static final ObjectReader OBJECT_READER;
+    static {
+        OBJECT_MAPPER = new ObjectMapper()
+            .registerModules(new Jdk8Module())
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+            .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+            .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+        OBJECT_READER = OBJECT_MAPPER.reader();
+        OBJECT_WRITER = OBJECT_MAPPER.writer();
+    }
+
+
 
     private Json() {
     }
 
-    public static ObjectMapper mapper() {
-        return OBJECT_MAPPER;
+    /**
+     * Returns an immutable and thread-safe instance of an ObjectReader, used for object deserialization.
+     * @return
+     */
+    public static ObjectReader reader() {
+        return OBJECT_READER;
     }
 
-    public static ObjectMapper mapperWithoutSourceAutoclose(){
-        return OBJECT_MAPPER.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+    /**
+     * Returns an immutable and thread-safe instance of an ObjectWriter, used for object serialization
+     * @return
+     */
+    public static ObjectWriter writer() {
+        return OBJECT_WRITER;
+    }
+
+    /**
+     * The name of this method is super awkward to remind you that there aren't many cases for you to use it.
+     * It's main usage is in tests, where you might have reason to configure differently advanced parameters.
+     *
+     * Thise method creates a copy of an ObjectMapper.
+     * @return
+     */
+    public static ObjectMapper copyObjectMapperConfiguration() {
+        return OBJECT_MAPPER.copy();
     }
 
     public static String toString(Object value) {
         try {
-            return mapper().writeValueAsString(value);
+            return writer().writeValueAsString(value);
         } catch (JsonProcessingException e) {
             throw new SyndesisServerException(e);
         }

--- a/app/core/model/src/main/java/io/syndesis/model/ModelData.java
+++ b/app/core/model/src/main/java/io/syndesis/model/ModelData.java
@@ -56,7 +56,7 @@ public class ModelData<T extends WithId<T>> implements ToJson {
     @JsonProperty("data")
     public String getDataAsJson() throws JsonProcessingException {
         if (json == null) {
-            json = Json.mapper().writeValueAsString(data);
+            json = Json.writer().writeValueAsString(data);
         }
         return json;
     }
@@ -65,7 +65,7 @@ public class ModelData<T extends WithId<T>> implements ToJson {
     @JsonProperty("data")
     public void setDataFromJson(JsonNode json) throws JsonProcessingException {
         this.data = null;
-        this.json = Json.mapper().writeValueAsString(json);
+        this.json = Json.writer().writeValueAsString(json);
     }
 
     @JsonIgnore
@@ -73,7 +73,7 @@ public class ModelData<T extends WithId<T>> implements ToJson {
         if (data == null && kind != null && json != null) {
             @SuppressWarnings("unchecked")
             final Class<T> modelClass = (Class<T>) kind.getModelClass();
-            data = Json.mapper().readValue(json, modelClass);
+            data = Json.reader().forType(modelClass).readValue(json);
         }
         return data;
     }

--- a/app/core/model/src/main/java/io/syndesis/model/ToJson.java
+++ b/app/core/model/src/main/java/io/syndesis/model/ToJson.java
@@ -30,7 +30,7 @@ public interface ToJson {
     @JsonIgnore
     default String toJson() {
         try {
-            return Json.mapper().writeValueAsString(this);
+            return Json.writer().writeValueAsString(this);
         } catch (JsonProcessingException e) {
             throw new JsonProcessingRuntimeException(e);
         }

--- a/app/core/model/src/test/java/io/syndesis/model/StringTrimmingConverterTest.java
+++ b/app/core/model/src/test/java/io/syndesis/model/StringTrimmingConverterTest.java
@@ -47,7 +47,7 @@ public class StringTrimmingConverterTest {
                 .desiredStatus(IntegrationDeploymentState.Draft)
                 .build();
 
-        final Integration created = Json.mapper().readValue(Json.mapper().writeValueAsBytes(original), Integration.class);
+        final Integration created = Json.reader().forType(Integration.class).readValue(Json.writer().writeValueAsBytes(original));
 
         assertThat(created.getName()).isEqualTo("some-name");
         assertThat(created.getDescription()).isNotPresent();

--- a/app/core/model/src/test/java/io/syndesis/model/extension/ExtensionSerializationTest.java
+++ b/app/core/model/src/test/java/io/syndesis/model/extension/ExtensionSerializationTest.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.syndesis.core.Json;
 import org.junit.Test;
 
@@ -27,17 +29,18 @@ import static junit.framework.TestCase.fail;
 public class ExtensionSerializationTest {
     @Test
     public void testSerializeDeserialize() throws IOException {
-        final ObjectMapper mapper = Json.mapper();
+        final ObjectReader reader = Json.reader();
+        final ObjectWriter writer = Json.writer();
 
         try (InputStream source = getClass().getResourceAsStream("syndesis-extension-definition.json")) {
             try {
-                mapper.readValue(
-                    mapper.writeValueAsString(
+                reader.forType(Extension.class).readValue(
+                    writer.writeValueAsString(
                         new Extension.Builder()
-                            .createFrom(mapper.readValue(source, Extension.class))
+                            .createFrom(reader.forType(Extension.class).readValue(source))
                             .build()
-                    ),
-                    Extension.class
+                    )
+
                 );
             } catch (IOException e) {
                 fail("Should not throw an exception");

--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -97,6 +97,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzer.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzer.java
@@ -88,7 +88,7 @@ class DefaultBinaryExtensionAnalyzer implements BinaryExtensionAnalyzer {
             throw new IllegalArgumentException("Cannot find manifest file (" + MANIFEST_LOCATION + ") inside JAR");
         }
 
-        JsonNode tree = Json.mapper().readTree(entry.get());
+        JsonNode tree = Json.reader().readTree(entry.get());
         Extension extension = ExtensionConverter.getDefault().toInternalExtension(tree);
         if (extension == null) {
             throw new IllegalArgumentException("Cannot extract Extension from manifest file (" + MANIFEST_LOCATION + ") inside JAR");

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
@@ -15,12 +15,13 @@
  */
 package io.syndesis.extension.converter;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.syndesis.core.Json;
 import io.syndesis.model.extension.Extension;
+
+import java.io.IOException;
+import java.util.Optional;
 
 class DefaultExtensionConverter implements ExtensionConverter {
 
@@ -58,14 +59,14 @@ class DefaultExtensionConverter implements ExtensionConverter {
     }
 
     @Override
-    public Extension toInternalExtension(JsonNode tree) {
+    public Extension toInternalExtension(JsonNode tree) throws IOException {
         ObjectNode upgradedTree = updateToLatestVersion(toObjectNode(tree));
         ObjectNode convertedTree = convertPublicToInternalModel(upgradedTree);
         return unmarshal(convertedTree);
     }
 
     @Override
-    public JsonNode toPublicExtension(Extension extension) {
+    public JsonNode toPublicExtension(Extension extension) throws IOException {
         ObjectNode internalTree = marshal(extension);
         ObjectNode publicTree = convertInternalToPublicModel(internalTree);
         return updateToLatestVersion(publicTree);
@@ -89,12 +90,14 @@ class DefaultExtensionConverter implements ExtensionConverter {
                 .flatMap(t -> Optional.ofNullable(t.textValue()));
     }
 
-    private Extension unmarshal(JsonNode node) {
-        return Json.mapper().convertValue(node, Extension.class);
+    private Extension unmarshal(JsonNode node) throws IOException {
+        byte[] bytes = Json.writer().writeValueAsBytes(node);
+        return Json.reader().forType(Extension.class).readValue(bytes);
     }
 
-    private ObjectNode marshal(Extension extension) {
-        return Json.mapper().convertValue(extension, ObjectNode.class);
+    private ObjectNode marshal(Extension extension) throws IOException {
+        byte[] bytes = Json.writer().writeValueAsBytes(extension);
+        return Json.reader().forType(ObjectNode.class).readValue(bytes);
     }
 
     private ObjectNode toObjectNode(JsonNode tree) {

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/ExtensionConverter.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/ExtensionConverter.java
@@ -18,6 +18,8 @@ package io.syndesis.extension.converter;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.syndesis.model.extension.Extension;
 
+import java.io.IOException;
+
 /**
  * User-facing (public) extensions must follow a schema that is subject to backward-compatible changes only.
  * In order to allow the core API to evolve while supporting old extensions, the two schemas must be separated and
@@ -41,11 +43,11 @@ public interface ExtensionConverter {
     /**
      * Converts a public extension schema into the internal definition.
      */
-    Extension toInternalExtension(JsonNode tree);
+    Extension toInternalExtension(JsonNode tree) throws IOException;
 
     /**
      * Converts a internal extension into the public format.
      */
-    JsonNode toPublicExtension(Extension extension);
+    JsonNode toPublicExtension(Extension extension) throws IOException;
 
 }

--- a/app/extension/converter/src/test/java/io/syndesis/extension/converter/ExtensionSchemaValidationTest.java
+++ b/app/extension/converter/src/test/java/io/syndesis/extension/converter/ExtensionSchemaValidationTest.java
@@ -15,8 +15,6 @@
  */
 package io.syndesis.extension.converter;
 
-import java.util.OptionalInt;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,25 +30,32 @@ import io.syndesis.model.action.StepDescriptor;
 import io.syndesis.model.extension.Extension;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
+import java.io.IOException;
+import java.util.OptionalInt;
+
+import static org.junit.Assert.*;
 
 public class ExtensionSchemaValidationTest {
+
+    private final ObjectMapper OBJECT_MAPPER = Json.copyObjectMapperConfiguration();
+
+    Logger LOG = LoggerFactory.getLogger(ExtensionSchemaValidationTest.class);
 
     @Test
     @Ignore("Used to generate the initial extension definition")
     public void generateBaseExtensionDefinition() throws Exception {
-        ObjectMapper mapper = Json.mapper();
-        JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(mapper);
+
+        JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(OBJECT_MAPPER);
         com.fasterxml.jackson.module.jsonSchema.JsonSchema schema = schemaGen.generateSchema(Extension.class);
 
-        System.out.println(mapper.writeValueAsString(schema));
+        LOG.info(OBJECT_MAPPER.writeValueAsString(schema));
     }
 
     @Test
-    public void validateStepExtensionTest() throws ProcessingException {
+    public void validateStepExtensionTest() throws ProcessingException, IOException {
         String syndesisExtensionSchema = "/syndesis/syndesis-extension-definition-schema.json";
         JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:" + syndesisExtensionSchema);
         ExtensionConverter converter = new DefaultExtensionConverter();
@@ -83,7 +88,7 @@ public class ExtensionSchemaValidationTest {
     }
 
     @Test
-    public void upgradePublicModelExtensionTest() throws ProcessingException {
+    public void upgradePublicModelExtensionTest() throws ProcessingException, IOException {
         String syndesisExtensionSchema = "/syndesis/syndesis-extension-definition-schema.json";
         JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:" + syndesisExtensionSchema);
         ExtensionConverter converter = new DefaultExtensionConverter();
@@ -107,12 +112,12 @@ public class ExtensionSchemaValidationTest {
     }
 
     @Test
-    public void addSchemaVersionInPublicModelExtensionTest() throws ProcessingException {
+    public void addSchemaVersionInPublicModelExtensionTest() throws ProcessingException, IOException {
         String syndesisExtensionSchema = "/syndesis/syndesis-extension-definition-schema.json";
         JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:" + syndesisExtensionSchema);
         ExtensionConverter converter = new DefaultExtensionConverter();
 
-        ObjectNode tree = Json.mapper().createObjectNode()
+        ObjectNode tree = OBJECT_MAPPER.createObjectNode()
                 .put("extensionId", "my-extension")
                 .put("name", "Name")
                 .put("description", "Description")

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.project.generator;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -35,6 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
@@ -242,9 +244,11 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
                 TarArchiveOutputStream tos = new TarArchiveOutputStream(os)) {
                 tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
 
+                ObjectWriter writer = Json.writer();
+
                 addTarEntry(tos, "src/main/java/io/syndesis/example/Application.java", ProjectGeneratorHelper.generate(deployment, applicationJavaMustache));
                 addTarEntry(tos, "src/main/resources/application.properties", ProjectGeneratorHelper.generate(deployment, applicationPropertiesMustache));
-                addTarEntry(tos, "src/main/resources/syndesis/integration/integration.json", Json.mapper().writerWithDefaultPrettyPrinter().writeValueAsBytes(deployment));
+                addTarEntry(tos, "src/main/resources/syndesis/integration/integration.json", writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsBytes(deployment));
                 addTarEntry(tos, "pom.xml", generatePom(deployment));
                 addResource(tos, ".s2i/bin/assemble", "s2i/assemble");
                 addExtensions(tos, deployment);

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
@@ -70,7 +70,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         try (InputStream is = ResourceHelper.resolveResourceAsInputStream(getContext().getClassResolver(), configurationUri)) {
             if (is != null) {
                 LOGGER.info("Loading integration from: {}", configurationUri);
-                deployment = Json.mapper().readValue(is, IntegrationDeployment.class);
+                deployment = Json.reader().forType(IntegrationDeployment.class).readValue(is);
             } else {
                 throw new IllegalStateException("Unable to load deployment: " + configurationUri);
             }

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/RuleFilterStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/RuleFilterStepHandler.java
@@ -59,7 +59,7 @@ public class RuleFilterStepHandler extends AbstractFilterStepHandler {
             if (rulesString == null || rulesString.isEmpty()) {
                 return null;
             }
-            return Json.mapper().readValue(rulesString,new TypeReference<List<FilterRule>>(){});
+            return Json.reader().forType(new TypeReference<List<FilterRule>>(){}).readValue(rulesString);
         } catch (IOException e) {
             throw new IllegalStateException(String.format("Cannot deserialize %s: %s", rulesString, e.getMessage()),e);
         }

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
@@ -153,7 +153,7 @@ public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConn
         } else {
             String schema;
             try {
-                schema = Json.mapper().writer().writeValueAsString(unifiedSchema);
+                schema = Json.writer().writeValueAsString(unifiedSchema);
             } catch (final JsonProcessingException e) {
                 throw new IllegalStateException("Unable to serialize given JSON schema", e);
             }
@@ -190,7 +190,7 @@ public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConn
 
     private static JsonNode createSchemaFromModelImpl(final Model schema) {
         try {
-            final String schemaString = Json.mapper().writeValueAsString(schema);
+            final String schemaString = Json.writer().writeValueAsString(schema);
 
             return parseJsonSchema(schemaString);
         } catch (final JsonProcessingException e) {
@@ -201,7 +201,7 @@ public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConn
     private static JsonNode createSchemaFromProperty(final String specification, final Property schema) {
         if (schema instanceof MapProperty) {
             try {
-                final String schemaString = Json.mapper().writeValueAsString(schema);
+                final String schemaString = Json.writer().writeValueAsString(schema);
 
                 return parseJsonSchema(schemaString);
             } catch (final JsonProcessingException e) {
@@ -226,7 +226,7 @@ public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConn
 
     private static JsonNode parseJsonSchema(final String schema) {
         try {
-            return Json.mapper().readTree(schema);
+            return Json.reader().readTree(schema);
         } catch (final IOException e) {
             throw new IllegalStateException("Unable to parse given JSON schema: " + StringUtils.abbreviate(schema, 100), e);
         }

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/DataShapeHelper.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/DataShapeHelper.java
@@ -45,7 +45,7 @@ public final class DataShapeHelper {
     private static DataShape createShapeFromProperty(final String specification, final Property schema) {
         if (schema instanceof MapProperty) {
             try {
-                final String schemaString = Json.mapper().writeValueAsString(schema);
+                final String schemaString = Json.writer().writeValueAsString(schema);
 
                 return new DataShape.Builder().kind("json-schema").specification(schemaString).build();
             } catch (final JsonProcessingException e) {

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/JsonSchemaHelper.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/JsonSchemaHelper.java
@@ -87,7 +87,7 @@ public final class JsonSchemaHelper {
 
     public static String serializeJson(final ObjectNode schemaNode) {
         try {
-            return Json.mapper().writeValueAsString(schemaNode);
+            return Json.writer().writeValueAsString(schemaNode);
         } catch (final JsonProcessingException e) {
             throw new IllegalStateException("Unable to serialize JSON schema", e);
         }

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/SwaggerHelper.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/SwaggerHelper.java
@@ -102,7 +102,7 @@ public final class SwaggerHelper {
 
     public static String serialize(final Swagger swagger) {
         try {
-            return Json.mapper().writeValueAsString(swagger);
+            return Json.writer().writeValueAsString(swagger);
         } catch (final JsonProcessingException e) {
             throw new IllegalStateException("Unable to serialize Swagger specification", e);
         }
@@ -128,7 +128,7 @@ public final class SwaggerHelper {
 
         final JsonNode node = convertToJson(specificationToUse);
 
-        return Json.mapper().writeValueAsString(node);
+        return Json.writer().writeValueAsString(node);
     }
 
     private static boolean append(final List<Violation> violations, final ProcessingMessage message, final Optional<String> requiredLevel) {

--- a/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/AbstractSwaggerConnectorTest.java
+++ b/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/AbstractSwaggerConnectorTest.java
@@ -32,8 +32,8 @@ public abstract class AbstractSwaggerConnectorTest {
 
     private static ConnectorTemplate fetchSwaggerConnectorTemplateFromDeployment() {
         final Configuration configuration = Configuration.builder()//
-            .jsonProvider(new JacksonJsonProvider(Json.mapper()))//
-            .mappingProvider(new JacksonMappingProvider(Json.mapper()))//
+            .jsonProvider(new JacksonJsonProvider(Json.copyObjectMapperConfiguration()))//
+            .mappingProvider(new JacksonMappingProvider(Json.copyObjectMapperConfiguration()))//
             .build();
 
         final List<ConnectorTemplate> templates = JsonPath.using(configuration)

--- a/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/BaseSwaggerGeneratorExampleTest.java
+++ b/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/BaseSwaggerGeneratorExampleTest.java
@@ -40,7 +40,7 @@ abstract class BaseSwaggerGeneratorExampleTest extends AbstractSwaggerConnectorT
 
     public BaseSwaggerGeneratorExampleTest(final String connectorQualifier, final String name) throws IOException {
         specification = resource("/swagger/" + name + ".swagger.json", "/swagger/" + name + ".swagger.yaml");
-        expected = Json.mapper().readValue(resource("/swagger/" + name + "." + connectorQualifier + "_connector.json"), Connector.class);
+        expected = Json.reader().forType(Connector.class).readValue(resource("/swagger/" + name + "." + connectorQualifier + "_connector.json"));
     }
 
     @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")

--- a/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/TestHelper.java
+++ b/app/rest/connector-generator/src/test/java/io/syndesis/connector/generator/swagger/TestHelper.java
@@ -50,9 +50,9 @@ public final class TestHelper {
             return null;
         }
 
-        final Map<?, ?> tree = Json.mapper().readValue(json, Map.class);
+        final Map<?, ?> tree = Json.reader().forType(Map.class).readValue(json);
 
-        return Json.mapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).writerWithDefaultPrettyPrinter()
+        return Json.copyObjectMapperConfiguration().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).writerWithDefaultPrettyPrinter()
             .writeValueAsString(tree);
     }
 

--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -86,7 +86,7 @@ public class IntegrationController {
             // Never do anything that could block in this callback!
             if (event!=null && "change-event".equals(event)) {
                 try {
-                    ChangeEvent changeEvent = Json.mapper().readValue(data, ChangeEvent.class);
+                    ChangeEvent changeEvent = Json.reader().forType(ChangeEvent.class).readValue(data);
                     if (changeEvent != null) {
                         changeEvent.getId().ifPresent(id -> {
                             changeEvent.getKind()
@@ -175,7 +175,7 @@ public class IntegrationController {
                     if (LOG.isInfoEnabled()) {
                         LOG.info("{} : Setting status to {}{}", getLabel(integrationDeployment), update.getState(), (update.getStatusMessage() != null ? " (" + update.getStatusMessage() + ")" : ""));
                     }
-                    // handler.execute might block for while so refresh our copy of the integration
+                    // handler.execute might block for while so refresh our copyObjectMapperConfiguration of the integration
                     // data before we update the current status
                     if (update.getState() == IntegrationDeploymentState.Undeployed) {
                         dataManager.delete(IntegrationDeployment.class, integrationDeploymentId);

--- a/app/rest/dao/src/main/java/io/syndesis/dao/init/ReadApiClientData.java
+++ b/app/rest/dao/src/main/java/io/syndesis/dao/init/ReadApiClientData.java
@@ -61,12 +61,12 @@ public class ReadApiClientData {
                 throw new FileNotFoundException("Cannot find file " + fileName + " on classpath");
             }
             String jsonText = findAndReplaceTokens(from(is),System.getenv());
-            return Json.mapper().readValue(jsonText, MODEL_DATA_TYPE);
+            return Json.reader().forType(MODEL_DATA_TYPE).readValue(jsonText);
         }
     }
     public List<ModelData<?>> readDataFromString(String jsonText) throws JsonParseException, JsonMappingException, IOException {
         String json = findAndReplaceTokens(jsonText,System.getenv());
-        return Json.mapper().readValue(json, MODEL_DATA_TYPE);
+        return Json.reader().forType(MODEL_DATA_TYPE).readValue(json);
     }
     /**
      * Reads the InputStream and returns a String containing all content from the InputStream.

--- a/app/rest/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
+++ b/app/rest/dao/src/main/java/io/syndesis/dao/manager/DataManager.java
@@ -140,7 +140,7 @@ public class DataManager implements DataAccessObjectRegistry {
                             System.getenv()
                         );
 
-                        Connector connector = Json.mapper().readValue(text, Connector.class);
+                        Connector connector = Json.reader().forType(Connector.class).readValue(text);
 
                         if (connector != null) {
                             LOGGER.info("Load connector: {} from resource: {}", connector.getId().orElse(""), resource.getURI());

--- a/app/rest/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/app/rest/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -128,8 +128,8 @@ public class DataManagerTest {
 
         //making sure we can deserialize Enums such as StatusType
         Integration int2 = new Integration.Builder().createFrom(integration).desiredStatus(IntegrationDeploymentState.Active).build();
-        String json = Json.mapper().writeValueAsString(int2);
-        Integration int3 = Json.mapper().readValue(json, Integration.class);
+        String json = Json.writer().writeValueAsString(int2);
+        Integration int3 = Json.reader().forType(Integration.class).readValue(json);
         Assert.assertEquals(int2.getDesiredStatus(), int3.getDesiredStatus());
     }
 

--- a/app/rest/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
+++ b/app/rest/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
@@ -42,8 +42,6 @@ import org.junit.Test;
 
 public class ReadApiClientDataTest {
 
-    private final static ObjectMapper mapper = Json.mapper();
-
     @Test
     public void deserializeModelDataTest() throws IOException {
 
@@ -52,9 +50,9 @@ public class ReadApiClientDataTest {
                     .tags(new TreeSet<>(Arrays.asList("tag1", "tag2")))
                     .createdDate(new Date())
                     .build();
-        String integrationJson = mapper.writeValueAsString(integrationIn);
+        String integrationJson = Json.writer().writeValueAsString(integrationIn);
         System.out.println(integrationJson);
-        Integration integrationOut = mapper.readValue(integrationJson, Integration.class);
+        Integration integrationOut = Json.reader().forType(Integration.class).readValue(integrationJson);
         Assert.assertEquals(integrationIn.getDesiredStatus(), integrationOut.getDesiredStatus());
 
         //serialize
@@ -63,8 +61,8 @@ public class ReadApiClientDataTest {
         Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdIn.getDataAsJson());
 
         //deserialize
-        String json = mapper.writeValueAsString(mdIn);
-        ModelData<?> mdOut = mapper.readValue(json, ModelData.class);
+        String json = Json.writer().writeValueAsString(mdIn);
+        ModelData<?> mdOut = Json.reader().forType(ModelData.class).readValue(json);
         Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdOut.getDataAsJson());
     }
 

--- a/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/controller/ActivityTrackingController.java
+++ b/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/controller/ActivityTrackingController.java
@@ -230,7 +230,7 @@ public class ActivityTrackingController implements Closeable {
     }
 
     public void setPodLogState(String podName, PodLogState state) throws IOException {
-        jsonDB.set("/activity/pods/" + podName, Json.mapper().writeValueAsBytes(state));
+        jsonDB.set("/activity/pods/" + podName, Json.writer().writeValueAsBytes(state));
     }
 
     public PodLogState getPodLogState(String podName) throws IOException {
@@ -246,7 +246,7 @@ public class ActivityTrackingController implements Closeable {
         if (data == null) {
             return null;
         }
-        return Json.mapper().readValue(data, type);
+        return Json.reader().forType(type).readValue(data);
     }
 
     private void processEventQueue() {
@@ -283,7 +283,7 @@ public class ActivityTrackingController implements Closeable {
                     }
 
                     // Write the batch..
-                    jsonDB.update("/activity", Json.mapper().writeValueAsBytes(batch));
+                    jsonDB.update("/activity", Json.writer().writeValueAsBytes(batch));
                     LOG.info("Batch ingested {} log events", eventCounter);
 
                 } catch (IOException e) {

--- a/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/controller/PodLogMonitor.java
+++ b/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/controller/PodLogMonitor.java
@@ -168,7 +168,7 @@ class PodLogMonitor implements Consumer<InputStream> {
         String time = new String(line, 0, 30, StandardCharsets.US_ASCII);
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> json = Json.mapper().readValue(line, 31, line.length - 31, HashMap.class); //NOPMD
+            Map<String, Object> json = Json.reader().forType(HashMap.class).readValue(line, 31, line.length - 31); //NOPMD
 
             // are the required fields set?
             String exchange = validate((String) json.get("exchange"));

--- a/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/service/DBActivityTrackingService.java
+++ b/app/rest/db-logging/src/main/java/io/syndesis/rest/dblogging/service/DBActivityTrackingService.java
@@ -22,6 +22,7 @@ import static io.syndesis.rest.dblogging.service.JsonNodeSupport.removeBoolean;
 import static io.syndesis.rest.dblogging.service.JsonNodeSupport.removeLong;
 import static io.syndesis.rest.dblogging.service.JsonNodeSupport.removeString;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +89,7 @@ public class DBActivityTrackingService implements ActivityTrackingService {
             return new ArrayList<>();
         }
 
-        return toActivityList(Json.mapper().readTree(data));
+        return toActivityList(Json.reader().readTree(new ByteArrayInputStream(data)));
     }
 
     private List<Activity> toActivityList(JsonNode from) {

--- a/app/rest/inspector/src/main/java/io/syndesis/inspector/DataMapperBaseInspector.java
+++ b/app/rest/inspector/src/main/java/io/syndesis/inspector/DataMapperBaseInspector.java
@@ -86,7 +86,7 @@ abstract class DataMapperBaseInspector implements Inspector {
     protected final List<String> getPathsFromJavaClassJson(final String prefix, final String json, final List<String> visited) {
         final List<String> paths = new ArrayList<>();
         try {
-            final JsonNode node = Json.mapper().readTree(json);
+            final JsonNode node = Json.reader().readTree(json);
             if (node != null) {
                 final JsonNode javaClass = node.get(JAVA_CLASS);
                 if (javaClass != null) {

--- a/app/rest/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
+++ b/app/rest/jsondb/src/main/java/io/syndesis/jsondb/dao/JsonDbDao.java
@@ -15,21 +15,12 @@
  */
 package io.syndesis.jsondb.dao;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import io.syndesis.core.SyndesisServerException;
 import io.syndesis.core.Json;
+import io.syndesis.core.SyndesisServerException;
 import io.syndesis.dao.manager.DataAccessObject;
 import io.syndesis.dao.manager.operators.IdPrefixFilter;
 import io.syndesis.jsondb.GetOptions;
@@ -37,6 +28,14 @@ import io.syndesis.jsondb.JsonDB;
 import io.syndesis.model.Kind;
 import io.syndesis.model.ListResult;
 import io.syndesis.model.WithId;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Implements a DataAccessObject using the {@see: JsonDB}.
@@ -61,7 +60,7 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
             if( json==null || json.length == 0 ) {
                 return null;
             }
-            return Json.mapper().readValue(json, getType());
+            return Json.reader().forType(getType()).readValue(json);
         } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException|IOException e) {
             throw SyndesisServerException.launderThrowable(e);
         }
@@ -99,10 +98,10 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
             if( json!=null && json.length > 0 ) {
 
                 // Lets use jackson to parse the map of keys to our model instances
-                ObjectMapper mapper = Json.mapper();
-                TypeFactory typeFactory = mapper.getTypeFactory();
+                ObjectReader reader = Json.reader();
+                TypeFactory typeFactory = reader.getTypeFactory();
                 MapType mapType = typeFactory.constructMapType(LinkedHashMap.class, String.class, getType());
-                LinkedHashMap<String, T> map = mapper.readValue(json, mapType);
+                LinkedHashMap<String, T> map = reader.forType(mapType).readValue(json);
 
                 result = ListResult.of(map.values());
             } else {
@@ -129,7 +128,7 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
 
             String json = jsondb.getAsString(getCollectionPath(), new GetOptions().depth(1));
             if (json != null) {
-                Map<String,Boolean> map = Json.mapper().readValue(json, new TypeReference<Map<String,Boolean>>() {});
+                Map<String,Boolean> map = Json.reader().forType(new TypeReference<Map<String,Boolean>>() {}).readValue(json);
                 return map.keySet()
                      .stream().map(path -> path.substring(path.indexOf(':') + 1)).collect(Collectors.toSet());
             } else {
@@ -158,7 +157,7 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
                 return null;
             }
 
-            byte[] json = Json.mapper().writeValueAsBytes(entity);
+            byte[] json = Json.writer().writeValueAsBytes(entity);
             jsondb.set(dbPath, json);
 
             return entity;
@@ -176,7 +175,7 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
             // Only update if the entity existed.
             if( previousValue !=null ) {
                 String dbPath = getCollectionPath()+"/:"+entity.getId().get();
-                byte[] json = Json.mapper().writeValueAsBytes(entity);
+                byte[] json = Json.writer().writeValueAsBytes(entity);
                 jsondb.set(dbPath, json);
             }
             return previousValue;

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -143,7 +143,7 @@ public class IntegrationSupportHandler {
         return out -> {
             try (ZipOutputStream tos = new ZipOutputStream(out) ) {
                 ModelExport exportObject = ModelExport.of(Schema.VERSION, models);
-                addEntry(tos, EXPORT_MODEL_FILE_NAME, Json.mapper().writeValueAsBytes(exportObject));
+                addEntry(tos, EXPORT_MODEL_FILE_NAME, Json.writer().writeValueAsBytes(exportObject));
                 for (String extensionId : extensions) {
                     addEntry(tos, "extensions/" + Names.sanitize(extensionId) + ".jar", IOUtils.toByteArray(
                         extensionDataManager.getExtensionBinaryFile(extensionId)
@@ -198,7 +198,7 @@ public class IntegrationSupportHandler {
                     break;
                 }
                 if (EXPORT_MODEL_FILE_NAME.equals(entry.getName())) {
-                    ModelExport models = Json.mapperWithoutSourceAutoclose().readValue(zis, ModelExport.class);
+                    ModelExport models = Json.reader().forType(ModelExport.class).readValue(zis);
                     changeEvents.addAll(importModels(sec, models));
                     for (ChangeEvent changeEvent : changeEvents) {
                         if( changeEvent.getKind().get().equals("extension") ) {

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/support/RegexBasedMasqueradeReader.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/support/RegexBasedMasqueradeReader.java
@@ -39,7 +39,7 @@ public class RegexBasedMasqueradeReader extends FilterReader {
     // If true, the newline at the end of curLine has not been returned.
     // It would have been more convenient to append the newline
     // onto freshly fetched lines. However, that would incur another
-    // allocation and copy.
+    // allocation and copyObjectMapperConfiguration.
     boolean emitNewline;
 
     // Matcher used to test every line

--- a/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandlerTest.java
+++ b/app/rest/rest/src/test/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandlerTest.java
@@ -32,15 +32,9 @@ public class IntegrationSupportHandlerTest {
     @Test
     public void verifyJacksonBehaviorWithSourceStreams() throws IOException {
         ClassLoader classLoader = getClass().getClassLoader();
-        // default config closes source stream
+       // disabling feature inline, skipt closing source stream
         try(InputStream fis = spy(new FileInputStream(new File(classLoader.getResource("model.json").getFile())))){
-            ModelExport models = Json.mapper().readValue(fis, ModelExport.class);
-            verify(fis, times(1)).close();
-        }
-
-        // disabling feature inline, skipt closing source stream
-        try(InputStream fis = spy(new FileInputStream(new File(classLoader.getResource("model.json").getFile())))){
-            ModelExport models = Json.mapperWithoutSourceAutoclose().readValue(fis, ModelExport.class);
+            ModelExport models = Json.reader().forType(ModelExport.class).readValue(fis);
             verify(fis, times(0)).close();
         }
     }

--- a/app/rest/runtime/src/main/java/io/syndesis/runtime/JacksonContextResolver.java
+++ b/app/rest/runtime/src/main/java/io/syndesis/runtime/JacksonContextResolver.java
@@ -32,7 +32,7 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
     private final ObjectMapper objectMapper;
 
     public JacksonContextResolver() {
-        this.objectMapper = Json.mapper();
+        this.objectMapper = Json.copyObjectMapperConfiguration();
     }
 
     @Override

--- a/app/rest/runtime/src/main/java/io/syndesis/runtime/SchemaCheck.java
+++ b/app/rest/runtime/src/main/java/io/syndesis/runtime/SchemaCheck.java
@@ -66,7 +66,7 @@ public class SchemaCheck {
             return null;
         }
         try {
-            return Json.mapper().readValue(json, String.class);
+            return Json.reader().forType(String.class).readValue(json);
         } catch (IOException e) {
             throw SyndesisServerException.launderThrowable(e);
         }
@@ -75,7 +75,7 @@ public class SchemaCheck {
     public static void setClusterProperty(SqlJsonDB jsondb, String name, String value) {
         String json;
         try {
-            json = Json.mapper().writeValueAsString(value);
+            json = Json.writer().writeValueAsString(value);
         } catch (IOException e) {
             throw SyndesisServerException.launderThrowable(e);
         }

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/BaseITCase.java
@@ -257,7 +257,7 @@ public abstract class BaseITCase {
     }
     /* default */ static final class JsonJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
         JsonJackson2HttpMessageConverter() {
-            super(Json.mapper(), MediaType.parseMediaType("application/json"));
+            super(Json.copyObjectMapperConfiguration(), MediaType.parseMediaType("application/json"));
         }
     }
 

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/ExtensionsITCase.java
@@ -210,7 +210,7 @@ public class ExtensionsITCase extends BaseITCase {
         assertThat(createdCopy1.getBody().getId()).isPresent();
         String idCopy1 = createdCopy1.getBody().getId().get();
 
-        // Install copy
+        // Install copyObjectMapperConfiguration
         post("/api/v1/extensions/" + idCopy1 + "/install", null, Void.class,
             tokenRule.validToken(), HttpStatus.NO_CONTENT);
 
@@ -375,7 +375,7 @@ public class ExtensionsITCase extends BaseITCase {
                 .build();
 
             JsonNode extensionTree = ExtensionConverter.getDefault().toPublicExtension(extension);
-            byte[] content = Json.mapper().writeValueAsBytes(extensionTree);
+            byte[] content = Json.writer().writeValueAsBytes(extensionTree);
             IOUtils.write(content, jar);
             jar.closeEntry();
             jar.flush();

--- a/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
+++ b/app/rest/syndesis-builder-image-generator/src/main/java/io/syndesis/image/Application.java
@@ -141,7 +141,7 @@ public class Application implements ApplicationRunner {
 
             if (resources != null) {
                 for (Resource resource: resources) {
-                    Connector connector = Json.mapper().readValue(resource.getInputStream(), Connector.class);
+                    Connector connector = Json.reader().forType(Connector.class).readValue(resource.getInputStream());
 
                     if (connector != null) {
                         for (final Action action : connector.getActions()) {

--- a/app/verifier/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
+++ b/app/verifier/src/main/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapter.java
@@ -69,7 +69,7 @@ public final class SalesforceMetadataAdapter implements MetadataAdapter {
             try {
                 final String objectName = (String) properties.get(SalesforceEndpointConfig.SOBJECT_NAME);
                 final ObjectSchema inputOutputSchema = inputOutputSchemaFor(schemasToConsider, objectName);
-                final String specification = Json.mapper().writeValueAsString(inputOutputSchema);
+                final String specification = Json.writer().writeValueAsString(inputOutputSchema);
 
                 return new SyndesisMetadata(
                     enrichedProperties,

--- a/app/verifier/src/main/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapter.java
+++ b/app/verifier/src/main/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapter.java
@@ -93,12 +93,12 @@ public final class SqlMetadataAdapter implements MetadataAdapter {
                     new DataShape.Builder()
                         .kind("json-schema")
                         .type(builderIn.getTitle())
-                        .specification(Json.mapper().writeValueAsString(builderIn))
+                        .specification(Json.writer().writeValueAsString(builderIn))
                         .build(),
                     new DataShape.Builder()
                         .kind("json-schema")
                         .type(builderOut.getTitle())
-                        .specification(Json.mapper().writeValueAsString(builderOut))
+                        .specification(Json.writer().writeValueAsString(builderOut))
                         .build());
             } catch (JsonProcessingException e) {
                 throw new IllegalStateException(e);
@@ -148,12 +148,12 @@ public final class SqlMetadataAdapter implements MetadataAdapter {
                     new DataShape.Builder()
                         .kind("json-schema")
                         .type(builderIn.getTitle())
-                        .specification(Json.mapper().writeValueAsString(builderIn))
+                        .specification(Json.writer().writeValueAsString(builderIn))
                         .build(),
                     new DataShape.Builder()
                         .kind("json-schema")
                         .type(builderOut.getTitle())
-                        .specification(Json.mapper().writeValueAsString(builderOut))
+                        .specification(Json.writer().writeValueAsString(builderOut))
                         .build());
             } catch (JsonProcessingException e) {
                 throw new IllegalStateException(e);

--- a/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
+++ b/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SalesforceMetadataAdapterTest.java
@@ -100,7 +100,7 @@ public class SalesforceMetadataAdapterTest {
 
         assertThat(metadata.inputShape).isSameAs(metadata.inputShape);
         final Object oneOf = payload.getOneOf().iterator().next();
-        final ObjectSchema inSchema = Json.mapper().readValue(metadata.inputShape.getSpecification(), ObjectSchema.class);
+        final ObjectSchema inSchema = Json.reader().forType(ObjectSchema.class).readValue(metadata.inputShape.getSpecification()    );
 
         assertThat(inSchema).isEqualTo(oneOf);
         assertThat(inSchema.get$schema()).isEqualTo(JsonUtils.SCHEMA4);

--- a/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
+++ b/app/verifier/src/test/java/io/syndesis/verifier/v1/metadata/SqlMetadataAdapterTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.syndesis.connector.sql.DatabaseProduct;
 import io.syndesis.connector.sql.SqlConnectorMetaDataExtension;
 import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
@@ -115,7 +116,8 @@ public class SqlMetadataAdapterTest {
 
         SyndesisMetadata syndesisMetaData2 = adapter.adapt("sql-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_metadata.json"), StandardCharsets.UTF_8).trim();
-        String actualMetadata = Json.mapper().writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
+        ObjectWriter writer = Json.writer();
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
         assertEquals(expectedMetadata, actualMetadata);
 
     }
@@ -134,18 +136,19 @@ public class SqlMetadataAdapterTest {
         SyndesisMetadata syndesisMetaData = adapter.adapt("sql-stored-connector", parameters, metadata.get());
 
         String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
-        String actualListOfProcedures = Json.mapper().writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData);
+        ObjectWriter writer = Json.writer();
+        String actualListOfProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
         assertEquals(expectedListOfProcedures, actualListOfProcedures);
 
         parameters.put(SqlMetadataAdapter.PATTERN, SqlMetadataAdapter.FROM_PATTERN);
         String expectedListOfStartProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
-        String actualListOfStartProcedures = Json.mapper().writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData);
+                String actualListOfStartProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
         assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures);
 
         parameters.put("procedureName", "DEMO_ADD");
         SyndesisMetadata syndesisMetaData2 = adapter.adapt("sql-stored-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/demo_add_metadata.json"), StandardCharsets.UTF_8).trim();
-        String actualMetadata = Json.mapper().writerWithDefaultPrettyPrinter().writeValueAsString(syndesisMetaData2);
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
         assertEquals(expectedMetadata, actualMetadata);
 
     }


### PR DESCRIPTION
This is a major refactoring, mainly focused to:

- replace direct access to the shared `ObjectMapper` instance provided by `Json` class, since any client that borrowed the instance was allowed to bad behave and change the configuration of the global object, risking to leave it altered for the following user.
- we are using `ObjectReader` and `ObjectWriter` in place, that designed to be immutable.
- we have left out the ability to clone the original `ObjectMapper` that creates the reader and writer, but that's just for test purposes

Most of the invocation are 1 to 1 with the old usage, with the most notable exception of `.read()` calls, that now follow this pattern:

```java
Json.reader().forType(Connector.class).readValue(file);
```

Where the `class` information is passed in a fluent way to the `reader` before calling  a `read*` operation.


fixes #1411
fixes #1410