### PR TITLE
Use --template param explicitly with oc new-app

### DIFF
--- a/app/test/src/test/resources/setup.sh
+++ b/app/test/src/test/resources/setup.sh
@@ -52,7 +52,7 @@ if [ "true" == "$MINISHIFT_ENABLED" ]; then
 fi
 
 oc create -f ${SYNDESIS_TEMPLATE_URL} -n ${KUBERNETES_NAMESPACE}  || oc replace -f ${SYNDESIS_TEMPLATE_URL} -n ${KUBERNETES_NAMESPACE}
-oc new-app ${SYNDESIS_TEMPLATE_TYPE} \
+oc new-app --template=${SYNDESIS_TEMPLATE_TYPE} \
     -p ROUTE_HOSTNAME=$ROUTE_HOSTNAME \
     -p OPENSHIFT_MASTER=$(oc whoami --show-server) \
     -p OPENSHIFT_PROJECT=$(oc project -q) \

--- a/install/README.md
+++ b/install/README.md
@@ -46,7 +46,7 @@ All template parameters are required. Most of them have sane defaults, but some 
 In order to one of the templates described above these parameters must be provided:
 
 ```
-$ oc new-app syndesis -p \
+$ oc new-app --template=syndesis -p \
        ROUTE_HOSTNAME=<external hostname>
 ```
 
@@ -121,7 +121,7 @@ For development purposes you can also chose `syndesis-dev.yml` which enables Jav
 You can now use the template and the ServiceAccount created above to deploy Syndesis:
 
 ```bash
-$ oc new-app syndesis \
+$ oc new-app --template=syndesis \
     -p ROUTE_HOSTNAME=<EXTERNAL_HOSTNAME> \
     -p OPENSHIFT_MASTER=$(oc whoami --show-server) \
     -p OPENSHIFT_PROJECT=$(oc project -q) \

--- a/install/staging/README.md
+++ b/install/staging/README.md
@@ -13,7 +13,7 @@ oc create -f support/serviceaccount-as-oauthclient-restricted.yml
 oc create -f syndesis.yml
 
 # Instantiate application
-oc new-app syndesis \
+oc new-app --template=syndesis \
     -p ROUTE_HOSTNAME=$(oc project -q).b6ff.rh-idev.openshiftapps.com \
     -p OPENSHIFT_MASTER=$(oc whoami --show-server) \
     -p OPENSHIFT_PROJECT=$(oc project -q) \

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -103,7 +103,7 @@ create_and_apply_template() {
         template_name="${template_name}-restricted"
     fi
 
-    oc new-app ${template_name} \
+    oc new-app --template=${template_name} \
       -p ROUTE_HOSTNAME="${route}" \
       -p OPENSHIFT_MASTER="$(oc whoami --show-server)" \
       -p OPENSHIFT_PROJECT="$(oc project -q)" \

--- a/tools/bin/install-syndesis
+++ b/tools/bin/install-syndesis
@@ -78,7 +78,7 @@ create_and_apply_template() {
         "install/${template}.yml" \
         "$tag"
 
-    oc new-app $(get_template_name $template $tag) \
+    oc new-app --template=$(get_template_name $template $tag) \
       -p ROUTE_HOSTNAME="${route}" \
       -p OPENSHIFT_MASTER="$(oc whoami --show-server)" \
       -p OPENSHIFT_PROJECT="$(oc project -q)" \


### PR DESCRIPTION
Using "oc new-app <foo> " may not work for some oc client versions (at least oc 3.6) if <foo> is also a name of a directory in the current working directory:

"error: Unable to connect to the server: first path segment in URL cannot contain colon"

Using --template=<foo> works even if <foo> exists as a directory in CWD.