### PR TITLE
chore(ui): import RxJS like a pro

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -103,6 +103,7 @@
     "patternfly-sass": "3.23.2",
     "prettier": "^1.5.2",
     "puppeteer": "^1.0.0",
+    "rxjs-tslint-rules": "^3.9.0",
     "sass-lint": "1.10.2",
     "sw-precache": "5.0.0",
     "swagger-js-codegen": "1.7.12",

--- a/app/ui/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.ts
@@ -25,7 +25,6 @@ import {
 
 import { ObjectPropertyFilterPipe } from '../../object-property-filter.pipe';
 import { ObjectPropertySortPipe } from '../../object-property-sort.pipe';
-import 'rxjs/add/observable/empty';
 
 @Component({
   selector: 'syndesis-list-toolbar',

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -5,8 +5,6 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
 import { plural } from 'pluralize';
-import 'rxjs/add/observable/merge';
-import 'rxjs/add/operator/share';
 
 import { BaseEntity } from '@syndesis/ui/platform';
 import { RESTService } from './rest.service';

--- a/app/ui/src/app/store/entity/events.service.ts
+++ b/app/ui/src/app/store/entity/events.service.ts
@@ -5,7 +5,6 @@ import { ConfigService } from '../../config.service';
 import { Restangular } from 'ngx-restangular';
 import { log } from '../../logging';
 import { resolve } from 'url';
-import 'rxjs/add/operator/first';
 
 export class ChangeEvent {
   action: string;

--- a/app/ui/src/polyfills.ts
+++ b/app/ui/src/polyfills.ts
@@ -56,17 +56,24 @@ import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';  // Included with Angular CLI.
 
 /***************************************************************************************************
- * APPLICATION IMPORTS
+ * RxJS IMPORTS
  */
-
-import 'rxjs/add/operator/do';
 import 'rxjs/add/observable/empty';
-import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
+
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/combineLatest';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/take';
+
+/***************************************************************************************************
+ * APPLICATION IMPORTS
+ */

--- a/app/ui/tslint.json
+++ b/app/ui/tslint.json
@@ -2,6 +2,9 @@
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],
+  "extends": [
+    "rxjs-tslint-rules"
+  ],
   "rules": {
     // ***************************************************
     // TypeScript linting Ruleset
@@ -220,6 +223,19 @@
     "pipe-naming": ["camelCase"],
     "use-host-property-decorator": true,
     "use-input-property-decorator": true,
-    "use-output-property-decorator": true
+    "use-output-property-decorator": true,
+    // ***************************************************
+    // TSLint rules for RxJS
+    // ***************************************************
+    "rxjs-add": {
+      "options": [
+        {
+          "allowElsewhere": false,
+          "allowUnused": false,
+          "file": "polyfills.ts"
+        }
+      ],
+      "severity": "error"
+    }
   }
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -6514,7 +6514,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -6561,6 +6561,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
+rxjs-tslint-rules@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-3.9.0.tgz#7ea390f5255f7acb499245d5b14d69fdd6356698"
+  dependencies:
+    resolve "^1.4.0"
+    tslib "^1.8.0"
 
 rxjs@^5.0.0, rxjs@^5.5.2, rxjs@^5.5.6:
   version "5.5.6"
@@ -7505,7 +7512,7 @@ tsickle@^0.26.0:
     source-map "^0.5.6"
     source-map-support "^0.4.2"
 
-tslib@^1.7.1, tslib@^1.8.1:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 


### PR DESCRIPTION
The details page of custom API connector wasn't loading as the
`combineLatest` RxJS operator wasn't imported.

This follows the best practice in the blog post by Christian Liebel[1]
on how to properly import RxJS by only loading parts that are needed
from a centrally managed imports file.

This adds `rxjs.imports.ts` that should hold all RxJS imports needed and
adds a lint rule from `rxjs-tslint-rules` to enforce its use.

[1] https://christianliebel.com/2017/07/import-rxjs-correctly/