### PR TITLE
chore: increase heap size for rest/runtime IT

### DIFF
--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -431,6 +431,7 @@
               <goal>verify</goal>
             </goals>
             <configuration>
+              <argLine>-Xmx1024m</argLine>
               <additionalClasspathElements>
                 <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>


### PR DESCRIPTION
Hi @syndesisio/backend , can we do this? it seems rest/runtime integration tests have been failing with OOM, and this could avoid the OOM for me.