### PR TITLE
fix: CSS bugfix to force integration detail page span 100% vertically

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -27,7 +27,7 @@
         </div>
       </div>
     </div>
-    <div class="row">
+    <div class="integration-detail__body row">
       <div class="integration-detail__info">
         <h1 class="inline-block">
           <syndesis-editable-text [value]="integration.name" [validationFn]="validateName" (onSave)="attributeUpdated('name', $event, integration)"></syndesis-editable-text>

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.scss
@@ -1,6 +1,11 @@
 @import 'syndesis-sass';
 
 .integration-detail {
+  &__body {
+    display: flex;
+    flex: 2;
+    flex-direction: column;
+  }
   &__info {
     flex-grow: 0;
     padding: 0 0 $gutter $gutter;


### PR DESCRIPTION
This fix is a workaround for a regression detected on the integration detail view, where the body of the detail view does not resize vertically anymore to cover up the screen half