### PR TITLE
fix(build): revert PMD version upgrade

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -71,8 +71,8 @@
     <camel.version>2.21.0</camel.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
-    <dep.plugin.pmd.version>3.9.0</dep.plugin.pmd.version>
-    <dep.pmd.version>6.2.0</dep.pmd.version>
+    <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
+    <dep.pmd.version>5.8.1</dep.pmd.version>
     <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version> <!-- SUREFIRE-1422 -->
     <dep.plugin.failsafe.version>2.21.0</dep.plugin.failsafe.version> <!-- SUREFIRE-1422 -->
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -109,8 +109,7 @@
   </rule>
   <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
     <properties>
-      <property name="methodReportLevel" value="20" />
-      <property name="classReportLevel" value="100" />
+      <property name="reportLevel" value="20" />
     </properties>
     <priority>3</priority>
   </rule>
@@ -387,7 +386,7 @@
       <property name="minimum" value="3" />
     </properties>
   </rule>
-  <rule ref="rulesets/java/naming.xml/MIsLeadingVariableName">
+  <rule ref="rulesets/java/naming.xml/MisleadingVariableName">
     <priority>4</priority>
   </rule>
   <rule ref="rulesets/java/empty.xml/EmptyTryBlock">


### PR DESCRIPTION
This reverts PMD version upgrade as in 6.x PMD started using
unsynchronized access `WeakHashMap`, which can lead to endless loops.