### PR TITLE
fix: make the home link highlight properly when at the dashboard

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -154,8 +154,8 @@
        *ngIf="loggedIn">
     <ul class="list-group" role="list">
       <li class="list-group-item"
-          routerLinkActive="active">
-        <a routerLink="dashboard" role="link">
+          routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+        <a routerLink="/" role="link">
           <span class="fa fa-tachometer"
                 data-toggle="tooltip"
                 title="Dashboard"></span>


### PR DESCRIPTION
Since this wasn't happening for quite awhile:

![capture](https://user-images.githubusercontent.com/351660/38379604-37410784-38cf-11e8-9443-60abcbf2e69b.PNG)
