### PR TITLE
Activity: fix for serialization strategy and empty collections

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Activity.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Activity.java
@@ -18,6 +18,8 @@ package io.syndesis.server.endpoint.v1.handler.activity;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  */
@@ -30,6 +32,7 @@ public class Activity {
     private String ver;
     private String status;
     private Boolean failed;
+    @JsonInclude(Include.NON_ABSENT)
     private List<ActivityStep> steps;
     private JsonNode metadata;
 

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/service/DBActivityTrackingService.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/service/DBActivityTrackingService.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import io.syndesis.common.util.Json;
 import io.syndesis.server.endpoint.v1.handler.activity.Activity;
+import io.syndesis.server.endpoint.v1.handler.activity.ActivityStep;
 import io.syndesis.server.endpoint.v1.handler.activity.ActivityTrackingService;
 import io.syndesis.server.jsondb.GetOptions;
 import io.syndesis.server.jsondb.JsonDB;
@@ -80,7 +81,11 @@ public class DBActivityTrackingService implements ActivityTrackingService {
             Map.Entry<String, JsonNode> entry = i.next();
             try {
                 String value = entry.getValue().textValue();
-                rc.add(Json.reader().forType(Activity.class).readValue(value));
+                Activity activity = Json.reader().forType(Activity.class).readValue(value);
+                if (activity.getSteps() == null){
+                    activity.setSteps(new ArrayList<ActivityStep>());
+                }
+                rc.add(activity);
             } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException ignored) {
                 // We could get stuff like class cast exceptions..
                 LOG.debug("Could convert entry: {}", entry, ignored);


### PR DESCRIPTION
fixes #2065

This is quick and dirty, and one of the narrowest scope I could find to implement this.

Feel free to improve it but consider merging this to close this current blocker.
It would also deserve a unit test to avoid regressions in future.