### PR TITLE
fix(amq-connection): tweak forms to avoid double negative

### DIFF
--- a/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
+++ b/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
@@ -93,7 +93,7 @@
       "defaultValue": "false",
       "deprecated": false,
       "secret": false,
-      "labelHint": "For convenience in only development environments. Ensure certificate checks are enabled for secure production environments.",
+      "labelHint": "Ensure certificate checks are enabled for secure production environments. Disable for convenience in only development environments.",
       "order": "5"
     },
     "brokerCertificate": {

--- a/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
+++ b/app/connector/activemq/src/main/resources/META-INF/syndesis/connector/activemq.json
@@ -73,7 +73,7 @@
     },
     "skipCertificateCheck": {
       "kind": "property",
-      "displayName": "Skip Certificate Check",
+      "displayName": "Check Certificates",
       "group": "security",
       "label": "common,security",
       "required": false,
@@ -93,7 +93,7 @@
       "defaultValue": "false",
       "deprecated": false,
       "secret": false,
-      "labelHint": "For convenience in only development environments. Do not set for secure production environments.",
+      "labelHint": "For convenience in only development environments. Ensure certificate checks are enabled for secure production environments.",
       "order": "5"
     },
     "brokerCertificate": {
@@ -111,11 +111,11 @@
       "order": "6",
       "relation": [
         {
-          "action": "DISABLE",
+          "action": "ENABLE",
           "when": [
             {
               "id": "skipCertificateCheck",
-              "value": "false"
+              "value": "true"
             }
           ]
         }
@@ -136,11 +136,11 @@
       "order": "7",
       "relation": [
         {
-          "action": "DISABLE",
+          "action": "ENABLE",
           "when": [
             {
               "id": "skipCertificateCheck",
-              "value": "false"
+              "value": "true"
             }
           ]
         }
@@ -179,7 +179,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "labelHint": "Name of the queue or topic to send data to.",
+                "description": "Name of the queue or topic to send data to.",
                 "order": "1"
               },
               "destinationType": {
@@ -257,7 +257,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "labelHint": "Name of the queue or topic to receive data from.",
+                "description": "Name of the queue or topic to receive data from.",
                 "order": "1"
               },
               "destinationType": {
@@ -342,7 +342,7 @@
             "properties": {
               "destinationName": {
                 "kind": "path",
-                "displayName": "Name of the queue or topic to send data to.",
+                "displayName": "Destination Name",
                 "group": "common",
                 "required": true,
                 "type": "string",
@@ -351,7 +351,7 @@
                 "deprecated": false,
                 "secret": false,
                 "componentProperty": false,
-                "labelHint": "DestinationName is a JMS queue or topic name. By default the destinationName is interpreted as a queue name.",
+                "description": "Name of the queue or topic to send data to.",
                 "order": "1"
               },
               "destinationType": {

--- a/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
+++ b/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
@@ -93,7 +93,7 @@
       "defaultValue" : "false",
       "deprecated" : false,
       "secret" : false,
-      "labelHint" : "For convenience in only development environments. Ensure certificate checks are enabled for secure production environments.",
+      "labelHint" : "Ensure certificate checks are enabled for secure production environments. Disable for convenience in only development environments.",
       "order": "5"
     },
     "brokerCertificate" : {

--- a/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
+++ b/app/connector/amqp/src/main/resources/META-INF/syndesis/connector/amqp.json
@@ -73,7 +73,7 @@
     },
     "skipCertificateCheck" : {
       "kind" : "property",
-      "displayName" : "Skip Certificate Check",
+      "displayName" : "Check Certificates",
       "group" : "security",
       "label" : "common,security",
       "required" : false,
@@ -93,7 +93,7 @@
       "defaultValue" : "false",
       "deprecated" : false,
       "secret" : false,
-      "labelHint" : "For convenience in only development environments. Do not set for secure production environments.",
+      "labelHint" : "For convenience in only development environments. Ensure certificate checks are enabled for secure production environments.",
       "order": "5"
     },
     "brokerCertificate" : {
@@ -103,12 +103,23 @@
       "label" : "common,security",
       "required" : false,
       "componentProperty": true,
-      "type" : "string",
+      "type" : "textarea",
       "javaType" : "java.lang.String",
       "deprecated" : false,
       "secret" : false,
-      "labelHint" : "AMQ Broker X.509 PEM Certificate",
-      "order": "6"
+      "description" : "AMQ Broker X.509 PEM Certificate",
+      "order": "6",
+      "relation": [
+        {
+          "action": "ENABLE",
+          "when": [
+            {
+              "id": "skipCertificateCheck",
+              "value": "true"
+            }
+          ]
+        }
+      ]
     },
     "clientCertificate" : {
       "kind" : "property",
@@ -117,12 +128,23 @@
       "label" : "common,security",
       "required" : false,
       "componentProperty": true,
-      "type" : "string",
+      "type" : "textarea",
       "javaType" : "java.lang.String",
       "deprecated" : false,
       "secret" : false,
-      "labelHint" : "AMQ Client X.509 PEM Certificate",
-      "order": "7"
+      "description" : "AMQ Client X.509 PEM Certificate",
+      "order": "7",
+      "relation": [
+        {
+          "action": "ENABLE",
+          "when": [
+            {
+              "id": "skipCertificateCheck",
+              "value": "true"
+            }
+          ]
+        }
+      ]
     }
   },
   "actions": [


### PR DESCRIPTION
This PR applies some tweaks to the amq/amqp connection configuration to improve the language around setting or skipping a certificate check.

Outstanding question - should the amqp connection also use the same description for the type of broker/client certificate that's used?

@TovaCohen @dongniwang let me know if you see any issues!

switch language around so that amq connection config flow is more intuitive