### PR TITLE
fix(build): remove duplicate dependency declaration

### DIFF
--- a/app/connectors/connector-verifier/pom.xml
+++ b/app/connectors/connector-verifier/pom.xml
@@ -40,11 +40,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.syndesis.common</groupId>
-      <artifactId>common-util</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
     </dependency>


### PR DESCRIPTION
Dependency `io.syndesis.common:common-util` is declared twice, this
results in a warning when Maven builds the project. This removes that
duplicate dependency.