### PR TITLE
refactor(openshift): debug option for build

### DIFF
--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftConfigurationProperties.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftConfigurationProperties.java
@@ -45,6 +45,16 @@ public class OpenShiftConfigurationProperties {
 
     private String integrationDataPath = "${JAVA_DATA_DIR}/syndesis/loader";
 
+    private boolean debug;
+
+    public void setDebug(final boolean debug) {
+        this.debug = debug;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
     public boolean isEnabled() {
         return enabled;
     }

--- a/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
+++ b/app/rest/openshift/src/main/java/io/syndesis/openshift/OpenShiftServiceImpl.java
@@ -266,6 +266,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
                 // TODO: This environment setup needs to be externalized into application.properties
                 // https://github.com/syndesisio/syndesis-rest/issues/682
                 .withEnv(new EnvVar("MAVEN_OPTS", config.getMavenOptions(), null))
+                .withEnv(new EnvVar("BUILD_LOGLEVEL", config.isDebug() ? "5" : "1", null))
               .endSourceStrategy()
             .endStrategy()
             .withNewOutput().withNewTo().withKind("ImageStreamTag").withName(name + ":latest").endTo().endOutput()


### PR DESCRIPTION
I think we could benefit from having the debug level higher for
integration builds. The default of `0` will give us just one line in the
build log:

```
Receiving source from STDIN as archive ...
```

This increases default to `1`, giving the following lines in the log:

```
Receiving source from STDIN as archive ...
Image "172.30.1.1:5000/syndesis/syndesis-s2i@sha256:c64b875d33a..." not available locally, pulling ...
Receiving source from STDIN as archive ...
Image "172.30.1.1:5000/syndesis/syndesis-s2i@sha256:c64b875d33a..." not available locally, pulling ...
Preparing to build syndesis/test-23:31a71c7a
Preparing to build syndesis/test-23:31a71c7a
Copying sources from "/tmp/s2i-build381774301/upload/src" to "/tmp/s2i-build381774301/upload/src"
Running "assemble" in "syndesis/test-23:31a71c7a"
Copying sources from "/tmp/s2i-build381774301/upload/src" to "/tmp/s2i-build381774301/upload/src"
Clean build will be performed
Running "assemble" in "syndesis/test-23:31a71c7a"
==================================================================
Starting S2I Java Build .....
S2I source build for Maven detected
Found pom.xml ...
Running 'mvn -Dmaven.repo.local=/tmp/artifacts/m2 package -DskipTests -e -Dfabric8.skip=true -B '
==================================================================
Starting S2I Java Build .....
S2I source build for Maven detected
Found pom.xml ...
Running 'mvn -Dmaven.repo.local=/tmp/artifacts/m2 package -DskipTests -e -Dfabric8.skip=true -B '
Apache Maven 3.3.3 (7994120775791599e205a5524ec3e0dfe41d4a06; 2015-04-22T11:57:37+00:00)
Maven home: /opt/maven
Java version: 1.8.0_151, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.151-1.b12.el7_4.x86_64/jre
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "4.4.41-boot2docker", arch: "amd64", family: "unix"
Apache Maven 3.3.3 (7994120775791599e205a5524ec3e0dfe41d4a06; 2015-04-22T11:57:37+00:00)
Maven home: /opt/maven
Java version: 1.8.0_151, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.151-1.b12.el7_4.x86_64/jre
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "4.4.41-boot2docker", arch: "amd64", family: "unix"
[INFO] Error stacktraces are turned on.
[INFO] Error stacktraces are turned on.
...
Pushed 17/29 layers, 59% complete
Pushed 18/29 layers, 62% complete
Pushed 19/29 layers, 66% complete
Pushed 20/29 layers, 69% complete
Pushed 21/29 layers, 73% complete
Pushed 22/29 layers, 76% complete
Pushed 23/29 layers, 79% complete
Pushed 24/29 layers, 83% complete
Pushed 25/29 layers, 86% complete
Pushed 26/29 layers, 90% complete
Push successful
```

With it some of the lines are duplicated, I consider this to be better
than having no output at all.

Also adds an option to increase it to `5` by setting `debug` property to
`true`. For instance by adding `OPENSHIFT_DEBUG=true` environment
variable, for the maximum debug verbosity in the build log.