### PR TITLE
fix: clicks on modal backdrop will not trigger undesired actions anymore

### DIFF
--- a/app/ui/src/app/common/modal/modal.service.ts
+++ b/app/ui/src/app/common/modal/modal.service.ts
@@ -18,7 +18,7 @@ export class ModalService {
 
   show(id = 'modal'): Promise<Modal> {
     const modal = this.registeredModals.get(id);
-    modal.bsModalRef = this.bsModalService.show(modal.template);
+    modal.bsModalRef = this.bsModalService.show(modal.template, { ignoreBackdropClick: true });
     return this.bsModalService.onHide
       .take(1)
       .toPromise()


### PR DESCRIPTION
Fixes #1662 

TL;DR : Overlays cannot be closed anymore by clicking outside the modal element.

Unfortunately it took me nearly 4 hours to figure out what was happening, since the state of the `ModalService` and the behavior of the client consumers is scattered across too many places. Ideally we should be able to close the modals by clicking outside by using a combination of `@HostListener('document:click')` and the `event.target` element of the clicked element. This way we can trigger/dispatch modal `hide()` and `show()` behaviors in confidence.

Unfortunately the current layout of `<ng-templates>` found in the component element makes this impossible. One day we should rule out the current implementation and use a router-based one whose state is managed by the application store instead, so we can inspect wether there're active modals or not, what modals are being displayed, provide back/forward navigation and seep-linking support and build simpler template-driven modals.

In the meantime, this is the best I managed to come out with. :(