### PR TITLE
fix: (#1892) Unpublishing is now displayed as a status when unpublishing an integration.

### DIFF
--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/UnpublishHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/UnpublishHandler.java
@@ -44,7 +44,7 @@ public class UnpublishHandler extends BaseHandler implements StateChangeHandler 
         Map<String, String> stepsDone = new HashMap<>(integrationDeployment.getStepsDone());
         stepsDone.remove("deploy"); //we are literally undoing this step.
 
-        IntegrationDeploymentState currentState = integrationDeployment.getCurrentState();
+        IntegrationDeploymentState currentState = IntegrationDeploymentState.Pending;
 
         Map<String, String> labels = new HashMap<>();
         labels.put(OpenShiftService.INTEGRATION_ID_LABEL, Labels.validate(integrationDeployment.getIntegrationId().get()));
@@ -53,7 +53,6 @@ public class UnpublishHandler extends BaseHandler implements StateChangeHandler 
         if (!openShiftService().getDeploymentsByLabel(labels).isEmpty()) {
             try {
                 openShiftService().scale(integrationDeployment.getSpec().getName(), labels, 0, 1, TimeUnit.MINUTES);
-                currentState = IntegrationDeploymentState.Unpublished;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return new StateUpdate(currentState, stepsDone);

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
@@ -88,9 +88,8 @@ public interface OpenShiftService {
      * @param desiredReplicas how many replicas to scale to
      * @param amount of time to wait for scaling
      * @param timeUnit of the time
-     * @return true if scaling was completed, false otherwise.
      */
-    boolean scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException;
+    void scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException;
 
 
     /**

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -108,7 +108,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     public void scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException {
         String sName = openshiftName(name);
 
-        DeploymentConfig deploymentConfig = getDeploymentsByLabel(labels)
+        getDeploymentsByLabel(labels)
             .stream()
             .filter(d -> d.getMetadata().getName().equals(sName))
             .map(d -> new DeploymentConfigBuilder(d).editSpec().withReplicas(desiredReplicas).endSpec().build())

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -333,22 +333,6 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         throw SyndesisServerException.launderThrowable(new TimeoutException("Timed out waiting for build completion."));
     }
 
-    private DeploymentConfig waitForDeployment(DeploymentConfig r, long timeout, TimeUnit timeUnit) throws InterruptedException {
-        long end = System.currentTimeMillis() + timeUnit.toMillis(timeout);
-        DeploymentConfig next = r;
-
-        while ( System.currentTimeMillis() < end) {
-            if (next.getSpec().getReplicas().equals(next.getStatus().getReplicas())) {
-                return next;
-            }
-            next = openShiftClient.deploymentConfigs().inNamespace(next.getMetadata().getNamespace()).withName(next.getMetadata().getName()).get();
-            Thread.sleep(5000);
-        }
-        throw SyndesisServerException.launderThrowable(new TimeoutException("Timed out waiting for build completion."));
-
-    }
-
-
     protected static String openshiftName(String name) {
         return OPENSHIFT_PREFIX + Names.sanitize(name);
     }

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -107,13 +107,11 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     @Override
     public void scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException {
         String sName = openshiftName(name);
-
         getDeploymentsByLabel(labels)
             .stream()
             .filter(d -> d.getMetadata().getName().equals(sName))
             .map(d -> new DeploymentConfigBuilder(d).editSpec().withReplicas(desiredReplicas).endSpec().build())
-            .map(d -> openShiftClient.deploymentConfigs().createOrReplace(d))
-            .findAny().orElse(null);
+            .findAny().ifPresent(d -> openShiftClient.deploymentConfigs().createOrReplace(d));
     }
 
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -105,7 +105,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     }
 
     @Override
-    public boolean scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException {
+    public void scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException {
         String sName = openshiftName(name);
 
         DeploymentConfig deploymentConfig = getDeploymentsByLabel(labels)
@@ -114,11 +114,6 @@ public class OpenShiftServiceImpl implements OpenShiftService {
             .map(d -> new DeploymentConfigBuilder(d).editSpec().withReplicas(desiredReplicas).endSpec().build())
             .map(d -> openShiftClient.deploymentConfigs().createOrReplace(d))
             .findAny().orElse(null);
-
-        if (deploymentConfig == null) {
-            return false;
-        }
-       return waitForDeployment(deploymentConfig, amount, timeUnit).getSpec().getReplicas().equals(desiredReplicas);
     }
 
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceNoOp.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceNoOp.java
@@ -56,8 +56,7 @@ public class OpenShiftServiceNoOp implements OpenShiftService {
     }
 
     @Override
-    public boolean scale(String name, Map<String, String> lables, int desiredReplicas, long amount, TimeUnit timeUnit)  {
-        return false;
+    public void scale(String name, Map<String, String> lables, int desiredReplicas, long amount, TimeUnit timeUnit)  {
     }
 
     @Override

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceNoOp.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceNoOp.java
@@ -57,6 +57,7 @@ public class OpenShiftServiceNoOp implements OpenShiftService {
 
     @Override
     public void scale(String name, Map<String, String> lables, int desiredReplicas, long amount, TimeUnit timeUnit)  {
+        // Empty no-op just for testing
     }
 
     @Override

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -35,7 +35,7 @@
 
         <ng-container [ngSwitch]="integration.currentState">	 
           <ng-container *ngSwitchCase="'Pending'">	  
-            <div class="spinner spinner-sm spinner-inline"></div> {{integration.targetState == 'Published' ? 'Publishing...' : 'Unpublishing...'}}
+            <div class="spinner spinner-sm spinner-inline"></div> {{ integration.targetState == 'Published' ? 'Publishing...' : 'Unpublishing...' }}
           </ng-container>
           <ng-container *ngSwitchCase="'Published'">
             <span class="pficon pficon-ok"></span> Published version {{ integration.deploymentVersion }}

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -33,9 +33,9 @@
           <syndesis-editable-text [value]="integration.name" [validationFn]="validateName" (onSave)="nameUpdated($event)"></syndesis-editable-text>
         </h1>
 
-        <ng-container [ngSwitch]="integration.currentState">
-          <ng-container *ngSwitchCase="'Pending'">
-            <div class="spinner spinner-sm spinner-inline"></div> Publishing...
+        <ng-container [ngSwitch]="integration.currentState">	 
+          <ng-container *ngSwitchCase="'Pending'">	  
+            <div class="spinner spinner-sm spinner-inline"></div> {{integration.targetState == 'Published' ? 'Publishing...' : 'Unpublishing...'}}
           </ng-container>
           <ng-container *ngSwitchCase="'Published'">
             <span class="pficon pficon-ok"></span> Published version {{ integration.deploymentVersion }}
@@ -47,6 +47,7 @@
             <span class="pficon pficon-error"></span> Published version {{ integration.deploymentVersion }}
           </ng-container>
         </ng-container>
+
       </div>
 
       <div *ngIf="integration.messages && integration.messages.length" class="col-md-12">


### PR DESCRIPTION
We no long block until integration is scaled down. We set the status to pending and return. Followup calls to the Unpublish handler will determine when the integration is actually unpublished and set the correct status then. This allows the "Unpublishing" text to appear in the ui.