### PR TITLE
[monitoring] Updated UI component and delta refreshing implemented

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
@@ -9,60 +9,76 @@
   Error: the activity logs could not be refreshed. Please try again by clicking on 'Refresh'.
 </syndesis-validation-error>
 
-<pfng-list [items]="activities" [config]="{ useExpandItems: true }" [itemTemplate]="itemTemplate" [expandTemplate]="expandTemplate"
-  [actionTemplate]="actionTemplate">
-  <ng-template #itemTemplate let-activity="item" let-index="index">
-    <div class="list-pf-content-wrapper">
-      <div class="list-pf-main-content">
-        <div class="list-pf-title">
-          {{ activity.at | date: 'M/d/yy' }}
-        </div>
-        <div class="list-pf-description text-overflow-pf">
-          {{ activity.at | date: 'mediumTime' }}
-        </div>
-        <div class="list-pf-description text-overflow-pf">
-          Version {{ activity.ver || 'unknown' }}
-        </div>
-        <div class="list-pf-description text-overflow-pf" *ngIf="activity.failed; else notFailed">
-          <i class="pficon pficon-error-circle-o"></i> Errors found
-        </div>
-        <ng-template #notFailed>
-          <div class="list-pf-description text-overflow-pf">
-            <i class="pficon pficon-ok"></i> No errors
+<div class="list-group list-view-pf list-view-pf-view">
+  <div class="list-group-item"
+    *ngFor="let activity of activities"
+    [class.list-view-pf-expand-active]="activity.id == selectedActivity?.id">
+    <div class="list-group-item-header" (click)="onSelectActivity($event, activity)">
+      <div class="list-view-pf-expand" [class.active]="activity.id == selectedActivity?.id">
+        <span class="fa fa-angle-right" [class.fa-angle-down]="activity.id == selectedActivity?.id"></span>
+      </div>
+
+      <div class="list-view-pf-main-info">
+        <div class="list-view-pf-body">
+          <div class="list-view-pf-description">
+            <div class="list-group-item-heading">
+              {{ activity.at | date: 'M/d/yy' }}
+            </div>
+            <div class="list-group-item-text">
+              {{ activity.at | date: 'mediumTime' }}
+            </div>
           </div>
-        </ng-template>
+          <div class="list-view-pf-additional-info">
+            <div class="list-view-pf-additional-info-item">
+              Version {{ activity.ver || 'unknown' }}
+            </div>
+            <div class="list-view-pf-additional-info-item" *ngIf="activity.failed; else notFailed">
+              <i class="pficon pficon-error-circle-o"></i> Errors found
+            </div>
+            <ng-template #notFailed>
+              <div class="list-view-pf-additional-info-item">
+                <i class="pficon pficon-ok"></i> No errors
+              </div>
+            </ng-template>
+          </div>
+        </div>
       </div>
     </div>
-  </ng-template>
-  <ng-template #expandTemplate let-activity="item" let-index="index">
-    <table class="table table-bordered">
-      <thead>
-        <tr>
-          <th>Step</th>
-          <th>Time</th>
-          <th>Duration</th>
-          <th>Status</th>
-          <th>Output</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let step of activity.steps">
-          <td>{{ step.name }}</td>
-          <td>{{ step.at | date:'medium' }}</td>
-          <td>{{ step.duration | synDuration: 's' }}</td>
-          <td *ngIf="step.isFailed"><i class="pficon pficon-error-circle-o"></i> Error</td>
-          <td *ngIf="!step.isFailed"><i class="pficon pficon-ok"></i> Success</td>
-          <td>{{ step.output }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </ng-template>
-  <ng-template #actionTemplate let-activity="item" let-index="index">
+    <div class="list-group-item-container container-fluid" [class.hidden]="activity.id != selectedActivity?.id">
+      <div class="close" (click)="onSelectActivity($event, activity)">
+        <span class="pficon pficon-close"></span>
+      </div>
+      <div class="row">
+        <div class="col-md-11">
+          <table class="table table-bordered">
+            <thead>
+              <tr>
+                <th>Step</th>
+                <th>Time</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th>Output</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let step of activity.steps">
+                <td>{{ step.name }}</td>
+                <td>{{ step.at | date:'medium' }}</td>
+                <td>{{ step.duration | synDuration: 's' }}</td>
+                <td *ngIf="step.isFailed">
+                  <i class="pficon pficon-error-circle-o"></i> Error</td>
+                <td *ngIf="!step.isFailed">
+                  <i class="pficon pficon-ok"></i> Success</td>
+                <td>{{ step.output }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
-  </ng-template>
-</pfng-list>
-
-<pfng-pagination *ngIf="showPagination" class="integration-activity__pagination" [config]="paginationConfig"
-  (onPageNumberChange)="renderActivitiesByPage()"
+<pfng-pagination *ngIf="showPagination" class="integration-activity__pagination" [config]="paginationConfig" (onPageNumberChange)="renderActivitiesByPage()"
   (onPageSizeChange)="renderActivitiesByPage()">
 </pfng-pagination>

--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.scss
@@ -5,7 +5,7 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    padding: 0 0 $gutter;
+    padding: 0;
 
     &-text {
       color: $color-pf-black-400;
@@ -18,4 +18,15 @@
     border: 0;
     margin: $gutter 0;
   }
+}
+
+// Patternfly overrides
+.list-group-item-container {
+  .table {
+    margin-top: 20px;
+  }
+}
+
+.list-view-pf-expand {
+  margin-top: 15px;
 }

--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
@@ -22,6 +22,8 @@ export class IntegrationActivityComponent implements OnInit {
     pageSizeIncrements: [15, 40, 75]
   };
 
+  selectedActivity: Activity;
+
   private allActivities: Activity[] = [];
 
   constructor(private integrationSupportService: IntegrationSupportService) { }
@@ -62,15 +64,24 @@ export class IntegrationActivityComponent implements OnInit {
     this.activities = this.allActivities.slice(pageItemIndex, pageItemIndex + this.paginationConfig.pageSize);
   }
 
+  onSelectActivity(event: Event, activity: Activity): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.selectedActivity = this.selectedActivity && this.selectedActivity.id === activity.id ? null : activity;
+  }
+
   private updateActivities(activities: Activity[]): void {
     this.onRefresh = false;
     this.lastRefresh = new Date();
-    this.showPagination = (activities.length > this.paginationConfig.pageSize);
-    this.allActivities = activities.sort((activity1, activity2) => {
-      return activity1.at < activity1.at ? -1 : activity1.at > activity1.at ? 1 : 0;
-    });
 
-    this.paginationConfig.totalItems = activities.length;
+    const aggregatedActivities = [...activities, ...this.allActivities];
+    
+    this.allActivities = Array.from(new Set(aggregatedActivities.map(activity => activity.id)))
+      .map(id => aggregatedActivities.find(activity => activity.id === id))
+      .sort((activity1, activity2) => activity2.at - activity1.at);
+    
+    this.showPagination = (this.allActivities.length > this.paginationConfig.pageSize);
+    this.paginationConfig.totalItems = this.allActivities.length;
     this.paginationConfig.pageNumber = 1;
     this.renderActivitiesByPage();
   }


### PR DESCRIPTION
This PR wraps up the outstanding UI work required for #1855 and implements the late feedback provided by @michael-coker and @amysueg in the issue's discussion thread.

### UI Enhancements
The UX folks wanted the activity log listing to feature the [list view expansion](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/list-view-simple-expansion.html) look and feel. Unfortunately patternfly-ng still does not provide support for that feature in the list component, so I eventually removed the original component and recreated that functionality as an Angular implementation over the original PF raw code.

This also allowed for finetuning margins and paddings to better match the original designs provided.

### Data enhancements
The API showed off an unexpected behavior where only the last 9 items were returned on each call. This might be considered a bug or perhaps the API had been originally designed to return just a cursor of deltas.

In any event, the frontend implementation has been updated to take advantage of this circumstance and digest the information coming from the API (either a cursor of deltas or a full recordset) in an accumulative fashion, so the data is merged with the already fetched records, duplicates are removed and items are sorted by date in descending order.

This has also allowed to reinstate the pagination widgets with page size setup functionality.

### Screenshots

![captura de pantalla 2018-03-13 a las 16 50 53](https://user-images.githubusercontent.com/1104146/37354519-256b4762-26e2-11e8-9e09-a314b24d7b33.png)

![captura de pantalla 2018-03-13 a las 16 51 14](https://user-images.githubusercontent.com/1104146/37354525-2989e0b0-26e2-11e8-8960-5022d3de8d02.png)
