### PR TITLE
chore(build): upgrade PMD

### DIFF
--- a/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorFactories.java
+++ b/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorFactories.java
@@ -107,7 +107,7 @@ public final class HttpConnectorFactories {
 
         String path = (String) options.remove("path");
         if (StringUtils.isNotEmpty(path)) {
-            if (!path.startsWith("/")) {
+            if (path.charAt(0) != '/') {
                 path = "/" + path;
             }
 

--- a/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorVerifierExtension.java
+++ b/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorVerifierExtension.java
@@ -29,8 +29,8 @@ import org.apache.camel.util.StringHelper;
 import org.apache.commons.lang3.StringUtils;
 
 public class HttpConnectorVerifierExtension extends DefaultComponentVerifierExtension {
-    private String componentScheme;
-    private String supportedScheme;
+    private final String componentScheme;
+    private final String supportedScheme;
 
     public HttpConnectorVerifierExtension(String componentScheme, String supportedScheme, CamelContext context) {
         super(componentScheme, context);
@@ -62,7 +62,7 @@ public class HttpConnectorVerifierExtension extends DefaultComponentVerifierExte
 
         String path = (String) options.remove("path");
         if (ObjectHelper.isNotEmpty(path)) {
-            if (!path.startsWith("/")) {
+            if (path.charAt(0) != '/') {
                 path = "/" + path;
             }
 

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizer.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizer.java
@@ -101,7 +101,7 @@ public class DataShapeCustomizer implements ComponentProxyCustomizer, CamelConte
         }
 
         @Override
-        public final void process(final Exchange exchange) {
+        public void process(final Exchange exchange) {
             if (exchange.isFailed()) {
                 return;
             }

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
@@ -83,7 +83,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
  * @author pantinor
  */
 @Mojo(name = "generate-metadata", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresProject = true, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
-@SuppressWarnings({ "PMD.GodClass", "PMD.TooManyFields" })
+@SuppressWarnings({ "PMD.GodClass", "PMD.TooManyFields", "PMD.TooManyMethods" })
 public class GenerateMetadataMojo extends AbstractMojo {
     public enum InspectionMode {
         RESOURCE,
@@ -125,6 +125,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
     private String tags;
 
     @Parameter(defaultValue = "RESOURCE_AND_SPECIFICATION")
+    @SuppressWarnings("PMD.ImmutableField")
     private InspectionMode inspectionMode = InspectionMode.RESOURCE_AND_SPECIFICATION;
 
     /**

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/layout/ModuleLayoutFactory.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/layout/ModuleLayoutFactory.java
@@ -32,7 +32,7 @@ public class ModuleLayoutFactory implements LayoutFactory {
             LibraryScope.CUSTOM)
     );
 
-    private boolean filterDestinationScopes;
+    private final boolean filterDestinationScopes;
 
     public ModuleLayoutFactory(boolean filterDestinationScopes) {
         this.filterDestinationScopes = filterDestinationScopes;

--- a/app/meta/src/main/java/io/syndesis/connector/meta/Application.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/Application.java
@@ -38,6 +38,7 @@ import org.springframework.web.filter.CommonsRequestLoggingFilter;
  * @author roland
  * @since 20/03/2017
  */
+@SuppressWarnings("PMD.UseUtilityClass")
 @SpringBootApplication
 public class Application {
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);

--- a/app/meta/src/main/java/io/syndesis/connector/meta/v1/DriverUploadEndpoint.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/v1/DriverUploadEndpoint.java
@@ -80,7 +80,7 @@ public class DriverUploadEndpoint {
 
     private void storeFile(String location, MultipartFormDataInput dataInput) {
         // Store the artifact into /deployments/ext
-        try (final InputStream is = getBinaryArtifact(dataInput)) {
+        try (InputStream is = getBinaryArtifact(dataInput)) {
             final File file = new File(location);
 
             Files.copy(is, file.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -71,8 +71,8 @@
     <camel.version>2.21.0</camel.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
-    <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
-    <dep.pmd.version>5.8.1</dep.pmd.version>
+    <dep.plugin.pmd.version>3.9.0</dep.plugin.pmd.version>
+    <dep.pmd.version>6.2.0</dep.pmd.version>
     <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version> <!-- SUREFIRE-1422 -->
     <dep.plugin.failsafe.version>2.21.0</dep.plugin.failsafe.version> <!-- SUREFIRE-1422 -->
 
@@ -581,7 +581,7 @@
         <plugin>
           <artifactId>maven-pmd-plugin</artifactId>
           <configuration>
-            <analysisCache>true</analysisCache>
+            <analysisCache>false</analysisCache>
             <printFailingErrors>true</printFailingErrors>
             <rulesets>
               <ruleset>/syndesis/ruleset.xml</ruleset>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -61,7 +61,6 @@ import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.dao.file.FileDataManager;
 import io.syndesis.server.dao.manager.DataManager;
-import io.syndesis.server.endpoint.v1.handler.connection.ConnectionHandler;
 import io.syndesis.server.endpoint.v1.handler.integration.IntegrationHandler;
 import io.syndesis.server.jsondb.CloseableJsonDB;
 import io.syndesis.server.jsondb.JsonDB;
@@ -92,7 +91,6 @@ public class IntegrationSupportHandler {
     private final DataManager dataManager;
     private final IntegrationResourceManager resourceManager;
     private final IntegrationHandler integrationHandler;
-    private final ConnectionHandler connectionHandler;
     private final FileDataManager extensionDataManager;
 
     public IntegrationSupportHandler(
@@ -102,7 +100,6 @@ public class IntegrationSupportHandler {
         final DataManager dataManager,
         final IntegrationResourceManager resourceManager,
         final IntegrationHandler integrationHandler,
-        final ConnectionHandler connectionHandler,
         final FileDataManager extensionDataManager) {
         this.migrator = migrator;
         this.jsonDB = jsonDB;
@@ -111,7 +108,6 @@ public class IntegrationSupportHandler {
         this.dataManager = dataManager;
         this.resourceManager = resourceManager;
         this.integrationHandler = integrationHandler;
-        this.connectionHandler = connectionHandler;
         this.extensionDataManager = extensionDataManager;
     }
 
@@ -317,7 +313,7 @@ public class IntegrationSupportHandler {
         return result;
     }
 
-    private  void importIntegrations(SecurityContext sec, JsonDbDao<Integration> export, ArrayList<ChangeEvent> result) {
+    private void importIntegrations(SecurityContext sec, JsonDbDao<Integration> export, List<ChangeEvent> result) {
         for (Integration integration : export.fetchAll().getItems()) {
             Integration.Builder builder = new Integration.Builder()
                 .createFrom(integration)
@@ -340,7 +336,7 @@ public class IntegrationSupportHandler {
         }
     }
 
-    private <T extends WithId<T>> void importModels(JsonDbDao<T> export, ArrayList<ChangeEvent> result) {
+    private <T extends WithId<T>> void importModels(JsonDbDao<T> export, List<ChangeEvent> result) {
         for (T item : export.fetchAll().getItems()) {
             Kind kind = item.getKind();
             String id = item.getId().get();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -332,7 +332,6 @@ public class IntegrationSupportHandler {
                 integrationHandler.update(id, builder.version(previous.getVersion()+1).build());
                 result.add(ChangeEvent.of("updated", integration.getKind().getModelName(), id));
             }
-            break;
         }
     }
 

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/JsonRecordConsumer.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/JsonRecordConsumer.java
@@ -252,6 +252,7 @@ class JsonRecordConsumer implements Consumer<JsonRecord>, Closeable {
                 jg.writeBoolean(false);
                 break;
             default:
+                break;
         }
     }
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -109,7 +109,8 @@
   </rule>
   <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
     <properties>
-      <property name="reportLevel" value="20" />
+      <property name="methodReportLevel" value="20" />
+      <property name="classReportLevel" value="100" />
     </properties>
     <priority>3</priority>
   </rule>
@@ -386,7 +387,7 @@
       <property name="minimum" value="3" />
     </properties>
   </rule>
-  <rule ref="rulesets/java/naming.xml/MisleadingVariableName">
+  <rule ref="rulesets/java/naming.xml/MIsLeadingVariableName">
     <priority>4</priority>
   </rule>
   <rule ref="rulesets/java/empty.xml/EmptyTryBlock">


### PR DESCRIPTION
This upgrades PMD Maven plugin to 3.9.0 and PMD version to 6.2.0 in an
attempt to try to fix a race issue when running PMD check from Maven
multiple times without performing a clean.

This unfortunately does not help to resolve the issue, and I had to
disable PMD cache.

This fixes PMD issues brought about with the PMD upgrade. Seems that
some of the issues were not reported with the previous version.

Removes the `break` that would prevent any additional integrations in
the submitted export ZIP file from being imported.

Fixes #2209, #2240