### PR TITLE
Related to #1752: add extension-tag dependency type

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Dependency.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Dependency.java
@@ -25,7 +25,8 @@ public interface Dependency {
 
     enum Type {
         MAVEN,
-        EXTENSION
+        EXTENSION,
+        EXTENSION_TAG
     }
 
     /**
@@ -58,6 +59,11 @@ public interface Dependency {
     }
 
     @JsonIgnore
+    default boolean isExtensionTag() {
+        return isOfType(Type.EXTENSION_TAG);
+    }
+
+    @JsonIgnore
     static Dependency from(Type type, String id) {
         return new Builder().type(type).id(id).build();
     }
@@ -70,6 +76,11 @@ public interface Dependency {
     @JsonIgnore
     static Dependency extension(String id) {
         return from(Type.EXTENSION, id);
+    }
+
+    @JsonIgnore
+    static Dependency libraryTag(String id) {
+        return from(Type.EXTENSION_TAG, id);
     }
 
     // *****************

--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -7,6 +7,10 @@
     {
       "type": "MAVEN",
       "id": "@project.groupId@:@project.artifactId@:@project.version@"
+    },
+    {
+      "type": "EXTENSION_TAG",
+      "id": "jdbc-driver"
     }
   ],
   "configuredProperties": {},

--- a/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
+++ b/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
@@ -159,6 +159,11 @@ public abstract class ConnectorTestSupport extends CamelTestSupport {
         }
 
         @Override
+        public List<Extension> loadExtensionsByTag(String tag) {
+            return Collections.emptyList();
+        }
+
+        @Override
         public String decrypt(String encrypted) {
             return encrypted;
         }

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestResourceManager.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestResourceManager.java
@@ -18,9 +18,11 @@ package io.syndesis.integration.project.generator;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -53,6 +55,15 @@ final class TestResourceManager implements IntegrationResourceManager {
         return Optional.ofNullable(resources.get(id))
             .filter(Extension.class::isInstance)
             .map(Extension.class::cast);
+    }
+
+    @Override
+    public List<Extension> loadExtensionsByTag(String tag) {
+        return resources.values().stream()
+            .filter(Extension.class::isInstance)
+            .map(Extension.class::cast)
+            .filter(extension ->  extension.getTags().contains(tag))
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
+++ b/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -203,6 +204,11 @@ public class Application implements ApplicationRunner {
         @Override
         public Optional<Extension> loadExtension(String id) {
             return Optional.empty();
+        }
+
+        @Override
+        public List<Extension> loadExtensionsByTag(String tag) {
+            return Collections.emptyList();
         }
 
         @Override

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
@@ -35,7 +35,12 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.swagger.annotations.Api;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -188,7 +188,7 @@ public class IntegrationSupportHandler {
         for (String id : ids) {
             Integration integration = integrationHandler.get(id);
             addToExport(memJsonDB, integration);
-            resourceManager.collectDependencies(integration.getSteps()).stream()
+            resourceManager.collectDependencies(integration.getSteps(), true).stream()
                 .filter(Dependency::isExtension)
                 .map(Dependency::getId)
                 .forEach(extensions::add);

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/IntegrationConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/IntegrationConfiguration.java
@@ -17,8 +17,11 @@ package io.syndesis.server.runtime;
 
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import io.syndesis.common.model.ListResult;
 import io.syndesis.server.dao.file.FileDataManager;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.dao.manager.EncryptionComponent;
@@ -51,6 +54,18 @@ public class IntegrationConfiguration {
             @Override
             public Optional<Extension> loadExtension(String id) {
                 return Optional.ofNullable(extensionDataManager.getExtensionMetadata(id));
+            }
+
+            @Override
+            public List<Extension> loadExtensionsByTag(String tag) {
+                return dataManager.fetchAll(Extension.class,
+                    resultList -> new ListResult.Builder<Extension>()
+                        .items(resultList.getItems().stream()
+                            .filter(extension -> extension.getTags().contains(tag))
+                            .collect(Collectors.toList()))
+                        .totalCount(resultList.getTotalCount())
+                        .build()
+                ).getItems();
             }
 
             @Override


### PR DESCRIPTION
This adds support for EXTENSION_TAG dependencies. A connector that depends on a extension tag will automatically include all extension with that tag on the classpath.

This is needed to automatically import all jdbc drivers.