### PR TITLE
Clean up support page HTML/CSS, global CSS for PF toolbar labels

### DIFF
--- a/app/ui/src/app/support/support.component.html
+++ b/app/ui/src/app/support/support.component.html
@@ -45,21 +45,21 @@
               </div>
               <!-- Toolbar -->
               <div *ngIf="!allLogsSelected" class="container-fluid">
-              <pfng-toolbar [config]="toolbarConfig"
-                            (onFilterChange)="filterChanged($event)"
-                            (onSortChange)="sortChanged($event)"
-                            [viewTemplate]="viewTemplate">
-                <ng-template #viewTemplate>
-                  <div class="toolbar-pf-action-right">
-                    <div class="form-group">
-                      <strong>{{ selectedItems() }}</strong> of <strong>{{ totalItems() }}</strong> Items
+                <pfng-toolbar [config]="toolbarConfig"
+                              (onFilterChange)="filterChanged($event)"
+                              (onSortChange)="sortChanged($event)"
+                              [viewTemplate]="viewTemplate">
+                  <ng-template #viewTemplate>
+                    <div class="toolbar-pf-action-right">
+                      <div class="form-group">
+                        <strong>{{ selectedItems() }}</strong> of <strong>{{ totalItems() }}</strong> Items
+                      </div>
+                      <div class="form-group" *ngIf="filtersText">
+                        <a role="button" (click)="selectAllMatchingFiler(pfnglist)">Select All</a>
+                      </div>
                     </div>
-                    <div class="form-group" *ngIf="filtersText">
-                      <a role="button" (click)="selectAllMatchingFiler(pfnglist)">Select All</a>
-                    </div>
-                  </div>
-                </ng-template>  
-              </pfng-toolbar>
+                  </ng-template>  
+                </pfng-toolbar>
                 <div class="row">
                   <!-- List displayed here -->
                   <syndesis-loading >

--- a/app/ui/src/app/support/support.component.scss
+++ b/app/ui/src/app/support/support.component.scss
@@ -8,27 +8,8 @@
     font-size: $font-size-base;
     padding-top: 5px;
   }
-
-  
-}
-
-.float-left {
-  float: left;
-}
-
-#spinner {
-  margin-top: 0.8em;
-  margin-left: 2em;
 }
 
 .spinner {
  margin-left: 1em;
-}
-
-.toolbar-pf {
-  .filter-pf {
-    .list-inline {
-      margin-left: -3px;
-    }
-  }
 }

--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -98,3 +98,12 @@ body.cards-pf {
   margin-top: 5px;
   position: relative;
 }
+
+// Create some space before the first label in the PatternFly toolbar
+.toolbar-pf {
+  .filter-pf {
+    .list-inline {
+      margin-left: -3px;
+    }
+  }
+}


### PR DESCRIPTION
Just some cleanup on the support page.

Also creating some space before the first label applied in the PT toolbar filter (global change)

Before

![screen shot 2018-02-16 at 10 06 27 am](https://user-images.githubusercontent.com/35148959/36316877-23cb782c-1301-11e8-9fa4-2e0614a6905d.png)

After

![screen shot 2018-02-16 at 10 07 36 am](https://user-images.githubusercontent.com/35148959/36316927-4f6cffd2-1301-11e8-8740-ca50ae5d28ee.png)
