### PR TITLE
chore (UI): LOOK MA! No Restangular! 

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -53,7 +53,6 @@
     "ng2-file-upload": "1.3.0",
     "ngx-bootstrap": "^2.0.2",
     "ngx-chips": "^1.6.2",
-    "ngx-restangular": "2.0.2",
     "patternfly": "3.26.1",
     "patternfly-ng": "^3.0.0",
     "pluralize": "5.0.0",

--- a/app/ui/src/app/api/providers/api-http-interceptor.service.ts
+++ b/app/ui/src/app/api/providers/api-http-interceptor.service.ts
@@ -1,26 +1,26 @@
 import { Injectable } from '@angular/core';
-import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpResponse, HttpEventType } from '@angular/common/http';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpEventType } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { NotificationService } from '@syndesis/ui/common';
 import { NotificationType } from 'patternfly-ng';
 
 @Injectable()
 export class ApiHttpInterceptor implements HttpInterceptor {
-    constructor(private notificationService: NotificationService) { }
+  constructor(private notificationService: NotificationService) { }
 
-    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(req).map((event: HttpEvent<any>) => {
-            if (event.type === HttpEventType.Response) {
-                if (event.body && event.body['_meta'] && event.body['_meta']['message']) {
-                    const meta = event.body['_meta'];
-                    this.notificationService.popNotification({
-                        type: meta['type'] ? NotificationType[meta['type']] as string : NotificationType.INFO,
-                        header: '',
-                        message: meta['message']
-                    });
-                }
-            }
-            return event;
-        });
-    }
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(request).map((event: HttpEvent<any>) => {
+      if (event.type === HttpEventType.Response) {
+        if (event.body && event.body['_meta'] && event.body['_meta']['message']) {
+          const meta = event.body['_meta'];
+          this.notificationService.popNotification({
+            type: meta['type'] ? NotificationType[meta['type']] as string : NotificationType.INFO,
+            header: '',
+            message: meta['message']
+          });
+        }
+      }
+      return event;
+    });
+  }
 }

--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -56,6 +56,7 @@ export class ApiHttpProviderService extends ApiHttpService {
       get: <T>(options?: ApiRequestOptions | any) => this.get<T>(url, options),
       post: <T>(body: any, options?: ApiRequestOptions | any) => this.post<T>([endpointKey, ...endpointParams], body, options),
       put: <T>(body: any, options?: ApiRequestOptions | any) => this.put<T>([endpointKey, ...endpointParams], body, options),
+      patch: <T>(body: any, options?: ApiRequestOptions | any) => this.put<T>([endpointKey, ...endpointParams], body, options),
       delete: <T>(options?: ApiRequestOptions | any) => this.delete<T>(url, options),
       upload: <T>(fileMap?: FileMap, body?: StringMap<any>, options?: ApiUploadOptions) => {
         return this.upload<T>([endpointKey, ...endpointParams], fileMap, body, options);
@@ -84,6 +85,14 @@ export class ApiHttpProviderService extends ApiHttpService {
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
     return this.httpClient
       .put<T>(url, body, options)
+      .catch(error => Observable.throw(this.catchError(error)));
+  }
+  
+  patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
+    const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    return this.httpClient
+      .patch<T>(url, body, options)
       .catch(error => Observable.throw(this.catchError(error)));
   }
 

--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -87,7 +87,7 @@ export class ApiHttpProviderService extends ApiHttpService {
       .put<T>(url, body, options)
       .catch(error => Observable.throw(this.catchError(error)));
   }
-  
+
   patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);

--- a/app/ui/src/app/api/testing/index.ts
+++ b/app/ui/src/app/api/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './test-api.module';

--- a/app/ui/src/app/api/testing/test-api-http.service.ts
+++ b/app/ui/src/app/api/testing/test-api-http.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+
+import {
+  ApiHttpService,
+  ApiEndpoint, ApiRequestProgress,
+  ApiRequestOptions, ApiUploadOptions,
+  StringMap, FileMap
+} from '../../platform';
+
+@Injectable()
+export class TestApiHttpService extends ApiHttpService {
+  private uploadProgressSubject = new Subject<ApiRequestProgress>();
+
+  constructor() {
+    super();
+    this.uploadProgressSubject.next({
+      percentage: 0,
+      isComplete: false,
+      bytesLoaded: 0,
+      bytesTotal: 0
+    });
+  }
+
+  getEndpointUrl(endpointKey: string, ...endpointParams: any[]): string {
+    return '';
+  }
+
+  setEndpointUrl(endpointKey: string, ...endpointParams: any[]): ApiEndpoint {
+    const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+
+    return {
+      url,
+      get: <T>(options?: ApiRequestOptions | any) => this.get<T>(url, options),
+      post: <T>(body: any, options?: ApiRequestOptions | any) => this.post<T>([endpointKey, ...endpointParams], body, options),
+      put: <T>(body: any, options?: ApiRequestOptions | any) => this.put<T>([endpointKey, ...endpointParams], body, options),
+      patch: <T>(body: any, options?: ApiRequestOptions | any) => this.put<T>([endpointKey, ...endpointParams], body, options),
+      delete: <T>(options?: ApiRequestOptions | any) => this.delete<T>(url, options),
+      upload: <T>(fileMap?: FileMap, body?: StringMap<any>, options?: ApiUploadOptions) => {
+        return this.upload<T>([endpointKey, ...endpointParams], fileMap, body, options);
+      }
+    };
+  }
+
+  get<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
+    return Observable.of(null as T);
+  }
+
+  post<T>(endpoint: string | any[], body?: any, options?: ApiRequestOptions | any): Observable<T> {
+    return Observable.of(null as T);
+  }
+
+  put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
+    return Observable.of(null as T);
+  }
+
+  patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
+    return Observable.of(null as T);
+  }
+
+  delete<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
+    return Observable.of(null as T);
+  }
+
+  get uploadProgressEvent$(): Observable<ApiRequestProgress> {
+    return this.uploadProgressSubject.asObservable();
+  }
+
+  upload<T>(endpoint: string | any[], fileMap: FileMap, body?: StringMap<any>, options?: ApiUploadOptions): Observable<T> {
+    this.emitProgressEvent();
+
+    return Observable.of(null as T);
+  }
+
+  private emitProgressEvent(): void {
+    this.uploadProgressSubject.next({
+      percentage: 100,
+      isComplete: true,
+      bytesLoaded: 1000,
+      bytesTotal: 1000
+    });
+  }
+}

--- a/app/ui/src/app/api/testing/test-api.module.ts
+++ b/app/ui/src/app/api/testing/test-api.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+
+import { ApiHttpService } from '@syndesis/ui/platform';
+import { TestApiHttpService } from './test-api-http.service';
+
+@NgModule({
+  imports: [CommonModule, HttpClientModule],
+  exports: [HttpClientModule],
+  providers: [
+    TestApiHttpService,
+    {
+      provide: ApiHttpService,
+      useClass: TestApiHttpService
+    }
+  ],
+})
+export class TestApiModule { }

--- a/app/ui/src/app/app.component.spec.ts
+++ b/app/ui/src/app/app.component.spec.ts
@@ -1,17 +1,14 @@
 import { async, TestBed } from '@angular/core/testing';
-import { BaseRequestOptions, Http, RequestOptions } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CollapseModule, ModalModule } from 'ngx-bootstrap';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { RestangularModule } from 'ngx-restangular';
 import { NotificationModule } from 'patternfly-ng';
 import { StoreModule as NgRxStoreModule, Store } from '@ngrx/store';
 
 import { AppComponent } from './app.component';
 import { SyndesisCommonModule } from './common/common.module';
 import { NavigationService } from './common/navigation.service';
-import { UserService } from '@syndesis/ui/platform';
+import { UserService, ApiHttpService } from '@syndesis/ui/platform';
 import { ConfigService } from './config.service';
 import { StoreModule } from './store/store.module';
 import { TestSupportService } from './store/test-support.service';
@@ -27,7 +24,6 @@ describe('AppComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        RestangularModule,
         StoreModule,
         SyndesisCommonModule.forRoot(),
         ModalModule.forRoot(),
@@ -42,15 +38,7 @@ describe('AppComponent', () => {
         UserService,
         TestSupportService,
         NavigationService,
-        MockBackend,
-        { provide: RequestOptions, useClass: BaseRequestOptions },
-        {
-          provide: Http,
-          useFactory: (backend, options) => {
-            return new Http(backend, options);
-          },
-          deps: [MockBackend, RequestOptions]
-        },
+        ApiHttpService,
         { provide: ConfigService, useValue: configServiceStub }
       ],
       declarations: [AppComponent]

--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -6,10 +6,8 @@ import {
   Inject
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { Response } from '@angular/http';
 import { Meta, Title } from '@angular/platform-browser';
 import { saveAs } from 'file-saver';
-import { Restangular } from 'ngx-restangular';
 import { Notification, NotificationEvent } from 'patternfly-ng';
 import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
@@ -25,8 +23,6 @@ import { NotificationService } from '@syndesis/ui/common/ui-patternfly/notificat
   selector: 'syndesis-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  changeDetection: ChangeDetectionStrategy.Default,
-  providers: [Restangular, TestSupportService]
 })
 export class AppComponent implements OnInit, AfterViewInit {
   // TODO icon?
@@ -85,7 +81,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     private store: Store<PlatformState>,
     private config: ConfigService,
     private userService: UserService,
-    public testSupport: TestSupportService,
+    private testSupport: TestSupportService,
     private notificationService: NotificationService,
     private navigationService: NavigationService,
     private modalService: ModalService,
@@ -167,20 +163,15 @@ export class AppComponent implements OnInit, AfterViewInit {
    * Function that resets the database.
    */
   resetDB() {
-    this.testSupport.resetDB().subscribe((value: Response) => {
-      log.debugc(() => 'DB has been reset');
-    });
+    this.testSupport.resetDB().subscribe(() => log.debugc(() => 'DB has been reset'));
   }
 
   /**
    * Function that exports the database.
    */
   exportDB() {
-    this.testSupport.snapshotDB().subscribe((value: Response) => {
-      const blob = new Blob([value.text()], {
-        type: 'text/plain;charset=utf-8'
-      });
-      saveAs(blob, 'syndesis-db-export.json');
+    this.testSupport.snapshotDB().subscribe((value: Blob) => {
+      saveAs(value, 'syndesis-db-export.json');
     });
   }
 
@@ -192,9 +183,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       if (modal.result) {
         return this.testSupport
           .restoreDB(modal['json'])
-          .take(1)
-          .toPromise()
-          .then(_ => log.debugc(() => 'DB has been imported'));
+          .subscribe(() => log.debugc(() => 'DB has been imported'));
       }
     });
   }

--- a/app/ui/src/app/app.module.ts
+++ b/app/ui/src/app/app.module.ts
@@ -1,14 +1,12 @@
 import { APP_INITIALIZER, NgModule, InjectionToken } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
 import { VendorModule } from '@syndesis/ui/vendor';
 import { TagInputModule } from 'ngx-chips';
-import { Restangular, RestangularModule } from 'ngx-restangular';
 import { NotificationModule } from 'patternfly-ng';
 import { DataMapperModule } from '@atlasmap/atlasmap.data.mapper';
 
@@ -22,50 +20,12 @@ import { appConfigInitializer, ConfigService } from './config.service';
 import { StoreModule as LegacyStoreModule } from './store/store.module';
 import { platformReducer, PlatformEffects, platformEndpoints, SYNDESIS_GUARDS } from './platform';
 
-export function restangularProviderConfigurer(restangularProvider: any, configService: ConfigService) {
-  restangularProvider.setPlainByDefault(true);
-  configService.asyncSettings$.first().subscribe(settings => {
-    restangularProvider.setBaseUrl(settings.apiEndpoint);
-  });
-
-  restangularProvider.addResponseInterceptor((data: any, operation: string) => {
-    switch (operation) {
-      case 'getList':
-        if (!Array.isArray(data)) {
-          data = data.items || [];
-        }
-        break;
-      case 'put':
-        if (data === null) {
-          data = [];
-        }
-        break;
-      default:
-    }
-    return data;
-  });
-}
-
-export const RESTANGULAR_MAPPER = new InjectionToken<Restangular>(
-  'restangularMapper'
-);
-
-export function mapperRestangularProvider(restangular: Restangular, config: ConfigService) {
-  return restangular.withConfig(restangularConfigurer => {
-    const mapperEndpoint = config.getSettings().mapperEndpoint;
-    restangularConfigurer.setBaseUrl(
-      mapperEndpoint ? mapperEndpoint : '/mapper/v1'
-    );
-  });
-}
-
 @NgModule({
   declarations: [AppComponent],
   imports: [
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
-    HttpModule,
     ApiModule.forRoot(platformEndpoints),
     CoreModule.forRoot(),
     DynamicFormsCoreModule.forRoot(),
@@ -79,7 +39,6 @@ export function mapperRestangularProvider(restangular: Restangular, config: Conf
     SyndesisCommonModule.forRoot(),
     DataMapperModule,
     NotificationModule,
-    RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
   ],
   providers: [
     ...SYNDESIS_GUARDS,
@@ -89,11 +48,6 @@ export function mapperRestangularProvider(restangular: Restangular, config: Conf
       useFactory: appConfigInitializer,
       deps: [ConfigService],
       multi: true
-    },
-    {
-      provide: RESTANGULAR_MAPPER,
-      useFactory: mapperRestangularProvider,
-      deps: [Restangular, ConfigService]
     },
   ],
   bootstrap: [AppComponent]

--- a/app/ui/src/app/config.service.spec.ts
+++ b/app/ui/src/app/config.service.spec.ts
@@ -1,9 +1,7 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
 import { HttpClientModule } from '@angular/common/http';
-import { MockBackend } from '@angular/http/testing';
 
 import { ConfigService } from './config.service';
 
@@ -11,18 +9,7 @@ describe('ConfigService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
-      providers: [
-        ConfigService,
-        MockBackend,
-        { provide: RequestOptions, useClass: BaseRequestOptions },
-        {
-          provide: Http,
-          useFactory: (backend, options) => {
-            return new Http(backend, options);
-          },
-          deps: [MockBackend, RequestOptions]
-        }
-      ]
+      providers: [ConfigService]
     });
   });
 

--- a/app/ui/src/app/connections/list-page/list-page.component.spec.ts
+++ b/app/ui/src/app/connections/list-page/list-page.component.spec.ts
@@ -1,64 +1,50 @@
-// /* tslint:disable:no-unused-variable */
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-// import { RouterTestingModule } from '@angular/router/testing';
-// import { MockBackend } from '@angular/http/testing';
-// import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-// import { RestangularModule } from 'ngx-restangular';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
-// import { ModalModule } from 'ngx-bootstrap/modal';
-// import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-// import { NotificationModule } from 'patternfly-ng';
-// import { ToolbarModule } from 'patternfly-ng';
-// import { StoreModule } from '../../store/store.module';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { NotificationModule } from 'patternfly-ng';
 
-// import { SyndesisCommonModule } from '../../common/common.module';
-// import { PatternflyUIModule } from '../../common/ui-patternfly/ui-patternfly.module';
-// import { ConnectionsListPage } from './list-page.component';
-// import { ConnectionsListComponent } from '../list/list.component';
+import { TestApiModule } from '@syndesis/ui/api/testing';
 
-// describe('ConnectionListPage', () => {
-//   let component: ConnectionsListPage;
-//   let fixture: ComponentFixture<ConnectionsListPage>;
+import { StoreModule } from '../../store/store.module';
+import { SyndesisCommonModule } from '../../common/common.module';
+import { PatternflyUIModule } from '../../common/ui-patternfly/ui-patternfly.module';
+import { ConnectionsListPage } from './list-page.component';
+import { ConnectionsListComponent } from '../list/list.component';
 
-//   beforeEach(
-//     async(() => {
-//       TestBed.configureTestingModule({
-//         imports: [
-//           SyndesisCommonModule.forRoot(),
-//           StoreModule,
-//           RouterTestingModule.withRoutes([]),
-//           RestangularModule.forRoot(),
-//           ModalModule.forRoot(),
-//           BsDropdownModule.forRoot(),
-//           NotificationModule,
-//           PatternflyUIModule,
-//         ],
-//         declarations: [
-//           ConnectionsListPage,
-//           ConnectionsListComponent,
-//         ],
-//         providers: [
-//           MockBackend,
-//           { provide: RequestOptions, useClass: BaseRequestOptions },
-//           {
-//             provide: Http,
-//             useFactory: (backend, options) => {
-//               return new Http(backend, options);
-//             },
-//             deps: [MockBackend, RequestOptions],
-//           },
-//         ],
-//       }).compileComponents();
-//     }),
-//   );
+describe('ConnectionListPage', () => {
+  let component: ConnectionsListPage;
+  let fixture: ComponentFixture<ConnectionsListPage>;
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(ConnectionsListPage);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          TestApiModule,
+          SyndesisCommonModule.forRoot(),
+          StoreModule,
+          RouterTestingModule.withRoutes([]),
+          ModalModule.forRoot(),
+          BsDropdownModule.forRoot(),
+          NotificationModule,
+          PatternflyUIModule,
+        ],
+        declarations: [
+          ConnectionsListPage,
+          ConnectionsListComponent,
+        ]
+      }).compileComponents();
+    }),
+  );
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConnectionsListPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/app/ui/src/app/connections/list/list.component.spec.ts
+++ b/app/ui/src/app/connections/list/list.component.spec.ts
@@ -1,11 +1,8 @@
-/* tslint:disable:no-unused-variable */
+import { DebugElement } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
-import { DebugElement } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { RestangularModule } from 'ngx-restangular';
-import { HttpClientModule } from '@angular/common/http';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
@@ -14,6 +11,7 @@ import { StoreModule } from '../../store/store.module';
 
 import { SyndesisCommonModule } from '../../common/common.module';
 import { ConnectionsListComponent } from './list.component';
+import { TestApiModule } from '@syndesis/ui/api/testing';
 
 describe('ConnectionsListComponent', () => {
   let component: ConnectionsListComponent;
@@ -23,9 +21,8 @@ describe('ConnectionsListComponent', () => {
     async(() => {
       TestBed.configureTestingModule({
         imports: [
+          TestApiModule,
           CommonModule,
-          HttpClientModule,
-          RestangularModule.forRoot(),
           SyndesisCommonModule.forRoot(),
           RouterTestingModule.withRoutes([]),
           ModalModule.forRoot(),

--- a/app/ui/src/app/core/providers/integration-support-provider.service.ts
+++ b/app/ui/src/app/core/providers/integration-support-provider.service.ts
@@ -16,7 +16,6 @@ import { Action,
   PUBLISHED
 } from '@syndesis/ui/platform';
 import { EventsService } from '@syndesis/ui/store';
-import { RequestMethod, ResponseContentType } from '@angular/http';
 
 @Injectable()
 export class IntegrationSupportProviderService extends IntegrationSupportService {

--- a/app/ui/src/app/core/providers/user-provider.service.spec.ts
+++ b/app/ui/src/app/core/providers/user-provider.service.spec.ts
@@ -1,25 +1,19 @@
-/* tslint:disable:no-unused-variable */
-
 import { TestBed, async, inject } from '@angular/core/testing';
 
-import { RestangularModule } from 'ngx-restangular';
-
-import { UserProviderService } from './user-provider.service';
 import { ApiModule } from '@syndesis/ui/api';
 import { ConfigService } from '@syndesis/ui/config.service';
+
+import { UserProviderService } from './user-provider.service';
 
 describe('UserProviderServiceProvider', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        ApiModule.forRoot(),
-        RestangularModule.forRoot()],
+      imports: [ApiModule.forRoot()],
       providers: [UserProviderService, ConfigService]
     });
   });
 
-  it(
-    'should ...',
+  it('should ...',
     inject([UserProviderService], (service: UserProviderService) => {
       expect(service).toBeTruthy();
     })

--- a/app/ui/src/app/dashboard/dashboard.component.spec.ts
+++ b/app/ui/src/app/dashboard/dashboard.component.spec.ts
@@ -1,10 +1,5 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MockBackend } from '@angular/http/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-import { RestangularModule } from 'ngx-restangular';
-import { HttpClientModule } from '@angular/common/http';
 import { StoreModule, Store } from '@ngrx/store';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
@@ -43,7 +38,6 @@ xdescribe('DashboardComponent', () => {
           ApiModule.forRoot(),
           CoreModule.forRoot(),
           LegacyStore,
-          HttpClientModule,
           ActionModule,
           ListModule,
           ChartModule,
@@ -53,7 +47,6 @@ xdescribe('DashboardComponent', () => {
           BsDropdownModule.forRoot(),
           StoreModule,
           RouterTestingModule.withRoutes([]),
-          RestangularModule,
           NotificationModule,
           IntegrationListModule,
           SyndesisCommonModule
@@ -68,16 +61,7 @@ xdescribe('DashboardComponent', () => {
         providers: [
           ConfigService,
           ModalService,
-          MockBackend,
           Store,
-          { provide: RequestOptions, useClass: BaseRequestOptions },
-          {
-            provide: Http,
-            useFactory: (backend, options) => {
-              return new Http(backend, options);
-            },
-            deps: [MockBackend, RequestOptions]
-          }
         ]
       };
       TestBed.configureTestingModule(moduleConfig).compileComponents();

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.spec.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.spec.ts
@@ -1,49 +1,20 @@
-/* tslint:disable:no-unused-variable */
-import { TestBed, async, inject, ComponentFixture } from '@angular/core/testing';
-import { IntegrationConfigureActionComponent } from './action-configure.component';
-import { ApiEndpointsLazyLoaderService } from '../../../api/providers/api-endpoints-lazy-loader.service';
-import {
-    ApiConfigService,
-    ActionDescriptor,
-    ActionDescriptorStep,
-    DataShape,
-    UserService,
-    FormFactoryService,
-    IntegrationSupportService
-} from '@syndesis/ui/platform';
-
-import { RouterTestingModule } from '@angular/router/testing';
-import { CurrentFlowService, FlowPageService } from '@syndesis/ui/integration/edit-page';
-import { ActivatedRoute } from '@angular/router';
-import { IntegrationSupportModule } from '@syndesis/ui/integration/integration-support.module';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-
+import { TestBed, async, inject, ComponentFixture } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { ReactiveFormsModule, FormGroup, FormControl, FormsModule } from '@angular/forms';
-import { CoreModule } from '@syndesis/ui/core';
+import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
 
-import {
-    DynamicFormsCoreModule,
-    DynamicFormService,
-    DynamicCheckboxModel,
-    DynamicCheckboxGroupModel,
-    DynamicDatePickerModel,
-    DynamicEditorModel,
-    DynamicFileUploadModel,
-    DynamicFormArrayModel,
-    DynamicFormControlModel,
-    DynamicFormGroupModel,
-    DynamicInputModel,
-    DynamicRadioGroupModel,
-    DynamicSelectModel,
-    DynamicSliderModel,
-    DynamicSwitchModel,
-    DynamicTextAreaModel,
-    DynamicTimePickerModel
-} from '@ng-dynamic-forms/core';
+import { CoreModule } from '@syndesis/ui/core';
+import { ActionDescriptor, ActionDescriptorStep } from '@syndesis/ui/platform';
+
 import { ApiModule } from '@syndesis/ui/api';
 import { ConfigService } from '@syndesis/ui/config.service';
 import { EventsService, IntegrationStore, IntegrationService, StepStore } from '@syndesis/ui/store';
-import { RestangularModule } from 'ngx-restangular';
+
+import { CurrentFlowService, FlowPageService } from '@syndesis/ui/integration/edit-page';
+import { IntegrationSupportModule } from '@syndesis/ui/integration/integration-support.module';
+import { IntegrationConfigureActionComponent } from './action-configure.component';
 
 describe('IntegrationConfigureActionComponent', () => {
     let component: IntegrationConfigureActionComponent;
@@ -59,8 +30,7 @@ describe('IntegrationConfigureActionComponent', () => {
                     ReactiveFormsModule,
                     DynamicFormsCoreModule.forRoot(),
                     CoreModule.forRoot(),
-                    ApiModule.forRoot(),
-                    RestangularModule.forRoot()
+                    ApiModule.forRoot()
                 ],
                 declarations: [IntegrationConfigureActionComponent],
                 providers: [

--- a/app/ui/src/app/integration/edit-page/current-flow.service.spec.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.spec.ts
@@ -1,10 +1,4 @@
-
-/* tslint:disable */
 import { TestBed, async, inject } from '@angular/core/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
-import { RestangularModule } from 'ngx-restangular';
-import { HttpClientModule } from '@angular/common/http';
 
 import { Connection,
   Action,
@@ -27,8 +21,6 @@ describe('CurrentFlow', () => {
     TestBed.configureTestingModule({
       imports: [
         ApiModule.forRoot(),
-        HttpClientModule,
-        RestangularModule.forRoot(),
         CoreModule.forRoot(),
         IntegrationSupportModule,
       ],
@@ -38,16 +30,7 @@ describe('CurrentFlow', () => {
         IntegrationService,
         EventsService,
         ConfigService,
-        StepStore,
-        MockBackend,
-        { provide: RequestOptions, useClass: BaseRequestOptions },
-        {
-          provide: Http,
-          useFactory: (backend, options) => {
-            return new Http(backend, options);
-          },
-          deps: [MockBackend, RequestOptions]
-        }
+        StepStore
       ]
     });
   });

--- a/app/ui/src/app/integration/edit-page/edit-page.component.spec.ts
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.spec.ts
@@ -2,9 +2,6 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MockBackend } from '@angular/http/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-import { RestangularModule } from 'ngx-restangular';
 import { ToolbarModule } from 'patternfly-ng';
 
 import { SyndesisCommonModule, NavigationService } from '@syndesis/ui/common';
@@ -31,7 +28,6 @@ describe('IntegrationsEditComponent', () => {
           FormsModule,
           SyndesisCommonModule,
           ModalModule,
-          RestangularModule.forRoot(),
           RouterTestingModule.withRoutes([]),
           PopoverModule.forRoot(),
           CollapseModule.forRoot(),
@@ -45,18 +41,6 @@ describe('IntegrationsEditComponent', () => {
           FlowViewStepComponent
         ],
         providers: [
-          MockBackend,
-          {
-            provide: RequestOptions,
-            useClass: BaseRequestOptions
-          },
-          {
-            provide: Http,
-            useFactory: (backend, options) => {
-              return new Http(backend, options);
-            },
-            deps: [MockBackend, RequestOptions]
-          },
           CurrentFlowService,
           NavigationService,
         ]

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.spec.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.spec.ts
@@ -1,14 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MockBackend } from '@angular/http/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TabsModule, CollapseModule, PopoverModule } from 'ngx-bootstrap';
 import { ModalModule } from 'ngx-bootstrap/modal';
-
-import { RestangularModule } from 'ngx-restangular';
 
 import { ApiModule } from '@syndesis/ui/api';
 import { CoreModule } from '@syndesis/ui/core';
@@ -31,11 +26,9 @@ describe('FlowViewComponent', () => {
         imports: [
           CoreModule.forRoot(),
           ApiModule.forRoot(),
-          HttpClientModule,
           CommonModule,
           FormsModule,
           RouterTestingModule.withRoutes([]),
-          RestangularModule,
           ConnectionsModule,
           ModalModule.forRoot(),
           TabsModule.forRoot(),
@@ -47,18 +40,6 @@ describe('FlowViewComponent', () => {
         ],
         declarations: [FlowViewComponent, FlowViewStepComponent],
         providers: [
-          MockBackend,
-          {
-            provide: RequestOptions,
-            useClass: BaseRequestOptions
-          },
-          {
-            provide: Http,
-            useFactory: (backend, options) => {
-              return new Http(backend, options);
-            },
-            deps: [MockBackend, RequestOptions]
-          },
           CurrentFlowService,
           FlowPageService,
           IntegrationStore,

--- a/app/ui/src/app/integration/list-page/list-page.component.spec.ts
+++ b/app/ui/src/app/integration/list-page/list-page.component.spec.ts
@@ -1,9 +1,6 @@
 /* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MockBackend } from '@angular/http/testing';
-import { RequestOptions, BaseRequestOptions, Http } from '@angular/http';
-import { RestangularModule } from 'ngx-restangular';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
@@ -27,7 +24,6 @@ xdescribe('IntegrationsListPage', () => {
           SyndesisCommonModule.forRoot(),
           StoreModule,
           RouterTestingModule.withRoutes([]),
-          RestangularModule.forRoot(),
           ModalModule.forRoot(),
           TooltipModule.forRoot(),
           TabsModule.forRoot(),
@@ -35,18 +31,7 @@ xdescribe('IntegrationsListPage', () => {
           PatternflyUIModule,
           IntegrationListModule
         ],
-        declarations: [IntegrationListPage],
-        providers: [
-          MockBackend,
-          { provide: RequestOptions, useClass: BaseRequestOptions },
-          {
-            provide: Http,
-            useFactory: (backend, options) => {
-              return new Http(backend, options);
-            },
-            deps: [MockBackend, RequestOptions]
-          }
-        ]
+        declarations: [IntegrationListPage]
       }).compileComponents();
     })
   );

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -67,6 +67,15 @@ export abstract class ApiHttpService {
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
   abstract put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
+  
+  /**
+   * Sends a PATCH request containing the given body to the selected API endpoint URL.
+   * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
+   * @param body Request body. Can be any type.
+   * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
+   * @returns {Observable<T>} Observable typed as T containing the server response.
+   */
+  abstract patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
 
   /**
    * Sends a DELETE request to the selected API endpoint URL.

--- a/app/ui/src/app/platform/types/api/api-http.service.ts
+++ b/app/ui/src/app/platform/types/api/api-http.service.ts
@@ -48,7 +48,7 @@ export abstract class ApiHttpService {
    * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract get<T>(endpoint: string | any[], options?: ApiRequestOptions|any): Observable<T>;
+  abstract get<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T>;
 
   /**
    * Sends a POST request containing the given body to the selected API endpoint URL.
@@ -57,7 +57,7 @@ export abstract class ApiHttpService {
    * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract post<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
+  abstract post<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T>;
 
   /**
    * Sends a PUT request containing the given body to the selected API endpoint URL.
@@ -66,8 +66,8 @@ export abstract class ApiHttpService {
    * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
-  
+  abstract put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T>;
+
   /**
    * Sends a PATCH request containing the given body to the selected API endpoint URL.
    * @param endpoint URL of the API endpoint to use, provided by `ApiConfigService`.
@@ -75,7 +75,7 @@ export abstract class ApiHttpService {
    * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions|any): Observable<T>;
+  abstract patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T>;
 
   /**
    * Sends a DELETE request to the selected API endpoint URL.
@@ -83,7 +83,7 @@ export abstract class ApiHttpService {
    * @param options Optional. Adds additional metadata to the request, such as custom headers or response types, credentials, etc.
    * @returns {Observable<T>} Observable typed as T containing the server response.
    */
-  abstract delete<T>(endpoint: string | any[], options?: ApiRequestOptions|any): Observable<T>;
+  abstract delete<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T>;
 
   /**
    * Sends a multipart message wrapped by a POST/PUT request to the API, allowing one or several file uploads along with JSON objects.

--- a/app/ui/src/app/platform/types/api/api.models.ts
+++ b/app/ui/src/app/platform/types/api/api.models.ts
@@ -44,6 +44,7 @@ export interface ApiEndpoint {
   get<T>(options?: ApiRequestOptions): Observable<T>;
   post<T>(body: any, options?: ApiRequestOptions): Observable<T>;
   put<T>(body: any, options?: ApiRequestOptions): Observable<T>;
+  patch<T>(body: any, options?: ApiRequestOptions): Observable<T>;
   delete<T>(body?: any, options?: ApiRequestOptions): Observable<T>;
   upload<T>(fileMap?: FileMap, body?: StringMap<any>, options?: ApiUploadOptions): Observable<T>;
 }

--- a/app/ui/src/app/store/action/action.service.ts
+++ b/app/ui/src/app/store/action/action.service.ts
@@ -1,12 +1,11 @@
 import { Injectable } from '@angular/core';
-import { Restangular } from 'ngx-restangular';
 
-import { Action, Actions } from '@syndesis/ui/platform';
-import { RESTService } from '../entity/rest.service';
+import { ApiHttpService, Action, Actions } from '@syndesis/ui/platform';
+import { RESTService } from '../entity';
 
 @Injectable()
 export class ActionService extends RESTService<Action, Actions> {
-  constructor(restangular: Restangular) {
-    super(restangular.service('actions'), 'action');
+  constructor(apiHttpService: ApiHttpService) {
+    super(apiHttpService, 'actions', 'action');
   }
 }

--- a/app/ui/src/app/store/connection/connection.service.ts
+++ b/app/ui/src/app/store/connection/connection.service.ts
@@ -1,24 +1,21 @@
 import { Injectable } from '@angular/core';
-import { Restangular } from 'ngx-restangular';
 import { ValidationErrors } from '@angular/forms';
 
-import { Connection, Connections } from '@syndesis/ui/platform';
+import { ApiHttpService, Connection, Connections } from '@syndesis/ui/platform';
 import { TypeFactory } from '@syndesis/ui/model';
-import { RESTService } from '../entity/rest.service';
+import { RESTService } from '../entity';
 
 @Injectable()
 export class ConnectionService extends RESTService<Connection, Connections> {
-  private validationService;
-
-  constructor(restangular: Restangular) {
-    super(restangular.service('connections'), 'connection');
-    this.validationService = restangular.service('connections/validation');
+  constructor(apiHttpService: ApiHttpService) {
+    super(apiHttpService, 'connections', 'connection');
   }
 
   validateName(name: string): Promise<ValidationErrors | null> {
     const connection = TypeFactory.create<Connection>();
     connection.name = name;
-    return this.validationService
+
+    return this.apiHttpService.setEndpointUrl('/connections/validation')
       .post(connection)
       .toPromise()
       .then(response => null)

--- a/app/ui/src/app/store/entity/events.service.ts
+++ b/app/ui/src/app/store/entity/events.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
-import { ConfigService } from '../../config.service';
-import { Restangular } from 'ngx-restangular';
-import { log } from '../../logging';
 import { resolve } from 'url';
+
+import { ConfigService } from '@syndesis/ui/config.service';
+import { log } from '@syndesis/ui/logging';
+import { ApiHttpService } from '@syndesis/ui/platform';
 
 export class ChangeEvent {
   action: string;
@@ -30,7 +31,7 @@ export class EventsService {
   private retries = 0;
   private preferredProtocol = null;
 
-  constructor(private configService: ConfigService, private restangular: Restangular) {
+  constructor(private configService: ConfigService, private apiHttpService: ApiHttpService) {
     this.configService.asyncSettings$.subscribe(() => this.startConnection(this.retries % 2 === 0));
   }
 
@@ -78,37 +79,34 @@ export class EventsService {
     this.starting = true;
 
     try {
-      this.restangular
-        .all('event/reservations')
-        .customPOST()
-        .first()
-        .subscribe(
-          response => {
-            const apiEndpoint = this.configService.getSettings().apiEndpoint;
-            const reservation = response.data;
-            try {
-              if (connectUsingWebSockets) {
-                let wsApiEndpoint = resolve(window.location.href, apiEndpoint);
-                wsApiEndpoint = wsApiEndpoint.replace(/^http/, 'ws');
-                (wsApiEndpoint += '/event/streams.ws/' + reservation),
-                  this.connectWebSocket(wsApiEndpoint);
-                log.info('Connecting using web socket');
-                this.starting = false;
-              } else {
-                this.connectEventSource(
-                  apiEndpoint + '/event/streams/' + reservation
-                );
-                this.starting = false;
-                log.info('Connecting using server side events');
-              }
-            } catch (error) {
-              this.onFailure(error);
+      this.apiHttpService
+        .setEndpointUrl('/event/reservations')
+        .post<{ data: any }>({})
+        .subscribe(response => {
+          const apiEndpoint = this.configService.getSettings().apiEndpoint;
+          const reservation = response.data;
+          
+          try {
+            if (connectUsingWebSockets) {
+              let wsApiEndpoint = resolve(window.location.href, apiEndpoint);
+              wsApiEndpoint = wsApiEndpoint.replace(/^http/, 'ws');
+              (wsApiEndpoint += '/event/streams.ws/' + reservation),
+                this.connectWebSocket(wsApiEndpoint);
+              log.info('Connecting using web socket');
+              this.starting = false;
+            } else {
+              this.connectEventSource(
+                apiEndpoint + '/event/streams/' + reservation
+              );
+              this.starting = false;
+              log.info('Connecting using server side events');
             }
-          },
-          error => {
+          } catch (error) {
             this.onFailure(error);
           }
-        );
+        },
+        error => this.onFailure(error)
+      );
     } catch (error) {
       this.onFailure(error);
     }
@@ -116,13 +114,13 @@ export class EventsService {
 
   private connectEventSource(url: string) {
     this.eventSource = new EventSource(url);
-    this.eventSource.addEventListener('message', event => {
+    this.eventSource.addEventListener('message', (event: any) => {
       this.starting = false;
       this.preferredProtocol = 'es';
       log.info('sse.message: ' + JSON.stringify(event.data));
       this.messageEvents.next(event.data);
     });
-    this.eventSource.addEventListener('change-event', event => {
+    this.eventSource.addEventListener('change-event', (event: any) => {
       const value = JSON.parse(event.data) as ChangeEvent;
       log.info('sse.change-event: ' + JSON.stringify(value));
       this.changeEvents.next(value);

--- a/app/ui/src/app/store/entity/events.service.ts
+++ b/app/ui/src/app/store/entity/events.service.ts
@@ -85,7 +85,7 @@ export class EventsService {
         .subscribe(response => {
           const apiEndpoint = this.configService.getSettings().apiEndpoint;
           const reservation = response.data;
-          
+
           try {
             if (connectUsingWebSockets) {
               let wsApiEndpoint = resolve(window.location.href, apiEndpoint);
@@ -105,8 +105,8 @@ export class EventsService {
             this.onFailure(error);
           }
         },
-        error => this.onFailure(error)
-      );
+          error => this.onFailure(error)
+        );
     } catch (error) {
       this.onFailure(error);
     }

--- a/app/ui/src/app/store/entity/rest.service.ts
+++ b/app/ui/src/app/store/entity/rest.service.ts
@@ -1,35 +1,53 @@
-import { Restangular } from 'ngx-restangular';
 import { Observable } from 'rxjs/Observable';
 
-import { BaseEntity } from '@syndesis/ui/platform';
+import { BaseEntity, ApiHttpService } from '@syndesis/ui/platform';
 
 export abstract class RESTService<T extends BaseEntity, L extends Array<T>> {
   protected constructor(
-    public restangularService: Restangular,
-    public kind: String
-  ) {}
+    public apiHttpService: ApiHttpService,
+    public endpoint: string,
+    public kind: string
+  ) { }
 
   get(id: string): Observable<T> {
-    return this.restangularService.one(id).get();
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment(id))
+      .get();
   }
 
   list(): Observable<L> {
-    return this.restangularService.getList();
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment())
+      .get()
+      .map((response: any) => Array.isArray(response) ? response : response.items || []);
   }
 
   create(obj: T): Observable<T> {
-    return this.restangularService.post(obj);
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment())
+      .post(obj);
   }
 
   update(obj: T): Observable<T> {
-    return this.restangularService.one(obj.id).customPUT(obj);
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment(obj.id))
+      .put(obj)
+      .map((response: any) => response !== null ? response : []);
   }
 
-  delete(obj: T) {
-    return this.restangularService.one(obj.id).remove();
+  delete(obj: T): Observable<any> {
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment(obj.id))
+      .delete();
   }
 
-  patch(id: string, attributes: any) {
-    return this.restangularService.one(id).patch(attributes);
+  patch(id: string, attributes: any): Observable<any> {
+    return this.apiHttpService
+      .setEndpointUrl(this.getEndpointSegment(id))
+      .patch(attributes);
+  }
+
+  private getEndpointSegment(id?: string): string {
+    return id ? `/${this.endpoint}/${id}` : `/${this.endpoint}`;
   }
 }

--- a/app/ui/src/app/store/extension/extension.service.ts
+++ b/app/ui/src/app/store/extension/extension.service.ts
@@ -1,38 +1,35 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Http, Response, ResponseContentType } from '@angular/http';
-import { Restangular } from 'ngx-restangular';
 
-import { RESTService } from '../entity/rest.service';
-import { Extension, Extensions } from '@syndesis/ui/platform';
+import { RESTService } from '../entity';
+import { ApiHttpService, Extension, Extensions, Integrations } from '@syndesis/ui/platform';
 
 @Injectable()
 export class ExtensionService extends RESTService<Extension, Extensions> {
-  constructor(restangular: Restangular, private http: Http) {
-    super(restangular.service('extensions'), 'extension');
+  constructor(public apiHttpService: ApiHttpService) {
+    super(apiHttpService, 'extensions', 'extension');
   }
 
   public getUploadUrl(id?: string) {
-    let url = this.restangularService.one().getRestangularUrl();
-    if (id) {
-      url = url + '?updatedId=' + id;
-    }
-    return url;
+    const url = this.apiHttpService.getEndpointUrl('/extensions');
+    return id ? `${url}?updatedId=${id}` : url;
   }
 
-  public importExtension(id: string): Observable<Response> {
-    const url = this.restangularService.one(id).one('install').getRestangularUrl();
-    return this.http.post(url, {});
+  public importExtension(id: string): Observable<any> {
+    return this.apiHttpService
+      .setEndpointUrl(`/extensions/${id}/install`)
+      .post({});
   }
 
-  public loadIntegrations(id: string): Observable<Response> {
-    const url = this.restangularService.one(id).one('integrations').getRestangularUrl();
-    return this.http.get(url);
+  public loadIntegrations(id: string): Observable<Integrations> {
+    return this.apiHttpService
+      .setEndpointUrl(`/extensions/${id}/integrations`)
+      .get();
   }
 
   public list(): Observable<Extensions> {
-    return super.list().map( extensions => {
-      return extensions.filter( extension => extension.status !== 'Deleted');
+    return super.list().map(extensions => {
+      return extensions.filter(extension => extension.status !== 'Deleted');
     });
   }
 }

--- a/app/ui/src/app/store/extension/extension.store.ts
+++ b/app/ui/src/app/store/extension/extension.store.ts
@@ -1,22 +1,17 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Response } from '@angular/http';
-import { ExtensionService } from './extension.service';
+
 import { Extension, Extensions, Integrations } from '@syndesis/ui/platform';
-import { AbstractStore } from '../entity/entity.store';
-import { EventsService } from '../entity/events.service';
+import { AbstractStore, EventsService } from '../entity';
+import { ExtensionService } from './extension.service';
 
 @Injectable()
-export class ExtensionStore extends AbstractStore<
-  Extension,
-  Extensions,
-  ExtensionService
-> {
+export class ExtensionStore extends AbstractStore<Extension, Extensions, ExtensionService> {
   constructor(extensionService: ExtensionService, eventService: EventsService) {
     super(extensionService, eventService, [], {} as Extension);
   }
 
-  protected get kind() {
+  protected get kind(): string {
     return 'Extension';
   }
 
@@ -29,7 +24,6 @@ export class ExtensionStore extends AbstractStore<
   }
 
   public loadIntegrations(id: string): Observable<Integrations> {
-    return this.service.loadIntegrations(id).map( resp => <Integrations> resp.json() );
+    return this.service.loadIntegrations(id);
   }
-
 }

--- a/app/ui/src/app/store/integration/integration.service.ts
+++ b/app/ui/src/app/store/integration/integration.service.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@angular/core';
 
-import { Restangular } from 'ngx-restangular';
-
-import { RESTService } from '../entity/rest.service';
-import { Integration, Integrations, IntegrationState } from '@syndesis/ui/platform';
-import { Observable } from 'rxjs/Observable';
-import { Http, Response, ResponseContentType } from '@angular/http';
+import { ApiHttpService, Integration, Integrations, IntegrationState } from '@syndesis/ui/platform';
+import { RESTService } from '../entity';
 
 @Injectable()
 export class IntegrationService extends RESTService<Integration, Integrations> {
-  constructor(restangular: Restangular, private http: Http) {
-    super(restangular.service('integrations'), 'integration');
+  constructor(apiHttpService: ApiHttpService) {
+    super(apiHttpService, 'integrations', 'integration');
   }
-
 }

--- a/app/ui/src/app/store/integration/integration.store.ts
+++ b/app/ui/src/app/store/integration/integration.store.ts
@@ -6,20 +6,11 @@ import { IntegrationService } from './integration.service';
 
 import { createIntegration, createStep, Integration, Integrations } from '@syndesis/ui/platform';
 
-import { AbstractStore } from '../entity/entity.store';
-import { EventsService } from '../entity/events.service';
-import { Response } from '@angular/http';
+import { AbstractStore, EventsService } from '../entity';
 
 @Injectable()
-export class IntegrationStore extends AbstractStore<
-  Integration,
-  Integrations,
-  IntegrationService
-> {
-  constructor(
-    integrationService: IntegrationService,
-    eventService: EventsService
-  ) {
+export class IntegrationStore extends AbstractStore<Integration, Integrations, IntegrationService> {
+  constructor(integrationService: IntegrationService, eventService: EventsService) {
     super(integrationService, eventService, [], <Integration>{});
   }
 

--- a/app/ui/src/app/store/oauthApp/oauth-app.service.ts
+++ b/app/ui/src/app/store/oauthApp/oauth-app.service.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { Restangular } from 'ngx-restangular';
-
-import { RESTService } from '../entity/rest.service';
+import { ApiHttpService } from '@syndesis/ui/platform';
 import { OAuthApp, OAuthApps } from '@syndesis/ui/settings';
+import { RESTService } from '../entity';
 
 @Injectable()
 export class OAuthAppService extends RESTService<OAuthApp, OAuthApps> {
-  constructor(restangular: Restangular) {
-    super(restangular.service('setup/oauth-apps'), 'oauth-app');
+  constructor(apiHttpService: ApiHttpService) {
+    super(apiHttpService, 'setup/oauth-apps', 'oauth-app');
   }
 }

--- a/app/ui/src/app/store/store.module.ts
+++ b/app/ui/src/app/store/store.module.ts
@@ -1,6 +1,4 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
-import { HttpModule } from '@angular/http';
-import { RestangularModule } from 'ngx-restangular';
 
 import { ActionService } from './action/action.service';
 import { ActionStore } from './action/action.store';
@@ -18,7 +16,6 @@ import { StepStore } from './step/step.store';
 import { TestSupportService } from './test-support.service';
 
 @NgModule({
-  imports: [HttpModule],
   providers: [
     ActionService,
     ConnectionService,
@@ -38,11 +35,7 @@ import { TestSupportService } from './test-support.service';
   ]
 })
 export class StoreModule {
-  constructor(
-    @Optional()
-    @SkipSelf()
-    parentModule: StoreModule
-  ) {
+  constructor(@Optional() @SkipSelf() parentModule: StoreModule) {
     if (parentModule) {
       throw new Error(
         'StoreModule is already loaded. Import it in the AppModule only'

--- a/app/ui/src/app/store/test-support.service.ts
+++ b/app/ui/src/app/store/test-support.service.ts
@@ -1,27 +1,22 @@
 import { Injectable } from '@angular/core';
-import { Http } from '@angular/http';
-import { Restangular } from 'ngx-restangular';
+import { Observable } from 'rxjs/Observable';
+
+import { ApiHttpService } from '@syndesis/ui/platform';
 
 @Injectable()
 export class TestSupportService {
-  service: Restangular = undefined;
 
-  constructor(public restangular: Restangular, public http: Http) {
-    this.service = restangular.service('test-support');
-  }
+  constructor(public apiHttpClient: ApiHttpService) { }
 
   resetDB() {
-    const url = this.service.one('reset-db').getRestangularUrl();
-    return this.http.get(url);
+    return this.apiHttpClient.setEndpointUrl('/test-support/reset-db').get();
   }
-
-  snapshotDB() {
-    const url = this.service.one('snapshot-db').getRestangularUrl();
-    return this.http.get(url);
+  
+  snapshotDB(): Observable<Blob> {
+    return this.apiHttpClient.setEndpointUrl('/test-support/snapshot-db').get({ responseType: 'blob' });
   }
-
+  
   restoreDB(data: any) {
-    const url = this.service.one('restore-db').getRestangularUrl();
-    return this.http.post(url, data);
+    return this.apiHttpClient.setEndpointUrl('/test-support/restore-db').post(data);
   }
 }

--- a/app/ui/src/app/store/test-support.service.ts
+++ b/app/ui/src/app/store/test-support.service.ts
@@ -11,11 +11,11 @@ export class TestSupportService {
   resetDB() {
     return this.apiHttpClient.setEndpointUrl('/test-support/reset-db').get();
   }
-  
+
   snapshotDB(): Observable<Blob> {
     return this.apiHttpClient.setEndpointUrl('/test-support/snapshot-db').get({ responseType: 'blob' });
   }
-  
+
   restoreDB(data: any) {
     return this.apiHttpClient.setEndpointUrl('/test-support/restore-db').post(data);
   }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -4967,18 +4967,6 @@ ngx-chips@^1.6.2:
   dependencies:
     ng2-material-dropdown "~0.8.2"
 
-ngx-restangular@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ngx-restangular/-/ngx-restangular-2.0.2.tgz#3c98929b80885db9bcee4d901cb9cbec78fcc027"
-  dependencies:
-    "@angular/core" "^5.0.0"
-    "@angular/http" "^5.0.0"
-    "@angular/platform-browser" "^5.0.0"
-    "@types/lodash" "^4.14.62"
-    core-js ">=2.4.1"
-    rxjs "^5.0.0"
-    typescript ">=2.4.2 <2.5"
-
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"


### PR DESCRIPTION
Fixes #2188 

Restangular is not actually needed in this project, adds a level of "abstraction" (sic) that only obfuscates the data logic of our services and clutters NgModules with unnecessary boilerplate.

**This PR entails:**

- Removing all instances of Restangular app-wide, replacing it by implementations of our very own `ApiHttpService`.
- `ApiHttpService` now implements a `.patch(body: any)` method to address the REST PATCH verb, (obviously).
- Adding a new `TestApiModule` stub module that we can use in our unit tests to wrap a mock implementation of `ApiModule`, providing builtin support for `HttpClientModule` so we will not need to import it in our tests anymore. Its use case allows for handling circular references when importing `ApiModule.forRoot()` in our tests leads to a circular reference.
- Tests decluttered of unused dependencies and useless tokens.
- Commented tests reinstated. Whoever did that (you know who you are) deserves to burn in hell for the rest of eternity. ;P

This PR also clears the way to use the new capabilities of `HttpClientModule` across the project, allowing to address low level issues such as #2104 