### PR TITLE
add mixin and helper class for scrollable body areas in app

### DIFF
--- a/app/ui/src/app/connections/create-page/create-page.component.html
+++ b/app/ui/src/app/connections/create-page/create-page.component.html
@@ -1,5 +1,4 @@
 <!-- Toolbar -->
-
 <div class="row toolbar-pf toolbar">
   <div class="col-sm-12">
     <div class="toolbar-pf-actions">

--- a/app/ui/src/app/connections/create-page/create-page.component.scss
+++ b/app/ui/src/app/connections/create-page/create-page.component.scss
@@ -29,13 +29,13 @@
   syndesis-connections-connection-basics,
   syndesis-connections-configure-fields,
   syndesis-connections-review {
+    @include syn-scrollable-body;
     position: relative;
     flex: 1 1 auto;
     margin-left: -20px;
     padding-left: 20px;
     margin-right: -20px;
     padding-right: 20px;
-    @include syn-scrollable-body;
   }
 
   .connector-list {

--- a/app/ui/src/app/connections/create-page/create-page.component.scss
+++ b/app/ui/src/app/connections/create-page/create-page.component.scss
@@ -1,8 +1,7 @@
+@import 'syndesis-sass';
+
 :host {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  overflow: visible;
+  @include syn-scrollable-parent;
 }
 
 .card-pf {
@@ -26,25 +25,24 @@
   flex: 0 0 auto;
 }
 
-/deep/ syndesis-connections-connection-basics,
-/deep/ syndesis-connections-configure-fields,
-/deep/ syndesis-connections-review {
-  position: relative;
-  flex: 1 1 auto;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  margin-left: -20px;
-  padding-left: 20px;
-  // Dock the scrollbar to the right
-  margin-right: -20px;
-  padding-right: 20px;
-  height: 100%;
-}
+::ng-deep {
+  syndesis-connections-connection-basics,
+  syndesis-connections-configure-fields,
+  syndesis-connections-review {
+    position: relative;
+    flex: 1 1 auto;
+    margin-left: -20px;
+    padding-left: 20px;
+    margin-right: -20px;
+    padding-right: 20px;
+    @include syn-scrollable-body;
+  }
 
-/deep/ .connector-list {
-  margin-top: -5px;
+  .connector-list {
+    margin-top: -5px;
 
-  .toolbar-pf {
-    margin: -20px -50px;
+    .toolbar-pf {
+      margin: -20px -50px;
+    }
   }
 }

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -28,84 +28,88 @@
       </ng-container>
     </button>
   </ng-template>
-  <div class="main-panel-inner action-configure">
+  <div class="action-configure syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Configure {{ action?.name }}</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
+      <div class="container-fluid">
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Configure {{ action?.name }}</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div class="title">
-        <h1>{{ step?.connection?.name }}</h1>
-        <h3>{{ action?.name }}</h3>
-      </div>
-      <syndesis-loading [loading]="loading">
-        <ng-container *ngIf="error">
-          <div class="row row-cards-pf">
-            <div class="card-pf">
-              <div class="card-pf-body">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <p [class]="error.class">
-                      <span [class]="error.icon"></span>
-                      {{ error.message }}
-                    </p>
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div class="title">
+          <h1>{{ step?.connection?.name }}</h1>
+          <h3>{{ action?.name }}</h3>
+        </div>
+        <syndesis-loading [loading]="loading">
+          <ng-container *ngIf="error">
+            <div class="row row-cards-pf">
+              <div class="card-pf">
+                <div class="card-pf-body">
+                  <div class="row">
+                    <div class="col-xs-12">
+                      <p [class]="error.class">
+                        <span [class]="error.icon"></span>
+                        {{ error.message }}
+                      </p>
+                    </div>
                   </div>
-                </div>
-                <div *ngIf="!hasConfiguration"
-                    class="row control-buttons">
-                  <div class="col-xs-12">
-                    <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+                  <div *ngIf="!hasConfiguration"
+                      class="row control-buttons">
+                    <div class="col-xs-12">
+                      <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </ng-container>
-        <ng-container *ngIf="hasConfiguration">
-          <p>{{ descriptor.description }}</p>
-          <div class="row row-cards-pf">
-            <div class="card-pf">
-              <div class="card-pf-body">
-                <form class="form-horizontal"
-                      [formGroup]="formGroup">
-                  <syndesis-form-control *ngFor="let controlModel of formModel"
-                                      [group]="formGroup"
-                                      [model]="controlModel"></syndesis-form-control>
+          </ng-container>
+          <ng-container *ngIf="hasConfiguration">
+            <p>{{ descriptor.description }}</p>
+            <div class="row row-cards-pf">
+              <div class="card-pf">
+                <div class="card-pf-body">
+                  <form class="form-horizontal"
+                        [formGroup]="formGroup">
+                    <syndesis-form-control *ngFor="let controlModel of formModel"
+                                        [group]="formGroup"
+                                        [model]="controlModel"></syndesis-form-control>
                     <div class="row control-buttons">
                       <div class="col-sm-9 col-sm-offset-3">
                         <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
                       </div>
                     </div>
-                </form>
+                  </form>
+                </div>
               </div>
             </div>
-          </div>
-        </ng-container>
-      </syndesis-loading>
+          </ng-container>
+        </syndesis-loading>
+      </div>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -28,7 +28,7 @@
       </ng-container>
     </button>
   </ng-template>
-  <div class="action-configure syn-scrollable">
+  <div class="syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <!-- Toolbar: Breadcrumbs -->
@@ -66,14 +66,15 @@
           <h3>{{ action?.name }}</h3>
         </div>
         <syndesis-loading [loading]="loading">
-          <ng-container *ngIf="error">
-            <div class="row row-cards-pf">
-              <div class="card-pf">
-                <div class="card-pf-body">
+          <p *ngIf="hasConfiguration">{{ descriptor.description }}</p>
+          <div class="row row-cards-pf">
+            <div class="card-pf">
+              <div class="card-pf-body">
+                <ng-container *ngIf="error">
                   <div class="row">
                     <div class="col-xs-12">
-                      <p [class]="error.class">
-                        <span [class]="error.icon"></span>
+                      <p [ngClass]="error.class">
+                        <span [ngClass]="error.icon"></span>
                         {{ error.message }}
                       </p>
                     </div>
@@ -84,15 +85,8 @@
                       <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
                     </div>
                   </div>
-                </div>
-              </div>
-            </div>
-          </ng-container>
-          <ng-container *ngIf="hasConfiguration">
-            <p>{{ descriptor.description }}</p>
-            <div class="row row-cards-pf">
-              <div class="card-pf">
-                <div class="card-pf-body">
+                </ng-container>
+                <ng-container *ngIf="hasConfiguration">
                   <form class="form-horizontal"
                         [formGroup]="formGroup">
                     <syndesis-form-control *ngFor="let controlModel of formModel"
@@ -104,10 +98,10 @@
                       </div>
                     </div>
                   </form>
-                </div>
+                </ng-container>
               </div>
             </div>
-          </ng-container>
+          </div>
         </syndesis-loading>
       </div>
     </div>

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -1,5 +1,5 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="action-select syn-scrollable">
+  <div class="syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <div class="container-fluid">
@@ -41,11 +41,11 @@
           <p>Choose an action for the selected connection.</p>
           <!-- Toolbar -->
           <syndesis-list-toolbar [items]="actions$"
-                                [filteredItems]="filteredActions$"></syndesis-list-toolbar>
+            [filteredItems]="filteredActions$"></syndesis-list-toolbar>
           <!-- Action List -->
           <syndesis-list-actions [actions]="filteredActions$ | async"
-                                [loading]="loading$ | async"
-                                (onSelected)="onSelected($event)"></syndesis-list-actions>
+            [loading]="loading$ | async"
+            (onSelected)="onSelected($event)"></syndesis-list-actions>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -1,54 +1,52 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="main-panel-inner action-select">
-
+  <div class="action-select syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
-
-      <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Choose Action</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
-              <syndesis-cancel-add-step></syndesis-cancel-add-step>
+      <div class="container-fluid">
+        <!-- Toolbar: Breadcrumbs -->
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Choose Action</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+                <syndesis-cancel-add-step></syndesis-cancel-add-step>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div class="title">
-        <h1>{{ step?.connection.name }} - Choose an Action</h1>
-      </div>
-
-      <!-- Actions -->
-      <div>
-        <p>Choose an action for the selected connection.</p>
-
-        <!-- Toolbar -->
-        <syndesis-list-toolbar [items]="actions$"
-                               [filteredItems]="filteredActions$"></syndesis-list-toolbar>
-
-        <!-- Action List -->
-        <syndesis-list-actions [actions]="filteredActions$ | async"
-                               [loading]="loading$ | async"
-                               (onSelected)="onSelected($event)"></syndesis-list-actions>
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div class="title">
+          <h1>{{ step?.connection.name }} - Choose an Action</h1>
+        </div>
+        <!-- Actions -->
+        <div>
+          <p>Choose an action for the selected connection.</p>
+          <!-- Toolbar -->
+          <syndesis-list-toolbar [items]="actions$"
+                                [filteredItems]="filteredActions$"></syndesis-list-toolbar>
+          <!-- Action List -->
+          <syndesis-list-actions [actions]="filteredActions$ | async"
+                                [loading]="loading$ | async"
+                                (onSelected)="onSelected($event)"></syndesis-list-actions>
+        </div>
       </div>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -1,60 +1,59 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="main-panel-inner connection-select">
-
+  <div class="connection-select syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
-
       <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Choose a {{ positionText | capitalize }} Connection</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
-              <syndesis-cancel-add-step></syndesis-cancel-add-step>
+      <div class="container-fluid">
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Choose a {{ positionText | capitalize }} Connection</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+                <syndesis-cancel-add-step></syndesis-cancel-add-step>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div class="title">
-        <h1>{{ 'Choose a ' + positionText + ' Connection' | titleize }} </h1>
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div class="title">
+          <h1>{{ 'Choose a ' + positionText + ' Connection' | titleize }} </h1>
+        </div>
+        <p>First choose a connection.</p>
+        <syndesis-list-toolbar [items]="connections$"
+                              [filteredItems]="filteredConnections$"
+                              [viewTemplate]="viewTemplate">
+          <ng-template #viewTemplate>
+            <button type="button"
+                    class="btn btn-default toolbar-pf-action-right"
+                    [routerLink]="['/connections/create']">
+              Create Connection
+            </button>
+          </ng-template>
+        </syndesis-list-toolbar>
+        <syndesis-connections-list [connections]="filteredConnections$ | async"
+                                  [loading]="loading$ | async"
+                                  (onSelected)="onSelected($event)"
+                                  [showKebab]="false"
+                                  [showNewConnection]="true"></syndesis-connections-list>
       </div>
-
-      <p>First choose a connection.</p>
-      <syndesis-list-toolbar [items]="connections$"
-                             [filteredItems]="filteredConnections$"
-                             [viewTemplate]="viewTemplate">
-        <ng-template #viewTemplate>
-          <button type="button"
-                  class="btn btn-default toolbar-pf-action-right"
-                  [routerLink]="['/connections/create']">
-            Create Connection
-          </button>
-        </ng-template>
-      </syndesis-list-toolbar>
-
-      <syndesis-connections-list [connections]="filteredConnections$ | async"
-                                 [loading]="loading$ | async"
-                                 (onSelected)="onSelected($event)"
-                                 [showKebab]="false"
-                                 [showNewConnection]="true"></syndesis-connections-list>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -1,5 +1,5 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="connection-select syn-scrollable">
+  <div class="syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <!-- Toolbar: Breadcrumbs -->

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
@@ -1,62 +1,66 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="main-panel-inner">
+  <div class="syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
-      <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Configure {{ actionName }}</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
+      <div class="container-fluid">
+        <!-- Toolbar: Breadcrumbs -->
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Configure {{ actionName }}</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div class="title">
-        <h1>{{ connectionName }}</h1>
-        <h3>Specify {{ direction | capitalize }} Data Type</h3>
-      </div>
-      <ng-container *ngIf="userDefined">
-        <div class="row">
-          <div class="col-md-12">
-            <p>This is a typeless connection. To use type-aware functionality, enter information that defines the data type</p>
-          </div>
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div class="title">
+          <h1>{{ connectionName }}</h1>
+          <h3>Specify {{ direction | capitalize }} Data Type</h3>
         </div>
-        <div class="row row-cards-pf">
-          <div class="card-pf">
-            <div class="card-pf-body">
-              <form class="form-horizontal"
-                    [formGroup]="formGroup">
-                <syndesis-form-control *ngFor="let controlModel of formModel"
-                                        [group]="formGroup"
-                                        [model]="controlModel"></syndesis-form-control>
-                <div class="row control-buttons">
-                  <div class="col-sm-9 col-sm-offset-3">
-                    <button class="btn btn-primary" type="button" (click)="continue()">Next</button>
-                  </div>
-                </div>
-              </form>
+        <ng-container *ngIf="userDefined">
+          <div class="row">
+            <div class="col-md-12">
+              <p>This is a typeless connection. To use type-aware functionality, enter information that defines the data type</p>
             </div>
           </div>
-        </div>
-      </ng-container>
+          <div class="row row-cards-pf">
+            <div class="card-pf">
+              <div class="card-pf-body">
+                <form class="form-horizontal"
+                      [formGroup]="formGroup">
+                  <syndesis-form-control *ngFor="let controlModel of formModel"
+                                          [group]="formGroup"
+                                          [model]="controlModel"></syndesis-form-control>
+                  <div class="row control-buttons">
+                    <div class="col-sm-9 col-sm-offset-3">
+                      <button class="btn btn-primary" type="button" (click)="continue()">Next</button>
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        </ng-container>
+      </div>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/edit-page.component.scss
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.scss
@@ -17,36 +17,9 @@
     flex-direction: row;
   }
 
-  .main-panel {
-    flex: 1 1 auto;
-    position: relative;
-    height: 100%;
-    overflow: auto;
-    padding: 20px;
-
-    ::ng-deep .main-panel-inner {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      overflow: visible;
-
-      .main-panel-body {
-      flex: 1 1 auto;
-      position: relative;
-      overflow-y: scroll;
-      margin-left: -20px;
-      padding-left: 20px;
-      margin-right: -20px;
-      padding-right: 20px;
-      margin-bottom: -20px;
-      padding-bottom: 20px;
-
-        &.mapper {
-          margin-left: 0;
-          margin-right: 0;
-        }
-      }
-    }
+  .mapper {
+    margin-left: 0;
+    margin-right: 0;
   }
 
   .wizard-sidebar {
@@ -69,17 +42,16 @@
     overflow-y: auto;
   }
 
+  .main-panel {
+    flex: 1 1 auto;
+  }
+
   ::ng-deep {
     .toolbar {
-      flex: 0 0 auto;
-      margin: 0 -20px;
-
       .toolbar-pf {
         background: none !important;
         border-bottom: 1px #d9d9d9 solid;
         box-shadow: none;
-        margin: 0;
-        padding: 0 0 10px 0;
 
         .breadcrumb {
           padding: 0;
@@ -93,11 +65,7 @@
             width: 80%;
           }
         }
-
-        .toolbar-pf-actions {
-          margin-bottom: 0;
-        }
-      }
+     }
     }
 
     .control-buttons {

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -22,7 +22,7 @@
 
   .flow-view-container {
     flex: 1 1 auto;
-    overflow-y: scroll;
+    overflow-y: auto;
     padding-top: 15px;
     padding-bottom: 20px;
     margin-right: -20px;

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -1,98 +1,102 @@
-<div class="main-panel-inner integration-basics">
+<div class="integration-basics syn-scrollable">
   <!-- Toolbar -->
   <div class="toolbar">
     <!-- Toolbar: Breadcrumbs -->
-    <div class="row toolbar-pf">
-      <div class="col-xs-12">
-        <div class="toolbar-pf-actions">
-          <div class="inline-block">
-            <ol class="breadcrumb">
-              <li>
-                <a [routerLink]="['/']">Home</a>
-              </li>
-              <li>
-                <a [routerLink]="['/integrations']">Integrations</a>
-              </li>
-              <li>
-                <a *ngIf="name"
-                   [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                <ng-container *ngIf="!name">New Integration</ng-container>
-              </li>
-            </ol>
-          </div>
-          <div class="toolbar-pf-action-right">
-            <button class="btn btn-default"
-                    (click)="cancel()">Cancel
-            </button> &nbsp;
-            <button class="btn btn-default"
-                    (click)="save()"
-                    [disabled]="!canContinue() || saveInProgress || publishInProgress">
-              <span *ngIf="saveInProgress" class="spinner spinner-sm spinner-inline"></span>Save as Draft
-            </button>
-            <button type="button"
-                    class="btn btn-primary"
-                    (click)="publish()"
-                    [disabled]="!canContinue() || saveInProgress || publishInProgress">
-              <span *ngIf="publishInProgress" class="spinner spinner-sm spinner-inline"></span>Publish</button>
+    <div class="container-fluid">
+      <div class="row toolbar-pf">
+        <div class="col-xs-12">
+          <div class="toolbar-pf-actions">
+            <div class="inline-block">
+              <ol class="breadcrumb">
+                <li>
+                  <a [routerLink]="['/']">Home</a>
+                </li>
+                <li>
+                  <a [routerLink]="['/integrations']">Integrations</a>
+                </li>
+                <li>
+                  <a *ngIf="name"
+                    [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                  <ng-container *ngIf="!name">New Integration</ng-container>
+                </li>
+              </ol>
+            </div>
+            <div class="toolbar-pf-action-right">
+              <button class="btn btn-default"
+                      (click)="cancel()">Cancel
+              </button> &nbsp;
+              <button class="btn btn-default"
+                      (click)="save()"
+                      [disabled]="!canContinue() || saveInProgress || publishInProgress">
+                <span *ngIf="saveInProgress" class="spinner spinner-sm spinner-inline"></span>Save as Draft
+              </button>
+              <button type="button"
+                      class="btn btn-primary"
+                      (click)="publish()"
+                      [disabled]="!canContinue() || saveInProgress || publishInProgress">
+                <span *ngIf="publishInProgress" class="spinner spinner-sm spinner-inline"></span>Publish</button>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-  <div class="main-panel-body wizard-pf-body clearfix">
-    <div *ngIf="errorMessage">
-      <div class="alert alert-danger">
-        <button type="button"
-                class="close"
-                (click)="errorMessage = undefined">
-                <span class="pficon pficon-close"></span>
-              </button>
-        <span class="pficon pficon-error-circle-o"></span>
-        <p>Error saving integration: </p>
-        <pre>{{ errorMessage }}</pre>
+  <div class="wizard-pf-body syn-scrollable--body">
+    <div class="container-fluid">
+      <div *ngIf="errorMessage">
+        <div class="alert alert-danger">
+          <button type="button"
+                  class="close"
+                  (click)="errorMessage = undefined">
+                  <span class="pficon pficon-close"></span>
+                </button>
+          <span class="pficon pficon-error-circle-o"></span>
+          <p>Error saving integration: </p>
+          <pre>{{ errorMessage }}</pre>
+        </div>
       </div>
-    </div>
-    <div class="title">
-      <h1>Create an integration</h1>
-    </div>
-    <p>Add details about this integration.</p>
-    <div class="row row-cards-pf">
-      <div class="card-pf">
-        <div class="card-pf-body">
-          <form class="form-horizontal">
-            <!-- replacing id with data-id to pass build errors -->
-            <div class="form-group required">
-              <label class="col-sm-3 control-label required-pf">
-                Integration Name
-              </label>
-              <div class="col-sm-9">
-                <input type="text"
-                      name="nameInput"
-                      data-id="nameInput"
-                      placeholder="{{ name }}"
-                      [(ngModel)]="name"
-                      class="form-control">
+      <div class="title">
+        <h1>Create an integration</h1>
+      </div>
+      <p>Add details about this integration.</p>
+      <div class="row row-cards-pf">
+        <div class="card-pf">
+          <div class="card-pf-body">
+            <form class="form-horizontal">
+              <!-- replacing id with data-id to pass build errors -->
+              <div class="form-group required">
+                <label class="col-sm-3 control-label required-pf">
+                  Integration Name
+                </label>
+                <div class="col-sm-9">
+                  <input type="text"
+                        name="nameInput"
+                        data-id="nameInput"
+                        placeholder="{{ name }}"
+                        [(ngModel)]="name"
+                        class="form-control">
+                </div>
               </div>
-            </div>
-            <div class="form-group">
-              <label class="col-sm-3 control-label">Description</label>
-              <div class="col-sm-9">
-                <textarea data-id="descriptionInput"
-                          name="descriptionInput"
-                          class="form-control"
-                          [(ngModel)]="description"
-                          rows="2"></textarea>
+              <div class="form-group">
+                <label class="col-sm-3 control-label">Description</label>
+                <div class="col-sm-9">
+                  <textarea data-id="descriptionInput"
+                            name="descriptionInput"
+                            class="form-control"
+                            [(ngModel)]="description"
+                            rows="2"></textarea>
+                </div>
               </div>
-            </div>
-            <!--
-            <div class="form-group required">
-              <label class="col-xs-4 control-label">Tag(s)</label>
-              <div class="col-xs-8">
-                <input type="text" name="tagsInput" data-id="tagsInput" [(ngModel)]="tags" class="form-control">
+              <!--
+              <div class="form-group required">
+                <label class="col-xs-4 control-label">Tag(s)</label>
+                <div class="col-xs-8">
+                  <input type="text" name="tagsInput" data-id="tagsInput" [(ngModel)]="tags" class="form-control">
+                </div>
               </div>
-            </div>
-            -->
-          </form>
+              -->
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -1,4 +1,4 @@
-<div class="integration-basics syn-scrollable">
+<div class="syn-scrollable">
   <!-- Toolbar -->
   <div class="toolbar">
     <!-- Toolbar: Breadcrumbs -->

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -1,90 +1,90 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="main-panel-inner save-or-add-step">
-
+  <div class="save-or-add-step syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration?.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Save or Add Step</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
-              <button class="btn btn-default"
-                      (click)="cancel()">Cancel
-            </button> &nbsp;
-              <button class="btn btn-default"
-                      (click)="save()"
-                      [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.saveInProgress" class="spinner spinner-sm spinner-inline"></span>Save as Draft
-            </button>
-              <button type="button"
-                      class="btn btn-primary"
-                      (click)="publish()"
-                      [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.publishInProgress" class="spinner spinner-sm spinner-inline"></span>Publish</button>
+      <div class="container-fluid">
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration?.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Save or Add Step</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+                <button class="btn btn-default"
+                        (click)="cancel()">Cancel
+              </button> &nbsp;
+                <button class="btn btn-default"
+                        (click)="save()"
+                        [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.saveInProgress" class="spinner spinner-sm spinner-inline"></span>Save as Draft
+              </button>
+                <button type="button"
+                        class="btn btn-primary"
+                        (click)="publish()"
+                        [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.publishInProgress" class="spinner spinner-sm spinner-inline"></span>Publish</button>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-
     <!-- Content -->
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div *ngIf="errorMessage">
-        <div class="alert alert-danger">
-          <button type="button"
-                  class="close"
-                  (click)="errorMessage = undefined">
-                <span class="pficon pficon-close"></span>
-              </button>
-          <span class="pficon pficon-error-circle-o"></span>
-          <p>Error saving integration: </p>
-          <pre>{{ errorMessage }}</pre>
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div *ngIf="errorMessage">
+          <div class="alert alert-danger">
+            <button type="button"
+                    class="close"
+                    (click)="errorMessage = undefined">
+                  <span class="pficon pficon-close"></span>
+                </button>
+            <span class="pficon pficon-error-circle-o"></span>
+            <p>Error saving integration: </p>
+            <pre>{{ errorMessage }}</pre>
+          </div>
         </div>
-      </div>
-      <div class="blank-slate-pf">
-        <div class="blank-slate-pf-icon">
-          <span class="pficon pficon pficon-add-circle-o"></span>
-        </div>
-        <h1>
-          Add to Integration
-        </h1>
-        <p>Now you can add additional connections as well as steps to your integration.</p>
-        <p>You can interact with the left hand panel to continue adding steps and connections to your integration as well.</p>
-
-        <!-- First Step -->
-        <div class="blank-slate-pf-secondary-action first-step"
-             *ngIf="getMiddleSteps().length === 0">
-          <button type="button"
-                  (click)="addNew('step')"
-                  class="btn btn-default">Add a Step</button>&nbsp;&nbsp;&nbsp;
-          <button type="button"
-                  (click)="addNew('connection')"
-                  class="btn btn-default">Add a Connection</button>
-        </div>
-
-        <!-- Middle Steps -->
-        <div class="blank-slate-pf-secondary-action middle-steps"
-             *ngIf="getMiddleSteps().length !== 0">
-          <button type="button"
-                  (click)="showPopouts('step')"
-                  class="btn btn-default">Add a Step</button> &nbsp;&nbsp;&nbsp;
-          <button type="button"
-                  (click)="showPopouts('connection')"
-                  class="btn btn-default">Add a Connection</button>
+        <div class="blank-slate-pf">
+          <div class="blank-slate-pf-icon">
+            <span class="pficon pficon pficon-add-circle-o"></span>
+          </div>
+          <h1>
+            Add to Integration
+          </h1>
+          <p>Now you can add additional connections as well as steps to your integration.</p>
+          <p>You can interact with the left hand panel to continue adding steps and connections to your integration as well.</p>
+          <!-- First Step -->
+          <div class="blank-slate-pf-secondary-action first-step"
+              *ngIf="getMiddleSteps().length === 0">
+            <button type="button"
+                    (click)="addNew('step')"
+                    class="btn btn-default">Add a Step</button>&nbsp;&nbsp;&nbsp;
+            <button type="button"
+                    (click)="addNew('connection')"
+                    class="btn btn-default">Add a Connection</button>
+          </div>
+          <!-- Middle Steps -->
+          <div class="blank-slate-pf-secondary-action middle-steps"
+              *ngIf="getMiddleSteps().length !== 0">
+            <button type="button"
+                    (click)="showPopouts('step')"
+                    class="btn btn-default">Add a Step</button> &nbsp;&nbsp;&nbsp;
+            <button type="button"
+                    (click)="showPopouts('connection')"
+                    class="btn btn-default">Add a Connection</button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -25,16 +25,23 @@
               </div>
               <div class="toolbar-pf-action-right">
                 <button class="btn btn-default"
-                        (click)="cancel()">Cancel
+                  (click)="cancel()">Cancel
               </button> &nbsp;
                 <button class="btn btn-default"
-                        (click)="save()"
-                        [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.saveInProgress" class="spinner spinner-sm spinner-inline"></span>Save as Draft
-              </button>
+                  (click)="save()"
+                  [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress">
+                  <span *ngIf="flowPageService.saveInProgress"
+                    class="spinner spinner-sm spinner-inline"></span>
+                  Save as Draft
+                </button>
                 <button type="button"
-                        class="btn btn-primary"
-                        (click)="publish()"
-                        [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress"><span *ngIf="flowPageService.publishInProgress" class="spinner spinner-sm spinner-inline"></span>Publish</button>
+                  class="btn btn-primary"
+                  (click)="publish()"
+                  [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress">
+                  <span *ngIf="flowPageService.publishInProgress"
+                    class="spinner spinner-sm spinner-inline"></span>
+                  Publish
+                </button>
               </div>
             </div>
           </div>
@@ -47,10 +54,10 @@
         <div *ngIf="errorMessage">
           <div class="alert alert-danger">
             <button type="button"
-                    class="close"
-                    (click)="errorMessage = undefined">
-                  <span class="pficon pficon-close"></span>
-                </button>
+              class="close"
+              (click)="errorMessage = undefined">
+              <span class="pficon pficon-close"></span>
+            </button>
             <span class="pficon pficon-error-circle-o"></span>
             <p>Error saving integration: </p>
             <pre>{{ errorMessage }}</pre>
@@ -69,21 +76,21 @@
           <div class="blank-slate-pf-secondary-action first-step"
               *ngIf="getMiddleSteps().length === 0">
             <button type="button"
-                    (click)="addNew('step')"
-                    class="btn btn-default">Add a Step</button>&nbsp;&nbsp;&nbsp;
+              (click)="addNew('step')"
+              class="btn btn-default">Add a Step</button>&nbsp;&nbsp;&nbsp;
             <button type="button"
-                    (click)="addNew('connection')"
-                    class="btn btn-default">Add a Connection</button>
+              (click)="addNew('connection')"
+              class="btn btn-default">Add a Connection</button>
           </div>
           <!-- Middle Steps -->
           <div class="blank-slate-pf-secondary-action middle-steps"
               *ngIf="getMiddleSteps().length !== 0">
             <button type="button"
-                    (click)="showPopouts('step')"
-                    class="btn btn-default">Add a Step</button> &nbsp;&nbsp;&nbsp;
+              (click)="showPopouts('step')"
+              class="btn btn-default">Add a Step</button> &nbsp;&nbsp;&nbsp;
             <button type="button"
-                    (click)="showPopouts('connection')"
-                    class="btn btn-default">Add a Connection</button>
+              (click)="showPopouts('connection')"
+              class="btn btn-default">Add a Connection</button>
           </div>
         </div>
       </div>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -14,78 +14,79 @@
       </ng-container>
     </button>
   </ng-template>
-  <div class="main-panel-inner step-configure"
+  <div class="step-configure syn-scrollable"
        *ngIf="step">
-
     <!-- Toolbar -->
     <div [class]="getToolbarClass()">
-
       <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
+      <div class="container-fluid">
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
 
-                <li class="active">Configure {{ step.stepKind | titleize:{separator: '-'} | capitalize }}</li>
-              </ol>
-            </div>
-
-            <!-- Toolbar: Integration actions -->
-            <div class="toolbar-pf-action-right">
-              <ng-container *ngIf="step.stepKind === 'mapper'">
-                <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
-              </ng-container>
+                  <li class="active">Configure {{ step.stepKind | titleize:{separator: '-'} | capitalize }}</li>
+                </ol>
+              </div>
+              <!-- Toolbar: Integration actions -->
+              <div class="toolbar-pf-action-right">
+                <ng-container *ngIf="step.stepKind === 'mapper'">
+                  <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+                </ng-container>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
     <!-- Page body -->
-    <syndesis-loading class="main-panel-body {{ step.stepKind !== 'mapper' ? 'body' : 'body mapper' }}"
+    <syndesis-loading class="syn-scrollable--body {{ step.stepKind !== 'mapper' ? 'body' : 'body mapper' }}"
                       [loading]="loading">
-      <ng-container *ngIf="error">
-        <div [class]="error.class"
-             [innerHtml]="error.message">
-        </div>
-      </ng-container>
-      <div [ngSwitch]="step.stepKind">
-        <div *ngSwitchCase="'mapper'">
-          <div class="row">
-            <div class="col-md-12" *ngIf="step">
-              <syndesis-data-mapper-host [position]="position"></syndesis-data-mapper-host>
+      <div class="container-fluid">
+        <ng-container *ngIf="error">
+          <div [class]="error.class"
+              [innerHtml]="error.message">
+          </div>
+        </ng-container>
+        <div [ngSwitch]="step.stepKind">
+          <div *ngSwitchCase="'mapper'">
+            <div class="row">
+              <div class="col-md-12" *ngIf="step">
+                <syndesis-data-mapper-host [position]="position"></syndesis-data-mapper-host>
+              </div>
             </div>
           </div>
-        </div>
-        <div *ngSwitchCase="'ruleFilter'">
-          <div class="row">
-            <div class="col-md-12"
-                  *ngIf="step && dataShape">
-              <div class="basic-filter">
-                <div class="title">
-                  <h1>Configure Basic Filter Step</h1>
-                </div>
-                <p>Define one or more rules for evaluating data to determine whether the integration should continue.</p>
-                <div class="row row-cards-pf">
-                  <div class="card-pf">
-                    <div class="card-pf-body">
-                      <syndesis-basic-filter [(configuredProperties)]="customProperties"
-                                              [(valid)]="valid"
-                                              [dataShape]="dataShape"
-                                              [position]="position"></syndesis-basic-filter>
-                      <div class="control-buttons">
-                        <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+          <div *ngSwitchCase="'ruleFilter'">
+            <div class="row">
+              <div class="col-md-12"
+                    *ngIf="step && dataShape">
+                <div class="basic-filter">
+                  <div class="title">
+                    <h1>Configure Basic Filter Step</h1>
+                  </div>
+                  <p>Define one or more rules for evaluating data to determine whether the integration should continue.</p>
+                  <div class="row row-cards-pf">
+                    <div class="card-pf">
+                      <div class="card-pf-body">
+                        <syndesis-basic-filter [(configuredProperties)]="customProperties"
+                                                [(valid)]="valid"
+                                                [dataShape]="dataShape"
+                                                [position]="position"></syndesis-basic-filter>
+                        <div class="control-buttons">
+                          <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -93,25 +94,25 @@
               </div>
             </div>
           </div>
-        </div>
-        <div *ngSwitchDefault>
-          <div class="title">
-            <h1>Configure {{ step.stepKind | titleize:{separator: '-'} | capitalize }}</h1>
-          </div>
-          <p>Fill out the fields associated with the selected step.</p>
-          <div *ngIf="formGroup">
-            <div class="row row-cards-pf">
-              <div class="card-pf">
-                <div class="card-pf-body">
-                  <form class="form-horizontal"
-                        [formGroup]="formGroup">
-                    <syndesis-form-control *ngFor="let controlModel of formModel"
-                                            [group]="formGroup"
-                                            [model]="controlModel"></syndesis-form-control>
-                  </form>
-                  <div class="row control-buttons">
-                    <div class="col-sm-9 col-sm-offset-3">
-                      <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+          <div *ngSwitchDefault>
+            <div class="title">
+              <h1>Configure {{ step.stepKind | titleize:{separator: '-'} | capitalize }}</h1>
+            </div>
+            <p>Fill out the fields associated with the selected step.</p>
+            <div *ngIf="formGroup">
+              <div class="row row-cards-pf">
+                <div class="card-pf">
+                  <div class="card-pf-body">
+                    <form class="form-horizontal"
+                          [formGroup]="formGroup">
+                      <syndesis-form-control *ngFor="let controlModel of formModel"
+                                              [group]="formGroup"
+                                              [model]="controlModel"></syndesis-form-control>
+                    </form>
+                    <div class="row control-buttons">
+                      <div class="col-sm-9 col-sm-offset-3">
+                        <ng-container *ngTemplateOutlet="controlButtons"></ng-container>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -14,7 +14,7 @@
       </ng-container>
     </button>
   </ng-template>
-  <div class="step-configure syn-scrollable"
+  <div class="syn-scrollable"
        *ngIf="step">
     <!-- Toolbar -->
     <div [class]="getToolbarClass()">

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -1,5 +1,5 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="step-select syn-scrollable">
+  <div class="syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
       <div class="container-fluid">

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -1,63 +1,66 @@
 <syndesis-loading [loading]="!currentFlowService.loaded">
-  <div class="main-panel-inner step-select">
+  <div class="step-select syn-scrollable">
     <!-- Toolbar -->
     <div class="toolbar">
-
-      <!-- Toolbar: Breadcrumbs -->
-      <div class="row toolbar-pf">
-        <div class="col-sm-12">
-          <div class="toolbar-pf-actions">
-            <div class="inline-block">
-              <ol class="breadcrumb">
-                <li>
-                  <a [routerLink]="['/']">Home</a>
-                </li>
-                <li>
-                  <a [routerLink]="['/integrations']">Integrations</a>
-                </li>
-                <li>
-                  <a *ngIf="flowPageService.integrationName"
-                     [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
-                  <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
-                </li>
-                <li class="active">Choose a Step</li>
-              </ol>
-            </div>
-            <div class="toolbar-pf-action-right">
-              <syndesis-cancel-add-step></syndesis-cancel-add-step>
+      <div class="container-fluid">
+        <!-- Toolbar: Breadcrumbs -->
+        <div class="row toolbar-pf">
+          <div class="col-sm-12">
+            <div class="toolbar-pf-actions">
+              <div class="inline-block">
+                <ol class="breadcrumb">
+                  <li>
+                    <a [routerLink]="['/']">Home</a>
+                  </li>
+                  <li>
+                    <a [routerLink]="['/integrations']">Integrations</a>
+                  </li>
+                  <li>
+                    <a *ngIf="flowPageService.integrationName"
+                      [routerLink]="['/integrations', currentFlowService.integration.id]">{{ flowPageService.integrationName }}</a>
+                    <ng-container *ngIf="!flowPageService.integrationName">New Integration</ng-container>
+                  </li>
+                  <li class="active">Choose a Step</li>
+                </ol>
+              </div>
+              <div class="toolbar-pf-action-right">
+                <syndesis-cancel-add-step></syndesis-cancel-add-step>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="main-panel-body wizard-pf-body clearfix">
-      <div class="title">
-        <h1>Choose a Step</h1>
-      </div>
-      <p>A step specifies an operation on the data in the integration.  Click one to add it.</p>
-      <syndesis-loading [loading]="loading$ | async">
-        <pfng-toolbar [config]="toolbarConfig"
-                      (onFilterChange)="onFilterChange($event)"
-                      (onFilterFieldSelect)="onFilterFieldSelect($event)"
-                      (onSortChange)="onSortChange($event)">
-        </pfng-toolbar>
-        <div *ngIf="steps"
-            class="list-group list-view-pf list-view-pf-view">
-          <div class="step list-group-item"
-              title="{{step.name}}"
-              *ngFor="let step of filteredSteps | stepVisible:{position: position}"
-              (click)="onSelect(step)"
-              [class.active]="isSelected(step)">
-            <div class="list-view-pf-main-info">
-              <div class="list-view-pf-body">
-                <div class="list-group-item-heading">{{ getName(step) }}</div>
-                <div class="list-group-item-text">{{ getDescription(step) }}
+    <div class="wizard-pf-body syn-scrollable--body">
+      <div class="container-fluid">
+        <div class="title">
+          <h1>Choose a Step</h1>
+        </div>
+        <p>A step specifies an operation on the data in the integration.  Click one to add it.</p>
+        <syndesis-loading [loading]="loading$ | async">
+          <pfng-toolbar [config]="toolbarConfig"
+                        (onFilterChange)="onFilterChange($event)"
+                        (onFilterFieldSelect)="onFilterFieldSelect($event)"
+                        (onSortChange)="onSortChange($event)">
+          </pfng-toolbar>
+          <div *ngIf="steps"
+              class="list-group list-view-pf list-view-pf-view">
+            <div class="step list-group-item"
+                title="{{step.name}}"
+                *ngFor="let step of filteredSteps | stepVisible:{position: position}"
+                (click)="onSelect(step)"
+                [class.active]="isSelected(step)">
+              <div class="list-view-pf-main-info">
+                <div class="list-view-pf-body">
+                  <div class="list-group-item-heading">{{ getName(step) }}</div>
+                  <div class="list-group-item-text">{{ getDescription(step) }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </syndesis-loading>
+        </syndesis-loading>
+      </div>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/scss/base/_mixins.scss
+++ b/app/ui/src/scss/base/_mixins.scss
@@ -29,3 +29,14 @@
   max-height: $size;
   max-width: $size;
 }
+
+@mixin syn-scrollable-parent {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+@mixin syn-scrollable-body {
+  flex: 1 1 auto;
+  overflow: auto;
+}

--- a/app/ui/src/scss/utils/_helpers.scss
+++ b/app/ui/src/scss/utils/_helpers.scss
@@ -79,3 +79,11 @@
 .syn-icon-small {
   @include syn-icon-box(24px);
 }
+
+.syn-scrollable {
+  @include syn-scrollable-parent;
+
+  .syn-scrollable--body {
+    @include syn-scrollable-body;
+  }
+}

--- a/app/ui/src/scss/utils/_helpers.scss
+++ b/app/ui/src/scss/utils/_helpers.scss
@@ -82,8 +82,8 @@
 
 .syn-scrollable {
   @include syn-scrollable-parent;
+}
 
-  .syn-scrollable--body {
-    @include syn-scrollable-body;
-  }
+.syn-scrollable--body {
+  @include syn-scrollable-body;
 }


### PR DESCRIPTION
Added 2 mixins `syn-scrollable-parent` and `syn-scrollable-body`, and 2 helpers `.syn-scrollable` and `.syn-scrollable--body` to support parts of the app where a main area should have an internal scrollable area.

Also updated the integration editor workflow, and connection creation workflow to utilize the new scss.