### PR TITLE
chore: Removed --pass-user-bearer-token for now

### DIFF
--- a/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/app/deploy/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -81,10 +81,9 @@
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
 {{#Restricted}}
-            - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
-            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+            # Disabled for now: --pass-user-bearer-token as this requires extra permission which only
+            # can be given by a cluster-admin
 {{/Restricted}}
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -330,7 +330,8 @@ objects:
           "appName": "Syndesis",
           "favicon32": "/favicon-32x32.png",
           "favicon16": "/favicon-16x16.png",
-          "touchIcon": "/apple-touch-icon.png"
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
        }
       }
 - apiVersion: v1
@@ -591,7 +592,6 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -251,7 +251,8 @@ objects:
           "appName": "Syndesis",
           "favicon32": "/favicon-32x32.png",
           "favicon16": "/favicon-16x16.png",
-          "touchIcon": "/apple-touch-icon.png"
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
        }
       }
 - apiVersion: v1
@@ -512,9 +513,8 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
-            - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
-            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+            # Disabled for now: --pass-user-bearer-token as this requires extra permission which only
+            # can be given by a cluster-admin
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -255,7 +255,8 @@ objects:
           "appName": "Syndesis",
           "favicon32": "/favicon-32x32.png",
           "favicon16": "/favicon-16x16.png",
-          "touchIcon": "/apple-touch-icon.png"
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
        }
       }
 - apiVersion: v1
@@ -516,7 +517,6 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -335,7 +335,8 @@ objects:
           "appName": "Syndesis",
           "favicon32": "/favicon-32x32.png",
           "favicon16": "/favicon-16x16.png",
-          "touchIcon": "/apple-touch-icon.png"
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
        }
       }
 - apiVersion: v1
@@ -596,9 +597,8 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
-            - --openshift-sar={"namespace":"${OPENSHIFT_PROJECT}","resource":"pods","verb":"get"}
-            - --openshift-delegate-urls={"/api":{"resource":"projects","verb":"get","resourceName":"${OPENSHIFT_PROJECT}","namespace":"${OPENSHIFT_PROJECT}"}}
+            # Disabled for now: --pass-user-bearer-token as this requires extra permission which only
+            # can be given by a cluster-admin
 
           env:
           - name: OAUTH_COOKIE_SECRET

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -339,7 +339,8 @@ objects:
           "appName": "Syndesis",
           "favicon32": "/favicon-32x32.png",
           "favicon16": "/favicon-16x16.png",
-          "touchIcon": "/apple-touch-icon.png"
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
        }
       }
 - apiVersion: v1
@@ -600,7 +601,6 @@ objects:
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            - --pass-user-bearer-token
 
           env:
           - name: OAUTH_COOKIE_SECRET


### PR DESCRIPTION
so that we can still install on clusters with restricted permissions.