### PR TITLE
fix: Fix AMQ template param definition

### DIFF
--- a/install/support/syndesis-amq.yml
+++ b/install/support/syndesis-amq.yml
@@ -14,7 +14,7 @@ metadata:
     openshift.io/provider-display-name: syndesis.io
     tags: messaging,amq,jboss
   name: amq63-basic
-  parameters:
+parameters:
   - description: The name for the application.
     displayName: Application Name
     name: APPLICATION_NAME


### PR DESCRIPTION
There's forgotten whitespace that prevent proper recognition of params.