### PR TITLE
user doc: Updates to use attributes in place of hardcoded URLs. 

### DIFF
--- a/doc/integrating_applications/docinfo.xml
+++ b/doc/integrating_applications/docinfo.xml
@@ -1,12 +1,12 @@
-<productname>Red Hat JBoss Fuse</productname>
-<productnumber>7.0-TP</productnumber>
-<subtitle>User's guide to integrating applications with Ignite</subtitle>
+<productname>Syndesis</productname>
+<productnumber>1.0</productnumber>
+<subtitle>User's guide to integrating applications with Syndesis</subtitle>
 <abstract>
- <para>Ignite provides integration as a service on the OpenShift Pro tier.</para>
+ <para>Syndesis provides integration as a service.</para>
 </abstract>
 <authorgroup>
   <org>
-    <orgname>JBoss Fuse Documentation Team</orgname>
+    <orgname>Fuse Documentation Team</orgname>
     <email>fuse-docs-support@redhat.com</email>
   </org>
 </authorgroup>

--- a/doc/integrating_applications/master.adoc
+++ b/doc/integrating_applications/master.adoc
@@ -1,25 +1,25 @@
-:prodname: Ignite
-:prodversion: 7.0-TP
+:prodname: Syndesis
+:prodversion: 7.0
 :imagesdir: topics
 :prodnameinurl: fuse-ignite
+:productpkg: red_hat_fuse
+:version: 7.0
+
+:LinkIgniteTutorials: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/ignite_sample_integration_tutorials/
+:NameOfIgniteTutorials: Ignite Sample Integration Tutorials
+
+:LinkIgniteIntegrationGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/integrating_applications_with_ignite/
+:NameOfIgniteIntegrationGuide: Integrating Applications with Ignite
+
+:LinkToolingUserGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/single/tooling_user_guide/index
+:NameOfToolingUserGuide: Tooling User Guide
+
 
 [id='integrating_applications']
-= Integrating Applications with Ignite
+= Integrating Applications with {prodname}
 
 This guide provides information and instructions for using
 {prodname}'s web interface to integrate applications.
-
-[IMPORTANT]
-====
-{prodname} is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs), might
-not be functionally complete, and Red Hat does not recommend to use them for
-production. These features provide early access to upcoming product features,
-enabling customers to test functionality and provide feedback during the
-development process.
-For more information on Red Hat Technology Preview features support scope,
-see https://access.redhat.com/support/offerings/techpreview/.
-====
 
 The content in this guide is organized as follows:
 
@@ -31,17 +31,8 @@ The content in this guide is organized as follows:
 * <<adding-customizations>>
 * <<managing-integrations>>
 
-To learn how to use {prodname} by creating sample integrations, see the
-https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/ignite_sample_integration_tutorials/[Sample Integration Tutorials].
-
-In this Technology Preview, consider the names Red Hat Fuse Online and
-Fuse Ignite as interchangeable.
-
-In this Technology Preview, only one integration at a time can
-be running. If you have a running (published) integration and you create a new
-integration and try to publish it, the new integration is automatically
-in the *Unpublished* state. You must stop the running integration before you can
-start the new integration.
+To learn how to use {prodname} by creating sample integrations, see:
+{LinkIgniteTutorials}[{NameOfIgniteTutorials}].
 
 include::topics/understanding.adoc[leveloffset=+1]
 

--- a/doc/integrating_applications/topics/about_extensions.adoc
+++ b/doc/integrating_applications/topics/about_extensions.adoc
@@ -22,10 +22,12 @@ An extension `.jar` file that you upload to {prodname} always contains
 exactly one extension.  
 
 For an example of uploading and using an extension that provides a step
-that operates on data between connections, see the
-link:https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/ignite_sample_integration_tutorials/#amq-to-rest-api[AMQ to REST API sample integration tutorial].
+that operates on data between connections, see the 
+{LinkIgniteTutorials}#amq-to-rest-api[AMQ to REST API sample integration tutorial].
 
 For custom connectors and custom steps, information about coding the 
 extension and creating the `.jar` file is in the
-link:https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/6.3/html/tooling_user_guide/igniteextension/[_Fuse Tooling Guide_].
-For extensions that provides JDBC drivers, see <<
+{LinkToolingUserGuide}[{NameOfToolingUserGuide}].
+
+For information about creating extensions that provides JDBC drivers, 
+see <<creating-jdbc-driver-library-extensions>>.

--- a/doc/integrating_applications/topics/how_you_use.adoc
+++ b/doc/integrating_applications/topics/how_you_use.adoc
@@ -3,7 +3,7 @@
 
 The best way to learn about how to use {prodname} is to create the sample
 integrations by following the instructions in the
-https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/ignite_sample_integration_tutorials/[sample integration tutorials].
+{LinkIgniteTutorials}[sample integration tutorials].
 Following is an abbreviated description of one of the samples to provide
 an overview of how you use {prodname}. These steps omit details so
 you should not try to follow them.

--- a/doc/master.adoc
+++ b/doc/master.adoc
@@ -1,5 +1,5 @@
-:prodname: Fuse Ignite
-:prodversion: 7.0-TP
+:prodname: Syndesis
+:prodversion: 7.0
 :imagesdir: topics
 :prodnameinurl: fuse-ignite
 

--- a/doc/shared/attributes.adoc
+++ b/doc/shared/attributes.adoc
@@ -1,4 +1,15 @@
-:prodname: Fuse Ignite
-:prodversion: 7.0-TP
+:prodname: Syndesis
+:prodversion: 7.0
 :imagesdir: topics
-:prodnameinurl: fuseignite
+:prodnameinurl: fuse-ignite
+:productpkg: red_hat_fuse
+:version: 7.0
+
+:LinkIgniteTutorials: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/ignite_sample_integration_tutorials/
+:NameOfIgniteTutorials: Ignite Sample Integration Tutorials
+
+:LinkIgniteIntegrationGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/integrating_applications_with_ignite/
+:NameOfIgniteIntegrationGuide: Integrating Applications with Ignite
+
+:LinkToolingUserGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/single/tooling_user_guide/index
+:NameOfToolingUserGuide: Tooling User Guide

--- a/doc/tutorials/master-docinfo.xml
+++ b/doc/tutorials/master-docinfo.xml
@@ -1,12 +1,12 @@
-<productname>Red Hat JBoss Fuse</productname>
-<productnumber>7.0-TP</productnumber>
+<productname>Syndesis</productname>
+<productnumber>1.0</productnumber>
 <subtitle>Instructions for Creating Sample Integrations</subtitle>
 <abstract>
- <para>Follow step-by-step instructions for using Ignite Technology Preview to create, deploy, and test sample integrations. </para>
+ <para>Follow step-by-step instructions to create, deploy, and test sample integrations. </para>
 </abstract>
 <authorgroup>
   <org>
-    <orgname>JBoss Fuse Documentation Team</orgname>
+    <orgname>Fuse Documentation Team</orgname>
     <email>fuse-docs-support@redhat.com</email>
   </org>
 </authorgroup>

--- a/doc/tutorials/master.adoc
+++ b/doc/tutorials/master.adoc
@@ -1,7 +1,19 @@
-:prodname: Ignite
-:prodversion: 7.0-TP
+:prodname: Syndesis
+:prodversion: 7.0
 :imagesdir: topics
 :prodnameinurl: fuse-ignite
+:productpkg: red_hat_fuse
+:version: 7.0
+
+:LinkIgniteTutorials: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/ignite_sample_integration_tutorials/
+:NameOfIgniteTutorials: Ignite Sample Integration Tutorials
+
+:LinkIgniteIntegrationGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/integrating_applications_with_ignite/
+:NameOfIgniteIntegrationGuide: Integrating Applications with Ignite
+
+:LinkToolingUserGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/single/tooling_user_guide/index
+:NameOfToolingUserGuide: Tooling User Guide
+
 
 [id='tutorials']
 = {prodname} Sample Integration Tutorials
@@ -11,38 +23,14 @@ application or service, operate on that data if you need to, and then send the
 data to a completely different application or service. You can do all this
 without writing code.
 
-[IMPORTANT]
-====
-{prodname} is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs), might
-not be functionally complete, and Red Hat does not recommend to use them for
-production. These features provide early access to upcoming product features,
-enabling customers to test functionality and provide feedback during the
-development process.
-For more information on Red Hat Technology Preview features support scope,
-see https://access.redhat.com/support/offerings/techpreview/.
-====
-
-In this Technology Preview, consider the names Red Hat Fuse Online and
-Fuse Ignite as interchangeable.
-
-In this Technology Preview, only one integration at a time can
-be running. If you have a running (published) integration and you create a new
-integration and try to publish it, the new integration is automatically
-in the *Unpublished* state. You must stop the running integration before you can
-publish (start) the new integration.
-
-Explore the {prodname} Technology Preview by creating these
+Explore {prodname} by creating these
 sample integrations:
 
 * <<twitter-to-salesforce>>
 * <<salesforce-to-db>>
 * <<amq-to-rest-api>>
 
-
-A
-https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/integrating_applications_with_ignite//[user guide]
-for {prodname} is also available.
+See also: {LinkIgniteIntegrationGuide}[{NameOfIgniteIntegrationGuide}]
 
 include::topics/comparison_of_sample_integrations.adoc[leveloffset=+1]
 

--- a/doc/tutorials/topics/amq2api_create_custom_step.adoc
+++ b/doc/tutorials/topics/amq2api_create_custom_step.adoc
@@ -35,5 +35,5 @@ the extension details page.
 [NOTE]
 ====
 For more information about coding an extension and creating its `.jar` file, see the
-link:https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/6.3/html/tooling_user_guide/igniteextension/[10.2 _JBoss Fuse Tooling Guide_].
+{LinkToolingUserGuide}igniteextension/[{NameOfToolingUserGuide}].
 ====


### PR DESCRIPTION
I should have made these updates in a new branch with an appropriate name. But I forgot. 
This is ready to merge. And I believe I can merge it myself. There are just doc updates for:
- Use attributes in place of explicit URLs. 
- Use "Syndesis" as the product name upstream only. 
- Remove references to "technology preview". 
