### PR TITLE
fix(rest): Blank action for API Client connectors

### DIFF
--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -39,6 +39,7 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.RefParameter;
 import io.syndesis.connector.generator.ConnectorGenerator;
 import io.syndesis.connector.generator.swagger.util.JsonSchemaHelper;
+import io.syndesis.connector.generator.swagger.util.OperationDescription;
 import io.syndesis.connector.generator.swagger.util.SwaggerHelper;
 import io.syndesis.connector.generator.util.ActionComparator;
 import io.syndesis.core.SyndesisServerException;
@@ -196,26 +197,12 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
                     .connectorId(connectorId)//
                     .build();
 
-                final String summary = trimToNull(operation.getSummary());
-                final String specifiedDescription = trimToNull(operation.getDescription());
-
-                final String name;
-                final String description;
-                if (summary == null && specifiedDescription == null) {
-                    name = entry.getKey() + " " + pathEntry.getKey();
-                    description = null;
-                } else if (specifiedDescription == null) {
-                    name = entry.getKey() + " " + pathEntry.getKey();
-                    description = summary;
-                } else {
-                    name = summary;
-                    description = specifiedDescription;
-                }
+                final OperationDescription description = SwaggerHelper.operationDescriptionOf(swagger, operation);
 
                 final ConnectorAction action = new ConnectorAction.Builder()//
                     .id(createActionId(connectorId, connectorGav, operation))//
-                    .name(name)//
-                    .description(description)//
+                    .name(description.name)//
+                    .description(description.description)//
                     .pattern(Action.Pattern.To)//
                     .descriptor(descriptor).tags(ofNullable(operation.getTags()).orElse(Collections.emptyList()))//
                     .build();

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/OperationDescription.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/OperationDescription.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.generator.swagger.util;
+
+import java.util.Objects;
+
+public final class OperationDescription {
+
+    public final String description;
+
+    public final String name;
+
+    public OperationDescription(final String name, final String description) {
+        this.name = Objects.requireNonNull(name, "operation name");
+        this.description = Objects.requireNonNull(description, "operation description");
+    }
+
+}

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/SwaggerHelper.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/swagger/util/SwaggerHelper.java
@@ -19,10 +19,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
+import io.swagger.models.HttpMethod;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import io.swagger.parser.util.RemoteUrl;
@@ -44,6 +48,8 @@ import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
+
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 public final class SwaggerHelper {
 
@@ -67,6 +73,24 @@ public final class SwaggerHelper {
 
     private SwaggerHelper() {
         // utility class
+    }
+
+    public static OperationDescription operationDescriptionOf(final Swagger swagger, final Operation operation) {
+        final Entry<String, Path> pathEntry = swagger.getPaths().entrySet().stream()
+            .filter(e -> e.getValue().getOperations().contains(operation)).findFirst().get();
+        final String path = pathEntry.getKey();
+
+        final Entry<HttpMethod, Operation> operationEntry = pathEntry.getValue().getOperationMap().entrySet().stream()
+            .filter(e -> e.getValue().equals(operation)).findFirst().get();
+        final HttpMethod method = operationEntry.getKey();
+
+        final String specifiedSummary = trimToNull(operation.getSummary());
+        final String specifiedDescription = trimToNull(operation.getDescription());
+
+        final String name = ofNullable(specifiedSummary).orElseGet(() -> method + " " + path);
+        final String description = ofNullable(specifiedDescription).orElseGet(() -> "Send " + method + " request to " + path);
+
+        return new OperationDescription(name, description);
     }
 
     public static SwaggerModelInfo parse(final String specification, final boolean validate) {
@@ -176,4 +200,5 @@ public final class SwaggerHelper {
                 .message("Unable to load the swagger schema file embedded in the artifact").build()).build();
         }
     }
+
 }

--- a/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/util/IconGenerator.java
+++ b/app/rest/connector-generator/src/main/java/io/syndesis/connector/generator/util/IconGenerator.java
@@ -91,7 +91,7 @@ public final class IconGenerator {
         }
     }
 
-    /* default */static String trimXml(final String xml) {
+    static String trimXml(final String xml) {
         return xml.replaceAll(">\\s*<", "><").replaceAll("\\s\\s+", " ").replaceAll(" />", "/>");
     }
 

--- a/app/rest/connector-generator/src/test/resources/swagger/basic_auth.unified_connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/basic_auth.unified_connector.json
@@ -113,6 +113,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-0",
       "name": "GET /operation",
+      "description": "Send GET request to /operation",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesiss.version@",
         "camelConnectorPrefix": "swagger-operation",

--- a/app/rest/connector-generator/src/test/resources/swagger/petstore.unified_connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/petstore.unified_connector.json
@@ -186,8 +186,8 @@
   "actions": [
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:updatePet",
-      "name": "PUT /pet",
-      "description": "Update an existing pet",
+      "name": "Update an existing pet",
+      "description": "Send PUT request to /pet",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -210,8 +210,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:addPet",
-      "name": "POST /pet",
-      "description": "Add a new pet to the store",
+      "name": "Add a new pet to the store",
+      "description": "Send POST request to /pet",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -309,8 +309,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:updatePetWithForm",
-      "name": "POST /pet/{petId}",
-      "description": "Updates a pet in the store with form data",
+      "name": "Updates a pet in the store with form data",
+      "description": "Send POST request to /pet/{petId}",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -333,8 +333,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:deletePet",
-      "name": "DELETE /pet/{petId}",
-      "description": "Deletes a pet",
+      "name": "Deletes a pet",
+      "description": "Send DELETE request to /pet/{petId}",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -357,8 +357,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:uploadFile",
-      "name": "POST /pet/{petId}/uploadImage",
-      "description": "uploads an image",
+      "name": "uploads an image",
+      "description": "Send POST request to /pet/{petId}/uploadImage",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -406,8 +406,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:placeOrder",
-      "name": "POST /store/order",
-      "description": "Place an order for a pet",
+      "name": "Place an order for a pet",
+      "description": "Send POST request to /store/order",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -504,8 +504,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:createUsersWithArrayInput",
-      "name": "POST /user/createWithArray",
-      "description": "Creates list of users with given input array",
+      "name": "Creates list of users with given input array",
+      "description": "Send POST request to /user/createWithArray",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -528,8 +528,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:createUsersWithListInput",
-      "name": "POST /user/createWithList",
-      "description": "Creates list of users with given input array",
+      "name": "Creates list of users with given input array",
+      "description": "Send POST request to /user/createWithList",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -552,8 +552,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:loginUser",
-      "name": "GET /user/login",
-      "description": "Logs user into the system",
+      "name": "Logs user into the system",
+      "description": "Send GET request to /user/login",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -576,8 +576,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:logoutUser",
-      "name": "GET /user/logout",
-      "description": "Logs out current logged in user session",
+      "name": "Logs out current logged in user session",
+      "description": "Send GET request to /user/logout",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",
@@ -599,8 +599,8 @@
     },
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:getUserByName",
-      "name": "GET /user/{username}",
-      "description": "Get user by user name",
+      "name": "Get user by user name",
+      "description": "Send GET request to /user/{username}",
       "descriptor": {
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@",
         "camelConnectorPrefix": "swagger-operation",

--- a/app/rest/connector-generator/src/test/resources/swagger/reverb.unified_connector.json
+++ b/app/rest/connector-generator/src/test/resources/swagger/reverb.unified_connector.json
@@ -8,6 +8,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-61",
       "name": "GET /articles",
+      "description": "Send GET request to /articles",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -73,6 +74,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-5",
       "name": "GET /categories/flat",
+      "description": "Send GET request to /categories/flat",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -204,6 +206,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-68",
       "name": "GET /comparison_shopping_pages/{id}",
+      "description": "Send GET request to /comparison_shopping_pages/{id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -434,6 +437,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-38",
       "name": "GET /curated_sets/{slug}",
+      "description": "Send GET request to /curated_sets/{slug}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -1456,6 +1460,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-95",
       "name": "DELETE /my/curated_set/product/{product_id}",
+      "description": "Send DELETE request to /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -1488,6 +1493,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-126",
       "name": "DELETE /my/follows/{follow_id}/alert",
+      "description": "Send DELETE request to /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -2972,6 +2978,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-94",
       "name": "POST /my/curated_set/product/{product_id}",
+      "description": "Send POST request to /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -3004,6 +3011,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-125",
       "name": "POST /my/follows/{follow_id}/alert",
+      "description": "Send POST request to /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -4323,6 +4331,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-57",
       "name": "GET /sales/{slug}",
+      "description": "Send GET request to /sales/{slug}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
@@ -4454,6 +4463,7 @@
     {
       "id": "io.syndesis.connector:connector-rest-swagger:@syndesis-connectors.version@:_id_:operation-62",
       "name": "GET /shipping/regions",
+      "description": "Send GET request to /shipping/regions",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
         "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",

--- a/app/rest/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
+++ b/app/rest/jsondb/src/test/java/io/syndesis/jsondb/impl/JsonDBTest.java
@@ -20,9 +20,7 @@ import static io.syndesis.core.util.Resources.getResourceAsText;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/app/rest/runtime/src/test/java/io/syndesis/runtime/MigrationsITCase.java
+++ b/app/rest/runtime/src/test/java/io/syndesis/runtime/MigrationsITCase.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.syndesis.core.Json;
 import io.syndesis.dao.manager.DataManager;
-import io.syndesis.jsondb.GetOptions;
 import io.syndesis.jsondb.impl.SqlJsonDB;
 
 @SpringBootTest()


### PR DESCRIPTION
Introduces `OperationDescription` and a helper method in `SwaggerHelper`
to determine name/description.

Fixes #1489