### PR TITLE
chore: Pull in ngx-bootstrap and patternfly modules into a shared module, us…

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -12,6 +12,7 @@
     "start": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js",
     "start:prod": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js --aot --prod",
     "start:minishift": "./scripts/minishift-setup.sh && yarn ng serve --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}'); ./scripts/minishift-restore.sh",
+    "start:minishift-aot": "./scripts/minishift-setup.sh && yarn ng serve --aot --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}'); ./scripts/minishift-restore.sh",
     "restore:minishift": "./scripts/minishift-restore.sh",
     "build:ci": "yarn ng build --aot --prod --progress=false",
     "build:noaot": "yarn ng build --aot=false --prod --progress=false",

--- a/app/ui/src/app/app.module.ts
+++ b/app/ui/src/app/app.module.ts
@@ -7,16 +7,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
 import { DynamicFormsBootstrapUIModule } from '@ng-dynamic-forms/ui-bootstrap';
-import {
-  AlertModule,
-  CollapseModule,
-  ModalModule,
-  PopoverModule,
-  TabsModule,
-  TooltipModule,
-  TypeaheadModule
-} from 'ngx-bootstrap';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { TagInputModule } from 'ngx-chips';
 import { Restangular, RestangularModule } from 'ngx-restangular';
 import { NotificationModule } from 'patternfly-ng';
@@ -79,14 +70,7 @@ export function mapperRestangularProvider(
     DynamicFormsCoreModule.forRoot(),
     DynamicFormsBootstrapUIModule,
     RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
-    TabsModule.forRoot(),
-    TooltipModule.forRoot(),
-    ModalModule.forRoot(),
-    BsDropdownModule.forRoot(),
-    CollapseModule.forRoot(),
-    AlertModule.forRoot(),
-    PopoverModule.forRoot(),
-    TypeaheadModule.forRoot(),
+    SyndesisVendorModule,
     TagInputModule,
     AppRoutingModule,
     LegacyStoreModule,

--- a/app/ui/src/app/common/common.module.ts
+++ b/app/ui/src/app/common/common.module.ts
@@ -2,7 +2,6 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { NotificationModule } from 'patternfly-ng';
 import { TagInputModule } from 'ngx-chips';
 
 import { CancelConfirmationModalComponent } from './cancel_confirmation_modal';
@@ -57,8 +56,6 @@ import { NavigationService } from './navigation.service';
     ...SYNDESYS_VALIDATION_DIRECTIVES
   ],
   exports: [
-    CommonModule,
-    ReactiveFormsModule, FormsModule,
     DerpPipe,
     ObjectPropertyFilterPipe,
     ObjectPropertySortPipe,

--- a/app/ui/src/app/common/ui-patternfly/ui-patternfly.module.ts
+++ b/app/ui/src/app/common/ui-patternfly/ui-patternfly.module.ts
@@ -4,24 +4,20 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { TextMaskModule } from 'angular2-text-mask';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
-import { TooltipModule } from 'ngx-bootstrap';
-import { ToolbarModule, CardModule, ListModule } from 'patternfly-ng';
 import { SyndesisFormComponent } from './syndesis-form-control.component';
 import { DurationFormControlComponent } from './duration-form-control.component';
 import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 
 @NgModule({
   imports: [
+    SyndesisVendorModule,
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
     TextMaskModule,
     DynamicFormsCoreModule,
-    TooltipModule.forRoot(),
     RouterModule,
-    ToolbarModule,
-    CardModule,
-    ListModule,
   ],
   declarations: [
     SyndesisFormComponent,
@@ -33,9 +29,6 @@ import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
     DynamicFormsCoreModule,
     SyndesisFormComponent,
     ListToolbarComponent,
-    ToolbarModule,
-    CardModule,
-    ListModule
   ]
 })
 export class PatternflyUIModule {}

--- a/app/ui/src/app/common/wizard_progress_bar/wizard-progress-bar.component.ts
+++ b/app/ui/src/app/common/wizard_progress_bar/wizard-progress-bar.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 
-import { SlugifyPipe } from '@syndesis/ui/common';
+import { SlugifyPipe } from '@syndesis/ui/common/slugify.pipe';
 
 @Component({
   selector: 'syndesis-wizard-progress-bar',

--- a/app/ui/src/app/connections/connections.module.ts
+++ b/app/ui/src/app/connections/connections.module.ts
@@ -3,10 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TagInputModule } from 'ngx-chips';
 
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { SyndesisCommonModule } from '../common/common.module';
 import { PatternflyUIModule } from '../common/ui-patternfly/ui-patternfly.module';
 import { ConnectionsCreatePage } from './create-page/create-page.component';
@@ -33,9 +32,8 @@ import { ConnectionConfigurationValidationComponent } from './common/configurati
     PatternflyUIModule,
     RouterModule,
     SyndesisCommonModule,
-    ModalModule,
-    BsDropdownModule.forRoot(),
-    TagInputModule
+    TagInputModule,
+    SyndesisVendorModule
   ],
   declarations: [
     ConnectionsCreatePage,

--- a/app/ui/src/app/customizations/api-connector/api-connector.module.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.module.ts
@@ -5,6 +5,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { SyndesisCommonModule, PatternflyUIModule } from '@syndesis/ui/common';
 import { ApiModule } from '@syndesis/ui/api';
 
@@ -23,6 +24,9 @@ import { ApiConnectorService } from './api-connector.service';
 @NgModule({
   imports: [
     CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    SyndesisVendorModule,
     PatternflyUIModule,
     SyndesisCommonModule,
     ApiConnectorRoutingModule,

--- a/app/ui/src/app/customizations/api-connector/index.ts
+++ b/app/ui/src/app/customizations/api-connector/index.ts
@@ -3,5 +3,4 @@ export * from './api-connector.api';
 export * from './api-connector.actions';
 export * from './api-connector.reducer';
 export * from './api-connector.models';
-export * from './api-connector.module';
 export * from './api-connector-lazy-loader.guard';

--- a/app/ui/src/app/customizations/customizations.module.ts
+++ b/app/ui/src/app/customizations/customizations.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { FileUploadModule } from 'ng2-file-upload';
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { SyndesisCommonModule, PatternflyUIModule } from '@syndesis/ui/common';
 
-import { ApiConnectorModule, ApiConnectorListComponent, ApiConnectorLazyLoaderGuard } from './api-connector';
+import { ApiConnectorListComponent, ApiConnectorLazyLoaderGuard } from './api-connector';
+import { ApiConnectorModule } from './api-connector/api-connector.module';
 import { CustomizationsComponent } from './customizations.component';
 
 import {
@@ -50,6 +52,7 @@ const routes: Routes = [
   imports: [
     CommonModule,
     SyndesisCommonModule,
+    SyndesisVendorModule,
     PatternflyUIModule,
     FileUploadModule,
     ApiConnectorModule,

--- a/app/ui/src/app/dashboard/dashboard.component.spec.ts
+++ b/app/ui/src/app/dashboard/dashboard.component.spec.ts
@@ -15,6 +15,8 @@ import { ActionModule, ListModule, NotificationModule } from 'patternfly-ng';
 import { ApiModule } from '@syndesis/ui/api';
 import { CoreModule } from '@syndesis/ui/core';
 import { StoreModule } from '@syndesis/ui/store';
+import { SyndesisCommonModule } from '@syndesis/ui/common';
+import { IntegrationListModule } from '@syndesis/ui/integration/list';
 import { DashboardComponent } from './dashboard.component';
 import { EmptyStateComponent } from './emptystate.component';
 import { DashboardConnectionsComponent } from './connections.component';
@@ -48,20 +50,15 @@ describe('DashboardComponent', () => {
           StoreModule,
           RouterTestingModule.withRoutes([]),
           RestangularModule,
-          NotificationModule
+          NotificationModule,
+          IntegrationListModule,
+          SyndesisCommonModule
         ],
         declarations: [
           DashboardComponent,
           EmptyStateComponent,
           DashboardConnectionsComponent,
-          DashboardIntegrationsComponent,
-          IntegrationStatusComponent,
-          IntegrationListComponent,
-          LoadingComponent,
-          IconPathPipe,
-          TruncateCharactersPipe,
-          ModalComponent,
-          IntegrationActionMenuComponent
+          DashboardIntegrationsComponent
         ],
         providers: [
           ConfigService,

--- a/app/ui/src/app/dashboard/dashboard.module.ts
+++ b/app/ui/src/app/dashboard/dashboard.module.ts
@@ -3,10 +3,8 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
-import { ModalModule } from 'ngx-bootstrap';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { SyndesisCommonModule } from '../common/common.module';
 import { IntegrationListModule } from '@syndesis/ui/integration/list';
 
@@ -25,11 +23,9 @@ const routes: Routes = [
     CommonModule,
     RouterModule.forChild(routes),
     SyndesisCommonModule,
+    SyndesisVendorModule,
     ChartsModule,
-    ModalModule,
-    TooltipModule,
     IntegrationListModule,
-    BsDropdownModule.forRoot()
   ],
   declarations: [
     DashboardComponent,

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -3,16 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
-import {
-  CollapseModule,
-  ModalModule,
-  PopoverModule,
-  TabsModule,
-  TooltipModule
-} from 'ngx-bootstrap';
 import { DataMapperModule } from '@atlasmap/atlasmap.data.mapper';
-import { ActionModule, ListModule, ToolbarModule } from 'patternfly-ng';
-
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { IntegrationListModule } from './list';
 import { IntegrationSupportModule } from './integration-support.module';
 import { IntegrationDetailComponent } from './detail-page';
@@ -95,17 +87,10 @@ const routes: Routes = [
     PatternflyUIModule,
     RouterModule.forChild(routes),
     ConnectionsModule,
-    TabsModule,
+    SyndesisVendorModule,
     SyndesisCommonModule,
-    CollapseModule,
-    TooltipModule,
-    ModalModule,
-    PopoverModule,
     DataMapperModule,
     FileUploadModule,
-    ActionModule,
-    ListModule,
-    ToolbarModule,
     IntegrationSupportModule,
     IntegrationListModule,
   ],

--- a/app/ui/src/app/integration/list/list.module.ts
+++ b/app/ui/src/app/integration/list/list.module.ts
@@ -1,22 +1,21 @@
-import { NgModule } from '@angular/core';
+import { NgModule, forwardRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActionModule, ListModule } from 'patternfly-ng';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
-
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { SyndesisCommonModule } from '@syndesis/ui/common';
 import { IntegrationSupportModule } from '../integration-support.module';
 import { IntegrationStatusComponent } from './status.component';
 import { IntegrationActionMenuComponent } from './action-menu.component';
 import { IntegrationListComponent } from './list.component';
 
+const syndesisCommonModuleFwd = forwardRef(() => SyndesisCommonModule);
+const integrationSupportModuleFwd = forwardRef(() => IntegrationSupportModule);
+
 @NgModule({
   imports: [
     CommonModule,
-    TooltipModule,
-    ActionModule,
-    ListModule,
-    SyndesisCommonModule,
-    IntegrationSupportModule
+    SyndesisVendorModule,
+    syndesisCommonModuleFwd,
+    integrationSupportModuleFwd
   ],
   declarations: [IntegrationActionMenuComponent, IntegrationStatusComponent, IntegrationListComponent],
   exports: [IntegrationActionMenuComponent, IntegrationListComponent, IntegrationStatusComponent]

--- a/app/ui/src/app/settings/settings.module.ts
+++ b/app/ui/src/app/settings/settings.module.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
-import { ListModule, ToolbarModule } from 'patternfly-ng';
 import { SyndesisCommonModule } from '../common/common.module';
 import { PatternflyUIModule } from '../common/ui-patternfly/ui-patternfly.module';
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 
 import { SettingsRootComponent } from './settings-root.component';
 import { OAuthAppsComponent } from './oauth-apps/oauth-apps.component';
@@ -36,9 +36,8 @@ const routes: Routes = [
     ReactiveFormsModule,
     DynamicFormsCoreModule,
     PatternflyUIModule,
-    ListModule,
-    ToolbarModule,
     RouterModule.forChild(routes),
+    SyndesisVendorModule,
     SyndesisCommonModule
   ],
   exports: [],

--- a/app/ui/src/app/support/support.module.ts
+++ b/app/ui/src/app/support/support.module.ts
@@ -5,6 +5,7 @@ import { SupportComponent } from './support.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { IntegrationSupportModule } from '../integration/integration-support.module';
 
+import { SyndesisVendorModule } from '@syndesis/ui/vendor.module';
 import { PatternflyUIModule } from '../common/ui-patternfly/ui-patternfly.module';
 import { SyndesisCommonModule } from '../common/common.module';
 
@@ -18,6 +19,7 @@ const routes: Routes = [
     FormsModule,
     ReactiveFormsModule,
     PatternflyUIModule,
+    SyndesisVendorModule,
     SyndesisCommonModule,
     IntegrationSupportModule,
     RouterModule.forChild(routes),

--- a/app/ui/src/app/vendor.module.ts
+++ b/app/ui/src/app/vendor.module.ts
@@ -1,0 +1,60 @@
+import { NgModule } from '@angular/core';
+
+import {
+  AlertModule,
+  CollapseModule,
+  ModalModule,
+  PopoverModule,
+  TabsModule,
+  TooltipModule,
+  TypeaheadModule,
+  BsDropdownModule,
+  ComponentLoaderFactory
+} from 'ngx-bootstrap';
+
+import {
+  ActionModule,
+  NotificationModule,
+  CardModule,
+  ListModule,
+  ToolbarModule,
+} from 'patternfly-ng';
+
+const imports = [
+  AlertModule.forRoot(),
+  CollapseModule.forRoot(),
+  ModalModule.forRoot(),
+  PopoverModule.forRoot(),
+  TabsModule.forRoot(),
+  TooltipModule.forRoot(),
+  TypeaheadModule.forRoot(),
+  BsDropdownModule.forRoot(),
+  ActionModule,
+  NotificationModule,
+  CardModule,
+  ListModule,
+  ToolbarModule
+];
+
+const _exports = [
+  AlertModule,
+  CollapseModule,
+  ModalModule,
+  PopoverModule,
+  TabsModule,
+  TooltipModule,
+  TypeaheadModule,
+  BsDropdownModule,
+  ActionModule,
+  NotificationModule,
+  CardModule,
+  ListModule,
+  ToolbarModule
+];
+
+@NgModule({
+  imports: imports,
+  providers: [ComponentLoaderFactory],
+  exports: _exports
+})
+export class SyndesisVendorModule {}


### PR DESCRIPTION
…e that to import everywhere, use forwardRef to work around some circular deps for dashboard test, add aot dev target

Some work towards #1426 decided to keep the refactoring