### PR TITLE
refactor(system-tests): upgrades and cleanup

### DIFF
--- a/app/common/pom.xml
+++ b/app/common/pom.xml
@@ -42,7 +42,6 @@
 
     <syndesis-connectors.version>${project.version}</syndesis-connectors.version>
 
-    <junit.version>4.12</junit.version>
     <mockwebserver.version>0.0.15</mockwebserver.version>
     <okhttp-eventsource.version>1.3.2</okhttp-eventsource.version>
     <postgresql.version>9.1-901-1.jdbc4</postgresql.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -101,6 +101,7 @@
     <mailapi.version>1.4.3</mailapi.version>
     <json-schema-core.version>1.2.8</json-schema-core.version>
     <json-schema-validator.version>2.2.8</json-schema-validator.version>
+    <junit.version>4.12</junit.version>
 
     <resteasy.version>3.1.4.Final</resteasy.version>
     <resteasy-spring-boot-starter.version>2.3.4-RELEASE</resteasy-spring-boot-starter.version>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -385,6 +385,12 @@
       </dependency>
 
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-parser</artifactId>
         <version>1.0.34</version>

--- a/app/test/pom.xml
+++ b/app/test/pom.xml
@@ -14,9 +14,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -29,90 +28,17 @@
   <groupId>io.syndesis.test</groupId>
   <artifactId>test</artifactId>
   <name>Test</name>
-  <inceptionYear>2016</inceptionYear>
-
-  <organization>
-    <name>Red Hat</name>
-    <url>http://redhat.com</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <!-- including A developer as it's required by the maven poms going into
-    central -->
-  <developers>
-    <developer>
-      <id>syndesis</id>
-      <name>Syndesis Development Team</name>
-      <organization>redhat</organization>
-      <organizationUrl>http://redhat.com/</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git@github.com:syndesisio/syndesis.git</connection>
-    <developerConnection>scm:git:git@github.com:syndesisio/syndesis.git
-    </developerConnection>
-    <url>http://github.com/syndesisio/syndesis</url>
-    <tag>${project.version}</tag>
-  </scm>
-
-  <distributionManagement>
-    <repository>
-      <id>oss-sonatype-staging</id>
-      <name>Sonatype Staging Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-  </distributionManagement>
-
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter-releases</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter-releases</id>
-      <name>jcenter</name>
-      <url>https://jcenter.bintray.com</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <name>Apache Development Snapshot Repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <properties>
+    <arquillian.version>1.4.0.Final</arquillian.version>
+    <arquillian-cube.version>1.15.2</arquillian-cube.version>
 
-    <arquillian.version>1.1.13.Final</arquillian.version>
-    <arquillian-cube.version>1.9.1</arquillian-cube.version>
+    <kubernetes-client.version>3.1.4</kubernetes-client.version>
+    <kubernetes-model.version>2.0.4</kubernetes-model.version>
+    <okhttp.version> 3.10.0</okhttp.version>
 
-    <junit.version>4.12</junit.version>
-    <kubernetes-client.version>2.6.3</kubernetes-client.version>
-    <kubernetes-model.version>1.1.4</kubernetes-model.version>
-    <okhttp.version>3.8.1</okhttp.version>
+    <basepom.test.fork-count>0</basepom.test.fork-count>
+    <basepom.test.reuse-vm>false</basepom.test.reuse-vm>
   </properties>
 
   <dependencyManagement>
@@ -199,8 +125,6 @@
       <version>${junit.version}</version>
     </dependency>
 
-
-
   </dependencies>
 
   <build>
@@ -217,25 +141,7 @@
           </ignoredResourcePatterns>
         </configuration>
       </plugin>
-      <plugin>
-	      <groupId>org.apache.maven.plugins</groupId>
-	      <artifactId>maven-surefire-plugin</artifactId>
-	      <configuration>
-		      <forkCount>0</forkCount>
-		      <reuseForks>false</reuseForks>
-      </configuration>
-      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>snapshot</id>
-      <properties>
-        <arquillian-cube.version>1.0.0.Final-SNAPSHOT</arquillian-cube.version>
-        <kubernetes-client.version>2.2-SNAPSHOT</kubernetes-client.version>
-      </properties>
-    </profile>
-  </profiles>
 
 </project>

--- a/app/test/src/test/java/io/syndesis/systests/DeploymentTest.java
+++ b/app/test/src/test/java/io/syndesis/systests/DeploymentTest.java
@@ -15,44 +15,41 @@
  */
 package io.syndesis.systests;
 
-import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
-import org.arquillian.cube.requirement.ArquillianConditionalRunner;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import javax.inject.Named;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
 public class DeploymentTest {
 
     @ArquillianResource
-    @Named("syndesis-ui")
-    DeploymentConfig ui;
+    KubernetesClient client;
 
     @ArquillianResource
     @Named("syndesis-server")
     DeploymentConfig rest;
 
     @ArquillianResource
-    KubernetesClient client;
-
-    @Test @Ignore
-    // This test is failing frequently and should be investigated
-    // https://github.com/syndesisio/syndesis-system-tests/issues/28
-    public void uiShouldBeReady() {
-        Assert.assertTrue(Readiness.isDeploymentConfigReady(ui));
-    }
+    @Named("syndesis-ui")
+    DeploymentConfig ui;
 
     @Test
     public void restShouldBeReady() {
         Assert.assertTrue(Readiness.isDeploymentConfigReady(rest));
+    }
+
+    @Test
+    public void uiShouldBeReady() {
+        Assert.assertTrue(Readiness.isDeploymentConfigReady(ui));
     }
 }

--- a/app/test/src/test/resources/arquillian.xml
+++ b/app/test/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
       <property name="namespace.cleanup.enabled">true</property>
       <property name="env.setup.script.url">setup.sh</property>
       <property name="env.teardown.script.url">teardown.sh</property>
-      <property name="wait.for.service.list">syndesis-server syndesis-ui</property>
+      <property name="wait.for.service.list">syndesis-server,syndesis-ui</property>
       <property name="wait.timeout">600000</property>
       <property name="logs.copy">true</property>
     </extension>

--- a/app/test/src/test/resources/setup.sh
+++ b/app/test/src/test/resources/setup.sh
@@ -21,8 +21,8 @@ if [ -z "${DEMO_DATA_ENABLED}" ]; then
 fi
 
 SYNDESIS_TEMPLATE_TYPE="syndesis"
-SYNDESIS_TEMPLATE_URL="${WORKSPACE}/deploy/${SYNDESIS_TEMPLATE_TYPE}.yml"
-SYNDESIS_OAUTHCLIENT_URL="${WORKSPACE}/deploy/support/serviceaccount-as-oauthclient-restricted.yml"
+SYNDESIS_TEMPLATE_URL="${WORKSPACE:-$(pwd)/../..}/install/${SYNDESIS_TEMPLATE_TYPE}.yml"
+SYNDESIS_OAUTHCLIENT_URL="${WORKSPACE:-$(pwd)/../..}/install/support/serviceaccount-as-oauthclient-restricted.yml"
 
 ROUTE_HOSTNAME=${KUBERNETES_NAMESPACE}.b6ff.rh-idev.openshiftapps.com
 


### PR DESCRIPTION
This upgrades versions of Arquillian, Arquillian Cube, Fabric8
Kubernetes Client and cleans up Maven POMs. Path to OpenShift templates
was fixed and if $WORKSPACE is not defined relative path to `/install`
is used. Test for UI readiness is enabled again.

Tested locally.