### PR TITLE
refactor(server): terser log message

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -73,6 +73,8 @@
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
     <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
     <dep.pmd.version>5.8.1</dep.pmd.version>
+    <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version> <!-- SUREFIRE-1422 -->
+    <dep.plugin.failsafe.version>2.21.0</dep.plugin.failsafe.version> <!-- SUREFIRE-1422 -->
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
     <basepom.test.fork-count>1</basepom.test.fork-count>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/ClientSideState.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/ClientSideState.java
@@ -182,7 +182,8 @@ public final class ClientSideState {
             try {
                 return Stream.of(restoreWithTimestamp(c, type));
             } catch (final IllegalArgumentException e) {
-                LOG.warn("Unable to restore client side state from cookie: {}", c, e);
+                LOG.warn("Unable to restore client side state: {}", e.getMessage());
+                LOG.debug("Unable to restore client side state from cookie: {}", c, e);
 
                 return Stream.empty();
             }


### PR DESCRIPTION
When unable to deserialize client side state cookie the log contains the
full stack trace. This changes the logging to log the full exception
only when DEBUG level is enabled.

Fixes #2045