### PR TITLE
feat: integration activity list sorted by date

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
@@ -18,7 +18,7 @@
           {{ activity.at | date: 'M/d/yy' }}
         </div>
         <div class="list-pf-description text-overflow-pf">
-          {{ activity.at | date: 'shortTime' }}
+          {{ activity.at | date: 'mediumTime' }}
         </div>
         <div class="list-pf-description text-overflow-pf">
           Version {{ activity.ver || 'unknown' }}
@@ -42,7 +42,7 @@
   </ng-template>
 </pfng-list>
 
-<pfng-pagination class="integration-activity__pagination" [config]="paginationConfig"
+<pfng-pagination *ngIf="showPagination" class="integration-activity__pagination" [config]="paginationConfig"
   (onPageNumberChange)="renderActivitiesByPage()"
   (onPageSizeChange)="renderActivitiesByPage()">
 </pfng-pagination>

--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
@@ -15,6 +15,7 @@ export class IntegrationActivityComponent implements OnInit {
   activities: Activity[] = [];
   onRefresh: boolean;
   onError: boolean;
+  showPagination: boolean;
   lastRefresh = new Date();
   paginationConfig: PaginationConfig = {
     pageSize: 15,
@@ -48,7 +49,10 @@ export class IntegrationActivityComponent implements OnInit {
   private updateActivities(activities: Activity[]): void {
     this.onRefresh = false;
     this.lastRefresh = new Date();
-    this.allActivities = activities;
+    this.showPagination = (activities.length > this.paginationConfig.pageSize);
+    this.allActivities = activities.sort((activity1, activity2) => {
+      return activity1.at < activity1.at ? -1 : activity1.at > activity1.at ? 1 : 0;
+    })
 
     this.paginationConfig.totalItems = activities.length;
     this.paginationConfig.pageNumber = 1;

--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
@@ -52,7 +52,7 @@ export class IntegrationActivityComponent implements OnInit {
     this.showPagination = (activities.length > this.paginationConfig.pageSize);
     this.allActivities = activities.sort((activity1, activity2) => {
       return activity1.at < activity1.at ? -1 : activity1.at > activity1.at ? 1 : 0;
-    })
+    });
 
     this.paginationConfig.totalItems = activities.length;
     this.paginationConfig.pageNumber = 1;


### PR DESCRIPTION
Fixes #1818 

On a side note, this PR also entails two additional enhancements, derived from side discussions held at #1597:

- Activity records now show a time data detailed to the second
- Pagination nav will only be displayed and enabled when the activity recordset exceeds the minimum page size, remaining hidden otherwise.