### PR TITLE
fix (#2177): LogStepHander now adds message headers to the expression

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
@@ -50,7 +50,7 @@ public class LogStepHandler implements IntegrationStepHandler {
         Boolean isBodyLoggingEnabled = isBodyLoggingEnabled(l.getConfiguredProperties());
 
         if (isContextLoggingEnabled) {
-            sb.append("Message Context: [${body}] ");
+            sb.append("Message Context: [${in.headers}] ");
         }
         if (isBodyLoggingEnabled) {
             sb.append("Body: [${body}] ");


### PR DESCRIPTION
when "message context logging" is enabled.