### PR TITLE
refactor(keygenerator): Changed to make it possible to use ids as label values

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/KeyGenerator.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/KeyGenerator.java
@@ -61,11 +61,7 @@ public final class KeyGenerator {
 
         buffer.putLong(getRandomPart(now));
 
-        try {
-            return Base64.encodeBytes(buffer.array(), 2, 15, Base64.ORDERED);
-        } catch (final IOException e) {
-            throw new SyndesisServerException(e);
-        }
+        return encodeKey(buffer.array());
     }
 
     static long getRandomPart(final long timeStamp) {
@@ -85,7 +81,7 @@ public final class KeyGenerator {
      * generated key.
      */
     public static long getKeyTimeMillis(String key) throws IOException {
-        byte[] decoded = Base64.decode(key, Base64.ORDERED);
+        byte[] decoded = Base64.decode(stripPreAndSuffix(key), Base64.ORDERED);
         if (decoded.length != 15) {
             throw new IOException("Invalid key: size is incorrect.");
         }
@@ -107,11 +103,23 @@ public final class KeyGenerator {
         buffer.put((byte) random1);
         buffer.putLong(random2);
 
+        return encodeKey(buffer.array());
+    }
+
+    private static String encodeKey(byte[] data) throws SyndesisServerException {
         try {
-            return Base64.encodeBytes(buffer.array(), 2, 15, Base64.ORDERED);
+            return "i" + Base64.encodeBytes(data, 2, 15, Base64.ORDERED) + "z";
         } catch (final IOException e) {
             throw new SyndesisServerException(e);
         }
     }
 
+
+    private static String stripPreAndSuffix(String key) {
+        if (key.length() >= 3) {
+            return key.substring(1, key.length() - 1);
+        } else {
+            throw new IllegalArgumentException(String.format("Can not parse key %s as identified, prefix and/or suffix is missing", key));
+        }
+    }
 }


### PR DESCRIPTION
This change, which preservers all characteristics of the keys, makes is possible to use ids directly as k8s label values.

Fixes #1868