### PR TITLE
feat(describe-data): improve language used around describe data form

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -8,7 +8,8 @@
 
   <ng-template #brandTemplate>
     <a routerLink="/"
-       class="navbar-brand">
+       class="navbar-brand"
+       role="link">
           <img *ngIf="iconDarkBg && iconDarkBg !== ''"
                [class]="productBuild ? 'navbar-brand-icon product' : 'navbar-brand-icon'"
                [src]="loggedIn ? iconDarkBg : iconWhiteBg"
@@ -77,16 +78,19 @@
               <li>
                 <a [href]="tutorialLink"
                    rel="nofollow"
+                   role="link"
                    target="_blank">Sample Integration Tutorials</a>
               </li>
               <li>
                 <a [href]="userGuideLink"
                    rel="nofollow"
+                   role="link"
                    target="_blank">User Guide</a>
               </li>
-              <li><a routerLink="/support">Support</a></li>
+              <li><a routerLink="/support" role="link">Support</a></li>
               <li><a href="mailto:fuse-ignite-tech-preview@redhat.com"
                    rel="nofollow"
+                   role="link"
                    target="_blank">Contact Us</a></li>
             </ul>
           </li>
@@ -122,17 +126,17 @@
                 id="userDropdownMenu"
                 aria-labelledby="userDropdown">
               <li>
-                <a (click)="logout()">Logout</a>
+                <a (click)="logout()" role="link">Logout</a>
               </li>
               <!--
               <li>
-                <a (click)="resetDB()">Reset DB</a>
+                <a (click)="resetDB()" role="link">Reset DB</a>
               </li>
               <li>
-                <a (click)="exportDB()">Export DB</a>
+                <a (click)="exportDB()" role="link">Export DB</a>
               </li>
               <li>
-                <a (click)="showImportDB()">Import DB</a>
+                <a (click)="showImportDB()" role="link">Import DB</a>
               </li>
               -->
             </ul>
@@ -150,7 +154,7 @@
     <ul class="list-group" role="list">
       <li class="list-group-item"
           routerLinkActive="active">
-        <a routerLink="dashboard">
+        <a routerLink="dashboard" role="link">
           <span class="fa fa-tachometer"
                 data-toggle="tooltip"
                 title="Dashboard"></span>
@@ -159,7 +163,7 @@
       </li>
       <li class="list-group-item"
           routerLinkActive="active">
-        <a routerLink="integrations">
+        <a routerLink="integrations" role="link">
           <span class="pficon pficon-topology"
                 data-toggle="tooltip"
                 title="Integrations"></span>
@@ -168,7 +172,7 @@
       </li>
       <li class="list-group-item"
           routerLinkActive="active">
-        <a routerLink="connections">
+        <a routerLink="connections" role="link">
           <span class="pficon pficon-network"
                 data-toggle="tooltip"
                 title="Connections"></span>
@@ -177,7 +181,7 @@
       </li>
       <li class="list-group-item"
           routerLinkActive="active">
-        <a routerLink="customizations">
+        <a routerLink="customizations" role="link">
           <span class="pficon pficon-network"
                 data-toggle="tooltip"
                 title="Customizations"></span>
@@ -186,7 +190,7 @@
       </li>
       <li class="list-group-item"
           routerLinkActive="active">
-        <a routerLink="settings">
+        <a routerLink="settings" role="link">
           <span class="fa fa-lock"
                 data-toggle="tooltip"
                 title="Settings"></span>

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -29,7 +29,7 @@ const DESCRIBE_DATA_FORM_CONFIG = {
     defaultValue: DataShapeKinds.ANY,
     enum: [
       {
-        label: 'Don\'t specify type',
+        label: 'Type specification not required',
         value: DataShapeKinds.ANY
       },
       {

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
@@ -1,8 +1,8 @@
 <div class="oauth-apps">
   <h1>OAuth Application Management</h1>
   <p>To connect to an application that uses the OAuth protocol, obtain a client ID and a client secret from the application. See the <a href="https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/integrating_applications_with_ignite/#obtaining-authorization-to-access-applications" target="_blank" rel="nofollow">documentation</a> for help.</p>
-  <p>During registration, enter this callback URL: {{ callbackURL }}.</p>
-      
+  <p>During registration, enter this callback URL: {{ callbackURL }}</p>
+
   <!-- Modal -->
   <syndesis-oauth-app-modal #modal></syndesis-oauth-app-modal>
 


### PR DESCRIPTION
This PR adjusts the language used in the select dropdown in the describe data component form, making it clearer to the user what selecting that option does.

Also removes the period at the end of a sentance on the oauth settings page so users don't accidentally copy it along with their callback url.

Adding the role attribute for anchor links ensures older version of JAWS screen reader acknowledges those as available links.

fixes https://github.com/syndesisio/syndesis/issues/1940

ux language tweaks for describe data step
remove period form end of callback url for easy copy/paste
set explicit roles on anchors for links