### PR TITLE
fix: align the draft area property to the returned integration object add a separate draft indicator to the list

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.html
@@ -1,5 +1,5 @@
 <syndesis-loading [loading]="!integration">
-  <dl class="dl-horizontal" *ngIf="integration?.draft">
+  <dl class="dl-horizontal" *ngIf="integration?.isDraft">
     <dt>Draft:</dt>
     <dd>
       <div class="list-pf">

--- a/app/ui/src/app/integration/list/list.component.html
+++ b/app/ui/src/app/integration/list/list.component.html
@@ -34,6 +34,11 @@
         <div class="list-pf-additional-content integration-status">
           <syndesis-integration-status *ngIf="complete"
                                        [integration]="integration"></syndesis-integration-status>
+          <div class="status not-pending" *ngIf="integration.isDraft">
+            <span class="label label-warning">
+              Draft
+            </span>
+          </div>                                       
           <span *ngIf="integration.board?.notices || integration.board?.warnings || integration.board?.errors">
             <span class="pficon pficon-warning-triangle-o"></span>
             Configuration Required

--- a/app/ui/src/app/integration/list/status.component.ts
+++ b/app/ui/src/app/integration/list/status.component.ts
@@ -42,10 +42,6 @@ export class IntegrationStatusComponent {
         return 'primary';
       case 'Unpublished':
         return 'inactive';
-      case 'Unpublished':
-        return 'danger';
-      case 'Draft':
-        return 'warning';
       default:
         return currentState;
     }
@@ -57,8 +53,6 @@ export class IntegrationStatusComponent {
         return 'Published';
       case 'Unpublished':
         return 'Unpublished';
-      case 'Pending':
-        return 'Publishing';
       default:
         return currentState;
     }

--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -36,7 +36,7 @@ export interface IntegrationOverview extends BaseEntity, WithLeveledMessages {
   version?: number;
   tags: Array<string>;
   description?: string;
-  draft: boolean;
+  isDraft: boolean;
   deployments?: Array<DeploymentOverview>;
   currentState: IntegrationStatus;
   targetState: IntegrationStatus;


### PR DESCRIPTION
relates to #2245 

Also cleans up some past search/replace/copypasta