### PR TITLE
fix(templates): Increase livenessProbe initialDelay for Java apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,4 @@ node_modules
 target
 ui/bin
 ui/node
-build
 

--- a/app/deploy/generator/04-syndesis-rest.yml.mustache
+++ b/app/deploy/generator/04-syndesis-rest.yml.mustache
@@ -89,7 +89,9 @@
             httpGet:
               port: 8080
               path: /api/v1/version
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: "/health"

--- a/app/deploy/generator/04-syndesis-verifier.yml.mustache
+++ b/app/deploy/generator/04-syndesis-verifier.yml.mustache
@@ -68,7 +68,9 @@
               path: /health
               port: 8181
               scheme: HTTP
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           ports:
           - containerPort: 8080
             name: http

--- a/app/deploy/generator/06-syndesis-prometheus.yml.mustache
+++ b/app/deploy/generator/06-syndesis-prometheus.yml.mustache
@@ -160,7 +160,6 @@
           args:
             - '--config.file=/etc/prometheus/prometheus.yml'
             - '--storage.tsdb.retention=30d'
-{{^Probeless}}
           livenessProbe:
             httpGet:
               port: 9090

--- a/app/deploy/syndesis-dev.yml
+++ b/app/deploy/syndesis-dev.yml
@@ -733,7 +733,9 @@ objects:
             httpGet:
               port: 8080
               path: /api/v1/version
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: "/health"
@@ -892,7 +894,9 @@ objects:
               path: /health
               port: 8181
               scheme: HTTP
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           ports:
           - containerPort: 8080
             name: http
@@ -1149,6 +1153,26 @@ objects:
             - targets:
               - localhost:9090
 
+          metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: go_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: http_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: net_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: process_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: prometheus_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: tsdb_(.+)
+            action: drop
+
         - job_name: integration-pods
 
           kubernetes_sd_configs:
@@ -1180,6 +1204,22 @@ objects:
           - source_labels: [__meta_kubernetes_pod_name]
             action: replace
             target_label: kubernetes_pod_name
+
+          metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: jmx_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: jvm_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: process_(.+)
+            action: drop
+          - source_labels: [type, __name__]
+            separator: ':'
+            regex: context:(org_apache_camel_ExchangesTotal|org_apache_camel_ExchangesFailed|io_syndesis_camel_StartTimestamp|io_syndesis_camel_LastExchangeCompletedTimestamp|io_syndesis_camel_LastExchangeFailureTimestamp)
+            action: keep
+
 - apiVersion: v1
   kind: Service
   metadata:
@@ -1244,7 +1284,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
             - '--config.file=/etc/prometheus/prometheus.yml'
-            - '--storage.tsdb.retention=1h'
+            - '--storage.tsdb.retention=30d'
           livenessProbe:
             httpGet:
               port: 9090

--- a/app/deploy/syndesis.yml
+++ b/app/deploy/syndesis.yml
@@ -731,7 +731,9 @@ objects:
             httpGet:
               port: 8080
               path: /api/v1/version
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: "/health"
@@ -888,7 +890,9 @@ objects:
               path: /health
               port: 8181
               scheme: HTTP
-            initialDelaySeconds: 180
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
           ports:
           - containerPort: 8080
             name: http
@@ -1145,6 +1149,26 @@ objects:
             - targets:
               - localhost:9090
 
+          metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: go_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: http_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: net_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: process_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: prometheus_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: tsdb_(.+)
+            action: drop
+
         - job_name: integration-pods
 
           kubernetes_sd_configs:
@@ -1176,6 +1200,22 @@ objects:
           - source_labels: [__meta_kubernetes_pod_name]
             action: replace
             target_label: kubernetes_pod_name
+
+          metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: jmx_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: jvm_(.+)
+            action: drop
+          - source_labels: [__name__]
+            regex: process_(.+)
+            action: drop
+          - source_labels: [type, __name__]
+            separator: ':'
+            regex: context:(org_apache_camel_ExchangesTotal|org_apache_camel_ExchangesFailed|io_syndesis_camel_StartTimestamp|io_syndesis_camel_LastExchangeCompletedTimestamp|io_syndesis_camel_LastExchangeFailureTimestamp)
+            action: keep
+
 - apiVersion: v1
   kind: Service
   metadata:
@@ -1240,7 +1280,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
             - '--config.file=/etc/prometheus/prometheus.yml'
-            - '--storage.tsdb.retention=1h'
+            - '--storage.tsdb.retention=30d'
           livenessProbe:
             httpGet:
               port: 9090

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,2 +1,3 @@
 *.html
 master.xml
+build


### PR DESCRIPTION
This is necessary since i.e. syndesis-rest has been grown so that it infers with the liveness probe which would kill the pod when it doesnt startup in 200s