### PR TITLE
GitHub issue template for new features and bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,7 +20,7 @@ Briefly describe the issue you are experiencing (or the feature you want to see 
 
 ## Screenshot
 <!--
-For features/bugs entailing a presentation layer, drag and drop a screenshot depicting the issue or supporting the UX narrative for the new functionality.
+For features/bugs tackling with UI functionality, drag and drop a screenshot depicting the desired presentation layer or supporting the UX narrative for the new functionality.
 -->
 
 ## API Endpoints and Schemas

--- a/app/ui/.github/ISSUE_TEMPLATE.md
+++ b/app/ui/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+## This is a...
+<!-- Check one of the following options with "x" -->
+<pre><code>
+[ ] Feature request
+[ ] Regression (a behavior that used to work and stopped working in a new release)
+[ ] Bug report  <!-- Please search GitHub for a similar issue or PR before submitting -->
+[ ] Documentation issue or request
+</code></pre>
+
+
+## The problem
+<!--
+Briefly describe the issue you are experiencing (or the feature you want to see implemented on Syndesis).
++ For BUGS, tell us what you were trying to do and what happened instead.
++ For NEW FEATURES, describe the _User Persona_ demanding it and its use case.
+-->
+
+## Expected behavior
+<!-- Describe what the desired behavior would be, enlistin gthe acceptance criteria. -->
+
+## Screenshot
+<!--
+For features/bugs entailing a presentation layer, drag and drop a screenshot depicting the issue or supporting the UX narrative for the new functionality.
+-->
+
+## API Endpoints and Schemas
+<!--
+For features or bugfixes entailing data exchanges between the UI and the REST API,
+enlist the different endpoints available and the payload/response schemas.
+-->
+
+## Tasks involved / Steps to Reproduce
+<!--
+Enlist all the acceptance criteria for new features or the steps required to reproduce the bug/regression reported.
+-->
+1. 
+2.
+3.
+4.


### PR DESCRIPTION
This PR summarizes what @paoloantinori, @rhuss and me discussed over the F2F regarding having a template model for new GH issues that would serve as a centralized point of reference for issues/bugs combining UI/API/Backend input.

The proposed template tries to cater with both bugs and new features. GitHub provides support for handling several issue templates in a single repository. However, I'd suggest to begin with this one and refine its content. In the future we can provide more than one template (new feature, bugs, etc), which we can trigger by means of custom browser script bookmarks (or even a custom browser extension).