### PR TITLE
fix(codestyle): downgrade PMD

### DIFF
--- a/app/connectors/connectors/sql/sql-common/src/main/java/io/syndesis/connector/sql/DatabaseMetaDataHelper.java
+++ b/app/connectors/connectors/sql/sql-common/src/main/java/io/syndesis/connector/sql/DatabaseMetaDataHelper.java
@@ -81,6 +81,7 @@ public final class DatabaseMetaDataHelper {
         return tablesInSchema;
     }
 
+    @SuppressWarnings("PMD.RemoteInterfaceNamingConvention")
     static ResultSet fetchTableColumns(final DatabaseMetaData meta, final String catalog,
             final String schema, final String tableName, final String columnName) throws SQLException {
 
@@ -118,6 +119,7 @@ public final class DatabaseMetaDataHelper {
         return paramList;
     }
 
+    @SuppressWarnings("PMD.RemoteInterfaceNamingConvention")
     private static ResultSet getColumns(final DatabaseMetaData meta, String catalog, 
             String schema, String tableName, String columnName, int expectedSize) throws SQLException {
         ResultSet columns = meta.getColumns(catalog, schema, tableName, columnName);
@@ -126,8 +128,8 @@ public final class DatabaseMetaDataHelper {
         int  numberOfRecords = numberOfRecords(columns);
         if (numberOfRecords == 0) {
             //Postgresql does lowercase instead, so let's try that if we don't have a match
-            table = table.toLowerCase();
-            column = columnName == null ? null : columnName.toLowerCase();
+            table = table.toLowerCase(Locale.US);
+            column = columnName == null ? null : columnName.toLowerCase(Locale.US);
             columns = meta.getColumns(catalog, schema, table, column);
             numberOfRecords = numberOfRecords(columns);
         }

--- a/app/core/model/src/main/java/io/syndesis/model/integration/IntegrationDeployment.java
+++ b/app/core/model/src/main/java/io/syndesis/model/integration/IntegrationDeployment.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.syndesis.core.IndexedProperty;

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -71,8 +71,8 @@
     <camel.version>2.20.1</camel.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
-    <dep.plugin.pmd.version>3.9.0</dep.plugin.pmd.version>
-    <dep.pmd.version>6.0.1</dep.pmd.version>
+    <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
+    <dep.pmd.version>5.8.1</dep.pmd.version>
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
     <basepom.test.fork-count>1</basepom.test.fork-count>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -574,6 +574,7 @@
           <artifactId>maven-pmd-plugin</artifactId>
           <configuration>
             <analysisCache>true</analysisCache>
+            <printFailingErrors>true</printFailingErrors>
             <rulesets>
               <ruleset>/syndesis/ruleset.xml</ruleset>
             </rulesets>

--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/IntegrationController.java
@@ -82,6 +82,7 @@ public class IntegrationController {
         eventBus.subscribe("integration-deployment-controller", getChangeEventSubscription());
     }
 
+    @SuppressWarnings("PMD.DoNotUseThreads")
     private static ThreadFactory threadFactory(String name) {
         return r -> new Thread(null, r, name);
     }

--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
@@ -22,7 +22,6 @@ import io.syndesis.controllers.ControllersConfigurationProperties;
 import io.syndesis.controllers.StateChangeHandler;
 import io.syndesis.controllers.StateChangeHandlerProvider;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.dao.manager.EncryptionComponent;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.openshift.OpenShiftService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,21 +34,18 @@ public class OnlineHandlerProvider extends BaseHandler implements StateChangeHan
     private final DataManager dataManager;
     private final IntegrationProjectGenerator projectGenerator;
     private final ControllersConfigurationProperties properties;
-    private final EncryptionComponent encryptionComponent;
 
     public OnlineHandlerProvider(
             DataManager dataManager,
             OpenShiftService openShiftService,
             IntegrationProjectGenerator projectGenerator,
-            ControllersConfigurationProperties properties,
-            EncryptionComponent encryptionComponent) {
+            ControllersConfigurationProperties properties) {
 
         super(openShiftService);
 
         this.dataManager = dataManager;
         this.projectGenerator = projectGenerator;
         this.properties = properties;
-        this.encryptionComponent = encryptionComponent;
     }
 
     @Override
@@ -59,8 +55,7 @@ public class OnlineHandlerProvider extends BaseHandler implements StateChangeHan
                 dataManager,
                 openShiftService(),
                 projectGenerator,
-                properties,
-                encryptionComponent
+                properties
             ),
             new UnpublishHandler(openShiftService()));
     }

--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
@@ -32,7 +32,6 @@ import io.syndesis.controllers.StateUpdate;
 import io.syndesis.core.Labels;
 import io.syndesis.core.SyndesisServerException;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.dao.manager.EncryptionComponent;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.IntegrationDeployment;
@@ -45,22 +44,19 @@ public class PublishHandler extends BaseHandler implements StateChangeHandler {
     private final DataManager dataManager;
     private final IntegrationProjectGenerator projectGenerator;
     private final ControllersConfigurationProperties properties;
-    private final EncryptionComponent encryptionComponent;
 
     @SuppressWarnings("PMD.DefaultPackage")
     PublishHandler(
         DataManager dataManager,
         OpenShiftService openShiftService,
         IntegrationProjectGenerator projectGenerator,
-        ControllersConfigurationProperties properties,
-        EncryptionComponent encryptionComponent) {
+        ControllersConfigurationProperties properties) {
 
         super(openShiftService);
 
         this.dataManager = dataManager;
         this.projectGenerator = projectGenerator;
         this.properties = properties;
-        this.encryptionComponent = encryptionComponent;
     }
 
     @Override

--- a/app/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/JsonRecordConsumer.java
+++ b/app/rest/jsondb/src/main/java/io/syndesis/jsondb/impl/JsonRecordConsumer.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 /**
  * Converts a stream of JsonRecords to json sent to a OutputStream.
  */
+@SuppressWarnings("PMD.GodClass")
 class JsonRecordConsumer implements Consumer<JsonRecord>, Closeable {
 
     private final String base;

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -31,6 +31,7 @@ import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.syndesis.core.Names;
 
+@SuppressWarnings({"PMD.BooleanGetMethodName", "PMD.LocalHomeNamingConvention"})
 public class OpenShiftServiceImpl implements OpenShiftService {
 
     private final NamespacedOpenShiftClient openShiftClient;

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -74,7 +74,6 @@ import io.syndesis.model.connection.Connector;
 import io.syndesis.model.extension.Extension;
 import io.syndesis.model.integration.Integration;
 import io.syndesis.model.integration.IntegrationDeployment;
-import io.syndesis.model.integration.IntegrationDeploymentState;
 import io.syndesis.model.integration.Step;
 import io.syndesis.rest.util.PaginationFilter;
 import io.syndesis.rest.util.ReflectiveSorter;

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -355,6 +355,9 @@
   </rule>
   <rule ref="rulesets/java/empty.xml/EmptyCatchBlock">
     <priority>4</priority>
+    <properties>
+      <property name="allowExceptionNameRegex" value="ignored" />
+    </properties>
   </rule>
   <rule ref="rulesets/java/strictexception.xml/AvoidThrowingNullPointerException">
     <priority>3</priority>
@@ -389,7 +392,7 @@
       <property name="minimum" value="3" />
     </properties>
   </rule>
-  <rule ref="rulesets/java/naming.xml/MisLeadingVariableName">
+  <rule ref="rulesets/java/naming.xml/MisleadingVariableName">
     <priority>4</priority>
   </rule>
   <rule ref="rulesets/java/empty.xml/EmptyTryBlock">


### PR DESCRIPTION
This switches PMD and pmd-maven-plugin versions to 5.8.1 - the version
used by Codacy in order to eliminate the stack trace shown at build.

Fixes #1449