### PR TITLE
Updates for Check Certificates field in AMQ, AMQP connector. Resolves…

### DIFF
--- a/doc/integrating_applications/topics/adding_s3_connection_start.adoc
+++ b/doc/integrating_applications/topics/adding_s3_connection_start.adoc
@@ -12,37 +12,23 @@ you want to use as the integration's start connection.
 * *Get Object* to obtain a file from the bucket that the connection
 accesses. To configure this action:
 
-<<<<<<< HEAD
-.. To obtain a file and then delete it from the bucket, select
-*Delete After Read*.
-
-.. In the *File Name* field, enter the name of the file that you want
-to obtain.
-=======
 .. In the *File Name* field, enter the name of the file that you want
 to obtain. 
 .. To obtain a file and then delete it from the bucket, select
 *Delete After Read*. 
->>>>>>> 5040886... Lots of updates including user doc for logging, metrics, amq, amqp, s3 connectors, custom connectors. 1623.
 
 * *Poll an Amazon S3 Bucket* to periodically obtain files from the bucket that the
 connection accesses. To configure this action:
-
-<<<<<<< HEAD
-.. To obtain files and then delete them from the bucket,
-select *Delete After Read*.
-=======
-.. In the *Delay* field, enter the number of milliseconds that elapse between
-polls. The default is 500 milliseconds. 
+.. In the *Delay* field, accept the default or enter the number of 
+milliseconds that elapse between
+polls. The default is 500 milliseconds.
 Alternatively, you can enter something like `3s`, `5m 30s`, or `2h` to
 indicate 3 seconds, or 5 minutes 30 seconds, or 2 hours, respectively.
-
->>>>>>> 5040886... Lots of updates including user doc for logging, metrics, amq, amqp, s3 connectors, custom connectors. 1623.
-.. In the *Max Messages Per Poll* field, enter the largest number of files
+.. In the *Maximum Objects to Retrieve* field, enter the largest number of files
 that one poll operation can obtain. The default is 10.
 +
 To have no limit on the number of files that can be obtained, specify
-`0` or a negative integer. When *Max Messages Per Poll* is unlimited,
+`0` or a negative integer. When *Maximum Objects to Retrieve* is unlimited,
 the poll action obtains all files in the bucket.
 +
 If the bucket contains more than the specified maximum number of files
@@ -52,20 +38,10 @@ modified or created. This behavior can be changed in AWS.
 .. In the *Prefix* field, optionally specify a regular expression
 that evaluates to a string. If you specify a
 prefix then this action retrieves a file
-<<<<<<< HEAD
 only when its name starts with that string.
-.. In the *Delay* field, enter the number of milliseconds that elapse between
-polls. The default is 500 milliseconds.
-Alternatively, you can enter something like `3s`, `5m 30s`, or `2h` to
-indicate 3 seconds, or 5 minutes 30 seconds, or 2 hours, respectively.
-. Click *Next*.
-include::add_describe_data_step.adoc[]
-=======
-only when its name starts with that string. 
 
 .. Indicate whether you want to  
 *Obtain files and then delete them from the bucket*.
 
-. Click *Next* to specify the action's output type. See 
+. Click *Done* to specify the action's output type. See 
 <<specifying-connection-input-output-types>>. 
->>>>>>> 5040886... Lots of updates including user doc for logging, metrics, amq, amqp, s3 connectors, custom connectors. 1623.

--- a/doc/integrating_applications/topics/create_amq_connection.adoc
+++ b/doc/integrating_applications/topics/create_amq_connection.adoc
@@ -19,14 +19,14 @@ to use to access this broker.
 .. In the *Client ID* field, enter the ID that allows connections to close
 and reopen without missing messages. The destination type must be a topic.
 .. If this connection will be used in a development
-environment, you can save some time by selecting
-*Skip Certificate Check*. This is a convenience for
+environment, you can save some time by disabling
+*Check Certificates*. Disabling the checking of certificates is a convenience for
 development environments. You
-should not select this option for secure production
+should not disable *Check Certificates* for secure production
 environments.
 .. In the *Broker Certificate* field, paste the broker's PEM certificate text.
-This is required except when you indicate that you want to skip
-checking the certificate. 
+This is required except when you disable
+checking the certificates. 
 .. In the *Client Certificate* field, paste the client's PEM certificate text. 
 Content in this field is always optional. 
 . Click *Validate*. {prodname} immediately tries to validate the 

--- a/doc/integrating_applications/topics/create_amqp_connection.adoc
+++ b/doc/integrating_applications/topics/create_amqp_connection.adoc
@@ -18,15 +18,15 @@ to use to access this broker.
 to use to access this broker. 
 .. In the *Client ID* field, enter the ID that allows connections to close 
 and reopen without missing messages. The destination type must be a topic. 
-.. If this connection will be used in a development 
-environment, you can save some time by enabling 
-*Skip Certificate Check*. This is a convenience for 
+.. If this connection will be used in a development
+environment, you can save some time by disabling
+*Check Certificates*. Disabling the checking of certificates is a convenience for
 development environments. You
-should not enable this option for secure production 
-environments. 
+should not disable *Check Certificates* for secure production
+environments.
 .. In the *Broker Certificate* field, paste the broker's PEM certificate text.
-This is required except when you indicate that you want to skip
-checking the certificate. 
+This is required except when disable
+checking the certificates. 
 .. In the *Client Certificate* field, paste the client's PEM certificate text. 
 Content in this field is always optional. 
 . Click *Validate*. {prodname} immediately tries to validate the 
@@ -43,4 +43,4 @@ enter `*Sample AMQP connection*`
 . In the upper right, click *Create* to see that the connection you 
 created is now available. If you
 entered the example name, you would 
-see that *AMQ 1* is now available. 
+see that *AMQP 1* is now available. 


### PR DESCRIPTION
… conflict in S3 start connection doc. 1623
This is ready to merge. Two updates change **Skip Certificate Checks** to **Check Certificates** (AMQ and AMQP connection configuration) and also update the description of the field. The other update corrects a messed up file. 