### PR TITLE
fix: collections fallback to empty arrays when the API returns no data under Http 200

### DIFF
--- a/app/ui/src/app/platform/types/integration/integration.reducer.ts
+++ b/app/ui/src/app/platform/types/integration/integration.reducer.ts
@@ -35,7 +35,7 @@ export function integrationReducer(state = initialState, action: any): Integrati
     }
 
     case IntegrationActions.FETCH_INTEGRATIONS_COMPLETE: {
-      const collection = (action as IntegrationActions.IntegrationsFetchComplete).payload;
+      const collection = (action as IntegrationActions.IntegrationsFetchComplete).payload || [];
       return {
         ...state,
         ...{ collection },
@@ -45,7 +45,7 @@ export function integrationReducer(state = initialState, action: any): Integrati
     }
 
     case IntegrationActions.REFRESH_OVERVIEWS: {
-      const overviews = (action as IntegrationActions.IntegrationsRefreshOverviews).payload;
+      const overviews = (action as IntegrationActions.IntegrationsRefreshOverviews).payload || [];
       const collection = [...state.collection].map(integration => {
         const integrationOverview = overviews.find(overview => overview.id === integration.id);
         return {...integration, ...integrationOverview };


### PR DESCRIPTION
Fixes an issue that evolves into a browser exception when no integrations exist, since the reducer and related components do expect at least an empty array returned from the backend.