### PR TITLE
remove fa-angle-double-left from "home" link in breadcrumbs

### DIFF
--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -38,7 +38,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -11,7 +11,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -11,7 +11,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -8,7 +8,7 @@
           <div class="inline-block">
             <ol class="breadcrumb">
               <li>
-                <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                <a [routerLink]="['/']">Home</a>
               </li>
               <li>
                 <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -10,7 +10,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -27,7 +27,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -10,7 +10,7 @@
             <div class="inline-block">
               <ol class="breadcrumb">
                 <li>
-                  <a [routerLink]="['/']"><i class="fa fa-angle-double-left"></i> Home</a>
+                  <a [routerLink]="['/']">Home</a>
                 </li>
                 <li>
                   <a [routerLink]="['/integrations']">Integrations</a>


### PR DESCRIPTION
Some pages had this and others didn't. Checked with UXD and looks like it's safe to pull it out.

From @sjcox-rh:

> @mcoker I honestly couldnt tell you why that was introduced. Im looking back through my designs now and now sure where it came from. Maybe a miscommunication with dev? Not sure.  I think it’s safe to just stick with the PF version.