### PR TITLE
fix(editor): update event bindings and force change detection

### DIFF
--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -130,9 +130,9 @@
                                        [model]="model"
                                        [fieldId]="fieldHash"
                                        [bindId]="bindId"
-                                       (blur)="onFocusChange($event)"
-                                       (change)="onValueChange($event)"
-                                       (focus)="onFocusChange($event)">
+                                       (dfBlur)="onBlur($event)"
+                                       (dfChange)="onValueChange($event)"
+                                       (dfFocus)="onFocus($event)">
             </syndesis-duration-control>
           </ng-container>
           <ng-container *ngSwitchDefault>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
@@ -33,6 +33,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
   routeSubscription: Subscription;
 
   constructor(
+    private cd: ChangeDetectorRef,
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
@@ -237,6 +238,10 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
         this.position = +params.get('position');
         this.loadForm();
       });
+  }
+
+  ngAfterViewInit() {
+    this.cd.detectChanges();
   }
 
   ngOnDestroy() {

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -33,7 +33,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
   routeSubscription: Subscription;
 
   constructor(
-    private cd: ChangeDetectorRef,
+    private changeDetectorRef: ChangeDetectorRef,
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
@@ -241,7 +241,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    this.cd.detectChanges();
+    this.changeDetectorRef.detectChanges();
   }
 
   ngOnDestroy() {

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -17,7 +17,7 @@ const category = getCategory('IntegrationsCreatePage');
   templateUrl: './step-configure.component.html',
   styleUrls: ['./step-configure.component.scss']
 })
-export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
+export class IntegrationStepConfigureComponent implements OnInit, OnDestroy, AfterViewInit {
   flowSubscription: Subscription;
   position: number;
   step: Step = undefined;


### PR DESCRIPTION
This PR forces a round of change detection on the after view init lifecycle hook. This is not ideal but does unbreak the UI. It's a sign of a larger design flaw but that could be addressed at a later point.

@deeleman setting these values in an async fashion didn't work, unfortunately, so I opted for ChangeDetectorRef. Let me know if there's a better way for the short term.

Should help https://github.com/syndesisio/syndesis/issues/1481

update missed event bindings from ng-dynamic-form upgrade
force change detection after view init for editor