### PR TITLE
[fix] adding syndesis.io/integration-name annotation

### DIFF
--- a/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
+++ b/app/rest/controllers/src/main/java/io/syndesis/controllers/integration/online/PublishHandler.java
@@ -135,6 +135,7 @@ public class PublishHandler extends BaseHandler implements StateChangeHandler {
             .addLabel(OpenShiftService.INTEGRATION_ID_LABEL, Labels.sanitize(integrationDeployment.getIntegrationId().orElseThrow(() -> new IllegalStateException("IntegrationDeployment should have an integrationId"))))
             .addLabel(OpenShiftService.DEPLOYMENT_ID_LABEL,  Integer.toString(integrationDeployment.getVersion()))
             .addLabel(OpenShiftService.USERNAME_LABEL, Labels.sanitize(username))
+            .addAnnotation(OpenShiftService.INTEGRATION_NAME_ANNOTATION, integration.getName())
             .addAnnotation(OpenShiftService.INTEGRATION_ID_ANNOTATION, integrationDeployment.getIntegrationId().get())
             .addAnnotation(OpenShiftService.DEPLOYMENT_VERSION_ANNOTATION, Integer.toString(integrationDeployment.getVersion()))
             .addSecretEntry("application.properties", propsToString(applicationProperties))

--- a/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/MetricsCollector.java
+++ b/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/MetricsCollector.java
@@ -101,7 +101,7 @@ public class MetricsCollector implements Runnable, Closeable {
                     executor.execute(new PodMetricsReader(
                             kubernetes,
                             p.getMetadata().getName(),
-                            p.getMetadata().getLabels().get("integration"),
+                            p.getMetadata().getAnnotations().get("syndesis.io/integration-name"),
                             p.getMetadata().getAnnotations().get("syndesis.io/integration-id"),
                             p.getMetadata().getAnnotations().get("syndesis.io/deployment-version"),
                             rmh))

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -26,6 +26,7 @@ import io.fabric8.openshift.api.model.User;
 public interface OpenShiftService {
 
     String INTEGRATION_ID_ANNOTATION = "syndesis.io/integration-id";
+    String INTEGRATION_NAME_ANNOTATION = "syndesis.io/integration-name";
     String DEPLOYMENT_VERSION_ANNOTATION = "syndesis.io/deployment-version";
     String INTEGRATION_ID_LABEL = "syndesis.io/integration-id";
     String DEPLOYMENT_ID_LABEL = "syndesis.io/deployment-id";


### PR DESCRIPTION
The label turns to lowercase, which is a problem. Case needs to be preserved to find the camel context in the integration pod.