### PR TITLE
(chore) add support for the 'order' property when connector/action form config specifies it

### DIFF
--- a/app/ui/src/app/connections/create-page/create-page.component.ts
+++ b/app/ui/src/app/connections/create-page/create-page.component.ts
@@ -91,10 +91,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
         target.push('connection-basics');
         break;
       case 'review':
-        if (
-          !this.current.connection.connector.properties ||
-          this.current.connection.connector.properties === ''
-        ) {
+        if (!this.current.connection.connector.properties) {
           target.push('connection-basics');
         } else {
           target.push('configure-fields');
@@ -116,10 +113,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
     const target = [];
     switch (page) {
       case 'connection-basics':
-        if (
-          !this.current.connection.connector.properties ||
-          this.current.connection.connector.properties === ''
-        ) {
+        if (!this.current.connection.connector.properties) {
           target.push('review');
         } else {
           target.push('configure-fields');

--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FormFactoryService, ConfigurationProperty, ConfiguredConfigurationProperty } from '@syndesis/ui/platform';
+import { FormFactoryService, ConfigurationProperty, ConfiguredConfigurationProperty, StringMap } from '@syndesis/ui/platform';
 import { DurationInputModel } from '@syndesis/ui/common/ui-patternfly/duration-form-control.model';
 import {
   DynamicFormControlModel,
@@ -18,9 +18,9 @@ export class FormFactoryProviderService extends FormFactoryService {
 
   createFormModel(
     properties:
-      | Map<string, ConfiguredConfigurationProperty>
-      | Map<string, ConfigurationProperty>
-      | Map<string, any>
+      | StringMap<ConfiguredConfigurationProperty>
+      | StringMap<ConfigurationProperty>
+      | StringMap<any>
       | {},
     values: any = {},
     controls: Array<string> = ['*']
@@ -90,6 +90,7 @@ export class FormFactoryProviderService extends FormFactoryService {
     if (controls.find(val => val === '*') === undefined) {
       controls.push('*');
     }
+    // TODO we can deprecate and remove this once connectors specify the order property
     // sort the form based on the controls array
     const wildcardIndex = controls.findIndex(val => val === '*');
     answer.sort((a, b) => {
@@ -102,6 +103,14 @@ export class FormFactoryProviderService extends FormFactoryService {
         bIndex = wildcardIndex;
       }
       return aIndex - bIndex;
+    });
+    // sort the form based on the 'order' property
+    answer.sort((a, b) => {
+      const aProp = properties[a.id];
+      const bProp = properties[b.id];
+      const aOrder = aProp.order || 0;
+      const bOrder = bProp.order || 0;
+      return bOrder - aOrder;
     });
     return answer;
   }

--- a/app/ui/src/app/platform/types/connection/connection.models.ts
+++ b/app/ui/src/app/platform/types/connection/connection.models.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, User, Action } from '@syndesis/ui/platform';
+import { BaseEntity, User, Action, StringMap, ConfigurationProperty } from '@syndesis/ui/platform';
 
 // these are related to oauth enabled connections
 export interface AcquisitionMethod extends BaseEntity {
@@ -26,10 +26,10 @@ export type Results = Array<Result>;
 
 export interface Connector extends BaseEntity {
   icon: string;
-  properties: {};
+  properties: StringMap<ConfigurationProperty>;
   actions: Array<Action>;
   connectorGroupId: string;
-  configuredProperties: {};
+  configuredProperties: StringMap<string>;
   description: string;
   connectorGroup: BaseEntity;
   tags: Array<string>;
@@ -45,7 +45,7 @@ export type Organizations = Array<Organization>;
 export interface Connection extends BaseEntity {
   icon: string;
   organization: Organization;
-  configuredProperties: {};
+  configuredProperties: StringMap<string>;
   organizationId: string;
   connectorId: string;
   options: {};

--- a/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
+++ b/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
@@ -1,36 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DynamicFormControlModel } from '@ng-dynamic-forms/core';
-import { BaseEntity } from '@syndesis/ui/platform';
-
-export interface ConfigurationProperty extends BaseEntity {
-  javaType: string;
-  type: string;
-  defaultValue: string;
-  displayName: string;
-  description: string;
-  group: string;
-  required: boolean;
-  secret: boolean;
-  label: string;
-  enum: Array<PropertyValue>;
-  componentProperty: boolean;
-  deprecated: boolean;
-  tags: Array<string>;
-}
-export type ConfigurationProperties = Array<ConfigurationProperty>;
-
-export interface PropertyValue extends BaseEntity {
-  value: string;
-  label: string;
-}
-
-export type PropertyValues = Array<PropertyValue>;
-
-export interface ConfiguredConfigurationProperty extends ConfigurationProperty {
-  value: any;
-  rows?: number;
-  cols?: number;
-}
+import { ConfigurationProperty, ConfiguredConfigurationProperty, StringMap } from '@syndesis/ui/platform';
 
 @Injectable()
 export abstract class FormFactoryService {
@@ -42,9 +12,9 @@ export abstract class FormFactoryService {
    */
   abstract createFormModel(
     properties?:
-      | Map<string, ConfiguredConfigurationProperty>
-      | Map<string, ConfigurationProperty>
-      | Map<string, any>
+      | StringMap<ConfiguredConfigurationProperty>
+      | StringMap<ConfigurationProperty>
+      | StringMap<any>
       | any,
     values?: any,
     controls?: Array<string>

--- a/app/ui/src/app/platform/types/platform.models.ts
+++ b/app/ui/src/app/platform/types/platform.models.ts
@@ -65,6 +65,35 @@ export interface BaseEntity {
   kind?: string;
   name?: string;
 }
+export interface ConfigurationProperty extends BaseEntity {
+  javaType: string;
+  type: string;
+  defaultValue: string;
+  displayName: string;
+  description: string;
+  group: string;
+  required: boolean;
+  secret: boolean;
+  label: string;
+  order: number;
+  enum: Array<PropertyValue>;
+  componentProperty: boolean;
+  deprecated: boolean;
+  tags: Array<string>;
+}
+export type ConfigurationProperties = Array<ConfigurationProperty>;
+
+export interface PropertyValue extends BaseEntity {
+  value: string;
+  label: string;
+}
+export type PropertyValues = Array<PropertyValue>;
+
+export interface ConfiguredConfigurationProperty extends ConfigurationProperty {
+  value: any;
+  rows?: number;
+  cols?: number;
+}
 
 export enum DataShapeKinds {
   ANY = 'any',
@@ -101,7 +130,7 @@ export type Actions = Array<Action>;
 
 export interface ActionDescriptor extends BaseEntity {
   componentScheme: string;
-  configuredProperties: {};
+  configuredProperties: StringMap<string>;
   propertyDefinitionSteps: Array<ActionDescriptorStep>;
   inputDataShape: DataShape;
   outputDataShape: DataShape;
@@ -111,8 +140,8 @@ export type ActionDescriptors = Array<ActionDescriptor>;
 
 export interface ActionDescriptorStep extends BaseEntity {
   description: string;
-  configuredProperties: {};
-  properties: {};
+  configuredProperties: StringMap<string>;
+  properties: StringMap<ConfigurationProperty>;
 }
 
 export type ActionDescriptorSteps = Array<ActionDescriptorStep>;


### PR DESCRIPTION
fixes #1204 

@lburgazzoli am I right that the property name is `order`?  I didn't see this property after updating my local instance, even with a full rebuild, but am guessing it's because by default no order is set currently on anything yet.

Also corrects some type info in the model.