### PR TITLE
Fix several issues with icon handling

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -217,6 +218,11 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
 
                 Icon icon = getDataManager().create(iconBuilder.build());
                 iconDao.write(icon.getId().get(), iconStream);
+
+                final String oldIconId = connectorToUpdate.getIcon();
+                if (oldIconId.toLowerCase(Locale.US).startsWith("db:")) {
+                    iconDao.delete(oldIconId.substring(3));
+                }
                 connectorToUpdate = connectorToUpdate.builder().icon("db:" + icon.getId().get()).build();
             } catch (IOException e) {
                 throw new IllegalArgumentException("Error while reading multipart request", e);

--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -55,7 +55,7 @@ public class SqlFileStore {
 
     private final DBI dbi;
 
-    private DatabaseKind databaseKind;
+    private final DatabaseKind databaseKind;
 
     public SqlFileStore(DBI dbi) {
         this.dbi = dbi;

--- a/app/ui/src/app/common/icon-path.pipe.ts
+++ b/app/ui/src/app/common/icon-path.pipe.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@syndesis/ui/config.service';
 
 interface IconConnection {
   icon: string | File;
+  iconFile?: File;
   connectorId?: string;
   id?: string;
 }
@@ -25,10 +26,10 @@ export class IconPathPipe implements PipeTransform {
   }
 
   transform(connection: IconConnection, isConnector?: boolean): SafeUrl | null {
-    if (connection && connection.icon instanceof File) {
-      const tempIconBlobPath = URL.createObjectURL(connection.icon);
+    if (connection && (connection.icon instanceof File || connection.iconFile)) {
+      const file = connection.iconFile || connection.icon;
+      const tempIconBlobPath = URL.createObjectURL(file);
       return this.toSafeUrl(tempIconBlobPath);
-
     } else if (connection && typeof (connection.icon) === 'string') {
       // TODO: Streamline this assignation block once we manage to create a common model
       //       schema for entities featuring icons, so we can remove all these conditional logic
@@ -43,7 +44,7 @@ export class IconPathPipe implements PipeTransform {
 
       if (connection.icon.toLowerCase().startsWith('db:') || connection.icon.startsWith('extension:')) {
         connectionId = isConnector ? connection.id : connectionId;
-        iconPath = `${this.apiEndpoint}/connectors/${connectionId}/icon`;
+        iconPath = `${this.apiEndpoint}/connectors/${connectionId}/icon?${connection.icon}`;
       }
 
       return this.toSafeUrl(iconPath);

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
@@ -105,7 +105,8 @@ export class ApiConnectorInfoComponent implements OnInit {
 
   @HostListener('document:click', ['$event'])
   private onDocumentClick(event: Event): void {
-    const elementTag = event.srcElement.tagName.toLowerCase();
+    const element: any = event.target;
+    const elementTag = element.tagName.toLowerCase();
     if (elementTag !== 'input' && elementTag !== 'textarea' && this.editControlKey) {
       setTimeout(() => this.onSubmit(), 0);
     }


### PR DESCRIPTION
 1. Browser API incompatibility: replace `event.srcElement` with `event.target`
    We should not use `event.srcElement` it's proprietary, we should use the standard `event.target`. Too bad that the type definitions are not up to date for `EventTarget`.
 2. Updated icon not showing up in Firefox: make icons reflect changes
    As the URL of the icon never changes when modifying the icons of API connectors the old icon is not replaced with the newly uploaded one regardless of `Cache-Control` headers in Firefox.
    This adds the icon id, from the database, as a query parameter to the icon URL which will make it reload the icon when it's changed.
    Also adds `iconFile` property as it is set at first icon submission in on the `CustomConnectorRequest`. This makes the icon change show up immediately. Very quickly after that the icon URL will be replaced from the data URL to the URL on the server by the event received from the server that the connector has changed.
 3. Leftover database rows on icon update: delete leftover icon from filestore
    When updating an icon a row is inserted in the database, if the icon existed before the update and was now replaced this would leave an orphan row in the database. This deletes this orphan row from the database.

Fixes #1433