### PR TITLE
Break classloading cycle on startup

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/bulletin/ConnectionBulletinBoard.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/bulletin/ConnectionBulletinBoard.java
@@ -47,7 +47,10 @@ import org.immutables.value.Value;
 @SuppressWarnings("immutables")
 @IndexedProperty("targetResourceId")
 public interface ConnectionBulletinBoard extends BulletinBoard<ConnectionBulletinBoard> {
-    ConnectionBulletinBoard EMPTY_BOARD = new ConnectionBulletinBoard.Builder().build();
+
+    static ConnectionBulletinBoard emptyBoard() {
+        return new ConnectionBulletinBoard.Builder().build();
+    }
 
     @Override
     default Kind getKind() {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -66,7 +66,6 @@ import io.syndesis.server.endpoint.v1.state.ClientSideState;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import static io.syndesis.common.model.bulletin.ConnectionBulletinBoard.EMPTY_BOARD;
 import static io.syndesis.common.model.bulletin.LeveledMessage.Level.ERROR;
 import static io.syndesis.common.model.bulletin.LeveledMessage.Level.WARN;
 
@@ -118,7 +117,7 @@ public class ConnectionHandler
         for (Connection connection: connections.getItems()) {
             final String id = connection.getId().get();
             final Connector connector = dataManager.fetch(Connector.class, connection.getConnectorId());
-            final ConnectionBulletinBoard board = dataManager.fetchByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id).orElse(EMPTY_BOARD);
+            final ConnectionBulletinBoard board = dataManager.fetchByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id).orElse(ConnectionBulletinBoard.emptyBoard());
 
             overviews.add(
                 new ConnectionOverview.Builder()
@@ -136,7 +135,7 @@ public class ConnectionHandler
     public ConnectionOverview get(final String id) {
         final DataManager dataManager = getDataManager();
         final Connection connection = dataManager.fetch(Connection.class, id);
-        final ConnectionBulletinBoard board = dataManager.fetchByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id).orElse(EMPTY_BOARD);
+        final ConnectionBulletinBoard board = dataManager.fetchByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id).orElse(ConnectionBulletinBoard.emptyBoard());
         final Connector connector = dataManager.fetch(Connector.class, connection.getConnectorId());
 
         return new ConnectionOverview.Builder()


### PR DESCRIPTION
Fixes #2200. If a BulletinBoard object is present in jsondb, syndesis failed at startup because of a classloading cycle leaving a uninitialized static variable.