### PR TITLE
ProjectGenerator, fix support for external Maven repos

### DIFF
--- a/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
+++ b/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import java.util.function.Consumer;
 
 import io.syndesis.common.util.Json;
+import io.syndesis.common.util.MavenProperties;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.integration.project.generator.ProjectGenerator;
 import io.syndesis.integration.project.generator.ProjectGeneratorConfiguration;
@@ -81,7 +82,7 @@ public abstract class ConnectorTestSupport extends CamelTestSupport {
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         try {
             ProjectGeneratorConfiguration configuration = new ProjectGeneratorConfiguration();
-            ProjectGenerator projectGenerator = new ProjectGenerator(configuration, new ResourceManager());
+            ProjectGenerator projectGenerator = new ProjectGenerator(configuration, new ResourceManager(), new MavenProperties());
 
             return projectGenerator.generateApplicationProperties(newIntegration());
         } catch (IOException e) {

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -41,6 +41,7 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import io.syndesis.common.util.CollectionsUtils;
 import io.syndesis.common.util.Json;
+import io.syndesis.common.util.MavenProperties;
 import io.syndesis.common.util.Names;
 import io.syndesis.common.util.Optionals;
 import io.syndesis.common.util.Predicates;
@@ -79,10 +80,12 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
     private final Mustache applicationJavaMustache;
     private final Mustache applicationPropertiesMustache;
     private final Mustache pomMustache;
+    private final MavenProperties mavenProperties;
 
-    public ProjectGenerator(ProjectGeneratorConfiguration configuration, IntegrationResourceManager resourceManager) throws IOException {
+    public ProjectGenerator(ProjectGeneratorConfiguration configuration, IntegrationResourceManager resourceManager, MavenProperties mavenProperties) throws IOException {
         this.configuration = configuration;
         this.resourceManager = resourceManager;
+        this.mavenProperties = mavenProperties;
 
         MustacheFactory mf = new DefaultMustacheFactory();
 
@@ -209,7 +212,7 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
                 integration.getName(),
                 integration.getDescription().orElse(null),
                 dependencies,
-                configuration.getMavenProperties()),
+                    mavenProperties),
             pomMustache
         );
     }

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorAutoConfiguration.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorAutoConfiguration.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.project.generator;
 
 import java.io.IOException;
 
+import io.syndesis.common.util.MavenProperties;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,9 +32,11 @@ public class ProjectGeneratorAutoConfiguration {
     private ProjectGeneratorConfiguration properties;
     @Autowired
     private IntegrationResourceManager resourceManager;
+    @Autowired
+    private MavenProperties mavenProperties;
 
     @Bean
     public IntegrationProjectGenerator integrationProjectGenerator() throws IOException {
-        return new ProjectGenerator(properties, resourceManager);
+        return new ProjectGenerator(properties, resourceManager, mavenProperties);
     }
 }

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
@@ -15,11 +15,10 @@
  */
 package io.syndesis.integration.project.generator;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import io.syndesis.common.util.MavenProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("generator")
 public class ProjectGeneratorConfiguration {
@@ -31,7 +30,6 @@ public class ProjectGeneratorConfiguration {
      * Templates configuration.
      */
     private final Templates templates = new Templates();
-    private final MavenProperties mavenProperties = new MavenProperties();
 
     public Boolean isSecretMaskingEnabled() {
         return secretMaskingEnabled;
@@ -55,10 +53,6 @@ public class ProjectGeneratorConfiguration {
 
     public Templates getTemplates() {
         return templates;
-    }
-
-    public MavenProperties getMavenProperties() {
-        return mavenProperties;
     }
 
     public static class Templates {

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Properties;
 
 import io.syndesis.common.util.KeyGenerator;
+import io.syndesis.common.util.MavenProperties;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.common.model.Dependency;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -185,9 +186,6 @@ public class ProjectGeneratorTest {
         );
 
         ProjectGeneratorConfiguration configuration = new ProjectGeneratorConfiguration();
-        configuration.getMavenProperties().addRepository("maven.central", "https://repo1.maven.org/maven2");
-        configuration.getMavenProperties().addRepository("redhat.ga", "https://maven.repository.redhat.com/ga");
-        configuration.getMavenProperties().addRepository("jboss.ea", "https://repository.jboss.org/nexus/content/groups/ea");
         configuration.getTemplates().setOverridePath(this.basePath);
         configuration.getTemplates().getAdditionalResources().addAll(this.additionalResources);
         configuration.setSecretMaskingEnabled(true);
@@ -207,6 +205,7 @@ public class ProjectGeneratorTest {
         assertThat(runtimeDir.resolve("extensions/my-extension-3.jar")).exists();
         assertThat(runtimeDir.resolve("src/main/resources/mapping-step-2.json")).exists();
     }
+
 
     @Test
     public void testGenerateApplicationProperties() throws IOException {
@@ -302,7 +301,7 @@ public class ProjectGeneratorTest {
 
         TestResourceManager resourceManager = new TestResourceManager();
         ProjectGeneratorConfiguration configuration = new ProjectGeneratorConfiguration();
-        ProjectGenerator generator = new ProjectGenerator(configuration, resourceManager);
+        ProjectGenerator generator = new ProjectGenerator(configuration, resourceManager, getMavenProperties());
         Integration integration = resourceManager.newIntegration(s1, s2);
         Properties properties = generator.generateApplicationProperties(integration);
 
@@ -319,7 +318,7 @@ public class ProjectGeneratorTest {
     // *****************************
 
     private Path generate(Integration integration, ProjectGeneratorConfiguration generatorConfiguration, TestResourceManager resourceManager) throws IOException {
-        final IntegrationProjectGenerator generator = new ProjectGenerator(generatorConfiguration, resourceManager);
+        final IntegrationProjectGenerator generator = new ProjectGenerator(generatorConfiguration, resourceManager, getMavenProperties());
 
         try (InputStream is = generator.generate(integration)) {
             Path ret = testFolder.newFolder("integration-project").toPath();
@@ -373,5 +372,13 @@ public class ProjectGeneratorTest {
         final String expected = new String(Files.readAllBytes(Paths.get(resource.toURI())), StandardCharsets.UTF_8).trim();
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    protected MavenProperties getMavenProperties() {
+        MavenProperties mavenProperties = new MavenProperties();
+        mavenProperties.addRepository("maven.central", "https://repo1.maven.org/maven2");
+        mavenProperties.addRepository("redhat.ga", "https://maven.repository.redhat.com/ga");
+        mavenProperties.addRepository("jboss.ea", "https://repository.jboss.org/nexus/content/groups/ea");
+        return mavenProperties;
     }
 }

--- a/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
+++ b/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.MavenProperties;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -61,6 +63,7 @@ import io.syndesis.common.model.extension.Extension;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 
+@EnableConfigurationProperties(MavenProperties.class)
 @SpringBootApplication(
     exclude = {
         DaoConfiguration.class,
@@ -71,6 +74,8 @@ import io.syndesis.common.model.integration.Step;
 public class Application implements ApplicationRunner {
     @Autowired
     private ResourceLoader resourceLoader;
+    @Autowired
+    private MavenProperties mavenProperties;
 
     @Value("${to:image}")
     private String to;
@@ -178,9 +183,9 @@ public class Application implements ApplicationRunner {
     }
 
     @SuppressWarnings("PMD.UseProperClassLoader")
-    private static void generate(Integration integration, File targetDir) throws IOException {
+    private void generate(Integration integration, File targetDir) throws IOException {
         ProjectGeneratorConfiguration configuration = new ProjectGeneratorConfiguration();
-        IntegrationProjectGenerator generator = new ProjectGenerator(configuration, new EmptyIntegrationResourceManager());
+        IntegrationProjectGenerator generator = new ProjectGenerator(configuration, new EmptyIntegrationResourceManager(), mavenProperties);
 
         Path dir =targetDir.toPath();
         Files.createDirectories(dir);

--- a/project/DevelopersGuide.md
+++ b/project/DevelopersGuide.md
@@ -249,3 +249,19 @@ controllers:
     maxIntegrationsPerUser: 4
     maxDeploymentsPerUser: 4
 ```
+
+## Add a Maven repo to S2I builds`
+```bash
+# provide your own maven repo endpoint, the following is just an example
+# cd ~/.m2/repository
+# python -m SimpleHTTPServer 8888 0.0.0.0
+
+# if you are using the above approach, pick up an ip for your host that will be reachable by the OpenShift containers
+MAVEN_REPO_ADDRESS="http://192.168.1.74:8888"
+# inject your repo
+oc replace -f <(oc get configmap syndesis-server-config -o yaml | sed "s#dao#maven:\\n  repositories:\\n    01_local: $MAVEN_REPO_ADDRESS\\ndao#" )
+# reprovision syndesis-server
+oc rollout latest syndesis-server
+
+# check logs at integration build time
+```


### PR DESCRIPTION
Support for external Maven repos was broken, since a new instance of `MavenProperties` object was used, instead of asking DI container to provide the one bound to the external properties.

This PR fixes it.

Manually tested locally.

See also detailed manual step to apply the configuration in the modified `DeveloperGuide.md`