### PR TITLE
truncate long connection names under integration details icons

### DIFF
--- a/app/ui/src/app/connections/list/list.component.html
+++ b/app/ui/src/app/connections/list/list.component.html
@@ -114,7 +114,7 @@
         </div>
       </ng-container>
       <ng-container *ngIf="showNewConnection && connections.length > 0">
-        <div class="connection new-connection col-xs-12 col-sm-3 col-md-2 card"
+        <div class="connection new-connection col-lg-3 col-md-4 col-sm-6 card"
              (click)="onSelect(undefined, $event)">
           <div class="card-pf card-pf-view card-pf-view-select card-pf-view-single-select">
             <div class="card-pf-body">

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -1,15 +1,18 @@
 <section class="integration-description">
-  <p *ngIf="integration.steps">
+  <div *ngIf="integration.steps">
     <ng-template ngFor let-step [ngForOf]="integration.steps" let-index="index" let-last="last">
       <div *ngIf="step" class="step-block inline-block text-center">
         <ng-container [ngSwitch]="step.stepKind">
           <ng-container *ngSwitchCase="'endpoint'">
-            <div id="{{ step.connection.name | synSlugify }}" class="text-center connection" (click)="onViewDetails(step)" title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
+            <div id="{{ step.connection.name | synSlugify }}"
+              class="text-center connection" 
+              (click)="onViewDetails(step)" 
+              title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
               <div [class]="'step-line ' + getStepLineClass(index)"></div>
               <div class="icon">
                 <img class="syn-icon-small" [src]="step.connection | synIconPath">
               </div>
-              <div>{{ step.connection.name | capitalize }}</div>
+              <div class="syn-truncate__ellipsis">{{ step.connection.name | capitalize }}</div>
             </div>
           </ng-container>
           <ng-container *ngSwitchDefault>
@@ -25,7 +28,7 @@
         <span *ngIf="!last" class="step-sep fa fa-angle-right"></span>
       </div>
     </ng-template>
-  </p>
+  </div>
   <p>
     <syndesis-editable-textarea
       [value]="integration.description"

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -1,39 +1,34 @@
 <section class="integration-description">
-  <div *ngIf="integration.steps">
-    <ng-template ngFor let-step [ngForOf]="integration.steps" let-index="index" let-last="last">
-      <div *ngIf="step" class="step-block inline-block text-center">
-        <ng-container [ngSwitch]="step.stepKind">
-          <ng-container *ngSwitchCase="'endpoint'">
-            <div id="{{ step.connection.name | synSlugify }}"
-              class="text-center connection" 
-              (click)="onViewDetails(step)" 
-              title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
-              <div [class]="'step-line ' + getStepLineClass(index)"></div>
-              <div class="icon">
-                <img class="syn-icon-small" [src]="step.connection | synIconPath">
-              </div>
-              <div class="syn-truncate__ellipsis">{{ step.connection.name | capitalize }}</div>
-            </div>
-          </ng-container>
-          <ng-container *ngSwitchDefault>
-            <div id="{{ (step.name || step.stepKind) | synSlugify }}" class="text-center step">
-              <div class="step-line"></div>
-              <div class="icon not-connection">
-                <div class="icon-line"></div>
-              </div>
-              <div>{{ stepStore.getStepName(step) }}</div>
-            </div>
-          </ng-container>
-        </ng-container>
-        <span *ngIf="!last" class="step-sep fa fa-angle-right"></span>
+  <div *ngFor="let step of integration?.steps; let index=index; let last=last"
+        class="step-block inline-block text-center">
+    <ng-container [ngSwitch]="step.stepKind">
+      <div *ngSwitchCase="'endpoint'"
+            id="{{ step.connection.name | synSlugify }}"
+            class="text-center connection" 
+            (click)="onViewDetails(step)" 
+            title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
+        <div [class]="'step-line ' + getStepLineClass(index)"></div>
+        <div class="icon">
+          <img class="syn-icon-small" [src]="step.connection | synIconPath">
+        </div>
+        <div class="syn-truncate__ellipsis">{{ step.connection.name | capitalize }}</div>
       </div>
-    </ng-template>
+      <div *ngSwitchDefault
+            id="{{ (step.name || step.stepKind) | synSlugify }}"
+            class="text-center step">
+        <div class="step-line"></div>
+        <div class="icon not-connection">
+          <div class="icon-line"></div>
+        </div>
+        <div>{{ stepStore.getStepName(step) }}</div>
+      </div>
+    </ng-container>
+    <span *ngIf="!last" class="step-sep fa fa-angle-right"></span>
   </div>
   <p>
-    <syndesis-editable-textarea
-      [value]="integration.description"
-      placeholder="No description set..."
-      (onSave)="onAttributeUpdated('description', $event)">
+    <syndesis-editable-textarea [value]="integration.description"
+                                placeholder="No description set..."
+                                (onSave)="onAttributeUpdated('description', $event)">
     </syndesis-editable-textarea>
   </p>
 </section>

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.scss
@@ -1,11 +1,11 @@
 @import 'syndesis-sass';
 
 .step-block {
-  white-space: nowrap;
   height: 100px;
-  min-width: 120px;
+  width: 120px;
   vertical-align: top;
   position: relative;
+  padding: 0 10px;
 
   .connection {
     cursor: pointer;
@@ -18,7 +18,7 @@
       padding-top: 12px;
 
       .icon {
-        margin-bottom: 10px;
+        margin-bottom: 15px;
       }
     }
   }
@@ -50,8 +50,7 @@
     padding: 11px;
     width: 55px;
     height: 55px;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0 auto 5px;    
     background-color: $color-pf-white;
 
     &.not-connection {
@@ -60,7 +59,7 @@
       padding: 5px 0px;
       border-radius: 100px;
       height: 33px;
-      margin-bottom: 10px;
+      margin-bottom: 15px;
       width: 32px;
 
       .icon-line {


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/2249

also snuck in a fix for a small bug where the empty state card for connections when you're creating an integration doesn't share the same bootstrap `col-*` classes as the rest of the cards so it was misaligned.