### PR TITLE
remove horizontal scroll on data mapper step

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.scss
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.scss
@@ -5,10 +5,8 @@
   overflow: visible;
   .toolbar {
     flex: 0 0 auto;
-    margin: 0 -20px;
     &.mapper {
       margin-top: 15px;
-      padding: 0 20px;
     }
     .toolbar-pf {
       background: none !important;


### PR DESCRIPTION
There is a horizontal scroll coming from a negative horizontal margin on the toolbar. Looks like the negative margin is just to counteract the horizontal padding on the toolbar.

Removed them both - the page looks the same, and horizontal scroll is gone.