### PR TITLE
chore(ui): display embedded connector icons

### DIFF
--- a/app/ui/src/app/common/icon-path.pipe.ts
+++ b/app/ui/src/app/common/icon-path.pipe.ts
@@ -37,6 +37,10 @@ export class IconPathPipe implements PipeTransform {
       const defaultIconSuffix = isConnector ? 'connection' : 'integration';
       let iconPath = `./../../assets/icons/${defaultIcon}.${defaultIconSuffix}.png`;
 
+      if (connection.icon.toLowerCase().startsWith('data:')) {
+        return this.toSafeUrl(connection.icon);
+      }
+
       if (connection.icon.toLowerCase().startsWith('db:') || connection.icon.startsWith('extension:')) {
         connectionId = isConnector ? connection.id : connectionId;
         iconPath = `${this.apiEndpoint}/connectors/${connectionId}/icon`;


### PR DESCRIPTION
Icons generated by the icon generator via #705 are embedded in the
`icon` property of the connector as data URIs. This uses them as
`<img src`.