### PR TITLE
user doc: Create doc for Dropbox connector (#1623 #1189)

### DIFF
--- a/doc/integrating_applications/topics/adding_dropbox_connection_finish.adoc
+++ b/doc/integrating_applications/topics/adding_dropbox_connection_finish.adoc
@@ -1,0 +1,23 @@
+[id='adding-dropbox-connection-finish']
+= Adding a Dropbox connection as a finish connection
+
+In an integration, to add a Dropbox connection as the finish connection,
+start creating the integration, add and configure the start connection,
+and then:
+
+. On the *Choose a Finish Connection* page, click the Dropbox connection that
+you want to use as the integration's finish connection. 
+. On the *Choose an Action* page, click the *Upload a file to Dropbox* 
+action to add the current integration data to the
+Dropbox account that this connection accesses. 
+. In the *Remote Path* field, enter the path of the Dropbox folder 
+in which to store the integration data. 
+. For the *Upload mode* select:
++
+** *Add* to rename a file that you are uploading if a file with the
+same name already exists in that Dropbox location.
+** *Force* to overwrite a file that is already in that Dropbox location if you are 
+uploading a file with the same name. 
+
+. Click *Next* to add this connection as the finish connection in the
+integration. 

--- a/doc/integrating_applications/topics/adding_dropbox_connection_middle.adoc
+++ b/doc/integrating_applications/topics/adding_dropbox_connection_middle.adoc
@@ -1,0 +1,36 @@
+[id='adding-dropbox-connection-middle']
+= Adding a Dropbox connection as a middle connection
+
+In an integration, to add a Dropbox connection between the start and 
+finish connections:
+
+. Add the start and finish connections to the integration.
+. In the left panel, hover over the plus sign that is in the location
+where you want to add a Dropbox connection.
+. In the popup, click *Add a Connection*.
+. On the *Choose a Connection* page, click the Dropbox connection that you 
+want the integration to use. 
+
+. On the *Choose an Action* page, select one of the following actions:
++
+* *Upload a file to Dropbox* to add the current integration data to the
+Dropbox account that this connection accesses. To configure this
+action:
+.. In the *Remote Path* field, enter the path of the Dropbox folder 
+in which to store the integration data. 
+
+.. For the *Upload mode* select:
++
+** *Add* to rename a file that you are uploading if a file with the
+same name already exists in that Dropbox location.
+** *Force* to overwrite a file that is already in that Dropbox location if you are 
+uploading a file with the same name. 
++
+* *Download from Dropbox* to obtain one or more files from the Dropbox
+account that this connection accesses. To configure this action,
+in the *Folder or filename path to download* field, enter the Dropbox
+folder path or the Dropbox file path of the content 
+you want to obtain. 
+
+. Click *Next* to add this connection to the
+integration. 

--- a/doc/integrating_applications/topics/adding_dropbox_connection_start.adoc
+++ b/doc/integrating_applications/topics/adding_dropbox_connection_start.adoc
@@ -1,0 +1,18 @@
+[id='adding-dropbox-connection-start']
+= Adding a Dropbox connection as the start connection
+
+In an integration, to add a Dropbox connection as the start connection:
+
+. In the {prodname} panel on the left, click *Integrations*.
+. Click *Create Integration*.
+. On the *Choose a Start Connection* page, click the Dropbox connection that
+you want to use as the integration's start connection. 
+. On the *Choose an Action* page, click the *Download from Dropbox* action
+to obtain one or more files from the Dropbox account that this connection
+accesses. 
+. To configure the action, in the *Folder or file name path to download* field,
+specify the filename path or the folder path for the content that you want
+the integration to obtain. 
+. Click *Next* to add the start connection to the integration. 
+
+. 

--- a/doc/integrating_applications/topics/adding_dropbox_connections.adoc
+++ b/doc/integrating_applications/topics/adding_dropbox_connections.adoc
@@ -1,0 +1,25 @@
+[id='adding-dropbox-connections']
+= Adding a Dropbox connection to an integration
+
+You must create a Dropbox connection before you can add a Dropbox
+connection to an integration. If you did not already create a Dropbox connection,
+see <<create-dropbox-connection>>.
+
+You must be creating an integration or updating an integration to
+add a connection to that integration. If you need to, see
+<<procedure-for-creating-an-integration>> or <<updating-integrations>>.
+
+The procedure for adding a Dropbox connection to an integration varies
+according to whether you are adding the connection as the
+start connection, the finish connection, or a middle connection.
+See the following topics:
+
+* <<adding-dropbox-connection-start>>
+* <<adding-dropbox-connection-finish>>
+* <<adding-dropbox-connection-middle>>
+
+include::adding_dropbox_connection_start.adoc[leveloffset=+1]
+
+include::adding_dropbox_connection_finish.adoc[leveloffset=+1]
+
+include::adding_dropbox_connection_middle.adoc[leveloffset=+1]

--- a/doc/integrating_applications/topics/connecting_to_applications.adoc
+++ b/doc/integrating_applications/topics/connecting_to_applications.adoc
@@ -10,6 +10,7 @@ creating connections and adding them to integrations:
 * <<connecting-to-s3>>
 * <<connecting-to-amq>>
 * <<connecting-to-amqp>>
+* <<connecting-to-dropbox>>
 * <<connecting-to-rest-apis>>
 * <<connecting-to-sf>>
 * <<connecting-to-databases>>
@@ -24,6 +25,8 @@ include::connecting_to_amazon_s3.adoc[leveloffset=+1]
 include::connecting_to_amq.adoc[leveloffset=+1]
 
 include::connecting_to_amqp.adoc[leveloffset=+1]
+
+include::connecting_to_dropbox.adoc[leveloffset=+1]
 
 include::connecting_to_rest_apis.adoc[leveloffset=+1]
 

--- a/doc/integrating_applications/topics/connecting_to_dropbox.adoc
+++ b/doc/integrating_applications/topics/connecting_to_dropbox.adoc
@@ -1,0 +1,15 @@
+[id='connecting-to-dropbox']
+= Connecting to Dropbox
+
+In an integration, you can download files from Dropbox or upload files
+to Dropbox. The following topics provide the details:
+
+* <<register-with-dropbox>>
+* <<create-dropbox-connection>>
+* <<adding-dropbox-connections>>
+
+include::register_with_dropbox.adoc[leveloffset=+1]
+
+include::create_dropbox_connection.adoc[leveloffset=+1]
+
+include::adding_dropbox_connections.adoc[leveloffset=+1]

--- a/doc/integrating_applications/topics/create_dropbox_connection.adoc
+++ b/doc/integrating_applications/topics/create_dropbox_connection.adoc
@@ -1,0 +1,50 @@
+[id='create-dropbox-connection']
+= Create a Dropbox connection
+
+A connection to Dropbox requires registration of
+{prodname} as an application that can access Dropbox.
+If you did not already register {prodname}, see <<register-with-dropbox>>.
+
+Follow the instructions below to create a Dropbox connection.
+You can use the same Dropbox connection in multiple integrations.
+
+To create a Dropbox connection:
+
+. In a new browser tab, go  to `https://www.dropbox.com` 
+and do the following:
+.. Sign in to the Dropbox account in which you created the app that
+registers access from your {prodname} installation. 
+.. Go to https://www.dropbox.com/developers/apps.
+.. Click the {prodname} app to display its settings.
+
+. In another browser tab, in {prodname}, do the following:
+.. In the left panel, click *Connections* to
+display any available connections.
+.. In the upper right, click *Create Connection* to display
+the available connectors. 
+.. Click the *Dropbox* connector.
+
+. Go back to the Dropbox settings display for your app and do the following:
+.. Scroll down to see *Generated Access Token*. 
+.. Click *Generate*. 
+.. Copy the generated access token to the clipboard. 
+
+. Back in {prodname}, in the *Configure Connection* page, in the 
+*Access Token* field, paste the generated
+access token. 
+. In the *Client Identifier* field, enter the name that you specified
+when you created the Dropbox app. 
+. Click *Validate*. {prodname} displays a message that indicates whether
+it can validate this connection. If validation fails, try again and 
+be sure to enter the correct values. 
+. When validation is successful, in the upper right, click *Next*.
+. In the *Connection Name* field, enter your choice of a name that
+helps you distinguish this connection from any other connections.
+For example, enter `*Dropbox Connect 1*`.
+. In the *Description* field, optionally enter any information that
+is helpful to know about this connection. For example,
+enter `*Sample Dropbox connection
+that can access all content in our company Dropbox account.*`
+. In the upper right, click *Create* to see that the connection you
+created is now available. If you entered the example name, you would
+see that *Dropbox Connect 1* is now available.

--- a/doc/integrating_applications/topics/making_extensions_available.adoc
+++ b/doc/integrating_applications/topics/making_extensions_available.adoc
@@ -26,6 +26,12 @@ For a connector extension, {prodname} displays
 the actions that are available to a connection that is created from this 
 custom connector. For a step extension, {prodname} displays
 the name of each custom step that the extension defines.
++
+For a library
+extension, if this extension contains a newer version of a JDBC driver that you 
+previously uploaded, then {prodname} uses the newer version for new
+connections. 
+
 
 . Click *Import Extension*. {prodname} makes the custom connector or 
 custom step(s) available and displays the extension's details page. 

--- a/doc/integrating_applications/topics/register_with_dropbox.adoc
+++ b/doc/integrating_applications/topics/register_with_dropbox.adoc
@@ -1,0 +1,41 @@
+[id='register-with-dropbox']
+= Register {prodname} as a Dropbox client
+
+You must register your installation of {prodname} as an application
+that can access Dropbox.
+This lets you create any number of integrations that connect
+to Dropbox. In other words, you need to register a particular
+installation of {prodname} with Dropbox only once.
+
+Perform these steps:
+
+. In {prodname}:
+.. In the left panel, click *Settings*.
+.. Under the page title, in the sentence that starts with *During
+registration*, copy the URL to the clipboard. 
+For example, the URL is something like this:
+`\https://app-proj9128.7b63.{prodnameinurl}.openshiftapps.com/api/v1/credentials/callback`.
+
+. In another browser tab, go  to `https://www.dropbox.com` 
+and do the following:
+.. Sign in to the Dropbox account that has the data that you want to
+access in an integration. 
+.. After signing in, go to https://www.dropbox.com/developers/apps.
+.. Click *Create App*.
+.. Select *Dropbox API*. 
+.. Choose whether {prodname} can access a single folder or all of the 
+folders and files. 
+.. Specify a name for your Dropbox app. For example, you might
+specify `*Ignite Access From Aslan LLC*`.
+.. Check the box to indicate that you agree to Dropbox API terms and 
+conditions. 
+.. Click *Create App*. 
+
+.. In the Dropbox *Settings* page for your new app, in
+the input field for *OAuth2 Redirect URIs*, paste your {prodname} URL,
+which you copied to the clipboard at the beginning of this procedure. 
+.. Click *Add*. 
+
+Your installation of {prodname} is now registered as a Dropbox client, which 
+means that {prodname} can access content in the Dropbox account that
+you signed into. 

--- a/doc/shared/register_with_sf.adoc
+++ b/doc/shared/register_with_sf.adoc
@@ -6,8 +6,8 @@
 You must register your installation of {prodname} as an application
 that can access Salesforce.
 This lets you create any number of integrations that connect
-to Salesforce. In other words, you need to register {prodname}
-with Salesforce only once.
+to Salesforce. In other words, you need to register a particular 
+installation of {prodname} with Salesforce only once.
 
 ifeval::["{context}" == "t2sf"]
 If you already registered {prodname} as a Salesforce

--- a/doc/shared/register_with_twitter.adoc
+++ b/doc/shared/register_with_twitter.adoc
@@ -4,8 +4,8 @@
 You must register your installation of {prodname} as an application
 that can access Twitter.
 This lets you create any number of integrations that connect
-to Twitter. In other words, you need to register {prodname}
-with Twitter only once.
+to Twitter. In other words, you need to register a particular
+installation of {prodname} with Twitter only once.
 
 Perform these steps:
 


### PR DESCRIPTION
This is the initial draft of the user doc for using the Dropbox connector. If you could review this so that I have your feedback by the start of my day on Wednesday, that would be great. You might want to review the Dropbox files in this order:
topics/connecting_to_dropbox.adoc
topics/register_with_dropbox.adoc
topics/create_dropbox_connection.adoc
topics/adding_dropbox_connections.adoc
topics/adding_dropbox_connection_start.adoc
topics/adding_dropbox_connection_finish.adoc
topics/adding_dropbox_connection_middle.adoc
The other files make a few other updates. 