### PR TITLE
fix: don't overwrite data shapes if the new ones don't have a specification

### DIFF
--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -118,24 +118,12 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
             this.integrationSupport
               .fetchMetadata(this.step.connection, this.step.action, data)
               .toPromise()
-              .then( (descriptor: ActionDescriptor) => {
+              .then((descriptor: ActionDescriptor) => {
                 this.currentFlowService.events.emit({
                   kind: 'integration-set-descriptor',
                   position: this.position,
                   descriptor,
                   onSave: () => {
-                    for (const actionProperty of Object.keys(data)) {
-                      if (data[actionProperty] == null) {
-                        this.step.configuredProperties[
-                          actionProperty
-                        ] = descriptor.propertyDefinitionSteps.map(
-                          actionDefinitionStep => {
-                            return actionDefinitionStep.properties[actionProperty]
-                              .defaultValue;
-                          }
-                        )[0];
-                      }
-                    }
                     /* All done... */
                     this.finishUp();
                   }
@@ -268,10 +256,10 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
     }
     const stepDefinitions = action.descriptor.propertyDefinitionSteps;
     for (let p = 0; p < this.page; p++) {
-      for (const prop in stepDefinitions[ p ].properties) {
+      for (const prop in stepDefinitions[p].properties) {
         /* We don't want null or undefined values here */
-        if (this.step.configuredProperties[ prop ] != null) {
-          props[ prop ] = this.step.configuredProperties[ prop ];
+        if (this.step.configuredProperties[prop] != null) {
+          props[prop] = this.step.configuredProperties[prop];
         }
       }
     }

--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -469,14 +469,28 @@ export class CurrentFlowService {
           step.action.descriptor = descriptor;
           return;
         }
-        // set the descriptor but avoid overwriting data shapes if they're user set
+        // update the step's configured properties with any defaults defined in the descriptor
+        const data = step.configuredProperties || {};
+        for (const actionProperty of Object.keys(data)) {
+          if (!data[actionProperty]) {
+            step.configuredProperties[
+              actionProperty
+            ] = descriptor.propertyDefinitionSteps.map(
+              actionDefinitionStep => {
+                return actionDefinitionStep.properties[actionProperty]
+                  .defaultValue;
+              }
+            )[0];
+          }
+        }
+        // set the descriptor but avoid overwriting data shapes if they're user set, or if the incoming datashapes don't have the spec set
         const inputDataShape = step.action.descriptor.inputDataShape;
         const outputDataShape = step.action.descriptor.outputDataShape;
         step.action.descriptor = descriptor;
-        if (this.isUserDefined(inputDataShape)) {
+        if (this.isUserDefined(inputDataShape) || !descriptor.inputDataShape.specification) {
           step.action.descriptor.inputDataShape = inputDataShape;
         }
-        if (this.isUserDefined(outputDataShape)) {
+        if (this.isUserDefined(outputDataShape) || !descriptor.outputDataShape.specification) {
           step.action.descriptor.outputDataShape = outputDataShape;
         }
         this.maybeDoAction(event['onSave']);


### PR DESCRIPTION
Fixes #1895 