### PR TITLE
fix(ui): show suggested tokenEndpoint parameter for API connector

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
@@ -19,11 +19,11 @@ export class ApiConnectorAuthComponent implements OnInit, OnDestroy {
   constructor(private formBuilder: FormBuilder) { }
 
   ngOnInit() {
-    const { authenticationType, authorizationEndpoint } = this.customConnectorRequest.properties;
+    const { authenticationType, authorizationEndpoint, tokenEndpoint } = this.customConnectorRequest.properties;
     this.authSetupForm = this.formBuilder.group({
       authenticationType: [authenticationType ? authenticationType.defaultValue : ''],
       authorizationEndpoint: [authorizationEndpoint ? authorizationEndpoint.defaultValue : ''],
-      tokenEndpoint: ['']
+      tokenEndpoint: [tokenEndpoint ? tokenEndpoint.defaultValue : '']
     });
 
     this.authSetupFormValueSubscription = this.authSetupForm

--- a/app/ui/src/app/customizations/api-connector/api-connector.models.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.models.ts
@@ -38,6 +38,9 @@ export interface ApiConnectorData {
     authorizationEndpoint?: {
       defaultValue: string;
     };
+    tokenEndpoint?: {
+      defaultValue: string;
+    };
   };
 }
 


### PR DESCRIPTION
`tokenEndpoint` from endpoint `POST /api/v1/connectors/custom/info` is
not taken into account and set as default value when creating API
connector that has `tokenEndpoint` defined.

This adds the `tokenEndpoint` property to `ApiConnectorData` and maps
that the returned value from the endpoint in
`ApiConnectorAuthComponent`.