### PR TITLE
Fix driver upload management

### DIFF
--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -182,7 +182,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
@@ -236,7 +236,7 @@
       <artifactId>connector-sftp</artifactId>
       <scope>runtime</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-dropbox</artifactId>
@@ -289,11 +289,6 @@
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-salesforce</artifactId>
       <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
     </dependency>
 
     <!-- === Testing Dependencies ======================================================== -->

--- a/app/meta/src/main/fabric8-includes/run-env.sh
+++ b/app/meta/src/main/fabric8-includes/run-env.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if ls $LOADER_HOME | grep -e ".*\.jar$" > /dev/null 2>&1; then
+    EXTENSION_JARS=$(ls $LOADER_HOME | grep -e ".*\.jar$")
+    export LOADER_PATH=$(echo $EXTENSION_JARS | sed 's/ /,/g')
+fi
+
+echo "Using the following extensions in the spring-boot loader path: $LOADER_PATH"

--- a/app/meta/src/test/java/io/syndesis/connector/meta/v1/DriverUploadTest.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/v1/DriverUploadTest.java
@@ -42,7 +42,7 @@ public class DriverUploadTest {
 
     final private static String FILE_NAME = "syndesis-library-jdbc-1.0.0.jar";
     final private static String FILE_CLASSPATH = "drivers/" + FILE_NAME;
-    
+
     @Test
     public void upload() throws IOException, URISyntaxException {
         URL driverClasspath = DriverUploadTest.class.getClassLoader().getResource(FILE_CLASSPATH);
@@ -51,7 +51,7 @@ public class DriverUploadTest {
         MultipartFormDataInput multiPart = mock(MultipartFormDataInput.class);
         InputPart inputPartFileContent = mock(InputPart.class);
         InputPart inputPartFileName = mock(InputPart.class);
-        
+
         List<InputPart> parts = new ArrayList<>();
         parts.add(inputPartFileContent);
         parts.add(inputPartFileName);
@@ -60,7 +60,7 @@ public class DriverUploadTest {
         when(multiPart.getFormDataPart("fileName", String.class, null)).thenReturn(FILE_NAME);
 
         String tempDir = System.getProperty("java.io.tmpdir");
-        System.setProperty("LOADER_PATH", tempDir);
+        System.setProperty("LOADER_HOME", tempDir);
         DriverUploadEndpoint endpoint = new DriverUploadEndpoint();
         Boolean reply = endpoint.upload(multiPart);
         assertThat(reply).isTrue();
@@ -71,13 +71,13 @@ public class DriverUploadTest {
         //Boolean isEquals = FileUtils.contentEquals(originalFile, uploadedFile);
         //assertThat(isEquals).isTrue();
     }
-    
+
     @Test @Ignore //Easy way to quickly upload an extension when running Application.main()
     public void upload2Server() throws IOException {
-        
+
         URL driverClasspath = DriverUploadTest.class.getClassLoader().getResource(FILE_CLASSPATH);
         assertThat(driverClasspath).isNotNull();
-        
+
         final WebTarget target = ClientBuilder.newClient()
                 .target(String.format("http://%s/api/v1/drivers",
                         "localhost:8080"));

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -542,6 +542,7 @@
               <exclude>connector/**/META-INF/syndesis/connector/verifier/*</exclude>
               <exclude>connector/**/springboot/*Configuration.java</exclude><!-- auto generated without headers -->
               <exclude>connector/**/springboot/*Common.java </exclude><!-- auto generated without headers -->
+              <exclude>meta/**/run-env.sh</exclude>
               <exclude>server/syndesis-builder-image-generator/image/**</exclude><!-- auto generated without headers -->
             </excludes>
           </configuration>

--- a/install/generator/04-syndesis-verifier.yml.mustache
+++ b/install/generator/04-syndesis-verifier.yml.mustache
@@ -59,7 +59,7 @@
           env:
           - name: JAVA_APP_DIR
             value: /deployments
-          - name: LOADER_PATH
+          - name: LOADER_HOME
             value: /deployments/ext
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -10,7 +10,7 @@ metadata:
 #
 # Allow localhost refs: true
 # Use docker images: false
-# Atlasmap Tag: 
+# Atlasmap Tag:
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
 #
@@ -894,7 +894,7 @@ objects:
           env:
           - name: JAVA_APP_DIR
             value: /deployments
-          - name: LOADER_PATH
+          - name: LOADER_HOME
             value: /deployments/ext
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -10,7 +10,7 @@ metadata:
 #
 # Allow localhost refs: false
 # Use docker images: false
-# Atlasmap Tag: 
+# Atlasmap Tag:
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
 #
@@ -892,7 +892,7 @@ objects:
           env:
           - name: JAVA_APP_DIR
             value: /deployments
-          - name: LOADER_PATH
+          - name: LOADER_HOME
             value: /deployments/ext
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"


### PR DESCRIPTION
This allows to add uploaded drivers in the loader path without having to unpack them. LOADER_HOME and LOADER_PATH are now used consistently in meta pod and integration pods. 

Requires template reinstall, as a env variable in the meta template is changed.