### PR TITLE
chore(server): improve update-controller

### DIFF
--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -75,9 +75,10 @@ resource:
   update:
     controller:
       enabled: true
-      initial-interval: 30
-      check-interval: 60
-      interval-unit: SECONDS
+      scheduler:
+        enabled: true
+        interval: 60
+        interval-unit: SECONDS
 
 # OpenShift infra value
 openshift:

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateConfiguration.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateConfiguration.java
@@ -24,14 +24,8 @@ public class ResourceUpdateConfiguration {
     // Enable/Disable connector upgrades checks
     private boolean enabled;
 
-    // Initial check interval
-    private long initialInterval = 30;
-
     // Interval between check
-    private long checkInterval = 60;
-
-    // Time unit for check interval
-    private TimeUnit intervalUnit = TimeUnit.SECONDS;
+    private Scheduler scheduler = new Scheduler();
 
     public boolean isEnabled() {
         return enabled;
@@ -41,27 +35,42 @@ public class ResourceUpdateConfiguration {
         this.enabled = enabled;
     }
 
-    public long getInitialInterval() {
-        return initialInterval;
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
-    public void setInitialInterval(long initialInterval) {
-        this.initialInterval = initialInterval;
-    }
+    public static class Scheduler {
+        // Enable/Disable connector upgrades scheduler
+        private boolean enabled = true;
 
-    public long getCheckInterval() {
-        return checkInterval;
-    }
+        // Interval between check
+        private long interval = 60;
 
-    public void setCheckInterval(long checkInterval) {
-        this.checkInterval = checkInterval;
-    }
+        // Time unit for check interval
+        private TimeUnit intervalUnit = TimeUnit.SECONDS;
 
-    public TimeUnit getIntervalUnit() {
-        return intervalUnit;
-    }
+        public boolean isEnabled() {
+            return enabled;
+        }
 
-    public void setIntervalUnit(TimeUnit intervalUnit) {
-        this.intervalUnit = intervalUnit;
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public long getInterval() {
+            return interval;
+        }
+
+        public void setInterval(long interval) {
+            this.interval = interval;
+        }
+
+        public TimeUnit getIntervalUnit() {
+            return intervalUnit;
+        }
+
+        public void setIntervalUnit(TimeUnit intervalUnit) {
+            this.intervalUnit = intervalUnit;
+        }
     }
 }

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateController.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateController.java
@@ -30,6 +30,8 @@ import io.syndesis.common.util.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 
 public class ResourceUpdateController {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUpdateController.class);
@@ -40,7 +42,8 @@ public class ResourceUpdateController {
     private final AtomicBoolean running;
     private final List<ChangeEvent> allEvents;
 
-    private ScheduledExecutorService scheduler;
+    @SuppressWarnings("PMD.AvoidUsingVolatile")
+    private volatile ScheduledExecutorService scheduler;
 
     @Autowired
     public ResourceUpdateController(ResourceUpdateConfiguration configuration, EventBus eventBus, List<ResourceUpdateHandler> handlers) {
@@ -55,14 +58,11 @@ public class ResourceUpdateController {
         }
     }
 
-    @SuppressWarnings({"FutureReturnValueIgnored", "PMD.DoNotUseThreads"})
     public void start() {
         if (configuration.isEnabled()) {
             running.set(true);
 
-            scheduler = Executors.newScheduledThreadPool(1, r -> new Thread(null, r, "ResourceUpdateController (scheduler)"));
-            scheduler.scheduleWithFixedDelay(this::run, configuration.getInitialInterval(), configuration.getCheckInterval(), configuration.getIntervalUnit());
-
+            LOGGER.debug("Subscribing to EventBus");
             eventBus.subscribe(getClass().getName(), this::onEvent);
         }
     }
@@ -103,6 +103,7 @@ public class ResourceUpdateController {
                 ChangeEvent event = allEvents.get(i);
 
                 if (handler.canHandle(event)) {
+                    LOGGER.debug("Trigger handler {}", handler);
                     handler.process(event);
 
                     // At the moment, handlers are not selective but they scan
@@ -123,7 +124,28 @@ public class ResourceUpdateController {
             ResourceUpdateHandler handler = handlers.get(i);
 
             if (handler.canHandle(event)) {
+                LOGGER.debug("Trigger handler {} for event {}", handler, event);
                 handler.process(event);
+            }
+        }
+    }
+
+    @SuppressWarnings({"FutureReturnValueIgnored", "PMD.DoNotUseThreads"})
+    @EventListener
+    public void onApplicationEvent(final ApplicationReadyEvent event) {
+        if (configuration.isEnabled()) {
+            scheduler = Executors.newScheduledThreadPool(1, r -> new Thread(null, r, "ResourceUpdateController (scheduler)"));
+
+            if (configuration.getScheduler().isEnabled()) {
+                LOGGER.debug("Register background resource update check task (interval={}, interval-unit={})",
+                    configuration.getScheduler().getInterval(),
+                    configuration.getScheduler().getIntervalUnit()
+                );
+
+                scheduler.scheduleWithFixedDelay(this::run, 0, configuration.getScheduler().getInterval(), configuration.getScheduler().getIntervalUnit());
+            } else {
+                LOGGER.debug("Execute one-time resource update check");
+                scheduler.execute(this::run);
             }
         }
     }


### PR DESCRIPTION
The update-controller can now be configured to perform an intial check for updated resources and then react to events instead of having also a background periodic task