### PR TITLE
fix(server): try to use correct input/output shapes

### DIFF
--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
@@ -169,7 +169,7 @@ public class DynamicActionSalesforceITCase extends BaseITCase {
             ConnectorDescriptor.class, tokenRule.validToken(), headers, HttpStatus.OK);
 
         final ConnectorDescriptor firstEnrichment = new ConnectorDescriptor.Builder()//
-            .inputDataShape(new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA).build())
+            .inputDataShape(new DataShape.Builder().kind(DataShapeKinds.ANY).build())
             .outputDataShape(new DataShape.Builder().kind(DataShapeKinds.JAVA)
                 .type("org.apache.camel.component.salesforce.api.dto.CreateSObjectResult").build())
             .withActionDefinitionStep("Select Salesforce object", "Select Salesforce object type to create",


### PR DESCRIPTION
**Builds on PR #1979, have a look at that one.**

With this if the result of metadata invocation for data shapes that
should contain specification/type, i.e. all that don't have their kind
defined as `none` or `any, and do not in fact contain those, for
instance if the meta data invocation fails or returns an erroneous data
shape, the resulting data shape will be set to `kind=any`.

Fixes #1967