### PR TITLE
(chore) rework elements for step index, tooltips, datamapper required indicator

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -14,15 +14,19 @@
   </ng-template>
 
   <ng-template #tooltipPopover>
-    <div>
-      <i class="fa fa-remove pull-right" (click)="hideInfoPopover()"></i>
-
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <button class="pull-right close" type="button" (click)="hideInfoPopover()">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <h3 class="panel-title">Connection Properties</h3>
+      </div>
+      <div class="panel-body">
       <!-- TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700 -->
       <!--
       <div *ngIf="previousStepShouldDefineDataShape"><p style="color:red"><b>Define a data type</b></p></div>
-      <div *ngIf="shouldAddDatamapper"><p style="color:red"><b>Add a datamapper step</b></p></div>
       -->
-        <dl class="dl-horizontal">
+        <dl>
           <dt>
             Name
           </dt>
@@ -30,7 +34,7 @@
             {{ step.connection?.name }}
           </dd>
         </dl>
-        <dl class="dl-horizontal">
+        <dl>
           <dt>
             Action
           </dt>
@@ -38,7 +42,7 @@
             {{ step.action?.name }}
           </dd>
         </dl>
-        <dl class="dl-horizontal" *ngIf="inputDataShapeText">
+        <dl *ngIf="inputDataShapeText && inputDataShapeText !== ''">
           <dt>
             Input Data Type
           </dt>
@@ -46,7 +50,7 @@
             {{ inputDataShapeText }}
           </dd>
         </dl>
-        <dl class="dl-horizontal" *ngIf="outputDataShapeText">
+        <dl *ngIf="outputDataShapeText">
           <dt>
             Output Data Type
           </dt>
@@ -54,6 +58,7 @@
             {{ outputDataShapeText }}
           </dd>
         </dl>
+      </div>
     </div>
   </ng-template>
 
@@ -89,12 +94,12 @@
           placement="right"
           (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
           container="body"></span>
-        
+
         <div class="step-content">
           <div class="step-name">
             {{ stepName }}
-          </div>  
-        
+          </div>
+
           <div class="step-icons">
             <!-- Delete Icon -->
             <i *ngIf="showDelete()"
@@ -109,7 +114,7 @@
               (click)="toggleInfoPopover(); $event.stopPropagation();"
               triggers=""
               container="body"></i>
-          </div>        
+          </div>
         </div>
       </div>
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -2,12 +2,14 @@
      class="flow-view-step">
 
   <ng-template #addDatamapper>
-    <div class="alert alert-warning">
+    <div class="alert alert-warning no-bottom-margin">
+      <!--
       <button type="button"
         (click)="hideAddDatamapperInfo()"
         class="close">
         <span class="pficon pficon-close"></span>
       </button>
+      -->
       <span class="pficon pficon-warning-triangle-o"></span>
       <p><strong>Data Type Mismatch:</strong> Add a data mapping step before this connection to resolve the difference.</p>
     </div>
@@ -15,9 +17,13 @@
 
   <ng-template #tooltipPopover>
     <div class="info-popover container-fluid">
-      <div class="row">
-          <i class="fa fa-remove pull-right" (click)="hideInfoPopover()" role="button"></i>
-      </div>
+      <!--
+      <button type="button"
+        (click)="hideInfoPopover()"
+        class="pull-right close">
+        <span class="pficon pficon-close"></span>
+      </button>
+      -->
       <!-- TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700 -->
       <!--
       <div *ngIf="previousStepShouldDefineDataShape"><p style="color:red"><b>Define a data type</b></p></div>
@@ -86,7 +92,9 @@
           [popover]="addDatamapper"
           #datamapperInfoPop="bs-popover"
           triggers=""
+          containerClass="flow-view-popover"
           placement="right"
+          outsideClick="true"
           (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
           container="body"></span>
 
@@ -103,6 +111,9 @@
               placement="right"
               (click)="toggleInfoPopover(); $event.stopPropagation();"
               triggers=""
+              containerClass="flow-view-popover"
+              popoverTitle="Connection Properties"
+              outsideClick="true"
               container="body"></i>
             <!-- Delete Icon -->
             <i *ngIf="showDelete()"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -59,8 +59,8 @@
 
   <!-- Icon Progress Line -->
   <div class="col-md-3 progress-line">
+    <span class="step-index">{{ stepIndex }}</span>
     <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()">
-      <span>{{ stepIndex }}</span>
       <i [class]="getIconClass()"
          *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
       <img class="syn-icon-small"
@@ -81,7 +81,7 @@
       <!-- Connection Title -->
       <div [ngClass]="getParentClass()"
             (click)="goto('action-configure')">
-        <span class="pficon pficon-warning-triangle-o"
+        <span class="pficon pficon-warning-triangle-o data-mismatch"
           *ngIf="shouldAddDatamapper"
           [popover]="addDatamapper"
           #datamapperInfoPop="bs-popover"
@@ -89,22 +89,28 @@
           placement="right"
           (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
           container="body"></span>
-        {{ stepName }}
-
-        <!-- Delete Icon -->
-        <i *ngIf="showDelete()"
-          class="fa fa-lg fa-trash pull-right"
-          title="Delete this connection"
-          (click)="deletePrompt(); $event.stopPropagation();"></i>
-
-        <!-- Info icon -->
-        <i class="fa fa-lg fa-info-circle pull-right"
-          [popover]="tooltipPopover"
-          #connectionInfoPop="bs-popover"
-          placement="right"
-          (click)="toggleInfoPopover(); $event.stopPropagation();"
-          triggers=""
-          container="body"></i>
+        
+        <div class="step-content">
+          <div class="step-name">
+            {{ stepName }}
+          </div>  
+        
+          <div class="step-icons">
+            <!-- Delete Icon -->
+            <i *ngIf="showDelete()"
+              class="fa fa-lg fa-trash pull-right"
+              title="Delete this connection"
+              (click)="deletePrompt(); $event.stopPropagation();"></i>
+            <!-- Info icon -->
+            <i class="fa fa-lg fa-info-circle pull-right"
+              [popover]="tooltipPopover"
+              #connectionInfoPop="bs-popover"
+              placement="right"
+              (click)="toggleInfoPopover(); $event.stopPropagation();"
+              triggers=""
+              container="body"></i>
+          </div>        
+        </div>
       </div>
 
       <!-- Connection Sub Pages -->

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -14,51 +14,46 @@
   </ng-template>
 
   <ng-template #tooltipPopover>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <button class="pull-right close" type="button" (click)="hideInfoPopover()">
-          <span class="pficon pficon-close"></span>
-        </button>
-        <h3 class="panel-title">Connection Properties</h3>
+    <div class="info-popover container-fluid">
+      <div class="row">
+          <i class="fa fa-remove pull-right" (click)="hideInfoPopover()" role="button"></i>
       </div>
-      <div class="panel-body">
       <!-- TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700 -->
       <!--
       <div *ngIf="previousStepShouldDefineDataShape"><p style="color:red"><b>Define a data type</b></p></div>
       -->
-        <dl>
-          <dt>
-            Name
-          </dt>
-          <dd>
-            {{ step.connection?.name }}
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            Action
-          </dt>
-          <dd>
-            {{ step.action?.name }}
-          </dd>
-        </dl>
-        <dl *ngIf="inputDataShapeText && inputDataShapeText !== ''">
-          <dt>
-            Input Data Type
-          </dt>
-          <dd>
-            {{ inputDataShapeText }}
-          </dd>
-        </dl>
-        <dl *ngIf="outputDataShapeText">
-          <dt>
-            Output Data Type
-          </dt>
-          <dd>
-            {{ outputDataShapeText }}
-          </dd>
-        </dl>
-      </div>
+      <dl class="row">
+        <dt class="col-xs-6 text-right">
+          Name
+        </dt>
+        <dd class="col-xs-6">
+          {{ step.connection?.name }}
+        </dd>
+      </dl>
+      <dl class="row">
+        <dt class="col-xs-6 text-right">
+          Action
+        </dt>
+        <dd class="col-xs-6">
+          {{ step.action?.name }}
+        </dd>
+      </dl>
+      <dl class="row" *ngIf="inputDataShapeText">
+        <dt class="col-xs-6 text-right">
+          Input Data Type
+        </dt>
+        <dd class="col-xs-6">
+          {{ inputDataShapeText }}
+        </dd>
+      </dl>
+      <dl class="row" *ngIf="outputDataShapeText">
+        <dt class="col-xs-6 text-right">
+          Output Data Type
+        </dt>
+        <dd class="col-xs-6">
+          {{ outputDataShapeText }}
+        </dd>
+      </dl>
     </div>
   </ng-template>
 
@@ -101,19 +96,19 @@
           </div>
 
           <div class="step-icons">
-            <!-- Delete Icon -->
-            <i *ngIf="showDelete()"
-              class="fa fa-lg fa-trash pull-right"
-              title="Delete this connection"
-              (click)="deletePrompt(); $event.stopPropagation();"></i>
             <!-- Info icon -->
-            <i class="fa fa-lg fa-info-circle pull-right"
+            <i class="fa fa-lg fa-info-circle"
               [popover]="tooltipPopover"
               #connectionInfoPop="bs-popover"
               placement="right"
               (click)="toggleInfoPopover(); $event.stopPropagation();"
               triggers=""
               container="body"></i>
+            <!-- Delete Icon -->
+            <i *ngIf="showDelete()"
+              class="fa fa-lg fa-trash"
+              title="Delete this connection"
+              (click)="deletePrompt(); $event.stopPropagation();"></i>
           </div>
         </div>
       </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -1,33 +1,67 @@
 <div *ngIf="step"
      class="flow-view-step">
 
+  <ng-template #addDatamapper>
+    <div class="alert alert-warning">
+      <button type="button"
+        (click)="hideAddDatamapperInfo()"
+        class="close">
+        <span class="pficon pficon-close"></span>
+      </button>
+      <span class="pficon pficon-warning-triangle-o"></span>
+      <p><strong>Data Type Mismatch:</strong> Add a data mapping step before this connection to resolve the difference.</p>
+    </div>
+  </ng-template>
+
   <ng-template #tooltipPopover>
-    <span>
+    <div>
+      <i class="fa fa-remove pull-right" (click)="hideInfoPopover()"></i>
 
       <!-- TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700 -->
+      <!--
       <div *ngIf="previousStepShouldDefineDataShape"><p style="color:red"><b>Define a data type</b></p></div>
       <div *ngIf="shouldAddDatamapper"><p style="color:red"><b>Add a datamapper step</b></p></div>
-
-      <strong [innerHtml]="getStepText()"></strong><br/>
-
-      <!-- TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700 -->
-      <div *ngIf="inputDataShapeText" >Input: {{ inputDataShapeText }}</div>
-      <div *ngIf="outputDataShapeText">Output: {{ outputDataShapeText }}</div>
-
-    </span>
+      -->
+        <dl class="dl-horizontal">
+          <dt>
+            Name
+          </dt>
+          <dd>
+            {{ step.connection?.name }}
+          </dd>
+        </dl>
+        <dl class="dl-horizontal">
+          <dt>
+            Action
+          </dt>
+          <dd>
+            {{ step.action?.name }}
+          </dd>
+        </dl>
+        <dl class="dl-horizontal" *ngIf="inputDataShapeText">
+          <dt>
+            Input Data Type
+          </dt>
+          <dd>
+            {{ inputDataShapeText }}
+          </dd>
+        </dl>
+        <dl class="dl-horizontal" *ngIf="outputDataShapeText">
+          <dt>
+            Output Data Type
+          </dt>
+          <dd>
+            {{ outputDataShapeText }}
+          </dd>
+        </dl>
+    </div>
   </ng-template>
 
   <!-- Icon Progress Line -->
   <div class="col-md-3 progress-line">
-    <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()"
-       [popover]="tooltipPopover"
-       #pop="bs-popover"
-       placement="right"
-       (mouseover)="showTooltip()"
-       (mouseleave)="hideTooltip()"
-       triggers=""
-       container="body">
-      <i [ngClass]="getIconClass()"
+    <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()">
+      <span>{{ stepIndex }}</span>
+      <i [class]="getIconClass()"
          *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
       <img class="syn-icon-small"
            *ngIf="step.stepKind === 'endpoint' && step.connection"
@@ -44,19 +78,33 @@
     <div *ngSwitchCase="'endpoint'"
          [ngClass]="getParentActiveClass() + ' step-container'">
 
-      <!-- Delete Icon -->
-      <i *ngIf="showDelete()"
-         class="delete-icon fa fa-lg fa-trash"
-         title="Delete this connection"
-         (click)="deletePrompt()"></i>
-
-
       <!-- Connection Title -->
       <div [ngClass]="getParentClass()"
             (click)="goto('action-configure')">
-        <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
-        <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
-        {{ getStepText() }}
+        <span class="pficon pficon-warning-triangle-o"
+          *ngIf="shouldAddDatamapper"
+          [popover]="addDatamapper"
+          #datamapperInfoPop="bs-popover"
+          triggers=""
+          placement="right"
+          (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
+          container="body"></span>
+        {{ stepName }}
+
+        <!-- Delete Icon -->
+        <i *ngIf="showDelete()"
+          class="fa fa-lg fa-trash pull-right"
+          title="Delete this connection"
+          (click)="deletePrompt(); $event.stopPropagation();"></i>
+
+        <!-- Info icon -->
+        <i class="fa fa-lg fa-info-circle pull-right"
+          [popover]="tooltipPopover"
+          #connectionInfoPop="bs-popover"
+          placement="right"
+          (click)="toggleInfoPopover(); $event.stopPropagation();"
+          triggers=""
+          container="body"></i>
       </div>
 
       <!-- Connection Sub Pages -->
@@ -96,19 +144,17 @@
     <div *ngSwitchDefault
          [ngClass]="getParentActiveClass() + ' step-container'">
 
-      <!-- Delete Icon -->
-      <i *ngIf="showDelete()"
-         class="delete-icon fa fa-lg fa-trash"
-         title="Delete this step"
-         [class.add-step-or-connection]="step.stepKind !== 'endpoint'"
-         (click)="deletePrompt()"></i>
-
       <!-- Step Heading -->
       <div [ngClass]="getParentClass()"
             (click)="goto('step-configure')">
-        <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
-        <i *ngIf="isCollapsed()" class="fa fa-chevron-right"></i>
-        {{ getStepText() }}
+        {{ stepName }}
+
+        <!-- Delete Icon -->
+        <i *ngIf="showDelete()"
+          class="fa fa-lg fa-trash pull-right"
+          title="Delete this step"
+          [class.add-step-or-connection]="step.stepKind !== 'endpoint'"
+          (click)="deletePrompt(); $event.stopPropagation();"></i>
       </div>
 
       <!-- Step Sub Pages -->

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -46,23 +46,35 @@
   ////////////////////////////////////////////////////////////////////////////////
   .progress-line {
     padding: 0;
-    text-align: center;
+    height: 55px;
 
     .fa {
       color: $color-pf-black-300;
       font-size: x-large;
     }
 
+    .step-index,
     .icon {
-      -moz-border-radius: 100px;
-      border-radius: 100px;
-      border-style: solid;
-      border-width: 3px;
-      border-color: $color-pf-black-300;
+      position: absolute;
+    }
+
+    .step-index {
+      left: 0;
+      top: 50%;
+      transform: translate(-20px, -50%);
+      width: 35px;
+      background: #d6eefa;
+      padding-left: 7px;
+    }
+
+    .icon {
+      border-radius: 50%;
+      border: 3px solid $color-pf-black-300;
       padding: 11px;
       width: 55px;
-      height: 55px;
+      height: 100%;
       background-color: #ffffff;
+      text-align: center;
 
       &.not-connection {
         background-color: #ffffff;
@@ -101,6 +113,7 @@
       &.incomplete {
         .fa {
           color: #d1d1d1;
+          line-height: 1.15;
         }
       }
     }
@@ -118,7 +131,7 @@
     position: relative;
     padding-left: 0;
     padding-right: 0;
-    padding-top: 8px;
+    padding-top: 9px;
 
     //----- Sidebar: Menu & Parent Step Container ----------------->>
     .step-container {
@@ -138,13 +151,43 @@
 
       //----- Sidebar: Menu: Parent Step ----------------->>
       .parent-step {
-        text-overflow: ellipsis;
-        overflow-x: hidden;
         background-color: $color-pf-black-300;
         cursor: pointer;
-        padding: 8px 18px 8px 8px;
-        text-transform: uppercase;
-        white-space: nowrap;
+        padding: 8px 18px 8px 8px;        
+        position: relative;
+
+        .data-mismatch {
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          background: #ec7a08;
+          display: flex;
+          align-items: center;
+          transform: translateX(-100%);
+          padding: 0 5px;
+
+          &::before {
+            color: #ffffff;
+          }
+        }
+
+        .step-content {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+
+          .step-name {
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow-x: hidden;
+            text-transform: uppercase;
+          }
+
+          .step-icons {
+            flex-shrink: 0;
+          }
+        }
 
         &.disabled {
           cursor: default;

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -257,3 +257,17 @@
     }
   }
 }
+
+.info-popover {
+  dl {
+    dt,
+    dd {
+      padding-left: 0;
+      word-break: break-word;
+    }
+
+    dt {
+      padding-right: 1em;
+    }
+  }
+}

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -153,7 +153,7 @@
       .parent-step {
         background-color: $color-pf-black-300;
         cursor: pointer;
-        padding: 8px 18px 8px 8px;        
+        padding: 8px 18px 8px 8px;
         position: relative;
 
         .data-mismatch {
@@ -258,7 +258,12 @@
   }
 }
 
+::ng-deep .flow-view-popover {
+  max-width: inherit;
+}
+
 .info-popover {
+  min-width: 350px;
   dl {
     dt,
     dd {

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -18,6 +18,8 @@ const category = getCategory('IntegrationsCreatePage');
   styleUrls: ['./flow-view-step.component.scss']
 })
 export class FlowViewStepComponent implements OnChanges {
+  stepIndex: number;
+  stepName: string;
   // the step object in the current flow
   @Input() step: Step;
 
@@ -30,7 +32,8 @@ export class FlowViewStepComponent implements OnChanges {
   // the current state/page of the current step
   @Input() currentState: string;
 
-  @ViewChild('pop') public pop: PopoverDirective;
+  @ViewChild('connectionInfoPop') connectionInfoPop: PopoverDirective;
+  @ViewChild('datamapperInfoPop') datamapperInfoPop: PopoverDirective;
 
   inputDataShapeText: string;
   outputDataShapeText: string;
@@ -51,14 +54,24 @@ export class FlowViewStepComponent implements OnChanges {
     return this.flowPageService.getCurrentStepKind(this.route);
   }
 
-  showTooltip() {
-    // TODO Apply UXD outcome - https://github.com/syndesisio/syndesis/issues/700
-    // for now showing everything as a tooltip
-    this.pop.show();
+  showInfoPopover() {
+    this.connectionInfoPop.show();
   }
 
-  hideTooltip() {
-    this.pop.hide();
+  hideInfoPopover() {
+    this.connectionInfoPop.hide();
+  }
+
+  toggleInfoPopover() {
+    this.connectionInfoPop.toggle();
+  }
+
+  toggleAddDatamapperInfo() {
+    this.datamapperInfoPop.toggle();
+  }
+
+  hideAddDatamapperInfo() {
+    this.datamapperInfoPop.hide();
   }
 
   getStepKind(step) {
@@ -275,39 +288,13 @@ export class FlowViewStepComponent implements OnChanges {
     });
   }
 
-  getStepText() {
-    if (!this.step) {
-      return 'Set up this step';
-    }
-    const prefix = 'Step ' + (this.getPosition() + 1) + ' - ';
-    switch (this.step.stepKind) {
-      case 'endpoint':
-        if (this.step.action && this.step.action.name) {
-          return prefix + this.step.action.name;
-        }
-        if (this.step.connection) {
-          return prefix + this.step.connection.name;
-        }
-        if (this.getPosition() === 0) {
-          return prefix + 'Start';
-        }
-        if (this.getPosition() === this.currentFlowService.getLastPosition()) {
-          return prefix + 'Finish';
-        }
-        return 'Set up this connection';
-      default:
-        if (this.step.name) {
-          return prefix + this.step.name;
-        }
-        return 'Set up this step';
-    }
-  }
-
   isCollapsed() {
     return this.getPosition() !== this.currentPosition;
   }
 
   ngOnChanges() {
+    this.stepIndex = this.getStepIndex();
+    this.stepName = this.getStepName(this.step);
     this.previousStepShouldDefineDataShape = false;
     this.shouldAddDatamapper = false;
     if (!this.step || !this.step.action || !this.step.action.descriptor) {
@@ -332,6 +319,37 @@ export class FlowViewStepComponent implements OnChanges {
     if (this.step !== this.currentFlowService.getEndStep()
       && this.step.action.descriptor.outputDataShape) {
       this.outputDataShapeText = this.getDataShapeText(this.step.action.descriptor.outputDataShape);
+    }
+  }
+
+  private getStepIndex() {
+    return this.getPosition() + 1;
+  }
+
+  private getStepName(step: Step) {
+    if (!step) {
+      return 'Set up this step';
+    }
+    switch (step.stepKind) {
+      case 'endpoint':
+        if (step.action && step.action.name) {
+          return step.action.name;
+        }
+        if (step.connection) {
+          return step.connection.name;
+        }
+        if (this.getPosition() === 0) {
+          return 'Start';
+        }
+        if (this.getPosition() === this.currentFlowService.getLastPosition()) {
+          return 'Finish';
+        }
+        return 'Set up this connection';
+      default:
+        if (step.name) {
+          return step.name;
+        }
+        return 'Set up this step';
     }
   }
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -22,7 +22,6 @@
 
   .flow-view-container {
     flex: 1 1 auto;
-    overflow-y: auto;
     padding-top: 15px;
     padding-bottom: 20px;
     margin-right: -20px;

--- a/app/ui/src/scss/utils/_helpers.scss
+++ b/app/ui/src/scss/utils/_helpers.scss
@@ -21,7 +21,7 @@
     border-color: color($color);
   }
 
-  @each $tone in map-keys(map-get($colors, nth($color, 1))) { 
+  @each $tone in map-keys(map-get($colors, nth($color, 1))) {
     .syn-color--#{$color}-#{$tone} {
       color: color($color, $tone);
     }
@@ -29,7 +29,7 @@
     .syn-bg--#{$color}-#{$tone} {
       background-color: color($color, $tone);
     }
-    
+
     .syn-border--#{$color}-#{$tone} {
       border-color: color($color, $tone);
     }
@@ -54,6 +54,10 @@
     display: flex;
     align-items: center;
   }
+}
+
+.no-bottom-margin {
+  margin-bottom: 0;
 }
 
 .syn-visuallyhidden {


### PR DESCRIPTION
fixes #1682 
fixes #1138 

Initial work for getting the data buckets-related indicators in place for the data buckets epic, mostly so I can share with @michael-coker and get his help :-)

current design:
https://github.com/syndesisio/syndesis/blob/master/ux/designs/data-buckets/data-buckets.md#visualizing-step-id-and-showing-data-type-information-integration-visualization-panel-ivp

WIP because while the text for the step name is broken up now into different elements there's still a fair bit of layout work that needs cleanup.  The trash icon originally was using absolute positioning and outside of the step name, I've changed that and added the info icon, put them to the right for now.

Also the popovers used for showing the data mismatch text and the datashape details for connections aren't laid out that well and need some further work.

@igarashitm FYI and also I forget, was there an issue for tracking implementing the updated design?