### PR TITLE
fix(build): system-test misc fixes

### DIFF
--- a/tools/bin/commands/system-test
+++ b/tools/bin/commands/system-test
@@ -34,9 +34,8 @@ system-test::run() {
             exit 1
         fi
         local log
-        log=$(oc login --server $server --token $token)
+        log=$(oc login $server --token $token)
         if [ $? -ne 0 ]; then
-           echo bla
            echo $log
            exit 1
         fi


### PR DESCRIPTION
Removes `--server` parameter to `oc` command, bit of cleanup.