### PR TITLE
feat: add inline notifications to connection detail page

### DIFF
--- a/app/ui/src/app/common/common.module.ts
+++ b/app/ui/src/app/common/common.module.ts
@@ -24,6 +24,7 @@ import { DurationDiffPipe } from './duration-diff.pipe';
 import { IconPathPipe } from './icon-path.pipe';
 import { ParseMarkdownLinksPipe } from './parse-markdown-links.pipe';
 import { ButtonComponent } from './button.component';
+import { InlineAlertComponent } from './inline-alert';
 
 // TODO: Move these services out to a CoreModule
 import { NotificationService } from './ui-patternfly';
@@ -56,6 +57,7 @@ import { NavigationService } from './navigation.service';
     WizardProgressBarComponent,
     CancelConfirmationModalComponent,
     DeleteConfirmationModalComponent,
+    InlineAlertComponent,
     ...SYNDESYS_EDITABLE_DIRECTIVES,
     ...SYNDESYS_VALIDATION_DIRECTIVES
   ],
@@ -78,6 +80,7 @@ import { NavigationService } from './navigation.service';
     WizardProgressBarComponent,
     CancelConfirmationModalComponent,
     DeleteConfirmationModalComponent,
+    InlineAlertComponent,
     ...SYNDESYS_EDITABLE_DIRECTIVES,
     ...SYNDESYS_VALIDATION_DIRECTIVES
   ]

--- a/app/ui/src/app/common/index.ts
+++ b/app/ui/src/app/common/index.ts
@@ -7,3 +7,4 @@ export * from './duration-diff.pipe';
 export * from './navigation.service';
 export * from './object-property-filter.pipe';
 export * from './object-property-sort.pipe';
+export * from './inline-alert';

--- a/app/ui/src/app/common/inline-alert/index.ts
+++ b/app/ui/src/app/common/inline-alert/index.ts
@@ -1,0 +1,1 @@
+export * from './inline-alert.component';

--- a/app/ui/src/app/common/inline-alert/inline-alert.component.html
+++ b/app/ui/src/app/common/inline-alert/inline-alert.component.html
@@ -1,0 +1,4 @@
+<div [ngClass]="['alert', alertLevel]">
+  <span [ngClass]="icon"></span>
+  <p [innerHTML]="messageString"></p>
+</div>

--- a/app/ui/src/app/common/inline-alert/inline-alert.component.ts
+++ b/app/ui/src/app/common/inline-alert/inline-alert.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { LeveledMessage, MessageLevel, StatusCodeDecoderService } from '@syndesis/ui/platform';
+
+@Component({
+    selector: 'syndesis-inline-alert',
+    templateUrl: './inline-alert.component.html',
+    styleUrls: []
+})
+export class InlineAlertComponent implements OnInit {
+  icon: string[];
+  messageString: any;
+  alertLevel: string;
+  @Input() message: LeveledMessage;
+
+  constructor(private statusCodeDecoderService: StatusCodeDecoderService) { }
+
+  ngOnInit() {
+    if (!this.message) {
+      return;
+    }
+    this.messageString = this.statusCodeDecoderService.getMessageString(this.message);
+    switch (this.message.level) {
+      case MessageLevel.WARN:
+        this.alertLevel = 'alert-warning';
+        this.icon = ['pficon', 'pficon-warning-triangle-o'];
+        break;
+      case MessageLevel.ERROR:
+        this.alertLevel = 'alert-danger';
+        this.icon = ['pficon', 'pficon-error-circle-o'];
+        break;
+      default:
+        this.alertLevel = 'alert-info';
+        this.icon = ['pficon', 'pficon-info'];
+    }
+
+  }
+}

--- a/app/ui/src/app/connections/detail-page/detail-page.component.ts
+++ b/app/ui/src/app/connections/detail-page/detail-page.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
-import { Connection } from '@syndesis/ui/platform';
+import { Connection, MessageCode, MessageLevel } from '@syndesis/ui/platform';
 import { ConnectionStore } from '../../store/connection/connection.store';
 
 @Component({
@@ -15,7 +15,7 @@ import { ConnectionStore } from '../../store/connection/connection.store';
         <syndesis-connection-detail-info [connection]="connection"
                                          (updated)="update($event)">
         </syndesis-connection-detail-info>
-        <br>
+        <br *ngIf="connection.board?.messages?.length !== 0">
         <syndesis-connection-detail-configuration [connection]="connection"
                                                   (updated)="update($event)">
         </syndesis-connection-detail-configuration>

--- a/app/ui/src/app/connections/detail-page/info.component.ts
+++ b/app/ui/src/app/connections/detail-page/info.component.ts
@@ -32,6 +32,11 @@ import { ConnectionConfigurationService } from '../common/configuration/configur
                                     (onSave)="onAttributeUpdated('description', $event)"></syndesis-editable-textarea>
       </dd>
     </dl>
+    <div *ngIf="connection.board?.messages && connection.board?.messages.length">
+      <div *ngFor="let message of connection.board.messages">
+        <syndesis-inline-alert [message]="message"></syndesis-inline-alert>
+      </div>
+    </div>
   `,
   styles: [`
     h1 dt { width: 46px; }

--- a/app/ui/src/app/core/core.module.ts
+++ b/app/ui/src/app/core/core.module.ts
@@ -38,6 +38,11 @@ export class CoreModule {
         {
           provide: SYNDESIS_ABSTRACT_PROVIDERS.IntegrationSupportService,
           useClass: SYNDESIS_PROVIDERS.IntegrationSupportProviderService
+        },
+        SYNDESIS_PROVIDERS.StatusCodeDecoderProviderService,
+        {
+          provide: SYNDESIS_ABSTRACT_PROVIDERS.StatusCodeDecoderService,
+          useClass: SYNDESIS_PROVIDERS.StatusCodeDecoderProviderService
         }
       ]},
     ];

--- a/app/ui/src/app/core/providers/index.ts
+++ b/app/ui/src/app/core/providers/index.ts
@@ -2,3 +2,4 @@ export * from './form-factory-provider.service';
 export * from './integration-provider.service';
 export * from './integration-support-provider.service';
 export * from './user-provider.service';
+export * from './status-code-decoder-provider.service';

--- a/app/ui/src/app/core/providers/status-code-decoder-provider.service.ts
+++ b/app/ui/src/app/core/providers/status-code-decoder-provider.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { StatusCodeDecoderService, MessageCode, LeveledMessage, StringMap } from '@syndesis/ui/platform';
+
+@Injectable()
+export class StatusCodeDecoderProviderService extends StatusCodeDecoderService {
+
+  // TODO eventually this would be in a separate json file, also better messages
+  private static messages = {
+    'SYNDESIS000': 'An unknown error has occurred', // generic message
+    'SYNDESIS001': 'There are parameter updates for this connection. Click <strong>Edit</strong> to update parameter settings.',
+    'SYNDESIS002': 'One or more properties have been updated or removed', // One or more properties have been added or removed
+    'SYNDESIS003': 'The connector associated with this connection has been deleted', // Connector has been deleted
+    'SYNDESIS004': 'The associated extension has been deleted', // Extension has been deleted
+    'SYNDESIS005': 'The associated action has been deleted', // Action has been deleted
+    'SYNDESIS006': 'One or more required properties is not set', // One or more required properties is not set
+    'SYNDESIS007': 'Secrets for this connection need to be updated', // Secrets update needed
+    'SYNDESIS008': 'There has a validation error', // Validation Error
+  } as StringMap<string>;
+
+  // TODO use 'context' for variable substitution in message string
+  getMessageString(message: LeveledMessage, context?: StringMap<any>) {
+    if (message.message) {
+      return message.message;
+    }
+    const answer = StatusCodeDecoderProviderService.messages[message.code];
+    return answer ? answer : 'An unknown error has occurred and no specific message corresponding to ' + message.code + ' has been set';
+  }
+}

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -48,22 +48,9 @@
         </ng-container>
       </div>
 
-      <div *ngIf="integration.messages && integration.messages.length" class="integration-detail__row">
+      <div *ngIf="integration.messages && integration.messages.length" class="integration-detail__row">        
         <div *ngFor="let message of integration.messages">
-          <ng-container [ngSwitch]="message.level">
-            <div class="alert alert-danger" *ngSwitchCase="'ERROR'">
-              <span class="pficon pficon-error-circle-o"></span>
-              <p [innerHtml]="message.message"></p>
-            </div>
-            <div class="alert alert-warning" *ngSwitchCase="'WARN'">
-              <span class="pficon pficon-warning-triangle-o"></span>
-              <p [innerHtml]="message.message"></p>
-            </div>
-            <div class="alert alert-info" *ngSwitchDefault>
-              <span class="pficon pficon-info"></span>
-              <p [innerHtml]="message.message"></p>
-            </div>
-          </ng-container>
+          <syndesis-inline-alert [message]="message"></syndesis-inline-alert>
         </div>
       </div>
 

--- a/app/ui/src/app/platform/types/connection/connection.models.ts
+++ b/app/ui/src/app/platform/types/connection/connection.models.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, User, Action, StringMap, ConfigurationProperty } from '@syndesis/ui/platform';
+import { BaseEntity, User, Action, StringMap, ConfigurationProperty, BulletinBoard } from '@syndesis/ui/platform';
 
 // these are related to oauth enabled connections
 export interface AcquisitionMethod extends BaseEntity {
@@ -42,8 +42,16 @@ export interface Organization extends BaseEntity {
 
 export type Organizations = Array<Organization>;
 
+export interface ConnectionBulletinBoard extends BaseEntity, BulletinBoard {
+  notices: number;
+  warnings: number;
+  errors: number;
+  targetResourceId?: string;
+}
+
 export interface Connection extends BaseEntity {
   icon: string;
+  board: ConnectionBulletinBoard;
   organization: Organization;
   configuredProperties: StringMap<string>;
   organizationId: string;

--- a/app/ui/src/app/platform/types/index.ts
+++ b/app/ui/src/app/platform/types/index.ts
@@ -5,6 +5,7 @@ export * from './form-factory';
 export * from './integration';
 export * from './metadata';
 export * from './user';
+export * from './status-code-decoder';
 
 import * as PlatformActions from './platform.actions';
 export * from './platform.api';

--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -1,4 +1,13 @@
-import { BaseReducerCollectionModel, Action, BaseEntity, Connection, User, key } from '@syndesis/ui/platform';
+import {
+  BaseReducerCollectionModel,
+  Action,
+  BaseEntity,
+  Connection,
+  User,
+  MessageLevel,
+  LeveledMessage,
+  key,
+  WithLeveledMessages } from '@syndesis/ui/platform';
 
 export class Step implements BaseEntity {
   id?: string;
@@ -23,18 +32,7 @@ export const ERROR = 'Error';
 
 export type IntegrationStatus = 'Pending' | 'Published' | 'Unpublished' | 'Error';
 
-export enum MessageLevel {
-  INFO = 'INFO',
-  WARN = 'WARN',
-  ERROR = 'ERROR'
-}
-
-export interface IntegrationMessage {
-  level: MessageLevel;
-  message: string;
-}
-
-export interface IntegrationOverview extends BaseEntity {
+export interface IntegrationOverview extends BaseEntity, WithLeveledMessages {
   version?: number;
   tags: Array<string>;
   description?: string;
@@ -44,7 +42,6 @@ export interface IntegrationOverview extends BaseEntity {
   targetState: IntegrationStatus;
   statusMessage?: string;
   deploymentVersion?: number;
-  messages: Array<IntegrationMessage>;
 }
 
 export type IntegrationOverviews = Array<IntegrationOverview>;

--- a/app/ui/src/app/platform/types/platform.models.ts
+++ b/app/ui/src/app/platform/types/platform.models.ts
@@ -62,11 +62,53 @@ export interface BaseRequestModel {
  * Global interfaces for modelling all kind of core Syndesis entities
  * TODO: Document each one in more detail
  */
-export interface BaseEntity {
+
+export interface WithId {
   id?: string;
+}
+
+export interface WithMetadata {
+  metadata?: StringMap<string>;
+}
+
+export interface BaseEntity extends WithId {
   kind?: string;
   name?: string;
 }
+
+export enum MessageLevel {
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR'
+}
+
+export enum MessageCode {
+  SYNDESIS000 = 'SYNDESIS000', // generic message
+  SYNDESIS001 = 'SYNDESIS001', // One or more properties have been updated
+  SYNDESIS002 = 'SYNDESIS002', // One or more properties have been added or removed
+  SYNDESIS003 = 'SYNDESIS003', // Connector has been deleted
+  SYNDESIS004 = 'SYNDESIS004', // Extension has been deleted
+  SYNDESIS005 = 'SYNDESIS005', // Action has been deleted
+  SYNDESIS006 = 'SYNDESIS006', // One or more required properties is not set
+  SYNDESIS007 = 'SYNDESIS007', // Secrets update needed
+  SYNDESIS008 = 'SYNDESIS008', // Validation Error
+}
+
+export interface LeveledMessage {
+  level?: MessageLevel;
+  code?: MessageCode;
+  message?: string;
+}
+
+export interface WithLeveledMessages {
+  messages?: Array<LeveledMessage>;
+}
+
+export interface WithModificationTimestamps {
+  createdAt?: number;
+  updatedAt?: number;
+}
+
 export interface ConfigurationProperty extends BaseEntity {
   javaType: string;
   type: string;
@@ -99,6 +141,10 @@ export interface ConfiguredConfigurationProperty extends ConfigurationProperty {
   value: any;
   rows?: number;
   cols?: number;
+}
+
+export interface BulletinBoard extends WithId, WithMetadata, WithLeveledMessages, WithModificationTimestamps {
+
 }
 
 export enum DataShapeKinds {

--- a/app/ui/src/app/platform/types/status-code-decoder/index.ts
+++ b/app/ui/src/app/platform/types/status-code-decoder/index.ts
@@ -1,0 +1,1 @@
+export * from './status-code-decoder.service';

--- a/app/ui/src/app/platform/types/status-code-decoder/status-code-decoder.service.ts
+++ b/app/ui/src/app/platform/types/status-code-decoder/status-code-decoder.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { LeveledMessage, StringMap } from '@syndesis/ui/platform';
+
+@Injectable()
+export abstract class StatusCodeDecoderService {
+  abstract getMessageString(message: LeveledMessage, context?: StringMap<any>);
+}


### PR DESCRIPTION
 fixes #2151 

Also syncs up some type interfaces with the backend a bit and adds an initial spike for a service to decode backend status codes to a string message with some TODOs in there.

Also adds an inline alert component to help cut down on the copypasta for leveled messages from the backend.