### PR TITLE
[feat] Adding metrics split out by deployment version

### DIFF
--- a/app/core/model/src/main/java/io/syndesis/model/metrics/IntegrationDeploymentMetrics.java
+++ b/app/core/model/src/main/java/io/syndesis/model/metrics/IntegrationDeploymentMetrics.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @SuppressWarnings("immutables")
 public interface IntegrationDeploymentMetrics extends Serializable{
 
+    String getVersion();
     /**
      * @return Number of successful messages
      */

--- a/app/rest/metrics-collector/pom.xml
+++ b/app/rest/metrics-collector/pom.xml
@@ -135,6 +135,7 @@
     <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
+        <scope>provided</scope>
     </dependency>
     <!-- === Testing Dependencies ======================================================== -->
 
@@ -153,12 +154,18 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
-      <scope>runtime</scope>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jdbi</groupId>
       <artifactId>jdbi</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/rest/metrics-collector/pom.xml
+++ b/app/rest/metrics-collector/pom.xml
@@ -132,6 +132,10 @@
       <artifactId>findbugs-annotations</artifactId>
     </dependency>
 
+    <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+    </dependency>
     <!-- === Testing Dependencies ======================================================== -->
 
     <dependency>

--- a/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/IntegrationMetricsHandler.java
+++ b/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/IntegrationMetricsHandler.java
@@ -109,9 +109,9 @@ public class IntegrationMetricsHandler {
                 .integrationDeploymentMetrics(dmList)
                 .build();
     }
-    
+
     @Data
-    class Metrics {
+    static class Metrics {
 
         private Long messages = 0L;
         private Long errors = 0L;
@@ -120,7 +120,7 @@ public class IntegrationMetricsHandler {
         private String version;
 
         public Metrics add(Set<String> livePodIds, RawMetrics raw) {
-            
+
             this.version = raw.getVersion();
             this.messages += raw.getMessages();
             this.errors += raw.getErrors();

--- a/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/JsonDBRawMetrics.java
+++ b/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/JsonDBRawMetrics.java
@@ -56,9 +56,7 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
 
         try {
             //persist the latest rawMetrics
-            String path = String.format("%s/integrations/%s/versions/%s/pods/%s",
-                RawMetrics.class.getSimpleName(),rawMetrics.getIntegrationId(),
-                    rawMetrics.getVersion(), rawMetrics.getPod());
+            String path = path(rawMetrics.getIntegrationId(), rawMetrics.getPod());
             String json = Json.writer().writeValueAsString(rawMetrics);
             if (jsonDB.exists(path)) {
                 //only update if not the same (don't cause unnecessary and expensive writes)
@@ -84,9 +82,10 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
      */
     @Override
     public Map<String,RawMetrics> getRawMetrics(String integrationId) throws IOException {
-        //try to obtain metrics in this integration
+        //try to obtain all raw metrics in this integration
         Map<String,RawMetrics> metrics = new HashMap<>();
-        String json = jsonDB.getAsString(path(integrationId));
+        String path = path(integrationId);
+        String json = jsonDB.getAsString(path);
         if (json != null) {
             metrics = Json.reader().forType(VALUE_TYPE_REF).readValue(json);
         }

--- a/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/PodMetricsReader.java
+++ b/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/PodMetricsReader.java
@@ -153,7 +153,7 @@ public class PodMetricsReader implements Runnable {
         ObjectName on = cache.get(camelContextName);
         if (on == null) {
             ObjectName found = null;
-            J4pSearchResponse sr = jolokia.execute(new J4pSearchRequest("*:type=context,*"));
+            J4pSearchResponse sr = jolokia.execute(new J4pSearchRequest("org.apache.camel:type=context,*"));
             if (sr != null) {
                 for (ObjectName name : sr.getObjectNames()) {
                     String id = name.getKeyProperty("name");

--- a/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/RawMetrics.java
+++ b/app/rest/metrics-collector/src/main/java/io/syndesis/rest/metrics/collector/RawMetrics.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public interface RawMetrics {
 
     String getIntegrationId();
-    Optional<String> getVersion();
+    String getVersion();
     String getPod();
 
     Long getMessages();

--- a/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
+++ b/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
@@ -75,9 +75,10 @@ public class MetricsCollectorTest {
         }
         this.jsondb.createTables();
 
+        jsondbRM = new JsonDBRawMetrics(jsondb);
+
         load();
 
-        jsondbRM = new JsonDBRawMetrics(jsondb);
         CacheManager cacheManager = new LRUCacheManager(100);
         EncryptionComponent encryptionComponent = new EncryptionComponent(null);
         ResourceLoader resourceLoader = new DefaultResourceLoader();
@@ -87,12 +88,12 @@ public class MetricsCollectorTest {
     }
 
     private void load() throws IOException, ParseException {
-        jsondb.set(JsonDBRawMetrics.path("intId1","pod1"), Json.writer().writeValueAsString(raw("intId1","1","pod1",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId1","pod2"), Json.writer().writeValueAsString(raw("intId1","1","pod2",3L, "31-01-2018 10:22:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId1","HISTORY1"), Json.writer().writeValueAsString(raw("intId1","1","HISTORY",3L, "22-01-2015 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId2","pod3"), Json.writer().writeValueAsString(raw("intId2","1","pod3",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId3","pod4"), Json.writer().writeValueAsString(raw("intId3","1","pod4",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId3","pod5"), Json.writer().writeValueAsString(raw("intId3","1","pod5",3L, "31-01-2018 10:20:56")));
+        jsondbRM.persist(raw("intId1","1","pod1",3L, "31-01-2018 10:20:56"));
+        jsondbRM.persist(raw("intId1","1","pod2",3L, "31-01-2018 10:22:56"));
+        jsondbRM.persist(raw("intId1","1","HISTORY1",3L, "22-01-2015 10:20:56"));
+        jsondbRM.persist(raw("intId2","1","pod3",3L, "31-01-2018 10:20:56"));
+        jsondbRM.persist(raw("intId3","1","pod4",3L, "31-01-2018 10:20:56"));
+        jsondbRM.persist(raw("intId3","1","pod5",3L, "31-01-2018 10:20:56"));
     }
 
     private RawMetrics raw(String integrationId, String version, String podName, Long messages, String startDateString) throws ParseException {

--- a/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
+++ b/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
@@ -114,7 +114,7 @@ public class MetricsCollectorTest {
         String json = jsondb.getAsString(JsonDBRawMetrics.path("intId1"), new GetOptions().prettyPrint(true));
         Map<String,RawMetrics> metrics = Json.reader().forType(new TypeReference<Map<String,RawMetrics>>() {}).readValue(json);
         assertThat(metrics.size()).isEqualTo(3);
-        //assertThat(metrics.keySet()).contains("HISTORY");
+        assertThat(metrics.keySet()).contains("HISTORY1");
     }
 
     @Test

--- a/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
+++ b/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -96,7 +95,7 @@ public class MetricsCollectorTest {
         jsondbRM.persist(raw("intId3","1","pod5",3L, "31-01-2018 10:20:56"));
     }
 
-    private RawMetrics raw(String integrationId, String version, String podName, Long messages, String startDateString) throws ParseException {
+    private RawMetrics raw(String integrationId, String version, String podName, Long messages, String startDateString) throws ParseException { //NOPMD
         Date startDate = sdf.parse(startDateString);
         return new RawMetrics.Builder()
                 .integrationId(integrationId)

--- a/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
+++ b/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/MetricsCollectorTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -86,19 +87,19 @@ public class MetricsCollectorTest {
     }
 
     private void load() throws IOException, ParseException {
-        jsondb.set(JsonDBRawMetrics.path("intId1","pod1"), Json.writer().writeValueAsString(raw("intId1","pod1",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId1","pod2"), Json.writer().writeValueAsString(raw("intId1","pod2",3L, "31-01-2018 10:22:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId1","HISTORY"), Json.writer().writeValueAsString(raw("intId1","HISTORY",3L, "22-01-2015 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId2","pod3"), Json.writer().writeValueAsString(raw("intId2","pod3",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId3","pod4"), Json.writer().writeValueAsString(raw("intId3","pod4",3L, "31-01-2018 10:20:56")));
-        jsondb.set(JsonDBRawMetrics.path("intId3","pod5"), Json.writer().writeValueAsString(raw("intId3","pod5",3L, "31-01-2018 10:20:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId1","pod1"), Json.writer().writeValueAsString(raw("intId1","1","pod1",3L, "31-01-2018 10:20:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId1","pod2"), Json.writer().writeValueAsString(raw("intId1","1","pod2",3L, "31-01-2018 10:22:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId1","HISTORY1"), Json.writer().writeValueAsString(raw("intId1","1","HISTORY",3L, "22-01-2015 10:20:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId2","pod3"), Json.writer().writeValueAsString(raw("intId2","1","pod3",3L, "31-01-2018 10:20:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId3","pod4"), Json.writer().writeValueAsString(raw("intId3","1","pod4",3L, "31-01-2018 10:20:56")));
+        jsondb.set(JsonDBRawMetrics.path("intId3","pod5"), Json.writer().writeValueAsString(raw("intId3","1","pod5",3L, "31-01-2018 10:20:56")));
     }
 
-    private RawMetrics raw(String integrationId, String podName, Long messages, String startDateString) throws ParseException {
+    private RawMetrics raw(String integrationId, String version, String podName, Long messages, String startDateString) throws ParseException {
         Date startDate = sdf.parse(startDateString);
         return new RawMetrics.Builder()
                 .integrationId(integrationId)
-                .version("1")
+                .version(version)
                 .pod(podName)
                 .messages(messages)
                 .errors(1L)
@@ -113,7 +114,7 @@ public class MetricsCollectorTest {
         String json = jsondb.getAsString(JsonDBRawMetrics.path("intId1"), new GetOptions().prettyPrint(true));
         Map<String,RawMetrics> metrics = Json.reader().forType(new TypeReference<Map<String,RawMetrics>>() {}).readValue(json);
         assertThat(metrics.size()).isEqualTo(3);
-        assertThat(metrics.keySet()).contains("HISTORY");
+        //assertThat(metrics.keySet()).contains("HISTORY");
     }
 
     @Test
@@ -121,14 +122,14 @@ public class MetricsCollectorTest {
         MetricsCollector collector = new MetricsCollector(null, jsondb, null);
         Map<String,RawMetrics> metrics = jsondbRM.getRawMetrics("intId1");
         assertThat(metrics.size()).isEqualTo(3);
-        assertThat(metrics.keySet()).contains("HISTORY");
+        assertThat(metrics.keySet()).contains("HISTORY1");
 
         //let's kill pod2, this so add pod2's metrics to the history
         Set<String> livePodIds = new HashSet<>(Arrays.asList("pod1"));
         jsondbRM.curate("intId1", metrics, livePodIds);
         Map<String,RawMetrics> metrics2 = jsondbRM.getRawMetrics("intId1");
         assertThat(metrics2.size()).isEqualTo(2);
-        assertThat(metrics2.keySet()).contains("HISTORY");
+        assertThat(metrics2.keySet()).contains("HISTORY1");
 
         collector.close();
     }
@@ -150,7 +151,7 @@ public class MetricsCollectorTest {
         assertThat(summary.getStart().get()).isEqualTo(sdf.parse("31-01-2018 10:20:56"));
 
         //Update pod2, add 6 messages
-        jsondb.update(JsonDBRawMetrics.path("intId1","pod2"), Json.writer().writeValueAsString(raw("intId1","pod2",9L,"31-01-2018 10:22:56")));
+        jsondb.update(JsonDBRawMetrics.path("intId1","pod2"), Json.writer().writeValueAsString(raw("intId1","2","pod2",9L,"31-01-2018 10:22:56")));
         Map<String,RawMetrics> updatedMetrics = jsondbRM.getRawMetrics(integrationId);
         IntegrationMetricsSummary updatedSummary = intMH
                 .compute(integrationId, updatedMetrics, livePodIds);
@@ -167,7 +168,7 @@ public class MetricsCollectorTest {
         //Update pod1 metrics and kill pod1
         Set<String> livePodIds = new HashSet<String>(
             Arrays.asList("pod2", "pod3", "pod4", "pod5"));
-        jsondb.update(JsonDBRawMetrics.path("intId1","pod1"), Json.writer().writeValueAsString(raw("intId1","pod1",12L,"31-01-2018 10:22:56")));
+        jsondb.update(JsonDBRawMetrics.path("intId1","pod1"), Json.writer().writeValueAsString(raw("intId1","1","pod1",12L,"31-01-2018 10:22:56")));
         Map<String,RawMetrics> metrics = jsondbRM.getRawMetrics(integrationId);
         IntegrationMetricsSummary summary = intMH
                 .compute(integrationId, metrics, livePodIds);

--- a/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/PodMetricsReaderTest.java
+++ b/app/rest/metrics-collector/src/test/java/io/syndesis/rest/metrics/collector/PodMetricsReaderTest.java
@@ -27,9 +27,9 @@ public class PodMetricsReaderTest {
 
     @Test @Ignore
     public void readTest() {
-        String podName = "metrics-test-2-90qwf";
-        String integration = "metrics-test";
-        String integrationId = "id1";
+        String podName = "dbtest1-2-3nvf3";
+        String integration = "DBTest1";
+        String integrationId = "-L5ApZneYNfmLWG-PKQt";
         String version = "1";
         PodMetricsReader reader = new PodMetricsReader(
                 new DefaultKubernetesClient(), 

--- a/app/rest/runtime/src/main/resources/application.yml
+++ b/app/rest/runtime/src/main/resources/application.yml
@@ -20,6 +20,8 @@ features:
       enabled: true
   dblogging:
     enabled: true
+  metricscollector:
+    enabled: true
 
 server:
   useForwardHeaders: true
@@ -105,4 +107,4 @@ prometheus:
   service: syndesis-prometheus
 
 metrics:
-  kind: prometheus
+  kind: sql


### PR DESCRIPTION
Example:
https://syndesis.192.168.64.24.nip.io/api/v1/metrics/integrations/-L5BM_0teut7ispMOjyE

```
{
  messages: 551,
  errors: 0,
  start: 1518479066000,
  lastProcessed: 1518479159000,
  integrationDeploymentMetrics: [
  {
    version: "1",
    messages: 458,
    errors: 0,
    lastProcessed: 1518478994000
  },
  {
    version: "2",
    messages: 93,
    errors: 0,
    start: 1518479066000,
    lastProcessed: 1518479159000
  }
  ],
  id: "-L5BM_0teut7ispMOjyE"
}
```