### PR TITLE
chore(build): add test reports from UI to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ save_junit: &save_junit
     when: always
     command: |
       mkdir -p /workspace/junit/
-      find . -type f -regextype posix-extended -regex ".*/target/(surefire|failsafe)-reports/.*xml" | xargs -i cp --backup --suffix=.xml {} /workspace/junit/
+      find . -type f -regextype posix-extended -regex ".*target/.*TESTS?-.*xml" | xargs -i cp --backup --suffix=.xml {} /workspace/junit/
 
 jobs:
   # UI has no dependencies, just load cache
@@ -86,6 +86,9 @@ jobs:
             apt-get update
             apt-get install libxss1
             ./tools/bin/syndesis build --batch-mode --module ui --image-mode=docker | tee build_log.txt
+      - <<: *save_junit
+      - store_test_results:
+          path: /workspace/junit
       - store_artifacts:
           path: ./build_ui_log.txt
       - save_cache:

--- a/app/ui/karma.conf.js
+++ b/app/ui/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function (config) {
       fixWebpackSourcePaths: true
     },
     junitReporter: {
-      outputDir: './junit'
+      outputDir: './target'
     },
     angularCli: {
       config: './angular-cli.json',
@@ -38,7 +38,7 @@ module.exports = function (config) {
     },
     reporters: config.angularCli && config.angularCli.codeCoverage
       ? ['mocha', 'coverage-istanbul', 'junit']
-      : ['mocha'],
+      : ['mocha', 'junit'],
     mochaReporter: {
       output: 'full'
     },


### PR DESCRIPTION
This changes the configuration of Karma test runner to output JUnit test
XML result file to `target` directory when the tests are run.
This in turn will be picked up by CircleCI so we can see what tests
failed without rummaging through the step console output.