### PR TITLE
Lifecycle, identify failed integration based on Build success

### DIFF
--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
@@ -90,8 +90,13 @@ public class PublishHandler extends BaseHandler implements StateChangeHandler {
 
         logInfo(integrationDeployment, "Build started: {}, isRunning: {}, Deployment ready: {}",
             isBuildStarted(integrationDeployment), isRunning(integrationDeployment), isReady(integrationDeployment));
+
         BuildStepPerformer stepPerformer = new BuildStepPerformer(integrationDeployment);
         logInfo(integrationDeployment, "Steps performed so far: " + stepPerformer.getStepsPerformed());
+
+        if (isBuildFailed(integrationDeployment)){
+            return new StateUpdate(IntegrationDeploymentState.Error, stepPerformer.getStepsPerformed(), "Error");
+        }
 
         final Integration integration = integrationOf(integrationDeployment);
         try {
@@ -171,6 +176,10 @@ public class PublishHandler extends BaseHandler implements StateChangeHandler {
 
     private boolean isBuildStarted(IntegrationDeployment integrationDeployment) {
         return openShiftService().isBuildStarted(integrationDeployment.getSpec().getName());
+    }
+
+    private boolean isBuildFailed(IntegrationDeployment integrationDeployment) {
+        return openShiftService().isBuildFailed(integrationDeployment.getSpec().getName());
     }
 
     private boolean isReady(IntegrationDeployment integrationDeployment) {

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -94,6 +94,13 @@ public interface OpenShiftService {
     boolean isScaled(String name, int desiredReplicas);
 
     /**
+     * Check whether a given build is failed
+     * @param name name of the build to check
+     * @return true if the build is failed
+     */
+    boolean isBuildFailed(String name);
+
+    /**
      * Returns the {@link DeploymentConfig}s that match the specified labels.
      * @param labels            The specified labels.
      * @return                  The list of {@link DeploymentConfig}s.

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -136,13 +136,21 @@ public class OpenShiftServiceImpl implements OpenShiftService {
 
     @Override
     public boolean isBuildStarted(String name) {
-        String sName = Names.sanitize(name);
-        return !openShiftClient.builds()
-                               .withLabel("openshift.io/build-config.name", sName)
-                               .withField("status", "Running")
-                               .list().getItems().isEmpty();
+        return checkBuildStatus(name, "Running");
     }
 
+    @Override
+    public boolean isBuildFailed(String name) {
+        return checkBuildStatus(name, "Error");
+    }
+
+    protected boolean checkBuildStatus(String name, String status){
+        String sName = Names.sanitize(name);
+        return !openShiftClient.builds()
+            .withLabel("openshift.io/build-config.name", sName)
+            .withField("status", status)
+            .list().getItems().isEmpty();
+    }
 
     @Override
     public List<DeploymentConfig> getDeploymentsByLabel(Map<String, String> labels) {

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceNoOp.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceNoOp.java
@@ -63,6 +63,11 @@ public class OpenShiftServiceNoOp implements OpenShiftService {
     }
 
     @Override
+    public boolean isBuildFailed(String name) {
+        return false;
+    }
+
+    @Override
     public List<DeploymentConfig> getDeploymentsByLabel(Map<String, String> labels) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
fixes #1460 

It remains out that the list integration page never live reload its data, so to see an integration marked as fail, you still have to:

- let some time to pass, so that the executor service re-check the progress
- reload/re-enter the integration list page