### PR TITLE
More robustness in handling client side state

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1090,6 +1090,12 @@
       </dependency>
 
       <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>${immutables.version}</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -73,6 +73,8 @@
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
     <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
     <dep.pmd.version>5.8.1</dep.pmd.version>
+    <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version> <!-- SUREFIRE-1422 -->
+    <dep.plugin.failsafe.version>2.21.0</dep.plugin.failsafe.version> <!-- SUREFIRE-1422 -->
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
     <basepom.test.fork-count>1</basepom.test.fork-count>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -119,6 +119,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
     </dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/ClientSideState.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/ClientSideState.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * <li>State remains opaque (encrypted) so client cannot determine what is
  * stored
  * <li>State tampering is detected by using MAC
- * <li>State timeout is enforced (default 15min)
+ * <li>State timeout is enforced (default 30min)
  * </ul>
  * <p>
  * Given a {@link KeySource} construct {@link ClientSideState} as:
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ClientSideState {
     // 15 min
-    public static final long DEFAULT_TIMEOUT = 15 * 60;
+    public static final long DEFAULT_TIMEOUT = 30 * 60;
 
     private static final Decoder DECODER = Base64.getUrlDecoder();
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/StaticEdition.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/state/StaticEdition.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.server.endpoint.v1.state;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 
@@ -31,12 +32,10 @@ public class StaticEdition extends Edition {
         private final SecretKey encryptionKey;
 
         StaticKeySource(final ClientSideStateProperties properties) {
-            final Decoder decoder = Base64.getDecoder();
             final String encryptionKeyAlgorithm = properties.getEncryptionAlgorithm().replaceFirst("/.*", "");
 
-            encryptionKey = new SecretKeySpec(decoder.decode(properties.getEncryptionKey()), encryptionKeyAlgorithm);
-            authenticationKey = new SecretKeySpec(decoder.decode(properties.getAuthenticationKey()),
-                properties.getAuthenticationAlgorithm());
+            encryptionKey = new SecretKeySpec(decode(properties.getEncryptionKey()), encryptionKeyAlgorithm);
+            authenticationKey = new SecretKeySpec(decode(properties.getAuthenticationKey()), properties.getAuthenticationAlgorithm());
         }
 
         @Override
@@ -60,4 +59,14 @@ public class StaticEdition extends Edition {
         return keySource;
     }
 
+    static byte[] decode(final String given) {
+        final Decoder decoder = Base64.getDecoder();
+
+        try {
+            return decoder.decode(given);
+        } catch (final IllegalArgumentException ignored) {
+            // given is not a base64 string
+            return given.getBytes(StandardCharsets.US_ASCII);
+        }
+    }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/state/StaticEditionTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/state/StaticEditionTest.java
@@ -15,33 +15,92 @@
  */
 package io.syndesis.server.endpoint.v1.state;
 
+import java.security.GeneralSecurityException;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.commons.lang.RandomStringUtils;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StaticEditionTest {
 
+    private static class KeySourceAssert extends AbstractAssert<KeySourceAssert, KeySource> {
+
+        private KeySourceAssert(final KeySource actual) {
+            super(actual, KeySourceAssert.class);
+        }
+
+        public void canBeUsedForCryptography() {
+            final SecretKey authenticationKey = actual.authenticationKey();
+            try {
+                final Mac mac = Mac.getInstance(authenticationKey.getAlgorithm());
+                mac.init(authenticationKey);
+            } catch (final GeneralSecurityException e) {
+                throw new AssertionError("Unable to utilize authentication key: " + authenticationKey, e);
+            }
+
+            final SecretKey encryptionKey = actual.encryptionKey();
+            try {
+                final Cipher cipher = Cipher.getInstance(encryptionKey.getAlgorithm());
+                cipher.init(Cipher.ENCRYPT_MODE, encryptionKey);
+            } catch (final GeneralSecurityException e) {
+                throw new AssertionError("Unable to utilize encryption key: " + encryptionKey, e);
+            }
+        }
+
+        public static KeySourceAssert assertThat(final KeySource actual) {
+            return new KeySourceAssert(actual);
+        }
+
+    }
+
     @Test
     public void shouldCreateEditionFromProperties() {
-        ClientSideStateProperties properties = new ClientSideStateProperties();
+        final ClientSideStateProperties properties = new ClientSideStateProperties();
         properties.setAuthenticationAlgorithm("HmacSHA1");
         properties.setAuthenticationKey("oID3dF6UovTkzMyr3a9dr0kgTnE=");
         properties.setEncryptionAlgorithm("AES/CBC/PKCS5Padding");
         properties.setEncryptionKey("T2NasjRXURA3dSL8dUQubQ==");
         properties.setTid(1L);
 
-        StaticEdition edition = new StaticEdition(properties);
+        final StaticEdition edition = new StaticEdition(properties);
 
         assertThat(edition.authenticationAlgorithm).isEqualTo("HmacSHA1");
         assertThat(edition.encryptionAlgorithm).isEqualTo("AES/CBC/PKCS5Padding");
         assertThat(edition.tid).isEqualTo(new byte[] {1});
-        assertThat(edition.keySource().authenticationKey())
-            .isEqualTo(new SecretKeySpec(new byte[] {(byte) 0xa0, (byte) 0x80, (byte) 0xf7, 0x74, 0x5e, (byte) 0x94,
-                (byte) 0xa2, (byte) 0xf4, (byte) 0xe4, (byte) 0xcc, (byte) 0xcc, (byte) 0xab, (byte) 0xdd, (byte) 0xaf,
-                0x5d, (byte) 0xaf, 0x49, 0x20, 0x4e, 0x71}, "HmacSHA1"));
-        assertThat(edition.keySource().encryptionKey()).isEqualTo(new SecretKeySpec(new byte[] {0x4f, 0x63, 0x5a,
-            (byte) 0xb2, 0x34, 0x57, 0x51, 0x10, 0x37, 0x75, 0x22, (byte) 0xfc, 0x75, 0x44, 0x2e, 0x6d}, "AES"));
+
+        final KeySource keySource = edition.keySource();
+        assertThat(keySource.authenticationKey())
+            .isEqualTo(new SecretKeySpec(
+                new byte[] {(byte) 0xa0, (byte) 0x80, (byte) 0xf7, 0x74, 0x5e, (byte) 0x94, (byte) 0xa2, (byte) 0xf4, (byte) 0xe4,
+                    (byte) 0xcc, (byte) 0xcc, (byte) 0xab, (byte) 0xdd, (byte) 0xaf, 0x5d, (byte) 0xaf, 0x49, 0x20, 0x4e, 0x71},
+                "HmacSHA1"));
+        assertThat(keySource.encryptionKey()).isEqualTo(new SecretKeySpec(
+            new byte[] {0x4f, 0x63, 0x5a, (byte) 0xb2, 0x34, 0x57, 0x51, 0x10, 0x37, 0x75, 0x22, (byte) 0xfc, 0x75, 0x44, 0x2e, 0x6d},
+            "AES"));
+
+        KeySourceAssert.assertThat(keySource).canBeUsedForCryptography();
+    }
+
+    @Test
+    public void shouldCreateEditionWithNonBase64Passwords() {
+        final ClientSideStateProperties properties = new ClientSideStateProperties();
+        properties.setAuthenticationAlgorithm("HmacSHA1");
+        properties.setAuthenticationKey(RandomStringUtils.random(32, true, true));
+        properties.setEncryptionAlgorithm("AES/CBC/PKCS5Padding");
+        properties.setEncryptionKey(RandomStringUtils.random(32, true, true));
+        properties.setTid(1L);
+
+        final StaticEdition edition = new StaticEdition(properties);
+
+        final KeySource keySource = edition.keySource();
+
+        KeySourceAssert.assertThat(keySource).canBeUsedForCryptography();
     }
 }

--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -7,9 +7,10 @@ metadata:
 #
 # Allow localhost refs: {{AllowLocalHost}}
 # Use docker images: {{WithDockerImages}}
-# Atlasmap Tag: {{Tags.Atlasmap}}
 # Syndesis Tag: {{Tags.Syndesis}}
 # Prometheus Tag: {{Tags.Prometheus}}
+# Postgresql Tag: {{Tags.Postgresql}}
+# OAuthProxy Tag: {{Tags.OAuthProxy}}
 #
   labels:
     app: syndesis
@@ -123,6 +124,18 @@ parameters:
   displayName: Memory Limit
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
+  required: true
+- description: Key used to perform authentication of client side stored state.
+  displayName: Client side state authentication key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_AUTHENTICATION_KEY
+  required: true
+- description: Key used to perform encryption of client side stored state.
+  displayName: Client side state encryption key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_ENCRYPTION_KEY
   required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.

--- a/install/generator/02-syndesis-secrets.yml.mustache
+++ b/install/generator/02-syndesis-secrets.yml.mustache
@@ -6,3 +6,12 @@
       app: syndesis
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: syndesis-server-secret
+    labels:
+      app: syndesis
+  stringData:
+    clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
+    clientStateEncryptionKey: ${CLIENT_STATE_ENCRYPTION_KEY}

--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -43,11 +43,11 @@
         END;
         $BODY$;
 
-        CREATE OR REPLACE FUNCTION create_lead( 
-          OUT first_name text, 
+        CREATE OR REPLACE FUNCTION create_lead(
+          OUT first_name text,
           OUT last_name text,
           OUT company text,
-          OUT lead_source text) 
+          OUT lead_source text)
           RETURNS SETOF record
           AS
           $$

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -76,6 +76,22 @@
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          - name: CLIENT_STATE_AUTHENTICATION_ALGORITHM
+            value: "HmacSHA1"
+          - name: CLIENT_STATE_AUTHENTICATION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateAuthenticationKey
+          - name: CLIENT_STATE_ENCRYPTION_ALGORITHM
+            value: "AES/CBC/PKCS5Padding"
+          - name: CLIENT_STATE_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateEncryptionKey
+          - name: CLIENT_STATE_TID
+            value: "1"
 {{#Debug}}
           - name: JAVA_DEBUG
             value: "true"

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -10,9 +10,10 @@ metadata:
 #
 # Allow localhost refs: true
 # Use docker images: false
-# Atlasmap Tag: 
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
+# Postgresql Tag: 9.5
+# OAuthProxy Tag: v1.1.0
 #
   labels:
     app: syndesis
@@ -126,6 +127,18 @@ parameters:
   displayName: Memory Limit
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
+  required: true
+- description: Key used to perform authentication of client side stored state.
+  displayName: Client side state authentication key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_AUTHENTICATION_KEY
+  required: true
+- description: Key used to perform encryption of client side stored state.
+  displayName: Client side state encryption key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_ENCRYPTION_KEY
   required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
@@ -399,11 +412,11 @@ objects:
         END;
         $BODY$;
 
-        CREATE OR REPLACE FUNCTION create_lead( 
-          OUT first_name text, 
+        CREATE OR REPLACE FUNCTION create_lead(
+          OUT first_name text,
           OUT last_name text,
           OUT company text,
-          OUT lead_source text) 
+          OUT lead_source text)
           RETURNS SETOF record
           AS
           $$

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -244,6 +244,15 @@ objects:
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: syndesis-server-secret
+    labels:
+      app: syndesis
+  stringData:
+    clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
+    clientStateEncryptionKey: ${CLIENT_STATE_ENCRYPTION_KEY}
+- apiVersion: v1
   kind: Service
   metadata:
     name: syndesis-ui
@@ -914,6 +923,22 @@ objects:
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          - name: CLIENT_STATE_AUTHENTICATION_ALGORITHM
+            value: "HmacSHA1"
+          - name: CLIENT_STATE_AUTHENTICATION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateAuthenticationKey
+          - name: CLIENT_STATE_ENCRYPTION_ALGORITHM
+            value: "AES/CBC/PKCS5Padding"
+          - name: CLIENT_STATE_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateEncryptionKey
+          - name: CLIENT_STATE_TID
+            value: "1"
           - name: JAVA_DEBUG
             value: "true"
           image: ' '

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -244,6 +244,15 @@ objects:
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: syndesis-server-secret
+    labels:
+      app: syndesis
+  stringData:
+    clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
+    clientStateEncryptionKey: ${CLIENT_STATE_ENCRYPTION_KEY}
+- apiVersion: v1
   kind: Service
   metadata:
     name: syndesis-ui
@@ -912,6 +921,22 @@ objects:
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
           - name: POSTGRESQL_SAMPLEDB_PASSWORD
             value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          - name: CLIENT_STATE_AUTHENTICATION_ALGORITHM
+            value: "HmacSHA1"
+          - name: CLIENT_STATE_AUTHENTICATION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateAuthenticationKey
+          - name: CLIENT_STATE_ENCRYPTION_ALGORITHM
+            value: "AES/CBC/PKCS5Padding"
+          - name: CLIENT_STATE_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-server-secret
+                key: clientStateEncryptionKey
+          - name: CLIENT_STATE_TID
+            value: "1"
           image: ' '
 
           imagePullPolicy: IfNotPresent

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -10,9 +10,10 @@ metadata:
 #
 # Allow localhost refs: false
 # Use docker images: false
-# Atlasmap Tag: 
 # Syndesis Tag: latest
 # Prometheus Tag: v2.1.0
+# Postgresql Tag: 9.5
+# OAuthProxy Tag: v1.1.0
 #
   labels:
     app: syndesis
@@ -126,6 +127,18 @@ parameters:
   displayName: Memory Limit
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
+  required: true
+- description: Key used to perform authentication of client side stored state.
+  displayName: Client side state authentication key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_AUTHENTICATION_KEY
+  required: true
+- description: Key used to perform encryption of client side stored state.
+  displayName: Client side state encryption key
+  from: '[a-zA-Z0-9]{32}'
+  generate: expression
+  name: CLIENT_STATE_ENCRYPTION_KEY
   required: true
 message: |-
   Syndesis is deployed to ${ROUTE_HOSTNAME}.
@@ -399,11 +412,11 @@ objects:
         END;
         $BODY$;
 
-        CREATE OR REPLACE FUNCTION create_lead( 
-          OUT first_name text, 
+        CREATE OR REPLACE FUNCTION create_lead(
+          OUT first_name text,
           OUT last_name text,
           OUT company text,
-          OUT lead_source text) 
+          OUT lead_source text)
           RETURNS SETOF record
           AS
           $$


### PR DESCRIPTION
In order to address #1949 this changes few things around:
 - increases client side state timeout from 15min to 30min, so cookies holding client state will be considered valid up until they're 30mins old
 - places the configuration of the client side state implementation in the OpenShift template and the keys used in the Secret, this allows the syndesis-server pod to validate/decrypt client side state cookies after restarts

This also tidies up the template header and removes some trailing whitespace from the templates.

Fixes #1949