### PR TITLE
Tools: don't remove .minishift/ folder, just its content

### DIFF
--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -108,7 +108,7 @@ delete_minishift() {
 
     minishift delete --clear-cache --force
     if [ $remove_all ] && [ -d ~/.minishift ]; then
-        rm -rf ~/.minishift
+        rm -rf ~/.minishift/*
     fi
 }
 


### PR DESCRIPTION
My `~/.minishift/` folder is actually a link to different location.
Removing content in this new way avoids breaking the link.