### PR TITLE
fix(meta): increased timeout to 15 seconds and added warning

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -118,13 +118,10 @@ public class ConnectionActionHandler {
 
         final ConnectorDescriptor enrichedDescriptor = applyMetadataTo(defaultDescriptor, dynamicActionMetadata);
 
-        final HystrixInvokableInfo<?> metaInfo = (HystrixInvokableInfo<?>) meta;
-        if (metaInfo.isFailedExecution()) {
-            final Throwable executionException = metaInfo.getFailedExecutionException();
-            return Meta.withError(enrichedDescriptor, executionException);
-        }
+        @SuppressWarnings("unchecked")
+        final HystrixInvokableInfo<ConnectorDescriptor> metaInfo = (HystrixInvokableInfo<ConnectorDescriptor>) meta;
 
-        return Meta.verbatim(enrichedDescriptor);
+        return Meta.from(enrichedDescriptor, metaInfo);
     }
 
     protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/MetadataConfigurationProperties.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/MetadataConfigurationProperties.java
@@ -22,7 +22,7 @@ public class MetadataConfigurationProperties {
 
     private static final int DEFAULT_THREAD_COUNT = 3;
 
-    private static final int DEFAULT_TIMEOUT = 1500;
+    private static final int DEFAULT_TIMEOUT = 15000;
 
     private String service = "syndesis-meta";
 


### PR DESCRIPTION
This increases the timeout to fetch metadata to 15 seconds (from 1.5 seconds) and adds a warning in case of timeouts.

Fixes #1886, #1867, #1842, #1865