### PR TITLE
fix(ui): display error from the backend

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-page.service.ts
+++ b/app/ui/src/app/integration/edit-page/flow-page.service.ts
@@ -71,6 +71,10 @@ export class FlowPageService {
         }
         const target = i.id ? ['/integrations', i.id] : ['/integrations'];
         this.router.navigate(target);
+      },
+      error: reason => {
+        this.errorMessage = reason;
+        this.saveInProgress = false;
       }
     });
   }

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -269,8 +269,12 @@ export abstract class AbstractStore<
     let errorMessage: any;
     switch (typeof error) {
       case 'object':
-      errorMessage = error;
-      break;
+        if (error['data']) {
+          errorMessage = error['data'].map(e => e.message).join(' ');
+        } else {
+          errorMessage = error;
+        }
+        break;
       case 'string':
         try {
           errorMessage = JSON.parse(error);


### PR DESCRIPTION
We should use the error message backend supplied when handling errors.
This checks if the backend returned an error like:

```json
[
  {
    "error": "UniqueProperty",
    "message": "Value 'test' is not unique",
    "property": "update.obj.name"
  }
]

```

And displays all error messages present.

Then the error message when saving integration with a non unique name presents the following error message:

![screenshot-2018-3-2 syndesis - development](https://user-images.githubusercontent.com/1306050/36876352-e190324a-1db4-11e8-9246-711fefa44af1.png)

Fixes #1464