### PR TITLE
fix(server): fix connection leak

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
@@ -47,6 +47,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okio.BufferedSink;
 import okio.Okio;
+import okio.Source;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
@@ -142,9 +143,10 @@ public final class ConnectorIconHandler extends BaseHandler {
             }
 
             final StreamingOutput streamingOutput = (out) -> {
-                final BufferedSink sink = Okio.buffer(Okio.sink(out));
-                sink.writeAll(Okio.source(iconDao.read(connectorIconId)));
-                sink.close();
+                try (BufferedSink sink = Okio.buffer(Okio.sink(out));
+                    Source source = Okio.source(iconDao.read(connectorIconId))) {
+                    sink.writeAll(source);
+                }
             };
             return Response.ok(streamingOutput, icon.getMediaType()).build();
         } else if (connectorIcon.startsWith("extension:")) {


### PR DESCRIPTION
The `InputStream` set on the Icon was not closed and as a result
database resources were never freed. This makes sure that the resources
are freed by wrapping their use in try-with-resources block.

Fixes #2015