### PR TITLE
fix(donut): remove draft state from dashboard integrations donut

### DIFF
--- a/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
+++ b/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
@@ -179,7 +179,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Name of the queue or topic to send data to.",
+                "labelHint": "Name of the queue or topic to send data to.",
                 "order": "1"
               },
               "destinationType": {
@@ -203,7 +203,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "topic",
-                "description": "By default, the destination is a topic.",
+                "labelHint": "By default, the destination is a topic.",
                 "order": "2"
               },
               "persistent": {
@@ -218,7 +218,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": true,
-                "description": "Message delivery is guaranteed when Persistent is selected.",
+                "labelHint": "Message delivery is guaranteed when Persistent is selected.",
                 "order": "3"
               }
             }
@@ -257,7 +257,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Name of the queue or topic to receive data from.",
+                "labelHint": "Name of the queue or topic to receive data from.",
                 "order": "1"
               },
               "destinationType": {
@@ -281,7 +281,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "topic",
-                "description": "By default, the destination is a topic.",
+                "labelHint": "By default, the destination is a topic.",
                 "order": "2"
               },
               "durableSubscriptionId": {
@@ -295,7 +295,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
+                "labelHint": "Set the ID that lets connections close and reopen with missing messages. Connection type must be a topic.",
                 "order": "3"
               },
               "messageSelector": {
@@ -309,7 +309,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Specify a filter expression to receive only data that meets certain criteria.",
+                "labelHint": "Specify a filter expression to receive only data that meets certain criteria.",
                 "order": "4"
               }
             }
@@ -351,7 +351,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "DestinationName is a JMS queue or topic name. By default the destinationName is interpreted as a queue name.",
+                "labelHint": "DestinationName is a JMS queue or topic name. By default the destinationName is interpreted as a queue name.",
                 "order": "1"
               },
               "destinationType": {
@@ -375,7 +375,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": "topic",
-                "description": "By default, the destination is a topic.",
+                "labelHint": "By default, the destination is a topic.",
                 "order": "2"
               },
               "messageSelector": {
@@ -389,7 +389,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "Specify a filter expression to receive only responses that meet certain criteria.",
+                "labelHint": "Specify a filter expression to receive only responses that meet certain criteria.",
                 "order": "3"
               },
               "namedReplyTo": {
@@ -403,7 +403,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "description": "The destination sends the response to this queue or topic.",
+                "labelHint": "The destination sends the response to this queue or topic.",
                 "order": "4"
               },
               "persistent": {
@@ -418,7 +418,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": true,
-                "description": "Message delivery is guaranteed when Persistent is selected.",
+                "labelHint": "Message delivery is guaranteed when Persistent is selected.",
                 "order": "5"
               },
               "responseTimeOut": {
@@ -433,7 +433,7 @@
                 "secret": false,
                 "componentProperty": false,
                 "defaultValue": 5000,
-                "description": "Amount of time a connection waits for a response message before throwing a runtime exception.",
+                "labelHint": "Amount of time a connection waits for a response message before throwing a runtime exception.",
                 "order": "6"
               }
             }

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
@@ -22,7 +22,8 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "labelHint": "Base Http Endpoint URL (eg 'www.redhat.com')"
+      "labelHint": "Base Http Endpoint URL",
+      "placeholder": "eg 'www.redhat.com'"
     }
   },
   "componentScheme": "http4",

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
@@ -22,7 +22,8 @@
       "javaType": "java.lang.String",
       "deprecated": false,
       "secret": false,
-      "labelHint": "Base Http Endpoint URL (eg 'www.redhat.com')"
+      "labelHint": "Base Http Endpoint URL",
+      "placeholder": "eg 'www.redhat.com'"
     }
   },
   "componentScheme": "https4",

--- a/app/ui/src/app/dashboard/dashboard_integrations/dashboard-integrations.component.ts
+++ b/app/ui/src/app/dashboard/dashboard_integrations/dashboard-integrations.component.ts
@@ -30,7 +30,6 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
 
   integrationChartData: any[] = [
     ['Published', 0],
-    ['Draft', 0],
     ['Unpublished', 0]
   ];
 
@@ -39,7 +38,6 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
     chartId: 'integrationsCounter',
     colors: {
       Published: '#0088CE',   // PatternFly Blue 400, Published
-      Draft: '#EC7A08',       // PatternFly Orange 400, Draft
       Unpublished: '#D1D1D1'  // PatternFly Black 300, Unpublished
     },
     donut: {
@@ -67,7 +65,6 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
       this.loading = false;
       this.integrationChartData = [
         [`Published`, this.countActiveIntegrations()],
-        [`Draft`, this.countDraftIntegrations()],
         [`Unpublished`, this.countInactiveIntegrations()]
       ];
     });
@@ -83,7 +80,6 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
 
   filterIntegrations() {
     const active = [];
-    const draft = [];
     const inactive = [];
     let total = 0;
     (this.integrations || []).forEach(integration => {
@@ -99,13 +95,9 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
         default:
           break;
       }
-      if (integration.draft) {
-        draft.push(integration);
-      }
     });
     return {
       active: active,
-      draft: draft,
       inactive: inactive,
       total: total
     };
@@ -113,10 +105,6 @@ export class DashboardIntegrationsComponent implements OnInit, OnDestroy {
 
   countActiveIntegrations() {
     return this.filterIntegrations().active.length;
-  }
-
-  countDraftIntegrations() {
-    return this.filterIntegrations().draft.length;
   }
 
   countInactiveIntegrations() {


### PR DESCRIPTION
This PR is mostly cleanup, removing "draft" from the dashboard donut counter to improve simplicity and clarity around what users actually have in their environment. Left support for it inside getLabelClass in case any of the other dashboard widgets need it.

removed draft state from dashboard integrations counter
tweak form properties for activemq connector