### PR TITLE
change breadcrumbs to "Choose a" when choosing a start/finish connection in an integration

### DIFF
--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -21,7 +21,7 @@
                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
                   <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
                 </li>
-                <li class="active">Select {{ positionText() | capitalize }} Connection</li>
+                <li class="active">Choose a {{ positionText() | capitalize }} Connection</li>
               </ol>
             </div>
             <div class="toolbar-pf-action-right">


### PR DESCRIPTION
From https://github.com/syndesisio/syndesis/issues/1262 match the text in the breadcrumbs to the text in the `<h1>` on the page. 