### PR TITLE
Nicer error handling when fetching dynamic metadata

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/DynamicActionMetadata.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/DynamicActionMetadata.java
@@ -26,6 +26,8 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = DynamicActionMetadata.Builder.class)
 public interface DynamicActionMetadata {
 
+    DynamicActionMetadata NOTHING = new DynamicActionMetadata.Builder().build();
+
     @Value.Immutable
     @JsonDeserialize(builder = ActionPropertySuggestion.Builder.class)
     interface ActionPropertySuggestion {

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/MetadataRetrieval.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/MetadataRetrieval.java
@@ -17,6 +17,8 @@ package io.syndesis.connector.support.verifier.api;
 
 import java.util.Map;
 
+import io.syndesis.common.util.SyndesisServerException;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
@@ -30,10 +32,13 @@ import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 public interface MetadataRetrieval {
 
     /**
-     * Converts Camel {@link MetaData} to
-     * {@link SyndesisMetadata}. Method will receive all properties that client
-     * specified and the retrieved {@link MetaData} from the
-     * appropriate Camel {@link MetaDataExtension}.
+     * Converts Camel {@link MetaData} to {@link SyndesisMetadata}. Method will
+     * receive all properties that client specified and the retrieved
+     * {@link MetaData} from the appropriate Camel {@link MetaDataExtension}.
      */
     SyndesisMetadata fetch(CamelContext context, String componentId, String actionId, Map<String, Object> properties);
+
+    default RuntimeException handle(final Exception e) {
+        return new SyndesisServerException("Unable to fetch and process metadata", e);
+    }
 }

--- a/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
@@ -25,6 +25,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import io.syndesis.common.util.SyndesisServerException;
+
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,8 +63,7 @@ public class VerifierExceptionMapper implements ExceptionMapper<Throwable> {
 
         LOG.error("Exception while handling request: {} {}", request.getMethod(), request.getRequestURI(), exception);
         if (LOG.isDebugEnabled()) {
-            final ContentCachingRequestWrapper requestCache = WebUtils.getNativeRequest(request,
-                ContentCachingRequestWrapper.class);
+            final ContentCachingRequestWrapper requestCache = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
 
             final Enumeration<String> headers = request.getHeaderNames();
             final StringJoiner headersJoined = new StringJoiner("\n");
@@ -79,14 +80,17 @@ public class VerifierExceptionMapper implements ExceptionMapper<Throwable> {
         return Response.serverError().entity(error).build();
     }
 
-    private String rootCauseMessage(final Throwable exception) {
+    private static String rootCauseMessage(final Throwable exception) {
+        if (exception instanceof SyndesisServerException) {
+            return exception.getMessage();
+        }
+
         Throwable rootCause = exception;
-        while (rootCause.getCause() != null) {
+        while (rootCause.getCause() != null && rootCause != rootCause.getCause()) {
             rootCause = rootCause.getCause();
         }
 
         return rootCause.getMessage();
-
     }
 
 }

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -298,6 +298,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <scope>test</scope>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -251,6 +251,12 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
+    </dependency>
+
+
     <!-- ===================================================================================== -->
 
     <!-- Atlasmap Data Mapper Services -->

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Meta.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Meta.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.dto;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import io.syndesis.server.endpoint.v1.dto.Meta.Data.Type;
+import io.syndesis.server.endpoint.v1.handler.exception.Errors;
+
+import org.immutables.value.Value;
+
+import static io.syndesis.server.endpoint.v1.dto.ImmutableData.builder;
+
+public final class Meta<T> extends Mixed {
+
+    private final Data data;
+
+    private final T value;
+
+    @Value.Immutable
+    public interface Data {
+
+        enum Type {
+            DANGER, INFO, SUCCESS, WARNING
+        }
+
+        Optional<String> getMessage();
+
+        Optional<Type> getType();
+    }
+
+    public Meta(final T value) {
+        this(value, builder().build());
+    }
+
+    private Meta(final T value, final Data data) {
+        super(value, Collections.singletonMap("_meta", data));
+
+        this.value = value;
+        this.data = data;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public static <V> Meta<V> verbatim(final V value) {
+        return new Meta<>(value);
+    }
+
+    public static <V> Meta<V> withError(final V value, final Throwable throwable) {
+        final String message = Errors.userMessageFrom(throwable);
+
+        return new Meta<>(value, builder().type(Type.DANGER).message(message).build());
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Mixed.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Mixed.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.dto;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import io.syndesis.server.endpoint.v1.dto.Mixed.MixedSerializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(using = MixedSerializer.class)
+abstract class Mixed {
+
+    private final List<Object> parts;
+
+    public static final class MixedSerializer extends JsonSerializer<Mixed> {
+
+        private static final class EnclosedJsonGenerator extends JsonGeneratorDelegate {
+
+            private int level;
+
+            public EnclosedJsonGenerator(final JsonGenerator d) {
+                super(d);
+            }
+
+            @Override
+            public void writeEndObject() throws IOException {
+                if (level > 1) {
+                    super.writeEndObject();
+                }
+                level--;
+            }
+
+            @Override
+            public void writeStartObject() throws IOException {
+                if (level != 0) {
+                    super.writeStartObject();
+                }
+                level++;
+            }
+
+            @Override
+            public void writeStartObject(final Object forValue) throws IOException {
+                if (level != 0) {
+                    super.writeStartObject();
+                }
+                level++;
+            }
+        }
+
+        @Override
+        public void serialize(final Mixed mixed, final JsonGenerator gen, final SerializerProvider serializers)
+            throws IOException, JsonProcessingException {
+            gen.writeStartObject();
+
+            for (final Object part : mixed.parts) {
+                serializers.defaultSerializeValue(part, new EnclosedJsonGenerator(gen));
+            }
+
+            gen.writeEndObject();
+        }
+
+    }
+
+    public Mixed(final Object... parts) {
+        this.parts = Arrays.asList(parts);
+    }
+
+    public List<Object> getParts() {
+        return parts;
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -27,10 +27,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
 import io.swagger.annotations.Api;
@@ -38,7 +34,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -47,32 +42,40 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.DynamicActionMetadata;
-import io.syndesis.common.model.connection.DynamicActionMetadata.ActionPropertySuggestion;
+import io.syndesis.server.dao.manager.EncryptionComponent;
+import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.verifier.VerificationConfigurationProperties;
+
+import com.netflix.hystrix.HystrixExecutable;
+import com.netflix.hystrix.HystrixInvokableInfo;
 
 @Api(value = "actions")
 public class ConnectionActionHandler {
     private final List<ConnectorAction> actions;
 
     private final VerificationConfigurationProperties config;
-    private final EncryptionComponent encryptionComponent;
 
     private final Connection connection;
 
-    private final Connector connector;
+    private final String connectorId;
 
-    public ConnectionActionHandler(final Connection connection, final VerificationConfigurationProperties config, EncryptionComponent encryptionComponent) {
+    private final EncryptionComponent encryptionComponent;
+
+    public ConnectionActionHandler(final Connection connection, final VerificationConfigurationProperties config,
+        final EncryptionComponent encryptionComponent) {
         this.connection = connection;
         this.config = config;
         this.encryptionComponent = encryptionComponent;
 
         final Optional<Connector> maybeConnector = connection.getConnector();
-        connector = maybeConnector.orElseThrow(() -> new EntityNotFoundException(
-            "Connection with id `" + connection.getId() + "` does not have a Connector defined"));
+        final Connector connector = maybeConnector.orElseThrow(
+            () -> new EntityNotFoundException("Connection with id `" + connection.getId() + "` does not have a Connector defined"));
 
-        actions = connector.getActions().stream()
-            .filter(ConnectorAction.class::isInstance)
-            .map(ConnectorAction.class::cast)
+        connectorId = connector.getId().get();
+
+        actions = connector.getActions().stream()//
+            .filter(ConnectorAction.class::isInstance)//
+            .map(ConnectorAction.class::cast)//
             .collect(Collectors.toList());
     }
 
@@ -80,83 +83,90 @@ public class ConnectionActionHandler {
     @Path(value = "/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation("Retrieves enriched action definition, that is an action definition that has input/output data shapes and property enums defined with respect to the given action properties")
-    @ApiResponses(@ApiResponse(code = 200, response = ConnectorDescriptor.class,
+    @ApiResponses(@ApiResponse(code = 200, reference = "#/definitions/ConnectorDescriptor",
         message = "A map of zero or more action property suggestions keyed by the property name"))
-    public ConnectorDescriptor enrichWithMetadata(
-        @PathParam("id") @ApiParam(required = true,
-            example = "io.syndesis:salesforce-create-or-update:latest") final String id,
+    public Meta<ConnectorDescriptor> enrichWithMetadata(
+        @PathParam("id") @ApiParam(required = true, example = "io.syndesis:salesforce-create-or-update:latest") final String id,
         final Map<String, String> properties) {
 
-        final ConnectorAction action = actions.stream()
-            .filter(a -> a.idEquals(id))
-            .findAny()
+        final ConnectorAction action = actions.stream()//
+            .filter(a -> a.idEquals(id))//
+            .findAny()//
             .orElseThrow(() -> new EntityNotFoundException("Action with id: " + id));
 
         final ConnectorDescriptor defaultDescriptor = action.getDescriptor();
 
         if (!action.getTags().contains("dynamic")) {
-            return defaultDescriptor;
+            return Meta.verbatim(defaultDescriptor);
         }
 
-        final String connectorId = connector.getId().get();
-
-        final Map<String, String> parameters = encryptionComponent.decrypt(new HashMap<>(Optional.ofNullable(properties).orElseGet(HashMap::new)));
+        final Map<String, String> parameters = encryptionComponent
+            .decrypt(new HashMap<>(Optional.ofNullable(properties).orElseGet(HashMap::new)));
         // put all action parameters with `null` values
         defaultDescriptor.getPropertyDefinitionSteps()
             .forEach(step -> step.getProperties().forEach((k, v) -> parameters.putIfAbsent(k, null)));
 
         // add the pattern as a property
-        if (action.getPattern()!=null) {
+        if (action.getPattern() != null) {
             parameters.put(action.getPattern().getDeclaringClass().getSimpleName(), action.getPattern().name());
         }
         // lastly put all connection properties
         parameters.putAll(encryptionComponent.decrypt(connection.getConfiguredProperties()));
 
-        final Client client = createClient();
-        final WebTarget target = client
-            .target(String.format("http://%s/api/v1/connectors/%s/actions/%s", config.getService(), connectorId, id));
+        final HystrixExecutable<DynamicActionMetadata> meta = createMetadataCommand(action, parameters);
+        final DynamicActionMetadata dynamicActionMetadata = meta.execute();
 
-        final ConnectorDescriptor.Builder enriched = new ConnectorDescriptor.Builder().createFrom(defaultDescriptor);
-        final DynamicActionMetadata dynamicActionMetadata = target.request(MediaType.APPLICATION_JSON)
-            .post(Entity.entity(parameters, MediaType.APPLICATION_JSON), DynamicActionMetadata.class);
+        final ConnectorDescriptor enrichedDescriptor = applyMetadataTo(defaultDescriptor, dynamicActionMetadata);
 
-        final Map<String, List<DynamicActionMetadata.ActionPropertySuggestion>> actionPropertySuggestions = dynamicActionMetadata
-            .properties();
+        final HystrixInvokableInfo<?> metaInfo = (HystrixInvokableInfo<?>) meta;
+        if (metaInfo.isFailedExecution()) {
+            final Throwable executionException = metaInfo.getFailedExecutionException();
+            return Meta.withError(enrichedDescriptor, executionException);
+        }
+
+        return Meta.verbatim(enrichedDescriptor);
+    }
+
+    protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
+        final Map<String, String> parameters) {
+        return new MetadataCommand(config.getService(), connectorId, action, parameters);
+    }
+
+    private static ConnectorDescriptor applyMetadataTo(final ConnectorDescriptor descriptor, final DynamicActionMetadata dynamicMetadata) {
+        final Map<String, List<DynamicActionMetadata.ActionPropertySuggestion>> actionPropertySuggestions = dynamicMetadata.properties();
+
+        final ConnectorDescriptor.Builder enriched = new ConnectorDescriptor.Builder().createFrom(descriptor);
         actionPropertySuggestions.forEach((k, vals) -> enriched.replaceConfigurationProperty(k,
             b -> b.addAllEnum(vals.stream().map(s -> ConfigurationProperty.PropertyValue.Builder.from(s))::iterator)));
 
-        //Setting the defaultValue as suggested by the metadata
-        for (Entry<String, List<ActionPropertySuggestion>> suggestions: actionPropertySuggestions.entrySet()) {
+        // Setting the defaultValue as suggested by the metadata
+        for (final Entry<String, List<DynamicActionMetadata.ActionPropertySuggestion>> suggestions : actionPropertySuggestions.entrySet()) {
             if (suggestions.getValue().size() == 1) {
-                for (DynamicActionMetadata.ActionPropertySuggestion suggestion : suggestions.getValue()) {
+                for (final DynamicActionMetadata.ActionPropertySuggestion suggestion : suggestions.getValue()) {
                     enriched.replaceConfigurationProperty(suggestion.displayValue(), v -> v.defaultValue(suggestion.value()));
                 }
             }
         }
 
-        final DataShape input = dynamicActionMetadata.inputShape();
-        if (shouldEnrichDataShape(defaultDescriptor.getInputDataShape(), input)) {
+        final DataShape input = dynamicMetadata.inputShape();
+        if (shouldEnrichDataShape(descriptor.getInputDataShape(), input)) {
             enriched.inputDataShape(input);
         }
 
-        final DataShape output = dynamicActionMetadata.outputShape();
-        if (shouldEnrichDataShape(defaultDescriptor.getOutputDataShape(), output)) {
+        final DataShape output = dynamicMetadata.outputShape();
+        if (shouldEnrichDataShape(descriptor.getOutputDataShape(), output)) {
             enriched.outputDataShape(output);
         }
 
         return enriched.build();
     }
 
-    protected Client createClient() {
-        return ClientBuilder.newClient();
+    private static boolean isMaleable(final DataShapeKinds kind) {
+        return kind != DataShapeKinds.JAVA;
     }
 
     private static boolean shouldEnrichDataShape(final Optional<DataShape> maybeExistingDataShape, final DataShape received) {
         return maybeExistingDataShape.isPresent() && isMaleable(maybeExistingDataShape.get().getKind()) && received != null
             && received.getKind() != null;
-    }
-
-    private static boolean isMaleable(DataShapeKinds kind) {
-        return kind != DataShapeKinds.JAVA;
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -44,7 +44,7 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.DynamicActionMetadata;
 import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.v1.dto.Meta;
-import io.syndesis.server.verifier.VerificationConfigurationProperties;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
 
 import com.netflix.hystrix.HystrixExecutable;
 import com.netflix.hystrix.HystrixInvokableInfo;
@@ -53,7 +53,7 @@ import com.netflix.hystrix.HystrixInvokableInfo;
 public class ConnectionActionHandler {
     private final List<ConnectorAction> actions;
 
-    private final VerificationConfigurationProperties config;
+    private final MetadataConfigurationProperties config;
 
     private final Connection connection;
 
@@ -61,7 +61,7 @@ public class ConnectionActionHandler {
 
     private final EncryptionComponent encryptionComponent;
 
-    public ConnectionActionHandler(final Connection connection, final VerificationConfigurationProperties config,
+    public ConnectionActionHandler(final Connection connection, final MetadataConfigurationProperties config,
         final EncryptionComponent encryptionComponent) {
         this.connection = connection;
         this.config = config;
@@ -129,7 +129,7 @@ public class ConnectionActionHandler {
 
     protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
         final Map<String, String> parameters) {
-        return new MetadataCommand(config.getService(), connectorId, action, parameters);
+        return new MetadataCommand(config, connectorId, action, parameters);
     }
 
     private static ConnectorDescriptor applyMetadataTo(final ConnectorDescriptor descriptor, final DynamicActionMetadata dynamicMetadata) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -183,7 +183,7 @@ public class ConnectionHandler extends BaseHandler implements Lister<Connection>
     }
 
     @Path("/{id}/actions")
-    public ConnectionActionHandler credentials(
+    public ConnectionActionHandler metadata(
         @NotNull final @PathParam("id") @ApiParam(required = true, example = "my-connection") String connectionId) {
         final Connection connection = get(connectionId);
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -65,7 +65,7 @@ import io.syndesis.server.endpoint.v1.operations.Lister;
 import io.syndesis.server.endpoint.v1.operations.Updater;
 import io.syndesis.server.endpoint.v1.operations.Validating;
 import io.syndesis.server.endpoint.v1.state.ClientSideState;
-import io.syndesis.server.verifier.VerificationConfigurationProperties;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
 
 @Path("/connections")
 @Api(value = "connections")
@@ -85,12 +85,12 @@ public class ConnectionHandler extends BaseHandler implements Lister<Connection>
 
     private final Validator validator;
 
-    private final VerificationConfigurationProperties config;
+    private final MetadataConfigurationProperties config;
     private final EncryptionComponent encryptionComponent;
     private final IntegrationHandler integrationHandler;
 
     public ConnectionHandler(final DataManager dataMgr, final Validator validator, final Credentials credentials,
-                             final ClientSideState state, final VerificationConfigurationProperties config, final EncryptionComponent encryptionComponent,
+                             final ClientSideState state, final MetadataConfigurationProperties config, final EncryptionComponent encryptionComponent,
                              IntegrationHandler integrationHandler) {
         super(dataMgr);
         this.validator = validator;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommand.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.connection;
+
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status.Family;
+
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.connection.DynamicActionMetadata;
+import io.syndesis.common.util.Json;
+import io.syndesis.server.endpoint.v1.SyndesisRestException;
+import io.syndesis.server.endpoint.v1.handler.exception.RestError;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+
+class MetadataCommand extends HystrixCommand<DynamicActionMetadata> {
+
+    private static final int THREAD_COUNT = 3;
+
+    private static final int TIMEOUT = 1500;
+
+    private final String metadataUrl;
+
+    private final Map<String, String> parameters;
+
+    MetadataCommand(final String service, final String connectorId, final ConnectorAction action, final Map<String, String> parameters) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Meta"))//
+            .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()//
+                .withCoreSize(THREAD_COUNT))//
+            .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()//
+                .withExecutionTimeoutInMilliseconds(TIMEOUT)));
+        this.parameters = parameters;
+
+        final String actionId = action.getId().get();
+
+        metadataUrl = String.format("http://%s/api/v1/connectors/%s/actions/%s", service, connectorId, actionId);
+    }
+
+    @Override
+    protected DynamicActionMetadata getFallback() {
+        return DynamicActionMetadata.NOTHING;
+    }
+
+    @Override
+    protected DynamicActionMetadata run() {
+        final Client client = createClient();
+        final WebTarget target = client.target(metadataUrl);
+
+        return target.request(MediaType.APPLICATION_JSON).post(Entity.entity(parameters, MediaType.APPLICATION_JSON),
+            DynamicActionMetadata.class);
+
+    }
+
+    private static Client createClient() {
+        return ClientBuilder.newClient().register((ClientResponseFilter) (requestContext, responseContext) -> {
+            if (responseContext.getStatusInfo().getFamily() == Family.SERVER_ERROR
+                && "application/json".equals(responseContext.getHeaderString(HttpHeaders.CONTENT_TYPE))) {
+                final RestError error = Json.reader().forType(RestError.class).readValue(responseContext.getEntityStream());
+
+                throw new SyndesisRestException(error.getDeveloperMsg(), error.getUserMsg(), error.getUserMsgDetail(),
+                    error.getErrorCode());
+            }
+        });
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommand.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommand.java
@@ -31,6 +31,7 @@ import io.syndesis.common.model.connection.DynamicActionMetadata;
 import io.syndesis.common.util.Json;
 import io.syndesis.server.endpoint.v1.SyndesisRestException;
 import io.syndesis.server.endpoint.v1.handler.exception.RestError;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
@@ -39,25 +40,22 @@ import com.netflix.hystrix.HystrixThreadPoolProperties;
 
 class MetadataCommand extends HystrixCommand<DynamicActionMetadata> {
 
-    private static final int THREAD_COUNT = 3;
-
-    private static final int TIMEOUT = 1500;
-
     private final String metadataUrl;
 
     private final Map<String, String> parameters;
 
-    MetadataCommand(final String service, final String connectorId, final ConnectorAction action, final Map<String, String> parameters) {
+    MetadataCommand(final MetadataConfigurationProperties configuration, final String connectorId, final ConnectorAction action,
+        final Map<String, String> parameters) {
         super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Meta"))//
             .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()//
-                .withCoreSize(THREAD_COUNT))//
+                .withCoreSize(configuration.getThreads()))//
             .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()//
-                .withExecutionTimeoutInMilliseconds(TIMEOUT)));
+                .withExecutionTimeoutInMilliseconds(configuration.getTimeout())));
         this.parameters = parameters;
 
         final String actionId = action.getId().get();
 
-        metadataUrl = String.format("http://%s/api/v1/connectors/%s/actions/%s", service, connectorId, actionId);
+        metadataUrl = String.format("http://%s/api/v1/connectors/%s/actions/%s", configuration.getService(), connectorId, actionId);
     }
 
     @Override

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/exception/Errors.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/exception/Errors.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.exception;
+
+import io.syndesis.server.endpoint.v1.SyndesisRestException;
+
+public final class Errors {
+
+    private Errors() {
+        // utility class
+    }
+
+    public static String userMessageFrom(final Throwable throwable) {
+        final SyndesisRestException restException = findException(throwable, SyndesisRestException.class);
+        if (restException != null) {
+            return restException.getUserMsg();
+        }
+
+        return throwable.getMessage();
+    }
+
+    private static <T extends Throwable> T findException(final Throwable top, final Class<T> type) {
+        Throwable current = top;
+        while (current != null && current.getCause() != current) {
+            if (type.isInstance(current)) {
+                return type.cast(current);
+            }
+
+            current = current.getCause();
+        }
+
+        return null;
+    }
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.dto;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.util.Json;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class MixedTest {
+
+    @Test
+    public void shouldSerializeAsEmptyMap() throws JSONException {
+        assertEquals("{}", serialize(create()), true);
+    }
+
+    @Test
+    public void shouldSerializeMultipleValue() throws JSONException {
+        final ConfigurationProperty.PropertyValue val1 = new ConfigurationProperty.PropertyValue.Builder().label("label").value("value")
+            .build();
+
+        final Map<String, String> val2 = Collections.singletonMap("key", "value");
+
+        assertEquals("{\"label\": \"label\", \"value\": \"value\", \"key\": \"value\"}", serialize(create(val1, val2)), true);
+    }
+
+    @Test
+    public void shouldSerializeSimpleValue() throws JSONException {
+        final ConfigurationProperty.PropertyValue val = new ConfigurationProperty.PropertyValue.Builder().label("label").value("value")
+            .build();
+
+        assertEquals("{\"label\": \"label\", \"value\": \"value\"}", serialize(create(val)), true);
+    }
+
+    private Mixed create(final Object... parts) {
+        return new Mixed(parts) {
+            // test object
+        };
+    }
+
+    private static String serialize(final Mixed value) {
+        try {
+            return Json.writer().writeValueAsString(value);
+        } catch (final JsonProcessingException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -19,30 +19,29 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 
-import io.syndesis.server.dao.manager.EncryptionComponent;
+import javax.ws.rs.client.Entity;
+
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.DynamicActionMetadata;
+import io.syndesis.server.dao.manager.EncryptionComponent;
+import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.verifier.VerificationConfigurationProperties;
-import org.junit.Before;
+
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import com.netflix.hystrix.HystrixExecutable;
+import com.netflix.hystrix.HystrixInvokableInfo;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class ConnectionActionHandlerTest {
 
@@ -50,13 +49,13 @@ public class ConnectionActionHandlerTest {
 
     private static final String SALESFORCE_LIMITS = "io.syndesis:limits:latest";
 
-    private final Client client = mock(Client.class);
-
     private final ConnectorDescriptor createOrUpdateSalesforceObjectDescriptor;
 
     private final ConnectionActionHandler handler;
 
-    private Builder invocationBuilder;
+    @SuppressWarnings("unchecked")
+    private final HystrixExecutable<DynamicActionMetadata> metadataCommand = mock(HystrixExecutable.class,
+        withSettings().extraInterfaces(HystrixInvokableInfo.class));
 
     public ConnectionActionHandlerTest() {
         createOrUpdateSalesforceObjectDescriptor = new ConnectorDescriptor.Builder()
@@ -88,54 +87,34 @@ public class ConnectionActionHandlerTest {
             .build();
 
         final Connector connector = new Connector.Builder().id("salesforce")
-            .addAction(new ConnectorAction.Builder()
-                .id(SALESFORCE_CREATE_OR_UPDATE)
-                .addTag("dynamic")
-                .descriptor(createOrUpdateSalesforceObjectDescriptor)
-                .build())
-            .addAction(new ConnectorAction.Builder()
-                .id(SALESFORCE_LIMITS)
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
+            .addAction(new ConnectorAction.Builder().id(SALESFORCE_CREATE_OR_UPDATE).addTag("dynamic")
+                .descriptor(createOrUpdateSalesforceObjectDescriptor).build())
+            .addAction(new ConnectorAction.Builder().id(SALESFORCE_LIMITS).descriptor(new ConnectorDescriptor.Builder().build()).build())
             .build();
 
-        final Connection connection = new Connection.Builder().connector(connector)
-            .putConfiguredProperty("clientId", "some-clientId").build();
+        final Connection connection = new Connection.Builder().connector(connector).putConfiguredProperty("clientId", "some-clientId")
+            .build();
 
         handler = new ConnectionActionHandler(connection, new VerificationConfigurationProperties(), new EncryptionComponent(null)) {
             @Override
-            protected Client createClient() {
-                return client;
+            protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
+                final Map<String, String> parameters) {
+                return metadataCommand;
             }
         };
     }
 
-    @Before
-    public void setupMocks() {
-        final WebTarget target = mock(WebTarget.class);
-        when(client.target(anyString())).thenReturn(target);
-
-        invocationBuilder = mock(Builder.class);
-        when(target.request(MediaType.APPLICATION_JSON)).thenReturn(invocationBuilder);
-    }
-
     @Test
     public void shouldElicitActionPropertySuggestions() {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        final Class<Entity<Map<String, Object>>> entityType = (Class) Entity.class;
-        final ArgumentCaptor<Entity<Map<String, Object>>> entity = ArgumentCaptor.forClass(entityType);
-
         final DynamicActionMetadata suggestions = new DynamicActionMetadata.Builder()
             .putProperty("sObjectName",
-                Collections
-                    .singletonList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Contact", "Contact")))
+                Collections.singletonList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Contact", "Contact")))
             .putProperty("sObjectIdName",
                 Arrays.asList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("ID", "Contact ID"),
                     DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Email", "Email"),
-                    DynamicActionMetadata.ActionPropertySuggestion.Builder.of("TwitterScreenName__c",
-                        "Twitter Screen Name")))
+                    DynamicActionMetadata.ActionPropertySuggestion.Builder.of("TwitterScreenName__c", "Twitter Screen Name")))
             .build();
-        when(invocationBuilder.post(entity.capture(), eq(DynamicActionMetadata.class))).thenReturn(suggestions);
+        when(metadataCommand.execute()).thenReturn(suggestions);
 
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
@@ -143,42 +122,40 @@ public class ConnectionActionHandlerTest {
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")))
             .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("ID", "Contact ID")))
+            .replaceConfigurationProperty("sObjectIdName", c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Email", "Email")))
             .replaceConfigurationProperty("sObjectIdName",
-                c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Email", "Email")))
-            .replaceConfigurationProperty("sObjectIdName",
-                c -> c.addEnum(
-                    ConfigurationProperty.PropertyValue.Builder.of("TwitterScreenName__c", "Twitter Screen Name")))
+                c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("TwitterScreenName__c", "Twitter Screen Name")))
             .build();
 
         final Map<String, String> parameters = new HashMap<>();
         parameters.put("sObjectName", "Contact");
 
-        assertThat(handler.enrichWithMetadata(SALESFORCE_CREATE_OR_UPDATE, parameters)).isEqualTo(enrichedDefinitioin);
+        final Meta<ConnectorDescriptor> meta = handler.enrichWithMetadata(SALESFORCE_CREATE_OR_UPDATE, parameters);
 
-        assertThat(entity.getValue().getEntity()).contains(entry("clientId", "some-clientId"),
-            entry("sObjectIdName", null), entry("sObjectName", "Contact"));
+        assertThat(meta.getValue()).isEqualTo(enrichedDefinitioin);
     }
 
     @Test
     public void shouldNotContactVerifierForNonDynamicActions() {
         final ConnectorDescriptor defaultDefinition = new ConnectorDescriptor.Builder().build();
-        assertThat(handler.enrichWithMetadata(SALESFORCE_LIMITS, null)).isEqualTo(defaultDefinition);
+        final Meta<ConnectorDescriptor> returnValue = handler.enrichWithMetadata(SALESFORCE_LIMITS, null);
+
+        assertThat(returnValue.getValue()).isEqualTo(defaultDefinition);
     }
 
     @Test
     public void shouldProvideActionDefinition() {
         @SuppressWarnings({"unchecked", "rawtypes"})
         final Class<Entity<Map<String, Object>>> entityType = (Class) Entity.class;
-        final ArgumentCaptor<Entity<Map<String, Object>>> entity = ArgumentCaptor.forClass(entityType);
+        ArgumentCaptor.forClass(entityType);
 
-        final DynamicActionMetadata suggestions = new DynamicActionMetadata.Builder().putProperty("sObjectName",
-            Arrays.asList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Account", "Account"),
+        final DynamicActionMetadata suggestions = new DynamicActionMetadata.Builder()
+            .putProperty("sObjectName", Arrays.asList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Account", "Account"),
                 DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Contact", "Contact")))
             .build();
-        when(invocationBuilder.post(entity.capture(), eq(DynamicActionMetadata.class))).thenReturn(suggestions);
+        when(metadataCommand.execute()).thenReturn(suggestions);
 
-        final ConnectorDescriptor definition = handler.enrichWithMetadata(SALESFORCE_CREATE_OR_UPDATE,
-            Collections.emptyMap());
+        final Meta<ConnectorDescriptor> meta = handler.enrichWithMetadata(SALESFORCE_CREATE_OR_UPDATE, Collections.emptyMap());
 
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
@@ -187,6 +164,6 @@ public class ConnectionActionHandlerTest {
                     ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")))
             .build();
 
-        assertThat(definition).isEqualTo(enrichedDefinitioin);
+        assertThat(meta.getValue()).isEqualTo(enrichedDefinitioin);
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -30,7 +30,7 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.DynamicActionMetadata;
 import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.v1.dto.Meta;
-import io.syndesis.server.verifier.VerificationConfigurationProperties;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -95,7 +95,7 @@ public class ConnectionActionHandlerTest {
         final Connection connection = new Connection.Builder().connector(connector).putConfiguredProperty("clientId", "some-clientId")
             .build();
 
-        handler = new ConnectionActionHandler(connection, new VerificationConfigurationProperties(), new EncryptionComponent(null)) {
+        handler = new ConnectionActionHandler(connection, new MetadataConfigurationProperties(), new EncryptionComponent(null)) {
             @Override
             protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
                 final Map<String, String> parameters) {

--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -84,7 +84,7 @@ openshift:
 github:
   enabled: true
 
-verifier:
+meta:
   kind: service
   service: syndesis-meta
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
@@ -130,7 +130,7 @@ public abstract class BaseITCase {
         public void initialize(final ConfigurableApplicationContext applicationContext) {
             final ConfigurableEnvironment environment = applicationContext.getEnvironment();
             environment.getPropertySources().addFirst(new MapPropertySource("test-source",
-                    Collections.singletonMap("verifier.service", "localhost:" + wireMock.port())));
+                    Collections.singletonMap("meta.service", "localhost:" + wireMock.port())));
         }
     }
 

--- a/app/server/runtime/src/test/resources/application-test.yml
+++ b/app/server/runtime/src/test/resources/application-test.yml
@@ -48,7 +48,7 @@ management:
 openshift:
   enabled: false
 
-verifier:
+meta:
   kind: always-ok
 
 client:

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/AlwaysOkVerifier.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/AlwaysOkVerifier.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
  */
 
 @Component
-@ConditionalOnProperty(value = "verifier.kind", havingValue = "always-ok")
+@ConditionalOnProperty(value = "meta.kind", havingValue = "always-ok")
 public class AlwaysOkVerifier implements Verifier {
 
     // All good ....

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
@@ -39,14 +39,14 @@ import org.springframework.stereotype.Component;
  * Implementation of a verifier which uses an external service
  */
 @Component
-@ConditionalOnProperty(value = "verifier.kind", havingValue = "service", matchIfMissing = true)
+@ConditionalOnProperty(value = "meta.kind", havingValue = "service", matchIfMissing = true)
 public class ExternalVerifierService implements Verifier {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModules(new Jdk8Module());
 
-    private final VerificationConfigurationProperties config;
+    private final MetadataConfigurationProperties config;
 
-    public ExternalVerifierService(VerificationConfigurationProperties config) {
+    public ExternalVerifierService(MetadataConfigurationProperties config) {
         this.config = config;
     }
 

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/MetadataConfigurationProperties.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/MetadataConfigurationProperties.java
@@ -17,16 +17,40 @@ package io.syndesis.server.verifier;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("verifier")
-public class VerificationConfigurationProperties {
+@ConfigurationProperties("meta")
+public class MetadataConfigurationProperties {
 
-    private String service = "ipass-verifier";
+    private static final int DEFAULT_THREAD_COUNT = 3;
+
+    private static final int DEFAULT_TIMEOUT = 1500;
+
+    private String service = "syndesis-meta";
+
+    private int threads = DEFAULT_THREAD_COUNT;
+
+    private int timeout = DEFAULT_TIMEOUT;
 
     public String getService() {
         return service;
     }
 
-    public void setService(String service) {
+    public int getThreads() {
+        return threads;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public void setService(final String service) {
         this.service = service;
+    }
+
+    public void setThreads(final int threads) {
+        this.threads = threads;
+    }
+
+    public void setTimeout(final int timeout) {
+        this.timeout = timeout;
     }
 }

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/VerifierConfiguration.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/VerifierConfiguration.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ComponentScan
-@EnableConfigurationProperties(VerificationConfigurationProperties.class)
+@EnableConfigurationProperties(MetadataConfigurationProperties.class)
 public class VerifierConfiguration {
 
 }

--- a/app/ui/src/app/api/api.module.ts
+++ b/app/ui/src/app/api/api.module.ts
@@ -1,6 +1,6 @@
 import { ModuleWithProviders, NgModule, Optional } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { ApiHttpService, ApiConfigService, Endpoints, API_ENDPOINTS } from '@syndesis/ui/platform';
 import * as SYNDESIS_PROVIDERS from './providers';
@@ -13,7 +13,7 @@ export function endpointsLazyLoaderFactory(apiEndpoints: Endpoints, apiConfigSer
   imports: [CommonModule, HttpClientModule],
 })
 export class ApiModule {
-  constructor(@Optional() private apiEndpointsLazyLoaderService: SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService) {}
+  constructor(@Optional() private apiEndpointsLazyLoaderService: SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService) { }
 
   static forRoot(apiEndpoints?: Endpoints): Array<ModuleWithProviders> {
     return [{
@@ -33,6 +33,11 @@ export class ApiModule {
         provide: ApiHttpService,
         useClass: SYNDESIS_PROVIDERS.ApiHttpProviderService
       },
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: SYNDESIS_PROVIDERS.ApiHttpInterceptor,
+        multi: true
+      }
       ]
     },
     ];

--- a/app/ui/src/app/api/providers/api-http-interceptor.service.ts
+++ b/app/ui/src/app/api/providers/api-http-interceptor.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpResponse, HttpEventType } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { NotificationService } from '@syndesis/ui/common';
+import { NotificationType } from 'patternfly-ng';
+
+@Injectable()
+export class ApiHttpInterceptor implements HttpInterceptor {
+    constructor(private notificationService: NotificationService) { }
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        return next.handle(req).map((event: HttpEvent<any>) => {
+            if (event.type === HttpEventType.Response) {
+                if (event.body && event.body['_meta'] && event.body['_meta']['message']) {
+                    const meta = event.body['_meta'];
+                    this.notificationService.popNotification({
+                        type: meta['type'] ? NotificationType[meta['type']] as string : NotificationType.INFO,
+                        header: '',
+                        message: meta['message']
+                    });
+                }
+            }
+            return event;
+        });
+    }
+}

--- a/app/ui/src/app/api/providers/index.ts
+++ b/app/ui/src/app/api/providers/index.ts
@@ -1,3 +1,4 @@
 export * from './api-config-provider.service';
 export * from './api-endpoints-lazy-loader.service';
 export * from './api-http-provider.service';
+export * from './api-http-interceptor.service';

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -282,7 +282,7 @@
     <priority>3</priority>
   </rule>
   <rule ref="rulesets/java/junit.xml/UseAssertTrueInsteadOfAssertEquals">
-    <priority>3</priority>
+    <priority>5</priority>
   </rule>
   <rule ref="rulesets/java/strictexception.xml/AvoidLosingExceptionInformation">
     <priority>3</priority>


### PR DESCRIPTION
There is much more details in the commit messages.

In nutshell this adds hystrix when invoking the `syndesis-meta` for dynamic metadata. This way we can guarantee if an error or no response within 1.5s is  received from `syndesis-meta` that it can be properly handled.

The handling part uses a new mixin for the API responses, by which we can add `_meta` property to any API response. This `_meta` property consists (currently) of only two properties (type & message).

Adds an interceptor for HTTP responses in the UI, that checks if the `_meta` property is present in the response and displays a toast notification with the provided content.

Fixes #1659