### PR TITLE
fix: slimmer inspections in connectors

### DIFF
--- a/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
+++ b/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.connector.support.maven;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.atlasmap.core.DefaultAtlasConversionService;
 import io.atlasmap.java.inspect.ClassInspectionService;
@@ -183,7 +184,7 @@ public class GenerateConnectorInspectionsMojo extends AbstractMojo {
                     getLog().info("Specification for type: " + type + " created");
                     ret = new DataShape.Builder()
                                        .createFrom(given)
-                                       .specification(mapper.writeValueAsString(c))
+                                       .specification(mapper.writer((PrettyPrinter) null).writeValueAsString(c))
                                        .build();
 
                 }


### PR DESCRIPTION
Seems that Atlasmap inspections embedded in connector JSON files are
causing the the Connection/Connector objects to be quite large. This is
mainly due to the use of pretty-printing when generating those embedded
JSON specifications.

By not using a pretty-printing JSON serialization this can be greatly
reduced, for 5 test connections the JSON payload for is reduced from
1.2M (1248066) to 685K (700638), i.e. 44% decrease in size.