### PR TITLE
feat(forms): add support for placeholder text in form controls

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -68,6 +68,8 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getLabelHint();
 
+    String getPlaceholder();
+
     String getDisplayName();
 
     List<PropertyValue> getEnum();

--- a/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
+++ b/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
@@ -26,7 +26,7 @@
       "deprecated": false,
       "secret": false,
       "labelHint": "Location to send data to or obtain data from.",
-      "description": "for example, failover://ssl://{BROKER-HOST}:{BROKER-PORT}",
+      "placeholder": "for example, failover://ssl://{BROKER-HOST}:{BROKER-PORT}",
       "order": "1"
     },
     "username": {
@@ -40,7 +40,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "controlHint": "Access the broker with this user’s authorization credentials.",
+      "labelHint": "Access the broker with this user’s authorization credentials.",
       "order": "2"
     },
     "password": {
@@ -54,7 +54,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": true,
-      "controlHint": "Password for the specified user account.",
+      "labelHint": "Password for the specified user account.",
       "order": "3"
     },
     "clientID": {
@@ -93,7 +93,7 @@
       "defaultValue": "false",
       "deprecated": false,
       "secret": false,
-      "description": "For convenience in only development environments. Do not set for secure production environments.",
+      "labelHint": "For convenience in only development environments. Do not set for secure production environments.",
       "order": "5"
     },
     "brokerCertificate": {
@@ -108,7 +108,18 @@
       "deprecated": false,
       "secret": false,
       "description": "AMQ Broker X.509 PEM Certificate",
-      "order": "6"
+      "order": "6",
+      "relation": [
+        {
+          "action": "DISABLE",
+          "when": [
+            {
+              "id": "skipCertificateCheck",
+              "value": "false"
+            }
+          ]
+        }
+      ]
     },
     "clientCertificate": {
       "kind": "property",
@@ -122,7 +133,18 @@
       "deprecated": false,
       "secret": false,
       "description": "AMQ Client X.509 PEM Certificate",
-      "order": "7"
+      "order": "7",
+      "relation": [
+        {
+          "action": "DISABLE",
+          "when": [
+            {
+              "id": "skipCertificateCheck",
+              "value": "false"
+            }
+          ]
+        }
+      ]
     }
   },
   "actions": [

--- a/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
+++ b/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
@@ -26,7 +26,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "description": "Location to send data to or obtain data from.",
+      "labelHint": "Location to send data to or obtain data from.",
       "order": "1"
     },
     "username": {
@@ -40,7 +40,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "description": "Access the broker with this user’s authorization credentials.",
+      "labelHint": "Access the broker with this user’s authorization credentials.",
       "order": "2"
     },
     "password": {
@@ -54,7 +54,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": true,
-      "description": "Password for the specified user account.",
+      "labelHint": "Password for the specified user account.",
       "order": "3"
     },
     "clientID" : {
@@ -68,7 +68,7 @@
       "javaType" : "java.lang.String",
       "deprecated" : false,
       "secret" : false,
-      "description" : "Required for connections to close and reopen without missing messages. Connection destination must be a topic.",
+      "labelHint" : "Required for connections to close and reopen without missing messages. Connection destination must be a topic.",
       "order": "4"
     },
     "skipCertificateCheck" : {
@@ -93,7 +93,7 @@
       "defaultValue" : "false",
       "deprecated" : false,
       "secret" : false,
-      "description" : "For convenience in only development environments. Do not set for secure production environments.",
+      "labelHint" : "For convenience in only development environments. Do not set for secure production environments.",
       "order": "5"
     },
     "brokerCertificate" : {
@@ -107,7 +107,7 @@
       "javaType" : "java.lang.String",
       "deprecated" : false,
       "secret" : false,
-      "description" : "AMQ Broker X.509 PEM Certificate",
+      "labelHint" : "AMQ Broker X.509 PEM Certificate",
       "order": "6"
     },
     "clientCertificate" : {
@@ -121,7 +121,7 @@
       "javaType" : "java.lang.String",
       "deprecated" : false,
       "secret" : false,
-      "description" : "AMQ Client X.509 PEM Certificate",
+      "labelHint" : "AMQ Client X.509 PEM Certificate",
       "order": "7"
     }
   },
@@ -157,7 +157,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Name of the queue or topic to send data to.",
+                "labelHint": "Name of the queue or topic to send data to.",
                 "order": "1"
               },
               "destinationType": {
@@ -181,7 +181,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "queue",
-                "description": "By default, the destination is a Queue.",
+                "labelHint": "By default, the destination is a Queue.",
                 "order": "2"
               },
               "deliveryPersistent": {
@@ -196,7 +196,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": true,
-                "description": "Message delivery is guaranteed when Persistent is selected.",
+                "labelHint": "Message delivery is guaranteed when Persistent is selected.",
                 "order": "3"
               }
             }
@@ -235,7 +235,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Name of the queue or topic to receive data from.",
+                "labelHint": "Name of the queue or topic to receive data from.",
                 "order": "1"
               },
               "destinationType": {
@@ -259,7 +259,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "queue",
-                "description": "By default, the destination is a Queue.",
+                "labelHint": "By default, the destination is a Queue.",
                 "order": "2"
               },
               "durableSubscriptionId": {
@@ -273,7 +273,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
+                "labelHint": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
                 "order": "3"
               },
               "messageSelector": {
@@ -287,7 +287,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Specify a filter expression to receive only data that meets certain criteria.",
+                "labelHint": "Specify a filter expression to receive only data that meets certain criteria.",
                 "order": "4"
               }
             }
@@ -326,7 +326,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Name of the queue or topic to receive data from.",
+                "labelHint": "Name of the queue or topic to receive data from.",
                 "order": "1"
               },
               "destinationType": {
@@ -350,7 +350,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "queue",
-                "description": "By default, the destination is a Queue.",
+                "labelHint": "By default, the destination is a Queue.",
                 "order": "2"
               },
               "durableSubscriptionId": {
@@ -364,7 +364,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
+                "labelHint": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
                 "order": "3"
               },
               "messageSelector": {
@@ -378,7 +378,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Specify a filter expression to receive only data that meets certain criteria.",
+                "labelHint": "Specify a filter expression to receive only data that meets certain criteria.",
                 "order": "4"
               }
             }

--- a/app/connector/aws-s3/src/main/resources/META-INF/syndesis/connector/aws-s3.json
+++ b/app/connector/aws-s3/src/main/resources/META-INF/syndesis/connector/aws-s3.json
@@ -24,7 +24,7 @@
           "deprecated": false,
           "secret": false,
           "raw": true,
-          "description": "Amazon AWS Access Key",
+          "labelHint": "Amazon AWS Access Key",
           "order": "1"
         },
         "secretKey": {
@@ -37,7 +37,7 @@
           "deprecated": false,
           "secret": true,
           "raw": true,
-          "description": "Amazon AWS Secret Key",
+          "labelHint": "Amazon AWS Secret Key",
           "order": "2"
         },
         "region": {
@@ -125,7 +125,7 @@
           "deprecated": false,
           "defaultValue" : "US_EAST_1",
           "secret": false,
-          "description": "The region where the bucket is located. This option is used in the com.amazonaws.services.s3.model.CreateBucketRequest.",
+          "labelHint": "The region where the bucket is located. This option is used in the com.amazonaws.services.s3.model.CreateBucketRequest.",
           "order": "3"
         },
         "bucketNameOrArn": {
@@ -137,7 +137,7 @@
           "javaType": "java.lang.String",
           "deprecated": false,
           "secret": false,
-          "description": "Bucket name or ARN",
+          "labelHint": "Bucket name or ARN",
           "order": "4"
         }
       },
@@ -195,7 +195,7 @@
                     "deprecated": false,
                     "secret": false,
                     "defaultValue": false,
-                    "description": "Delete objects from S3 after they have been retrieved. The delete is only performed if the Exchange is committed. If a rollback occurs the object is not deleted. If this option is false then the same objects will be retrieve over and over again on the polls. Therefore you need to use the Idempotent Consumer EIP in the route to filter out duplicates. You can filter using the link S3ConstantsBUCKET_NAME and link S3ConstantsKEY headers or only the link S3ConstantsKEY header.",
+                    "labelHint": "Delete objects from S3 after they have been retrieved. The delete is only performed if the Exchange is committed. If a rollback occurs the object is not deleted. If this option is false then the same objects will be retrieve over and over again on the polls. Therefore you need to use the Idempotent Consumer EIP in the route to filter out duplicates. You can filter using the link S3ConstantsBUCKET_NAME and link S3ConstantsKEY headers or only the link S3ConstantsKEY header.",
                     "order": "2"
                   },
                   "fileName": {
@@ -208,7 +208,7 @@
                     "javaType": "java.lang.String",
                     "deprecated": false,
                     "secret": false,
-                    "description": "To get the object from the bucket with the given file name",
+                    "labelHint": "To get the object from the bucket with the given file name",
                     "order": "1"
                   }
                 }
@@ -250,7 +250,7 @@
                     "deprecated": false,
                     "secret": false,
                     "defaultValue": false,
-                    "description": "Delete objects from S3 after they have been retrieved. The delete is only performed if the Exchange is committed. If a rollback occurs the object is not deleted. If this option is false then the same objects will be retrieve over and over again on the polls. Therefore you need to use the Idempotent Consumer EIP in the route to filter out duplicates. You can filter using the link S3ConstantsBUCKET_NAME and link S3ConstantsKEY headers or only the link S3ConstantsKEY header.",
+                    "labelHint": "Delete objects from S3 after they have been retrieved. The delete is only performed if the Exchange is committed. If a rollback occurs the object is not deleted. If this option is false then the same objects will be retrieve over and over again on the polls. Therefore you need to use the Idempotent Consumer EIP in the route to filter out duplicates. You can filter using the link S3ConstantsBUCKET_NAME and link S3ConstantsKEY headers or only the link S3ConstantsKEY header.",
                     "order": "4"
                   },
                   "maxMessagesPerPoll": {
@@ -264,7 +264,7 @@
                     "deprecated": false,
                     "secret": false,
                     "defaultValue": 10,
-                    "description": "Gets the maximum number of messages as a limit to poll at each polling. Is default unlimited but use 0 or negative number to disable it as unlimited.",
+                    "labelHint": "Gets the maximum number of messages as a limit to poll at each polling. Is default unlimited but use 0 or negative number to disable it as unlimited.",
                     "order": "2"
                   },
                   "prefix": {
@@ -277,7 +277,7 @@
                     "javaType": "java.lang.String",
                     "deprecated": false,
                     "secret": false,
-                    "description": "The prefix which is used in the com.amazonaws.services.s3.model.ListObjectsRequest to only consume objects we are interested in.",
+                    "labelHint": "The prefix which is used in the com.amazonaws.services.s3.model.ListObjectsRequest to only consume objects we are interested in.",
                     "order": "3"
                   },
                   "delay": {
@@ -292,7 +292,7 @@
                     "deprecated": false,
                     "secret": false,
                     "defaultValue": 500,
-                    "description": "Milliseconds before the next poll. You can also specify time values using units such as 60s (60 seconds) 5m30s (5 minutes and 30 seconds) and 1h (1 hour).",
+                    "labelHint": "Milliseconds before the next poll. You can also specify time values using units such as 60s (60 seconds) 5m30s (5 minutes and 30 seconds) and 1h (1 hour).",
                     "order": "1"
                   }
                 }

--- a/app/connector/dropbox/src/main/resources/META-INF/syndesis/connector/dropbox.json
+++ b/app/connector/dropbox/src/main/resources/META-INF/syndesis/connector/dropbox.json
@@ -25,7 +25,7 @@
             "secret": true,
             "componentProperty": true,
             "order": "1",
-            "description": "The access token to make API requests for a specific Dropbox user"
+            "labelHint": "The access token to make API requests for a specific Dropbox user"
         },
         "clientIdentifier": {
             "kind": "parameter",
@@ -38,7 +38,7 @@
             "secret": false,
             "componentProperty": true,
             "order": "2",
-            "description": "Name of the app registered to make API requests"
+            "labelHint": "Name of the app registered to make API requests"
         }
     },
     "actions": [
@@ -84,7 +84,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "order": "2",
-                                "description": "File upload mode"
+                                "labelHint": "File upload mode"
                             },
                             "remotePath": {
                                 "kind": "parameter",
@@ -96,7 +96,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "order": "1",
-                                "description": "Remote path where upload the file"
+                                "labelHint": "Remote path where upload the file"
                             }
                         }
                     }
@@ -134,7 +134,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "Folder or file name path to download"
+                                "labelHint": "Folder or file name path to download"
                             }
                         }
                     }

--- a/app/connector/ftp/src/main/resources/META-INF/syndesis/connector/ftp.json
+++ b/app/connector/ftp/src/main/resources/META-INF/syndesis/connector/ftp.json
@@ -11,7 +11,7 @@
     ],
     "componentScheme": "ftp",
     "configuredProperties": {
-        
+
     },
     "tags": [
         "verifier"
@@ -26,7 +26,7 @@
             "javaType": "java.lang.String",
             "deprecated": false,
             "secret": false,
-            "description": "User name to connect to the FTP server"
+            "labelHint": "User name to connect to the FTP server"
         },
         "host": {
             "kind": "path",
@@ -37,7 +37,7 @@
             "javaType": "java.lang.String",
             "deprecated": false,
             "secret": false,
-            "description": "FTP host"
+            "labelHint": "FTP host"
         },
         "port": {
             "kind": "path",
@@ -49,7 +49,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "21",
-            "description": "FTP port"
+            "labelHint": "FTP port"
         },
         "password": {
             "kind": "parameter",
@@ -61,7 +61,7 @@
             "deprecated": false,
             "secret": true,
             "raw": true,
-            "description": "Paasword"
+            "labelHint": "Password"
         },
         "timeout": {
             "kind": "parameter",
@@ -73,7 +73,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "30000",
-            "description": "Data timeout in millis"
+            "labelHint": "Data timeout in millis"
         },
         "connectTimeout": {
             "kind": "parameter",
@@ -85,7 +85,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "10000",
-            "description": "Connect timeout in millis"
+            "labelHint": "Connect timeout in millis"
         },
         "reconnectDelay": {
             "kind": "parameter",
@@ -97,7 +97,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "1000",
-            "description": "Reconnect delay"
+            "labelHint": "Reconnect delay"
         },
         "maximumReconnectAttempts": {
             "kind": "parameter",
@@ -109,7 +109,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "3",
-            "description": "Maximum reconnect attempts"
+            "labelHint": "Maximum reconnect attempts"
         },
         "binary": {
             "kind": "parameter",
@@ -131,7 +131,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "true",
-            "description": "Is file transfer mode binary"
+            "labelHint": "Is file transfer mode binary"
         },
         "passiveMode": {
             "kind": "parameter",
@@ -153,7 +153,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "true",
-            "description": "Is the connection mode passive"
+            "labelHint": "Is the connection mode passive"
         },
         "disconnect": {
             "kind": "parameter",
@@ -175,7 +175,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "false",
-            "description": "Disconnect from the server right after use"
+            "labelHint": "Disconnect from the server right after use"
         }
     },
     "actions": [
@@ -193,7 +193,7 @@
                     "kind": "none"
                 },
                 "configuredProperties": {
-                    
+
                 },
                 "propertyDefinitionSteps": [
                     {
@@ -209,7 +209,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "File name expression"
+                                "labelHint": "File name expression"
                             },
                             "directoryName": {
                                 "kind": "path",
@@ -220,7 +220,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "FTP directory dame"
+                                "labelHint": "FTP directory dame"
                             },
                             "fileExist": {
                                 "kind": "parameter",
@@ -258,7 +258,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "Override",
-                                "description": "What to do if file exist"
+                                "labelHint": "What to do if file exist"
                             },
                             "tempPrefix": {
                                 "kind": "parameter",
@@ -270,7 +270,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "Temporary file prefix while copying"
+                                "labelHint": "Temporary file prefix while copying"
                             },
                             "tempFileName": {
                                 "kind": "parameter",
@@ -282,7 +282,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "Temporary file name while copying"
+                                "labelHint": "Temporary file name while copying"
                             }
                         }
                     }
@@ -303,7 +303,7 @@
                     "kind": "any"
                 },
                 "configuredProperties": {
-                    
+
                 },
                 "propertyDefinitionSteps": [
                     {
@@ -319,7 +319,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "File name expression"
+                                "labelHint": "File name expression"
                             },
                             "directoryName": {
                                 "kind": "path",
@@ -330,7 +330,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "FTP directory dame"
+                                "labelHint": "FTP directory dame"
                             },
                             "initialDelay": {
                                 "kind": "parameter",
@@ -342,7 +342,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "1000",
-                                "description": "Initial delays in millis before the polling starts"
+                                "labelHint": "Initial delays in millis before the polling starts"
                             },
                             "delay": {
                                 "kind": "parameter",
@@ -354,7 +354,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "500",
-                                "description": "Delay in millis before the next polling starts"
+                                "labelHint": "Delay in millis before the next polling starts"
                             },
                             "delete": {
                                 "kind": "parameter",
@@ -376,7 +376,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "false",
-                                "description": "Delete the file after processing"
+                                "labelHint": "Delete the file after processing"
                             }
                         }
                     }

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
@@ -22,7 +22,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "description": "Base Http Endpoint URL (eg 'www.redhat.com')"
+      "labelHint": "Base Http Endpoint URL (eg 'www.redhat.com')"
     }
   },
   "componentScheme": "http4",
@@ -58,7 +58,7 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "Endpoint Path (eg '/path/to/endpoint')"
+                "labelHint": "Endpoint Path (eg '/path/to/endpoint')"
               },
               "httpMethod": {
                 "kind": "parameter",
@@ -104,7 +104,7 @@
                 "deprecated": false,
                 "defaultValue": "GET",
                 "secret": false,
-                "description": "The specific http method to execute."
+                "labelHint": "The specific http method to execute."
               }
             }
           }
@@ -142,7 +142,8 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "Endpoint Path (eg '/path/to/endpoint')"
+                "labelHint": "Endpoint Path",
+                "placeholder": "eg '/path/to/endpoint'"
               },
               "httpMethod": {
                 "kind": "parameter",
@@ -188,7 +189,7 @@
                 "deprecated": false,
                 "defaultValue": "GET",
                 "secret": false,
-                "description": "The specific http method to execute."
+                "labelHint": "The specific http method to execute."
               },
               "schedulerExpression": {
                 "kind": "parameter",
@@ -200,7 +201,7 @@
                 "deprecated": false,
                 "secret": false,
                 "defaultValue": 1000,
-                "description": "Delay in milliseconds between scheduling (executing)."
+                "labelHint": "Delay in milliseconds between scheduling (executing)."
               }
             }
           }

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
@@ -22,7 +22,7 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "description": "Base Http Endpoint URL (eg 'www.redhat.com')"
+      "labelHint": "Base Http Endpoint URL (eg 'www.redhat.com')"
     }
   },
   "componentScheme": "https4",
@@ -58,7 +58,7 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "Endpoint Path (eg '/path/to/endpoint')"
+                "labelHint": "Endpoint Path (eg '/path/to/endpoint')"
               },
               "httpMethod": {
                 "kind": "parameter",
@@ -104,7 +104,7 @@
                 "deprecated": false,
                 "defaultValue": "GET",
                 "secret": false,
-                "description": "The specific http method to execute."
+                "labelHint": "The specific http method to execute."
               }
             }
           }
@@ -142,7 +142,8 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "Endpoint Path (eg '/path/to/endpoint')"
+                "labelHint": "Endpoint Path",
+                "placeholder": "eg '/path/to/endpoint'"
               },
               "httpMethod": {
                 "kind": "parameter",
@@ -188,7 +189,7 @@
                 "deprecated": false,
                 "defaultValue": "GET",
                 "secret": false,
-                "description": "The specific http method to execute."
+                "labelHint": "The specific http method to execute."
               },
               "schedulerExpression": {
                 "kind": "parameter",
@@ -200,7 +201,7 @@
                 "deprecated": false,
                 "secret": false,
                 "defaultValue": 1000,
-                "description": "Delay in milliseconds between scheduling (executing)."
+                "labelHint": "Delay in milliseconds between scheduling (executing)."
               }
             }
           }

--- a/app/connector/mqtt/src/main/resources/META-INF/syndesis/connector/mqtt.json
+++ b/app/connector/mqtt/src/main/resources/META-INF/syndesis/connector/mqtt.json
@@ -11,7 +11,7 @@
     ],
     "componentScheme": "paho",
     "configuredProperties": {
-        
+
     },
     "tags": [
         "verifier"
@@ -26,7 +26,8 @@
             "javaType": "java.lang.String",
             "deprecated": false,
             "secret": false,
-            "description": "MQTT broker URL (eg 'tcp://localhost:1833')"
+            "labelHint": "MQTT broker URL",
+            "placeholder": "eg 'tcp://localhost:1833'"
         }
     },
     "actions": [
@@ -60,7 +61,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "MQTT queue/topic name"
+                                "labelHint": "MQTT queue/topic name"
                             }
                         }
                     }
@@ -97,7 +98,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "MQTT queue/topic name"
+                                "labelHint": "MQTT queue/topic name"
                             }
                         }
                     }

--- a/app/connector/sftp/src/main/resources/META-INF/syndesis/connector/sftp.json
+++ b/app/connector/sftp/src/main/resources/META-INF/syndesis/connector/sftp.json
@@ -11,7 +11,7 @@
     ],
     "componentScheme": "sftp",
     "configuredProperties": {
-        
+
     },
     "tags": [
         "verifier"
@@ -26,7 +26,7 @@
             "javaType": "java.lang.String",
             "deprecated": false,
             "secret": false,
-            "description": "User name to connect to the SFTP server"
+            "labelHint": "User name to connect to the SFTP server"
         },
         "host": {
             "kind": "path",
@@ -37,7 +37,7 @@
             "javaType": "java.lang.String",
             "deprecated": false,
             "secret": false,
-            "description": "SFTP host"
+            "labelHint": "SFTP host"
         },
         "port": {
             "kind": "path",
@@ -49,7 +49,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "22",
-            "description": "SFTP port"
+            "labelHint": "SFTP port"
         },
         "password": {
             "kind": "parameter",
@@ -61,7 +61,7 @@
             "deprecated": false,
             "secret": true,
             "raw": true,
-            "description": "Paasword"
+            "labelHint": "Password"
         },
         "timeout": {
             "kind": "parameter",
@@ -73,7 +73,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "30000",
-            "description": "Data timeout in millis"
+            "labelHint": "Data timeout in millis"
         },
         "connectTimeout": {
             "kind": "parameter",
@@ -85,7 +85,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "10000",
-            "description": "Connect timeout in millis"
+            "labelHint": "Connect timeout in millis"
         },
         "reconnectDelay": {
             "kind": "parameter",
@@ -97,7 +97,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "1000",
-            "description": "Reconnect delay"
+            "labelHint": "Reconnect delay"
         },
         "maximumReconnectAttempts": {
             "kind": "parameter",
@@ -109,7 +109,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "3",
-            "description": "Maximum reconnect attempts"
+            "labelHint": "Maximum reconnect attempts"
         },
         "binary": {
             "kind": "parameter",
@@ -131,7 +131,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "true",
-            "description": "Is file transfer mode binary"
+            "labelHint": "Is file transfer mode binary"
         },
         "passiveMode": {
             "kind": "parameter",
@@ -153,7 +153,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "true",
-            "description": "Is the connection mode passive"
+            "labelHint": "Is the connection mode passive"
         },
         "disconnect": {
             "kind": "parameter",
@@ -175,7 +175,7 @@
             "deprecated": false,
             "secret": false,
             "defaultValue": "false",
-            "description": "Disconnect from the server right after use"
+            "labelHint": "Disconnect from the server right after use"
         }
     },
     "actions": [
@@ -193,7 +193,7 @@
                     "kind": "none"
                 },
                 "configuredProperties": {
-                    
+
                 },
                 "propertyDefinitionSteps": [
                     {
@@ -209,7 +209,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "File name expression"
+                                "labelHint": "File name expression"
                             },
                             "directoryName": {
                                 "kind": "path",
@@ -220,7 +220,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "FTP directory dame"
+                                "labelHint": "FTP directory dame"
                             },
                             "fileExist": {
                                 "kind": "parameter",
@@ -258,7 +258,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "Override",
-                                "description": "What to do if file exist"
+                                "labelHint": "What to do if file exist"
                             },
                             "tempPrefix": {
                                 "kind": "parameter",
@@ -270,7 +270,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "Temporary file prefix while copying"
+                                "labelHint": "Temporary file prefix while copying"
                             },
                             "tempFileName": {
                                 "kind": "parameter",
@@ -282,7 +282,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "Temporary file name while copying"
+                                "labelHint": "Temporary file name while copying"
                             }
                         }
                     }
@@ -303,7 +303,7 @@
                     "kind": "any"
                 },
                 "configuredProperties": {
-                    
+
                 },
                 "propertyDefinitionSteps": [
                     {
@@ -319,7 +319,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "File name expression"
+                                "labelHint": "File name expression"
                             },
                             "directoryName": {
                                 "kind": "path",
@@ -330,7 +330,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "FTP directory dame"
+                                "labelHint": "FTP directory dame"
                             },
                             "initialDelay": {
                                 "kind": "parameter",
@@ -342,7 +342,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "1000",
-                                "description": "Initial delays in millis before the polling starts"
+                                "labelHint": "Initial delays in millis before the polling starts"
                             },
                             "delay": {
                                 "kind": "parameter",
@@ -354,7 +354,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "500",
-                                "description": "Delay in millis before the next polling starts"
+                                "labelHint": "Delay in millis before the next polling starts"
                             },
                             "delete": {
                                 "kind": "parameter",
@@ -376,7 +376,7 @@
                                 "deprecated": false,
                                 "secret": false,
                                 "defaultValue": "false",
-                                "description": "Delete the file after processing"
+                                "labelHint": "Delete the file after processing"
                             }
                         }
                     }

--- a/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
+++ b/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
@@ -10,7 +10,7 @@
         }
     ],
     "componentScheme": "slack",
-    "configuredProperties": {   
+    "configuredProperties": {
     },
     "tags": [
         "verifier"
@@ -26,7 +26,7 @@
             "deprecated": false,
             "secret": false,
             "order": "1",
-            "description": "The webhook URL used to send messages to"
+            "labelHint": "The webhook URL used to send messages to"
         },
         "sendingUsername": {
             "kind": "parameter",
@@ -38,7 +38,7 @@
             "deprecated": false,
             "secret": false,
             "order": "2",
-            "description": "This is the username that the bot will have when sending messages to a channel or user"
+            "labelHint": "This is the username that the bot will have when sending messages to a channel or user"
         },
         "iconUrl": {
             "kind": "parameter",
@@ -50,7 +50,7 @@
             "deprecated": false,
             "secret": false,
             "order": "4",
-            "description": "The avatar that the component will use when sending message to a channel or user"
+            "labelHint": "The avatar that the component will use when sending message to a channel or user"
         },
         "iconEmoji": {
             "kind": "parameter",
@@ -62,7 +62,7 @@
             "deprecated": false,
             "secret": false,
             "order": "3",
-            "description": "The Slack emogi that will be used for the message avatar"
+            "labelHint": "The Slack emogi that will be used for the message avatar"
         }
     },
     "actions": [
@@ -99,7 +99,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "The username to send the message to"
+                                "labelHint": "The username to send the message to"
                             }
                         }
                     }
@@ -139,7 +139,7 @@
                                 "javaType": "java.lang.String",
                                 "deprecated": false,
                                 "secret": false,
-                                "description": "The channel to send the message to"
+                                "labelHint": "The channel to send the message to"
                             }
                         }
                     }

--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -30,7 +30,7 @@
       "deprecated": false,
       "secret": false,
       "componentProperty": true,
-      "description": "JDBC URL of the database."
+      "labelHint": "JDBC URL of the database."
     },
     "user": {
       "kind": "property",
@@ -44,7 +44,7 @@
       "deprecated": false,
       "secret": false,
       "componentProperty": true,
-      "description": "Username for the database connection."
+      "labelHint": "Username for the database connection."
     },
     "password": {
       "kind": "property",
@@ -58,7 +58,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "Password for the database connection."
+      "labelHint": "Password for the database connection."
     },
     "schema": {
       "kind": "property",
@@ -72,7 +72,7 @@
       "deprecated": false,
       "secret": false,
       "componentProperty": true,
-      "description": "Database schema."
+      "labelHint": "Database schema."
     }
   },
   "connectorCustomizers": [
@@ -113,7 +113,8 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "SQL statement to be executed. Can contain input parameters prefixed by ':#' (for example ':#MYPARAMNAME')."
+                "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                "placeholder": "for example ':#MYPARAMNAME'"
               }
             }
           }
@@ -156,7 +157,7 @@
                 "javaType": "java.lang.String",
                 "deprecated": false,
                 "secret": false,
-                "description": "SQL SELECT statement to be executed."
+                "labelHint": "SQL SELECT statement to be executed."
               },
               "schedulerExpression": {
                 "kind": "parameter",
@@ -168,7 +169,7 @@
                 "deprecated": false,
                 "secret": false,
                 "defaultValue": 1000,
-                "description": "Delay in milliseconds between scheduling (executing)."
+                "labelHint": "Delay in milliseconds between scheduling (executing)."
               }
             }
           }
@@ -211,7 +212,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": true,
-                "description": "Name of the stored procedure."
+                "labelHint": "Name of the stored procedure."
               },
               "template": {
                 "kind": "path",
@@ -224,7 +225,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Stored procedure template to perform."
+                "labelHint": "Stored procedure template to perform."
               }
             }
           }
@@ -267,7 +268,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": true,
-                "description": "Name of the stored procedure."
+                "labelHint": "Name of the stored procedure."
               },
               "template": {
                 "kind": "path",
@@ -280,7 +281,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Stored Procedure template to perform."
+                "labelHint": "Stored Procedure template to perform."
               },
               "schedulerExpression": {
                 "kind": "parameter",
@@ -292,7 +293,7 @@
                 "deprecated": false,
                 "secret": false,
                 "defaultValue": 1000,
-                "description": "Delay in milliseconds between scheduling (executing)."
+                "labelHint": "Delay in milliseconds between scheduling (executing)."
               }
             }
           }

--- a/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
+++ b/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
@@ -26,7 +26,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token"
+      "labelHint": "The access token"
     },
     "accessTokenSecret": {
       "kind": "property",
@@ -40,7 +40,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token secret"
+      "labelHint": "The access token secret"
     },
     "consumerKey": {
       "kind": "property",
@@ -56,7 +56,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The consumer key"
+      "labelHint": "The consumer key"
     },
     "consumerSecret": {
       "kind": "property",
@@ -72,7 +72,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The consumer secret"
+      "labelHint": "The consumer secret"
     }
   },
   "actions": [
@@ -136,7 +136,7 @@
                 "secret": false,
                 "defaultValue": true,
                 "componentProperty": false,
-                "description": "Filter out old tweets that have previously been polled"
+                "labelHint": "Filter out old tweets that have previously been polled"
               },
               "keywords": {
                 "kind": "path",
@@ -149,7 +149,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Multiple search values can be separated with comma"
+                "labelHint": "Multiple search values can be separated with comma"
               },
               "delay": {
                 "kind": "parameter",
@@ -164,7 +164,7 @@
                 "secret": false,
                 "defaultValue": 5000,
                 "componentProperty": false,
-                "description": "Milliseconds before the next poll"
+                "labelHint": "Milliseconds before the next poll"
               }
             }
           }

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentDefinition.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentDefinition.java
@@ -92,6 +92,7 @@ public interface ComponentDefinition {
         Optional<String> getDescription();
         Optional<String> getControlHint();
         Optional<String> getLabelHint();
+        Optional<String> getPlaceholder();
         Optional<String> getName();
         Optional<String> getDefaultValue();
         Optional<String> getEnums();

--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -156,6 +156,7 @@ export class FormFactoryProviderService extends FormFactoryService {
       controlTooltip: field.controlHint,
       inputType: type,
       value: value || field.value || field.defaultValue,
+      placeholder: field.placeholder,
       hint: field.description,
       list: field.enum
         ? (<Array<any>>field.enum).map(val => {

--- a/app/ui/src/app/platform/types/platform.models.ts
+++ b/app/ui/src/app/platform/types/platform.models.ts
@@ -72,8 +72,9 @@ export interface ConfigurationProperty extends BaseEntity {
   defaultValue: string;
   displayName: string;
   description: string;
-  labelHint?: string;
-  controlHint?: string;
+  labelHint: string;
+  controlHint: string;
+  placeholder: string;
   group: string;
   required: boolean;
   secret: boolean;


### PR DESCRIPTION
This PR utilizes a new property name "labelHint" which used to be referred to as "description". It also adds a new property "placeholder" to allow our model driven forms to add placeholder text to text inputs to illustrate syntax for a given field. This also makes use of the new "relation" property for the brokerCertificate and clientCertificate fields in the amq connection config.

Should help https://github.com/syndesisio/syndesis/issues/992 and https://github.com/syndesisio/syndesis/issues/250

utilize new labelHint property in form field definitions
add new placeholder property in forms service
add form relation for amq client,broker certificate