### PR TITLE
refactor(server): return status 400 for errors from meta

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/MetaData.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/MetaData.java
@@ -17,6 +17,8 @@ package io.syndesis.server.endpoint.v1.dto;
 
 import java.util.Optional;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.immutables.value.Value;
 
 /**
@@ -27,7 +29,13 @@ import org.immutables.value.Value;
 public interface MetaData {
 
     enum Type {
-        DANGER, INFO, SUCCESS, WARNING
+        DANGER(Status.BAD_REQUEST), INFO(Status.OK), SUCCESS(Status.OK), WARNING(Status.BAD_REQUEST);
+
+        public final Status status;
+
+        private Type(final Status status) {
+            this.status = status;
+        }
     }
 
     Optional<String> getMessage();


### PR DESCRIPTION
When metadata call to `syndesis-meta` fails we should provide the UI with status 400 in addition to the `_meta` property being added.