### PR TITLE
Templates, bumped verifier pvc demands to 1Gi

### DIFF
--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -111,7 +111,7 @@ parameters:
   displayName: Verifier Volume Capacity
   name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 256Mi
+  value: 1Gi
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -10,7 +10,7 @@ metadata:
 #
 # Allow localhost refs: true
 # Use docker images: false
-# Atlasmap Tag:
+# Atlasmap Tag: 
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
 #
@@ -114,7 +114,7 @@ parameters:
   displayName: Verifier Volume Capacity
   name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 256Mi
+  value: 1Gi
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -10,7 +10,7 @@ metadata:
 #
 # Allow localhost refs: false
 # Use docker images: false
-# Atlasmap Tag:
+# Atlasmap Tag: 
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
 #
@@ -114,7 +114,7 @@ parameters:
   displayName: Verifier Volume Capacity
   name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 256Mi
+  value: 1Gi
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:


### PR DESCRIPTION
The requirement is related to an AWS limitation for EBS that would anyhow allocate 1Gi chunks, even if a pvc asks for less, wasting space and adding it from sight. 