### PR TITLE
fix: use the right fake link for the datamapper popover

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -6,13 +6,13 @@
       <div class="alert alert-warning no-bottom-margin"
         *ngIf="previousStepShouldDefineDataShape">
         <span class="pficon pficon-warning-triangle-o"></span>
-        <p><strong>Typeless Previous Step:</strong> <a href="javascript: null" (click)="visitPreviousStepDescribeData()">Define the data type</a> for the previous step to resolve this warning.</p>
+        <p><strong>Typeless Previous Step:</strong> <a [routerLink]="" (click)="visitPreviousStepDescribeData()">Define the data type</a> for the previous step to resolve this warning.</p>
       </div>
 
       <div class="alert alert-warning no-bottom-margin"
         *ngIf="shouldAddDatamapper">
         <span class="pficon pficon-warning-triangle-o"></span>
-        <p><strong>Data Type Mismatch:</strong> <a href="javascript: null" (click)="addDataMapper()">Add a data mapping step</a> before this connection to resolve the difference.</p>
+        <p><strong>Data Type Mismatch:</strong> <a [routerLink]="" (click)="addDataMapper()">Add a data mapping step</a> before this connection to resolve the difference.</p>
       </div>
 
     </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -308,6 +308,7 @@ export class FlowViewStepComponent implements OnChanges {
   }
 
   visitPreviousStepDescribeData() {
+    this.datamapperInfoPop.hide();
     const index = this.currentFlowService.getPreviousStepIndexWithDataShape(this.position);
     this.router.navigate(['describe-data', index, 'output'], {
       relativeTo: this.route
@@ -315,6 +316,7 @@ export class FlowViewStepComponent implements OnChanges {
   }
 
   addDataMapper() {
+    this.datamapperInfoPop.hide();
     const position = this.getPosition();
     this.currentFlowService.events.emit({
       kind: 'integration-insert-datamapper',


### PR DESCRIPTION
fixes #1781 

Also ensures the popovers for the data mapper alert go away when you click the link.