### PR TITLE
fix: Respect DataShapes returned via DynamicActionMetadata

### DIFF
--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
@@ -151,14 +150,6 @@ public class ConnectionActionHandler {
     }
 
     private static boolean shouldEnrichDataShape(final Optional<DataShape> maybeExistingDataShape, final DataShape received) {
-        if (maybeExistingDataShape.isPresent() && received != null) {
-            final DataShape existingDataShape = maybeExistingDataShape.get();
-
-            // We should enrich the datashape if the existing connector data shape has the same kind of the
-            // computed one and if the existing one does not carry its own specification
-            return Objects.equals(existingDataShape.getKind(), received.getKind()) && Objects.isNull(existingDataShape.getSpecification());
-        }
-
-        return false;
+        return maybeExistingDataShape.isPresent() && received != null && received.getKind() != null;
     }
 }

--- a/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/rest/rest/src/main/java/io/syndesis/rest/v1/handler/connection/ConnectionActionHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import javax.persistence.EntityNotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -39,6 +40,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.syndesis.dao.manager.EncryptionComponent;
 import io.syndesis.model.DataShape;
+import io.syndesis.model.DataShapeKinds;
 import io.syndesis.model.action.ConnectorAction;
 import io.syndesis.model.action.ConnectorDescriptor;
 import io.syndesis.model.connection.ConfigurationProperty;
@@ -150,6 +152,11 @@ public class ConnectionActionHandler {
     }
 
     private static boolean shouldEnrichDataShape(final Optional<DataShape> maybeExistingDataShape, final DataShape received) {
-        return maybeExistingDataShape.isPresent() && received != null && received.getKind() != null;
+        return maybeExistingDataShape.isPresent() && isMaleable(maybeExistingDataShape.get().getKind()) && received != null
+            && received.getKind() != null;
+    }
+
+    private static boolean isMaleable(DataShapeKinds kind) {
+        return kind != DataShapeKinds.JAVA;
     }
 }


### PR DESCRIPTION
SQL connector returns kind='none' if there's no parameter for the target SQL (#1621)