### PR TITLE
feat(forms): add basic support for relation property

### DIFF
--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -4,7 +4,7 @@
      [ngClass]="[elementContainerClass, gridContainerClass]">
 
   <label *ngIf="type !== 2 && model.label !== null"
-         [attr.for]="fieldHash"
+         [attr.for]="model.id"
          [class.required-pf]="model.required"
          [ngClass]="[elementLabelClass, gridLabelClass]">
     {{ model.label }}
@@ -30,7 +30,6 @@
 
         <input type="checkbox"
                [attr.tabindex]="model.tabIndex"
-               [attr.id]="fieldHash"
                [checked]="model.checked"
                [dynamicId]="bindId && model.id"
                [formControlName]="model.id"
@@ -98,7 +97,6 @@
       <!-- FORM GROUP -->
       <fieldset *ngSwitchCase="4"
                 [dynamicId]="bindId && model.id"
-                [attr.id]="fieldHash"
                 [formGroupName]="model.id"
                 [name]="model.name"
                 [ngClass]="elementControlClass">
@@ -128,7 +126,7 @@
           <ng-container *ngSwitchCase="'duration'">
             <syndesis-duration-control [group]="group"
                                        [model]="model"
-                                       [fieldId]="fieldHash"
+                                       [fieldId]="model.id"
                                        [bindId]="bindId"
                                        (dfBlur)="onBlur($event)"
                                        (dfChange)="onValueChange($event)"
@@ -150,7 +148,6 @@
                   [attr.multiple]="model.multiple"
                   [attr.step]="model.step"
                   [attr.tabindex]="model.tabIndex"
-                  [attr.id]="fieldHash"
                   [autofocus]="model.autoFocus"
                   [dynamicId]="bindId && model.id"
                   [formControlName]="model.id"
@@ -191,7 +188,6 @@
       <fieldset *ngSwitchCase="6"
                 role="radiogroup"
                 [attr.tabindex]="model.tabIndex"
-                [attr.id]="fieldHash"
                 [dynamicId]="bindId && model.id"
                 [name]="model.name"
                 [ngClass]="elementControlClass"
@@ -220,7 +216,6 @@
       <select *ngSwitchCase="7"
               class="form-control"
               [attr.tabindex]="model.tabIndex"
-              [attr.id]="fieldHash"
               [dynamicId]="bindId && model.id"
               [formControlName]="model.id"
               [name]="model.name"
@@ -242,7 +237,6 @@
       <textarea *ngSwitchCase="8"
                 class="form-control"
                 [attr.tabindex]="model.tabIndex"
-                [attr.id]="fieldHash"
                 [dynamicId]="bindId && model.id"
                 [cols]="model.cols"
                 [formControlName]="model.id"

--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.ts
@@ -69,7 +69,7 @@ export class SyndesisFormComponent extends DynamicFormControlComponent
   /* tslint:enable */
 
   @Input() asBootstrapFormGroup = true;
-  @Input() bindId = false;
+  @Input() bindId = true;
   @Input() hasErrorMessaging = false;
   @Input() context: DynamicFormArrayGroupModel | null = null;
   @Input() group: FormGroup;
@@ -84,7 +84,6 @@ export class SyndesisFormComponent extends DynamicFormControlComponent
   /* tslint:enable */
 
   type: SyndesisFormControlType | null;
-  fieldHash: string;
 
   constructor(
     protected detector: ChangeDetectorRef,
@@ -92,7 +91,6 @@ export class SyndesisFormComponent extends DynamicFormControlComponent
     protected validationService: DynamicFormValidationService
   ) {
     super(detector, layoutService, validationService);
-    this.fieldHash = Math.random().toString(36).substr(2, 16);
   }
 
   static getFormControlType(model: DynamicFormControlModel): SyndesisFormControlType {

--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -125,6 +125,7 @@ export class FormFactoryProviderService extends FormFactoryService {
       value: value || field.value || field.defaultValue,
       hint: field.description,
       required: field.required,
+      relation: field.relation
     }, {
         element: {
           label: 'control-label'
@@ -162,6 +163,7 @@ export class FormFactoryProviderService extends FormFactoryService {
         : undefined,
       required: type === 'hidden' ? undefined : field.required,
       autoComplete: field.secret ? 'off' : undefined,
+      relation: field.relation,
       validators: type === 'hidden' ? undefined : validators,
       errorMessages: errorMessages
     }, {
@@ -187,6 +189,7 @@ export class FormFactoryProviderService extends FormFactoryService {
       value: value || field.defaultValue || field.enum[0].value,
       hint: field.description,
       required: field.required,
+      relation: field.relation,
       validators: validators,
       errorMessages: errorMessages,
       options: field.enum
@@ -212,6 +215,7 @@ export class FormFactoryProviderService extends FormFactoryService {
       value: value || field.value || field.defaultValue,
       hint: field.description,
       required: field.required,
+      relation: field.relation,
       rows: field.rows,
       cols: field.cols,
       validators: validators,
@@ -237,6 +241,7 @@ export class FormFactoryProviderService extends FormFactoryService {
       id: key,
       label: field.displayName || key,
       hint: field.description,
+      relation: field.relation,
       value: (!!initialValue)
     }, {
         element: {

--- a/app/ui/src/app/platform/types/platform.models.ts
+++ b/app/ui/src/app/platform/types/platform.models.ts
@@ -1,3 +1,4 @@
+import { DynamicFormControlRelationGroup } from '@ng-dynamic-forms/core';
 /**
  * StringMap allows to model unboundered hash objects
  */
@@ -75,6 +76,7 @@ export interface ConfigurationProperty extends BaseEntity {
   required: boolean;
   secret: boolean;
   label: string;
+  relation: DynamicFormControlRelationGroup[];
   order: number;
   enum: Array<PropertyValue>;
   componentProperty: boolean;


### PR DESCRIPTION
#This PR adds support in the UI for the `relation` property from ng-dynamic-forms. The relation property allows one to supply structured logic in JSON format to control enabling/disabling form controls based on another form controls value.

This is part 1 of 2 toward making https://github.com/syndesisio/syndesis/issues/887 possible.

While ENABLE/DISABLE is currently supported all the way through the view layer, VISIBLE/HIDDEN are only supported at the model level, meaning you cannot (yet) supply VISIBLE/HIDDEN action values. For that, we will need to further augment `syndesis-form-control.component.html`. Partial support here is better than no support so I wanted to go ahead and get this in.

One expected regression is that the oauth forms in the settings section of the app will no longer flawlessly link labels to their form control counterparts. This was made possible previously by hacking in a fieldHash property to overcome an issue where the settings forms shared a ID which needs to be unique to achieve accessibility requirements. Because the relation property is hinged off of the ID in the form model, and not the ID that's used within the view template, that hack is no longer sufficient. I will create a new issue for that bug, as it can be resolved independent of this work.

Example usage:
https://github.com/udos86/ng-dynamic-forms#related-form-controls

remove fieldHash accessibility hack
bind IDs dynamically using ng-dynamic-forms built in props
add support for a new relation property in form factory provider service and platform model