### PR TITLE
chore(pmd): remove controversial rule AvoidUsingVolatile

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -252,9 +252,6 @@
   <rule ref="rulesets/java/codesize.xml/TooManyFields">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/controversial.xml/AvoidUsingVolatile">
-    <priority>3</priority>
-  </rule>
   <rule ref="rulesets/java/unnecessary.xml/UselessOverridingMethod">
     <priority>3</priority>
   </rule>


### PR DESCRIPTION
According to PMD documentation AvoidUsingVolatile is a controversial rule
whose rationale is:

    Use of the keyword 'volatile' is general used to fine tune a Java 
    application, and therefore, requires a good expertise of the Java 
    Memory Model. Moreover, its range of action is somewhat misknown. 
    
    Therefore, the volatile keyword should not be used for maintenance 
    purpose and portability.

Which basically means:

    You do not know what you are doing.