### PR TITLE
fix(forms): update event bindings

### DIFF
--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.component.html
@@ -9,7 +9,6 @@
            [attr.multiple]="model.multiple"
            [attr.step]="model.step"
            [attr.tabindex]="model.tabIndex"
-           [attr.id]="fieldId"
            [autofocus]="model.autoFocus"
            [dynamicId]="bindId && model.id"
            [(ngModel)]="baseValue"
@@ -23,18 +22,19 @@
            [spellcheck]="model.spellCheck"
            [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
            type="number"
-           (dfBlur)="inputBlurTriggered($event)"
-           (dfChange)="inputChangeTriggered($event)"
-           (dfFocus)="inputFocusTriggered($event)" />
+           (blur)="inputBlurTriggered($event)"
+           (change)="inputChangeTriggered($event)"
+           (focus)="inputFocusTriggered($event)" />
   </div>
   <div class="input-group">
-    <select [attr.id]="'select-' + fieldId"
+    <select [attr.id]="'select-' + model.id"
             class="duration-input__select"
             [(ngModel)]="duration"
             [ngModelOptions]="{standalone: true}"
-            (dfBlur)="selectBlurTriggered($event)"
-            (dfChange)="selectChangeTriggered($event)"
-            (dfFocus)="selectFocusTriggered($event)">
+            (blur)="selectBlurTriggered($event)"
+            (change)="selectChangeTriggered($event)"
+            (change)="selectChangeTriggered($event)"
+            (focus)="selectFocusTriggered($event)">
       <option value="" disabled>Choose a time unit</option>
       <option *ngFor="let duration of durations" [ngValue]="duration">{{ duration.label }}</option>
     </select>

--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
@@ -17,7 +17,6 @@ export class DurationFormControlComponent implements OnInit {
   elementControlClass: string;
   @Input() group: FormGroup;
   @Input() model: any;
-  @Input() fieldId: string;
   @Input() bindId: boolean;
 
   @Output() blur = new EventEmitter<any>();

--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -37,9 +37,9 @@
                [ngClass]="elementControlClass"
                [required]="model.required"
                [value]="model.value"
-               (dfBlur)="onBlur($event)"
-               (dfChange)="onValueChange($event)"
-               (dfFocus)="onFocus($event)">
+               (blur)="onBlur($event)"
+               (change)="onValueChange($event)"
+               (focus)="onFocus($event)">
         <span [innerHTML]="model.label"
               [ngClass]="[elementLabelClass, gridLabelClass]">
         </span>
@@ -82,9 +82,9 @@
                                  [model]="_model"
                                  [templates]="templateList"
                                  [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
-                                 (dfBlur)="onBlur($event)"
-                                 (dfChange)="onValueChange($event)"
-                                 (dfFocus)="onFocus($event)"></syndesis-form-control>
+                                 (blur)="onBlur($event)"
+                                 (change)="onValueChange($event)"
+                                 (focus)="onFocus($event)"></syndesis-form-control>
 
             <ng-container *ngTemplateOutlet="templates[2]?.templateRef; context: groupModel"></ng-container>
         </div>
@@ -113,9 +113,9 @@
                                [model]="_model"
                                [templates]="templateList"
                                [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
-                               (dfBlur)="onBlur($event)"
-                               (dfChange)="onValueChange($event)"
-                               (dfFocus)="onFocus($event)"></syndesis-form-control>
+                               (blur)="onBlur($event)"
+                               (change)="onValueChange($event)"
+                               (focus)="onFocus($event)"></syndesis-form-control>
       </fieldset>
 
       <!-- INPUT -->
@@ -126,11 +126,10 @@
           <ng-container *ngSwitchCase="'duration'">
             <syndesis-duration-control [group]="group"
                                        [model]="model"
-                                       [fieldId]="model.id"
                                        [bindId]="bindId"
-                                       (dfBlur)="onBlur($event)"
-                                       (dfChange)="onValueChange($event)"
-                                       (dfFocus)="onFocus($event)">
+                                       (blur)="onBlur($event)"
+                                       (change)="onValueChange($event)"
+                                       (focus)="onFocus($event)">
             </syndesis-duration-control>
           </ng-container>
           <ng-container *ngSwitchDefault>
@@ -163,9 +162,9 @@
                   [spellcheck]="model.spellCheck"
                   [textMask]="{mask: (model.mask || false), showMask: model.mask && !(model.placeholder)}"
                   [type]="model.inputType"
-                  (dfBlur)="onBlur($event)"
-                  (dfChange)="onValueChange($event)"
-                  (dfFocus)="onFocus($event)" />
+                  (blur)="onBlur($event)"
+                  (change)="onValueChange($event)"
+                  (focus)="onFocus($event)" />
 
             <div *ngIf="model.suffix"
                 class="input-group-addon"
@@ -191,7 +190,7 @@
                 [dynamicId]="bindId && model.id"
                 [name]="model.name"
                 [ngClass]="elementControlClass"
-                (dfChange)="onValueChange($event)">
+                (change)="onValueChange($event)">
 
         <legend *ngIf="model.legend"
                 [innerHTML]="model.legend"></legend>
@@ -205,8 +204,8 @@
                    [formControlName]="model.id"
                    [name]="model.name"
                    [value]="option.value"
-                   (dfBlur)="onBlur($event)"
-                   (dfFocus)="onFocus($event)" />
+                   (blur)="onBlur($event)"
+                   (focus)="onFocus($event)" />
             <span [innerHTML]="option.label"></span>
           </label>
         </div>
@@ -222,9 +221,9 @@
               [tooltip]="model.controlTooltip"
               [ngClass]="elementControlClass"
               [required]="model.required"
-              (dfBlur)="onBlur($event)"
-              (dfChange)="onValueChange($event)"
-              (dfFocus)="onFocus($event)">
+              (blur)="onBlur($event)"
+              (change)="onValueChange($event)"
+              (focus)="onFocus($event)">
 
         <option *ngFor="let option of model.options$ | async"
                 [attr.name]="model.name"
@@ -250,9 +249,9 @@
                 [rows]="model.rows"
                 [spellcheck]="model.spellCheck"
                 [wrap]="model.wrap"
-                (dfBlur)="onBlur($event)"
-                (dfChange)="onValueChange($event)"
-                (dfFocus)="onFocus($event)"></textarea>
+                (blur)="onBlur($event)"
+                (change)="onValueChange($event)"
+                (focus)="onFocus($event)"></textarea>
 
 
       <span *ngIf="showHint" class="help-block" [innerHTML]="model.hint" [ngClass]="getClass('element', 'hint')"></span>

--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.spec.ts
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.spec.ts
@@ -125,19 +125,19 @@ describe('SyndesisFormComponent test suite', () => {
 
   it('should listen to native focus events', () => {
     spyOn(component, 'onFocus');
-    testElement.triggerEventHandler('dfFocus', null);
+    testElement.triggerEventHandler('focus', null);
     expect(component.onFocus).toHaveBeenCalled();
   });
 
   it('should listen to native blur events', () => {
     spyOn(component, 'onBlur');
-    testElement.triggerEventHandler('dfBlur', null);
+    testElement.triggerEventHandler('blur', null);
     expect(component.onBlur).toHaveBeenCalled();
   });
 
   it('should listen to native change event', () => {
     spyOn(component, 'onValueChange');
-    testElement.triggerEventHandler('dfChange', null);
+    testElement.triggerEventHandler('change', null);
     expect(component.onValueChange).toHaveBeenCalled();
   });
 

--- a/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/syndesis-form-control.component.ts
@@ -77,10 +77,9 @@ export class SyndesisFormComponent extends DynamicFormControlComponent
   @Input() model: DynamicFormControlModel;
 
   /* tslint:disable */
-  @Output('dfBlur') blur: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
-  @Output('dfChange') change: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
-  @Output('dfFocus') focus: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
-  @Output('bsEvent') customEvent: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
+  @Output() blur: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
+  @Output() change: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
+  @Output() focus: EventEmitter<DynamicFormControlEvent> = new EventEmitter<DynamicFormControlEvent>();
   /* tslint:enable */
 
   type: SyndesisFormControlType | null;


### PR DESCRIPTION
This PR corrects the event bindings for our model driven forms, and in turn allows the correct callbacks to fire when the duration control's value has changed.

The same fix has been applied for all form controls.

bind to and declare appropriate event names
remove dom id from duration control that's no longer needed
remove unneeded @Input
update test

fixes #1930 