### PR TITLE
fix: Don't use multiple dashes in templates

### DIFF
--- a/app/deploy/generator/04-syndesis-db.yml.mustache
+++ b/app/deploy/generator/04-syndesis-db.yml.mustache
@@ -12,7 +12,7 @@
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -44,7 +44,7 @@
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1

--- a/app/deploy/syndesis-ci.yml
+++ b/app/deploy/syndesis-ci.yml
@@ -348,7 +348,7 @@ objects:
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -380,7 +380,7 @@ objects:
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
@@ -1160,6 +1160,8 @@ objects:
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_annotation_(syndesis.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: kubernetes_namespace

--- a/app/deploy/syndesis-dev-restricted.yml
+++ b/app/deploy/syndesis-dev-restricted.yml
@@ -269,7 +269,7 @@ objects:
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -301,7 +301,7 @@ objects:
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
@@ -1068,6 +1068,8 @@ objects:
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_annotation_(syndesis.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: kubernetes_namespace

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -273,7 +273,7 @@ objects:
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -305,7 +305,7 @@ objects:
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
@@ -1080,6 +1080,8 @@ objects:
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_annotation_(syndesis.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: kubernetes_namespace

--- a/app/deploy/syndesis-restricted.yml
+++ b/app/deploy/syndesis-restricted.yml
@@ -353,7 +353,7 @@ objects:
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -385,7 +385,7 @@ objects:
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
@@ -1175,6 +1175,8 @@ objects:
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_annotation_(syndesis.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: kubernetes_namespace

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -357,7 +357,7 @@ objects:
         echo "Waiting for Postgres server..."
         sleep 1
       done
-      echo "----- creating sampledb"
+      echo "***** creating sampledb"
       psql <<EOF
         CREATE DATABASE sampledb;
         CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
@@ -389,7 +389,7 @@ objects:
         $BODY$;
       EOF
 
-      echo "----- sampledb created"
+      echo "***** sampledb created"
     postStart.sh: |
       #!/bin/bash
       /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
@@ -1187,6 +1187,8 @@ objects:
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)
+          - action: labelmap
+            regex: __meta_kubernetes_pod_annotation_(syndesis.+)
           - source_labels: [__meta_kubernetes_namespace]
             action: replace
             target_label: kubernetes_namespace


### PR DESCRIPTION
Switch log delimited during stored procedure creation from `-----` to `*****` because of:

> YAML uses three dashes (“---”) to separate directives from document content. 

Such a use of dashes may cause premature end-of-file and incomplete unmarshalling to object.
For more details: https://github.com/fabric8io/kubernetes-client/pull/932

This breaks template loading in kubernetes-client since version `3.1.2`