### PR TITLE
fix: Use the higher value unit when the division result is 1 too

### DIFF
--- a/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
+++ b/app/ui/src/app/common/ui-patternfly/duration-form-control.component.ts
@@ -114,7 +114,7 @@ export class DurationFormControlComponent implements OnInit {
     }
     let duration;
     for (const _duration of this.durations) {
-      if ( value / _duration.value > 1 ) {
+      if ( value / _duration.value >= 1 ) {
         duration = _duration;
       } else {
         break;


### PR DESCRIPTION
Relates to #2093