### PR TITLE
fix(forms): correct and cleanup handling of form values

### DIFF
--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -222,7 +222,8 @@ export class FormFactoryProviderService extends FormFactoryService {
                          field: ConfiguredConfigurationProperty,
                          value: any
   ) {
-    const initialValue = value || field.value || field.defaultValue;
+    let initialValue = value || field.value || field.defaultValue;
+    initialValue = (initialValue === 'false') ? false : initialValue;
     return new DynamicCheckboxModel({
       id: key,
       label: field.displayName || key,

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -54,7 +54,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   }
 
   buildData(data: any) {
-    const formValue = this.formGroup ? this.formGroup.value : {};
+    const formValue = this.formFactory.supressNullValues(this.formGroup ? this.formGroup.value : {});
     return { ...this.step.configuredProperties, ...formValue, ...data };
   }
 

--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -406,12 +406,6 @@ export class CurrentFlowService {
         const action = event['action'];
         const properties = this.stringifyValues(event['properties']);
         const step = this.steps[position] || createStep();
-        // guard against null values becoming `"null"`
-        for (const _key of Object.keys(properties)) {
-          if (properties[_key] === 'null') {
-            delete properties[_key];
-          }
-        }
         step.configuredProperties = properties;
         this.steps[position] = step;
         this.maybeDoAction(event['onSave']);

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -81,6 +81,8 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy, Aft
       data = this.formGroup ? this.formGroup.value : {};
     }
 
+    data = this.formFactory.supressNullValues(data);
+
     // set a copy in the integration
     const properties = JSON.parse(JSON.stringify(data));
     this.currentFlowService.events.emit({
@@ -153,14 +155,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy, Aft
       return;
     }
     const values: any = this.getConfiguredProperties(step.configuredProperties);
-    if (values) {
-      // supress null values
-      for (const key in values) {
-        if (values[key] === 'null') {
-          values[key] = undefined;
-        }
-      }
-    }
+
     // Call formService to build the form
     this.formModel = this.formFactory.createFormModel(this.formConfig, values);
     this.formGroup = this.formService.createFormGroup(this.formModel);

--- a/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
+++ b/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
@@ -49,4 +49,13 @@ export abstract class FormFactoryService {
     values?: any,
     controls?: Array<string>
   ): DynamicFormControlModel[];
+
+  supressNullValues(data: object): object {
+    Object.keys(data).forEach(key => {
+      if (data[key] === null) {
+        delete data[key];
+      }
+    });
+    return data;
+  }
 }


### PR DESCRIPTION
This PR corrects a bug in the UI where the forms service doesn't correctly handle values for setting the initial state of the checkbox in our model driven forms. It also cleans up some messy checks in the UI for the string "null" by actualling checking for null values where appropriate.

Should help:
https://github.com/syndesisio/syndesis/issues/1560 and
https://github.com/syndesisio/syndesis/issues/1250

add helper method to form factory service for suppressing null values
accept string 'false' as a falsey value for checkbox config
remove checks for string 'null' as they are no longer needed