### PR TITLE
fix: activity table now degrades gracefully when no steps data is available

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.html
@@ -48,7 +48,7 @@
       </div>
       <div class="row">
         <div class="col-md-12">
-          <table class="table table-bordered">
+          <table class="table table-bordered" *ngIf="activity.steps && activity.steps.length; else noStepsFound;">
             <thead>
               <tr>
                 <th>Step</th>
@@ -76,6 +76,9 @@
               </tr>
             </tbody>
           </table>
+          <ng-template #noStepsFound>
+            <p>No steps information was found for this integration</p>
+          </ng-template>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-activity/integration-activity.component.ts
@@ -54,14 +54,16 @@ export class IntegrationActivityComponent implements OnInit {
         // TODO: In a real, efficient RFP environment, this should be performed as a
         //       one step operation within the reducer data logic and never within a component
         activitities.forEach(activity => {
-          activity.steps.forEach(step => {
-            // XXX: ANTIPATTERN AHEAD. The following code block mutates an object state
-            const integrationStep = this.integration.steps.find(_integrationStep => _integrationStep.id == step.id);
-            step.name = this.stepName(integrationStep);
-            step.isFailed = step.failure && step.failure.length > 0;
-            const errorMessages = [null, ...step.messages, step.failure].filter(messages => !!messages);
-            step.output = errorMessages.length > 0 ? errorMessages.join('\n') : null;
-          });
+          if (activity.steps && Array.isArray(activity.steps)) {
+            activity.steps.forEach(step => {
+              // XXX: ANTIPATTERN AHEAD. The following code block mutates an object state
+              const integrationStep = this.integration.steps.find(_integrationStep => _integrationStep.id == step.id);
+              step.name = this.stepName(integrationStep);
+              step.isFailed = step.failure && step.failure.length > 0;
+              const errorMessages = [null, ...step.messages, step.failure].filter(messages => !!messages);
+              step.output = errorMessages.length > 0 ? errorMessages.join('\n') : null;
+            });
+          }
         });
 
         return activitities;


### PR DESCRIPTION
Fixes #2065 

Whenever no steps are returned in the activity logs, the listview degrades gracefully and shows a default message, as depicted below:

<img width="1049" alt="captura de pantalla 2018-03-20 a las 17 19 04" src="https://user-images.githubusercontent.com/1104146/37667871-5e3839c0-2c63-11e8-850e-afd968c83fea.png">


