### PR TITLE
feature: Parameterised memory limit for 'sever' and 'meta'

### DIFF
--- a/doc/sdh/cli/cmd_install.adoc
+++ b/doc/sdh/cli/cmd_install.adoc
@@ -28,6 +28,8 @@ If you want to install to https://www.openshift.org/minishift/[Minishift] the <<
                               By default the resource descriptor is
                               downloaded from GitHub remotely.
 -o  --open                    Open Syndesis in browser when installation is ready
+    --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
+    --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
     --test-support            Allow test support endpoint for syndesis-server
 ----
 

--- a/doc/sdh/cli/cmd_minishift.adoc
+++ b/doc/sdh/cli/cmd_minishift.adoc
@@ -32,6 +32,8 @@ Options for minishift:
 -i  --image-mode <mode>       Which templates to install: "docker" for plain images,
                               "openshift" for image streams (default: "openshift")
 -o  --open                    Open Syndesis in the browser
+    --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
+    --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
     --test-support            Allow test support endpoint for syndesis-server
 ----
 

--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -98,20 +98,32 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
+  displayName: Prometheus Volume Capacity
+  name: PROMETHEUS_VOLUME_CAPACITY
+  value: 1Gi
+  required: true
 - description: Maximum amount of memory the Prometheus container can use.
   displayName: Memory Limit
   name: PROMETHEUS_MEMORY_LIMIT
   value: 255Mi
-- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
-  displayName: Prometheus Volume Capacity
-  name: PROMETHEUS_VOLUME_CAPACITY
+  required: true
+- description: Volume space available for Meta data, e.g. 512Mi, 2Gi.
+  displayName: Meta Volume Capacity
+  name: META_VOLUME_CAPACITY
   required: true
   value: 1Gi
-- description: Volume space available for Verifier data, e.g. 512Mi, 2Gi.
-  displayName: Verifier Volume Capacity
-  name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 1Gi
+- description: Maximum amount of memory the syndesis-meta service might use.
+  displayName: Memory Limit
+  name: META_MEMORY_LIMIT
+  value: 512Mi
+  required: true
+- description: Maximum amount of memory the syndesis-server service might use.
+  displayName: Memory Limit
+  name: SERVER_MEMORY_LIMIT
+  value: 800Mi
+  required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:

--- a/install/generator/04-syndesis-meta.yml.mustache
+++ b/install/generator/04-syndesis-meta.yml.mustache
@@ -16,16 +16,16 @@
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: syndesis-verifier
+    name: syndesis-meta
     labels:
       app: syndesis
-      component: syndesis-verifier
+      component: syndesis-meta
   spec:
     accessModes:
     - ReadWriteOnce
     resources:
       requests:
-        storage: ${VERIFIER_VOLUME_CAPACITY}
+        storage: ${META_VOLUME_CAPACITY}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -98,7 +98,7 @@
             protocol: TCP
           resources:
             limits:
-              memory: 512Mi
+              memory: ${META_MEMORY_LIMIT}
             requests:
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
@@ -111,7 +111,7 @@
         volumes:
         - name: ext-volume
           persistentVolumeClaim:
-            claimName: syndesis-verifier
+            claimName: syndesis-meta
         - name: config-volume
           configMap:
             name: syndesis-meta-config

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -113,7 +113,7 @@
           # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              memory: 612Mi
+              memory: ${SERVER_MEMORY_LIMIT}
             requests:
               memory: 256Mi
         volumes:

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -101,20 +101,32 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
+  displayName: Prometheus Volume Capacity
+  name: PROMETHEUS_VOLUME_CAPACITY
+  value: 1Gi
+  required: true
 - description: Maximum amount of memory the Prometheus container can use.
   displayName: Memory Limit
   name: PROMETHEUS_MEMORY_LIMIT
   value: 255Mi
-- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
-  displayName: Prometheus Volume Capacity
-  name: PROMETHEUS_VOLUME_CAPACITY
+  required: true
+- description: Volume space available for Meta data, e.g. 512Mi, 2Gi.
+  displayName: Meta Volume Capacity
+  name: META_VOLUME_CAPACITY
   required: true
   value: 1Gi
-- description: Volume space available for Verifier data, e.g. 512Mi, 2Gi.
-  displayName: Verifier Volume Capacity
-  name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 1Gi
+- description: Maximum amount of memory the syndesis-meta service might use.
+  displayName: Memory Limit
+  name: META_MEMORY_LIMIT
+  value: 512Mi
+  required: true
+- description: Maximum amount of memory the syndesis-server service might use.
+  displayName: Memory Limit
+  name: SERVER_MEMORY_LIMIT
+  value: 800Mi
+  required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:
@@ -537,6 +549,153 @@ objects:
   metadata:
     labels:
       app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta
+  spec:
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: syndesis
+      component: syndesis-meta
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: syndesis-meta
+    labels:
+      app: syndesis
+      component: syndesis-meta
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${META_VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta
+  spec:
+    replicas: 1
+    selector:
+      app: syndesis
+      component: syndesis-meta
+      deploymentconfig: syndesis-meta
+    strategy:
+      resources:
+        limits:
+          memory: "256Mi"
+        requests:
+          memory: "20Mi"
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: syndesis
+          component: syndesis-meta
+          deploymentconfig: syndesis-meta
+      spec:
+        serviceAccountName: syndesis-server
+        containers:
+        - name: syndesis-meta
+          env:
+          - name: JAVA_APP_DIR
+            value: /deployments
+          - name: LOADER_HOME
+            value: /deployments/ext
+          - name: JAVA_OPTIONS
+            value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
+          - name: JAVA_DEBUG
+            value: "true"
+          image: ' '
+
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          resources:
+            limits:
+              memory: ${META_MEMORY_LIMIT}
+            requests:
+              memory: 280Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
+          volumeMounts:
+          - name: config-volume
+            mountPath: /deployments/config
+          - name: ext-volume
+            mountPath: /deployments/ext
+        volumes:
+        - name: ext-volume
+          persistentVolumeClaim:
+            claimName: syndesis-meta
+        - name: config-volume
+          configMap:
+            name: syndesis-meta-config
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - syndesis-meta
+        from:
+          kind: ImageStreamTag
+          name: syndesis-meta:latest
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: ImageChange
+
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: syndesis
       component: syndesis-oauthproxy
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: syndesis-oauthproxy-tls
@@ -775,7 +934,7 @@ objects:
           # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              memory: 612Mi
+              memory: ${SERVER_MEMORY_LIMIT}
             requests:
               memory: 256Mi
         volumes:
@@ -846,153 +1005,6 @@ objects:
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta
-  spec:
-    ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
-    selector:
-      app: syndesis
-      component: syndesis-meta
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: syndesis-verifier
-    labels:
-      app: syndesis
-      component: syndesis-verifier
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${VERIFIER_VOLUME_CAPACITY}
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta
-  spec:
-    replicas: 1
-    selector:
-      app: syndesis
-      component: syndesis-meta
-      deploymentconfig: syndesis-meta
-    strategy:
-      resources:
-        limits:
-          memory: "256Mi"
-        requests:
-          memory: "20Mi"
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: syndesis
-          component: syndesis-meta
-          deploymentconfig: syndesis-meta
-      spec:
-        serviceAccountName: syndesis-server
-        containers:
-        - name: syndesis-meta
-          env:
-          - name: JAVA_APP_DIR
-            value: /deployments
-          - name: LOADER_HOME
-            value: /deployments/ext
-          - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
-          - name: JAVA_DEBUG
-            value: "true"
-          image: ' '
-
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8181
-              scheme: HTTP
-            initialDelaySeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8181
-              scheme: HTTP
-            initialDelaySeconds: 300
-            periodSeconds: 20
-            failureThreshold: 5
-          ports:
-          - containerPort: 8080
-            name: http
-            protocol: TCP
-          - containerPort: 9779
-            name: prometheus
-            protocol: TCP
-          - containerPort: 8778
-            name: jolokia
-            protocol: TCP
-          resources:
-            limits:
-              memory: 512Mi
-            requests:
-              memory: 280Mi
-          # spring-boot automatically picks up application.yml from ./config
-          workingDir: /deployments
-          volumeMounts:
-          - name: config-volume
-            mountPath: /deployments/config
-          - name: ext-volume
-            mountPath: /deployments/ext
-        volumes:
-        - name: ext-volume
-          persistentVolumeClaim:
-            claimName: syndesis-verifier
-        - name: config-volume
-          configMap:
-            name: syndesis-meta-config
-    triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - syndesis-meta
-        from:
-          kind: ImageStreamTag
-          name: syndesis-meta:latest
-          namespace: ${IMAGE_STREAM_NAMESPACE}
-      type: ImageChange
-
-    - type: ConfigChange
-
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta-config
-  data:
-    application.yml: |-
-      server:
-        port: 8080
-      # We only want the status, not the full data. Hence security on, sensitive off.
-      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
-      # For details
-      management:
-        port: 8181
-        security:
-          enabled: true
-      endpoints:
-        health:
-          sensitive: false
 - apiVersion: v1
   kind: Service
   metadata:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -101,20 +101,32 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
+  displayName: Prometheus Volume Capacity
+  name: PROMETHEUS_VOLUME_CAPACITY
+  value: 1Gi
+  required: true
 - description: Maximum amount of memory the Prometheus container can use.
   displayName: Memory Limit
   name: PROMETHEUS_MEMORY_LIMIT
   value: 255Mi
-- description: Volume space available for Prometheus data, e.g. 512Mi, 2Gi.
-  displayName: Prometheus Volume Capacity
-  name: PROMETHEUS_VOLUME_CAPACITY
+  required: true
+- description: Volume space available for Meta data, e.g. 512Mi, 2Gi.
+  displayName: Meta Volume Capacity
+  name: META_VOLUME_CAPACITY
   required: true
   value: 1Gi
-- description: Volume space available for Verifier data, e.g. 512Mi, 2Gi.
-  displayName: Verifier Volume Capacity
-  name: VERIFIER_VOLUME_CAPACITY
   required: true
-  value: 1Gi
+- description: Maximum amount of memory the syndesis-meta service might use.
+  displayName: Memory Limit
+  name: META_MEMORY_LIMIT
+  value: 512Mi
+  required: true
+- description: Maximum amount of memory the syndesis-server service might use.
+  displayName: Memory Limit
+  name: SERVER_MEMORY_LIMIT
+  value: 800Mi
+  required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
 objects:
@@ -537,6 +549,151 @@ objects:
   metadata:
     labels:
       app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta
+  spec:
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: syndesis
+      component: syndesis-meta
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: syndesis-meta
+    labels:
+      app: syndesis
+      component: syndesis-meta
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${META_VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta
+  spec:
+    replicas: 1
+    selector:
+      app: syndesis
+      component: syndesis-meta
+      deploymentconfig: syndesis-meta
+    strategy:
+      resources:
+        limits:
+          memory: "256Mi"
+        requests:
+          memory: "20Mi"
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: syndesis
+          component: syndesis-meta
+          deploymentconfig: syndesis-meta
+      spec:
+        serviceAccountName: syndesis-server
+        containers:
+        - name: syndesis-meta
+          env:
+          - name: JAVA_APP_DIR
+            value: /deployments
+          - name: LOADER_HOME
+            value: /deployments/ext
+          - name: JAVA_OPTIONS
+            value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
+          image: ' '
+
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 300
+            periodSeconds: 20
+            failureThreshold: 5
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          resources:
+            limits:
+              memory: ${META_MEMORY_LIMIT}
+            requests:
+              memory: 280Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
+          volumeMounts:
+          - name: config-volume
+            mountPath: /deployments/config
+          - name: ext-volume
+            mountPath: /deployments/ext
+        volumes:
+        - name: ext-volume
+          persistentVolumeClaim:
+            claimName: syndesis-meta
+        - name: config-volume
+          configMap:
+            name: syndesis-meta-config
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - syndesis-meta
+        from:
+          kind: ImageStreamTag
+          name: syndesis-meta:latest
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: ImageChange
+
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-meta
+    name: syndesis-meta-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: syndesis
       component: syndesis-oauthproxy
     annotations:
       service.alpha.openshift.io/serving-cert-secret-name: syndesis-oauthproxy-tls
@@ -773,7 +930,7 @@ objects:
           # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              memory: 612Mi
+              memory: ${SERVER_MEMORY_LIMIT}
             requests:
               memory: 256Mi
         volumes:
@@ -844,151 +1001,6 @@ objects:
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta
-  spec:
-    ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
-    selector:
-      app: syndesis
-      component: syndesis-meta
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: syndesis-verifier
-    labels:
-      app: syndesis
-      component: syndesis-verifier
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${VERIFIER_VOLUME_CAPACITY}
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta
-  spec:
-    replicas: 1
-    selector:
-      app: syndesis
-      component: syndesis-meta
-      deploymentconfig: syndesis-meta
-    strategy:
-      resources:
-        limits:
-          memory: "256Mi"
-        requests:
-          memory: "20Mi"
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          app: syndesis
-          component: syndesis-meta
-          deploymentconfig: syndesis-meta
-      spec:
-        serviceAccountName: syndesis-server
-        containers:
-        - name: syndesis-meta
-          env:
-          - name: JAVA_APP_DIR
-            value: /deployments
-          - name: LOADER_HOME
-            value: /deployments/ext
-          - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true -Duser.home=/tmp"
-          image: ' '
-
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8181
-              scheme: HTTP
-            initialDelaySeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8181
-              scheme: HTTP
-            initialDelaySeconds: 300
-            periodSeconds: 20
-            failureThreshold: 5
-          ports:
-          - containerPort: 8080
-            name: http
-            protocol: TCP
-          - containerPort: 9779
-            name: prometheus
-            protocol: TCP
-          - containerPort: 8778
-            name: jolokia
-            protocol: TCP
-          resources:
-            limits:
-              memory: 512Mi
-            requests:
-              memory: 280Mi
-          # spring-boot automatically picks up application.yml from ./config
-          workingDir: /deployments
-          volumeMounts:
-          - name: config-volume
-            mountPath: /deployments/config
-          - name: ext-volume
-            mountPath: /deployments/ext
-        volumes:
-        - name: ext-volume
-          persistentVolumeClaim:
-            claimName: syndesis-verifier
-        - name: config-volume
-          configMap:
-            name: syndesis-meta-config
-    triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - syndesis-meta
-        from:
-          kind: ImageStreamTag
-          name: syndesis-meta:latest
-          namespace: ${IMAGE_STREAM_NAMESPACE}
-      type: ImageChange
-
-    - type: ConfigChange
-
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: syndesis
-      component: syndesis-meta
-    name: syndesis-meta-config
-  data:
-    application.yml: |-
-      server:
-        port: 8080
-      # We only want the status, not the full data. Hence security on, sensitive off.
-      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
-      # For details
-      management:
-        port: 8181
-        security:
-          enabled: true
-      endpoints:
-        health:
-          sensitive: false
 - apiVersion: v1
   kind: Service
   metadata:

--- a/tools/bin/commands/install
+++ b/tools/bin/commands/install
@@ -20,6 +20,8 @@ install::usage() {
 -o  --open                    Open Syndesis in browser when installation is ready (implies --watch)
 -y  --yes                     Assume 'yes' automatically when asking for deleting
                               a given project.
+    --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
+    --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
     --test-support            Allow test support endpoint for syndesis-server
 EOT
 }
@@ -48,7 +50,7 @@ install::run() {
     create_oauthclient "$(readopt --tag)" "$(hasflag --local)"
 
     # Apply a template, based on the given arguments
-    create_and_apply_template "$route" "$(select_template $(hasflag --dev))" "$(readopt --tag)" "$(hasflag --local)" "$(hasflag --test-support)"
+    create_and_apply_template "$route" "$(select_template $(hasflag --dev))"
 
     if [ $(hasflag --watch -w) ] || [ $(hasflag --dev) ] || [ $(hasflag --open -o) ]; then
         wait_for_syndesis_to_be_ready

--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -31,6 +31,8 @@ minishift::usage() {
 -o  --open                    Open Syndesis in the browser
 -y  --yes                     Assume 'yes' automatically when asking for deleting
                               a given project.
+    --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
+    --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
     --test-support            Allow test support endpoint for syndesis-server
 EOT
 }
@@ -81,7 +83,7 @@ minishift::run() {
 
         create_oauthclient "$(readopt --tag)" "$(hasflag --local)"
 
-        create_and_apply_template "syndesis.$(minishift ip).nip.io" "$(select_template true)" "$(readopt --tag)" "$(hasflag --local)" "$(hasflag --test-support)"
+        create_and_apply_template "syndesis.$(minishift ip).nip.io" "$(select_template true)"
 
         wait_for_syndesis_to_be_ready
         patch_imagestreams_for_initial_image

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -85,9 +85,9 @@ create_oauthclient() {
 create_and_apply_template() {
     local route=$1
     local template=${2:-syndesis}
-    local tag=${3:-}
-    local use_local_resource=${4:-}
-    local test_support=${5:-false}
+    local tag="$(readopt --tag)"
+    local use_local_resource="$(hasflag --local)"
+    local test_support="$(hasflag --test-support)"
 
     if [ -z "$route" ]; then
         echo "No route given"
@@ -105,12 +105,23 @@ create_and_apply_template() {
         template_name="${template_name}-restricted"
     fi
 
+    local optional_args=""
+    if [ -n "$(readopt --memory-server)" ]; then
+      optional_args="$optional_args -p SERVER_MEMORY_LIMIT=$(readopt --memory-server)"
+    fi
+    if [ -n "$(readopt --memory-meta)" ]; then
+      optional_args="$optional_args -p META_MEMORY_LIMIT=$(readopt --memory-meta)"
+    fi
+    if [ $(hasflag --test-support) ]; then
+      optional_args="$optional_args -p TEST_SUPPORT_ENABLED=true"
+    fi
+
     oc new-app --template=${template_name} \
       -p ROUTE_HOSTNAME="${route}" \
       -p OPENSHIFT_MASTER="$(oc whoami --show-server)" \
       -p OPENSHIFT_PROJECT="$(oc project -q)" \
-      -p TEST_SUPPORT_ENABLED=${test_support} \
-      -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client)
+      -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client) \
+      $optional_args
 }
 
 # Try first a template with the tag as combination


### PR DESCRIPTION
* New defaults: 800Mi (server) and 512Mi (meta)
* 'syndesis minishift' and 'syndesis install' now has options --memory-rest and --memory-meta
* Updated documentation
* Streamlined scripts a bit