### PR TITLE
fix(checkbox): allow string "true" to set checked state by default

### DIFF
--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -217,13 +217,12 @@ export class FormFactoryProviderService extends FormFactoryService {
                          field: ConfiguredConfigurationProperty,
                          value: any
   ) {
-    // bandaid for rest service returning string 'true' instead of boolean true
-    let defaultValue = value || field.value || field.defaultValue;
+    const initialValue = value || field.value || field.defaultValue;
     return new DynamicCheckboxModel({
       id: key,
       label: field.displayName || key,
       hint: field.description,
-      value: (defaultValue === 'true') ? true : defaultValue
+      value: (!!initialValue)
     }, {
         element: {
           control: 'element-control checkbox'

--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -217,11 +217,13 @@ export class FormFactoryProviderService extends FormFactoryService {
                          field: ConfiguredConfigurationProperty,
                          value: any
   ) {
+    // bandaid for rest service returning string 'true' instead of boolean true
+    let defaultValue = value || field.value || field.defaultValue;
     return new DynamicCheckboxModel({
       id: key,
       label: field.displayName || key,
       hint: field.description,
-      value: value || field.value || field.defaultValue
+      value: (defaultValue === 'true') ? true : defaultValue
     }, {
         element: {
           control: 'element-control checkbox'


### PR DESCRIPTION
This PR allows the value string 'true' to set the checkboxes default checked state through our form factory service provider.

[This issue](https://github.com/syndesisio/syndesis/issues/991) was put on hold while many UI upgrades were in the works, now that this has settled we'd like to resume.

Notice in the attached image, the defaultValue property has the value string "true", instead of boolean true. This is the cause of the default value not being set correctly.

<img width="1429" alt="screen shot 2018-02-12 at 12 01 09 pm" src="https://user-images.githubusercontent.com/5942899/36111196-551fcd12-0ff3-11e8-83a3-5cde41306658.png">

Ideally, this PR can be dismissed and the fix be applied to the back end, so we don't have to perform this type of check in the UI - it really shouldn't be there. The value is set properly (boolean true) in deployment.json, so something seems to be changing this value before its exposed via rest service.

No idea what's involved in making this fix on the back end, which is why I'm posting this PR - in the interest of time.
