### PR TITLE
fix: Custom API Connector delete button is back with a repurposed confirmation modal

### DIFF
--- a/app/ui/src/app/common/delete_confirmation_modal/delete-confirmation-modal.component.ts
+++ b/app/ui/src/app/common/delete_confirmation_modal/delete-confirmation-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Output, EventEmitter, Input } from '@angular/core';
 
 @Component({
   selector: 'delete-confirmation-modal',
@@ -10,7 +10,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
             (click)="onModalClick(false)">
       <span class="pficon pficon-close"></span>
     </button>
-    <h4 class="modal-title">Delete Warning</h4>
+    <h4 class="modal-title">{{ title }}</h4>
   </div>
   <div class="modal-body">
     <div class="row">
@@ -34,6 +34,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
   `
 })
 export class DeleteConfirmationModalComponent {
+  @Input() title = 'Warning';
   @Output() delete = new EventEmitter<boolean>();
 
   onModalClick(doDelete: boolean): void {

--- a/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
@@ -48,7 +48,7 @@
             </div>
           </ng-template>
           <ng-template #actionTemplate let-item="item" let-index="index">
-            <button *ngIf="!(item.connectorGroup)" type="button" (click)="onDelete(item.id)" [disabled]="item.uses > 0" class="foo btn btn-default">
+            <button type="button" (click)="onDelete(item)" [disabled]="item.uses > 0" class="foo btn btn-default">
               Delete
             </button>
           </ng-template>
@@ -61,9 +61,11 @@
 
 <ng-template #confirmDeleteModalTemplate>
   <delete-confirmation-modal (delete)="onDeleteConfirm($event)">
-    <h3>Do you really want to delete this custom connector?</h3>
+    <h3>You can no longer edit a connection that was created from this connector.</h3>
     <p>
-      This action cannot be undone.
+      You can still add connections created from this connector to integrations. 
+      Deleting this connector does not affect running integrations.
     </p>
+    <p>Are you sure you want to delete the "{{ deletableApiConnectorName }}" connector?</p>
   </delete-confirmation-modal>
 </ng-template>

--- a/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.ts
@@ -30,6 +30,7 @@ export class ApiConnectorListComponent implements OnInit, OnDestroy {
     '=1': '<strong>1</strong> time',
     'other': '<strong>#</strong> times'
   };
+  deletableApiConnectorName: string;
 
   private confirmDeleteModalId = 'confirm-delete-modal';
 
@@ -91,7 +92,8 @@ export class ApiConnectorListComponent implements OnInit, OnDestroy {
     this.router.navigate([apiConnector.id], { relativeTo: this.route });
   }
 
-  onDelete(id: string): void {
+  onDelete({ id, name }): void {
+    this.deletableApiConnectorName = name;
     this.modalService.show(this.confirmDeleteModalId).then(modal => {
       if (modal.result) {
         this.apiConnectorStore.dispatch(ApiConnectorActions.delete(id));


### PR DESCRIPTION
Fixes #1827 

Behold humans, the beauty of deleting things...

![captura de pantalla 2018-03-13 a las 10 48 30](https://user-images.githubusercontent.com/1104146/37334168-6c43bc32-26ab-11e8-8042-7ce23c07bf89.png)
![captura de pantalla 2018-03-13 a las 10 48 40](https://user-images.githubusercontent.com/1104146/37334174-6e2c4de8-26ab-11e8-91f4-0be0ac271220.png)
