### PR TITLE
fix(endpoint): squash LeveledMessage

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.common.model.bulletin;
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.WithMetadata;
 import org.immutables.value.Value;
@@ -29,6 +31,11 @@ import static io.syndesis.common.model.bulletin.LeveledMessage.Level.INFO;
 @SuppressWarnings("immutables")
 public interface LeveledMessage extends WithMetadata {
 
+    enum Code {
+        SYNDESIS000, // Generic message
+        SYNDESIS001 // There are parameter updates for this connection
+    }
+
     enum Level {
         INFO,
         WARN,
@@ -40,7 +47,12 @@ public interface LeveledMessage extends WithMetadata {
         return INFO;
     }
 
-    String getMessage();
+    @Value.Default
+    default Code getCode() {
+        return Code.SYNDESIS000;
+    }
+
+    Optional<String> getMessage();
 
     class Builder extends ImmutableLeveledMessage.Builder {
         // allow access to the immutable builder

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/impl/ConnectorUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/impl/ConnectorUpdateHandler.java
@@ -28,7 +28,8 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.update.controller.AbstractResourceUpdateHandler;
-import io.syndesis.server.update.controller.ResourceUpdateHelper;
+
+import static io.syndesis.server.update.controller.ResourceUpdateHelper.computeSimpleBulletinMessages;
 
 
 public class ConnectorUpdateHandler extends AbstractResourceUpdateHandler<ConnectionBulletinBoard> {
@@ -66,7 +67,7 @@ public class ConnectorUpdateHandler extends AbstractResourceUpdateHandler<Connec
 
     private ConnectionBulletinBoard computeBoard(Connection connection, Connector oldConnector, Connector newConnector) {
         final DataManager dataManager = getDataManager();
-        final List<LeveledMessage> messages = ResourceUpdateHelper.computeBulletinMessages(oldConnector.getProperties(), newConnector.getProperties());
+        final List<LeveledMessage> messages = computeSimpleBulletinMessages(oldConnector.getProperties(), newConnector.getProperties());
         final String id = connection.getId().get();
         final ConnectionBulletinBoard board = dataManager.fetchByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id).orElse(null);
         final ConnectionBulletinBoard.Builder builder;

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/ResourceUpdateHelperTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/ResourceUpdateHelperTest.java
@@ -129,4 +129,34 @@ public class ResourceUpdateHelperTest {
         assertThat(messages.get(2).getMetadata()).containsEntry("property", "p1");
         assertThat(messages.get(2).getMetadata()).containsEntry("status", "updated");
     }
+
+    @Test
+    public void testUpdatedPropertySimple() {
+        Map<String, ConfigurationProperty> left = new HashMap<>();
+        Map<String, ConfigurationProperty> right = new HashMap<>();
+
+        left.put("property", new ConfigurationProperty.Builder().description("property").build());
+        right.put("property", new ConfigurationProperty.Builder().description("PROPERTY").build());
+        right.put("property2", new ConfigurationProperty.Builder().description("PROPERTY2").build());
+
+        List<LeveledMessage> messages = ResourceUpdateHelper.computeSimpleBulletinMessages(left, right);
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0)).hasFieldOrPropertyWithValue("level", LeveledMessage.Level.INFO);
+    }
+
+    @Test
+    public void testNewRequiresPropertySimpl() {
+        Map<String, ConfigurationProperty> left = new HashMap<>();
+        Map<String, ConfigurationProperty> right = new HashMap<>();
+
+        left.put("property", new ConfigurationProperty.Builder().description("property").build());
+        right.put("property", new ConfigurationProperty.Builder().description("PROPERTY").build());
+        right.put("property2", new ConfigurationProperty.Builder().description("PROPERTY2").required(true).build());
+
+        List<LeveledMessage> messages = ResourceUpdateHelper.computeSimpleBulletinMessages(left, right);
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0)).hasFieldOrPropertyWithValue("level", LeveledMessage.Level.WARN);
+    }
 }


### PR DESCRIPTION
See #2151

@gashcrumb I've squashed messages so:

* In case of simple a property gets updated:
  ```json
  {
    "board": {
      "targetResourceId": "i-L8czqFBPC1QT7GAqG5iz",
      "notices": 1,
      "warnings": 0,
      "errors": 0,
      "id": "i-L8czqGkPC1QT7GAqG5jz",
      "metadata": {
        "connector-id": "ext-io-syndesis-extensions-syndesis-connector-telegram",
        "connector-version-latest": "2",
        "connector-version-connection": "1"
      },
      "messages": [
        {
          "level": "INFO",
          "code": "SYNDESIS001"
        }
      ],
      "createdAt": 1522179990640,
      "updatedAt": 1522180068211
    }
  }
  ```

* In case of a new required field:
  ```json
  {
    "board": {
      "targetResourceId": "i-L8czqFBPC1QT7GAqG5iz",
      "notices": 0,
      "warnings": 1,
      "errors": 0,
      "id": "i-L8czqGkPC1QT7GAqG5jz",
      "metadata": {
        "connector-id": "ext-io-syndesis-extensions-syndesis-connector-telegram",
        "connector-version-latest": "3",
        "connector-version-connection": "1"
      },
      "messages": [
        {
          "level": "WARN",
          "code": "SYNDESIS001"
        }
      ],
      "createdAt": 1522179990640,
      "updatedAt": 1522180137925
    }
  }
  ```