### PR TITLE
refactor(rest): setup integration test memory

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -80,6 +80,7 @@
     <basepom.failsafe.reuse-vm>true</basepom.failsafe.reuse-vm>
         <!-- takes a really long time -->
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
+    <basepom.it.memory>1024m</basepom.it.memory>
 
     <!-- Plugin versions -->
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>

--- a/app/rest/runtime/pom.xml
+++ b/app/rest/runtime/pom.xml
@@ -431,7 +431,6 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <argLine>-Xmx1024m</argLine>
               <additionalClasspathElements>
                 <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
                 <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>


### PR DESCRIPTION
Since we're using basepom[1], the best way to set the heap size for
integration tests is to modify `basepom.it.memory` property, as when we
modify the `argLine` configuration property of surefire/failsafe Maven
plugins we can loose configuration parameters such as default encoding
or Jacoco agent command line parameters needed for code coverage.

[1] https://github.com/basepom/basepom