### PR TITLE
feat(ui): Prevent XSRF exploit by appending token to custom headers from server cookie

### DIFF
--- a/app/ui/src/app/api/api.module.ts
+++ b/app/ui/src/app/api/api.module.ts
@@ -14,7 +14,7 @@ export function endpointsLazyLoaderFactory(apiEndpoints: Endpoints, apiConfigSer
   imports: [
     CommonModule,
     HttpClientModule,
-    HttpClientXsrfModule.withOptions(environment.csrf)
+    HttpClientXsrfModule.withOptions(environment.xsrf)
   ],
 })
 export class ApiModule {

--- a/app/ui/src/app/api/api.module.ts
+++ b/app/ui/src/app/api/api.module.ts
@@ -1,19 +1,24 @@
 import { ModuleWithProviders, NgModule, Optional } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS, HttpClientXsrfModule } from '@angular/common/http';
 
+import { environment } from '../../environments/environment';
 import { ApiHttpService, ApiConfigService, Endpoints, API_ENDPOINTS } from '@syndesis/ui/platform';
-import * as SYNDESIS_PROVIDERS from './providers';
+import * as SYNDESIS_API_PROVIDERS from './providers';
 
 export function endpointsLazyLoaderFactory(apiEndpoints: Endpoints, apiConfigService: ApiConfigService) {
-  return new SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService(apiEndpoints, apiConfigService);
+  return new SYNDESIS_API_PROVIDERS.ApiEndpointsLazyLoaderService(apiEndpoints, apiConfigService);
 }
 
 @NgModule({
-  imports: [CommonModule, HttpClientModule],
+  imports: [
+    CommonModule,
+    HttpClientModule,
+    HttpClientXsrfModule.withOptions(environment.csrf)
+  ],
 })
 export class ApiModule {
-  constructor(@Optional() private apiEndpointsLazyLoaderService: SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService) { }
+  constructor(@Optional() private apiEndpointsLazyLoaderService: SYNDESIS_API_PROVIDERS.ApiEndpointsLazyLoaderService) { }
 
   static forRoot(apiEndpoints?: Endpoints): Array<ModuleWithProviders> {
     return [{
@@ -23,19 +28,24 @@ export class ApiModule {
         multi: true,
         useValue: apiEndpoints || {}
       },
-      SYNDESIS_PROVIDERS.ApiConfigProviderService,
+      SYNDESIS_API_PROVIDERS.ApiConfigProviderService,
       {
         provide: ApiConfigService,
-        useClass: SYNDESIS_PROVIDERS.ApiConfigProviderService
+        useClass: SYNDESIS_API_PROVIDERS.ApiConfigProviderService
       },
-      SYNDESIS_PROVIDERS.ApiHttpProviderService,
+      SYNDESIS_API_PROVIDERS.ApiHttpProviderService,
       {
         provide: ApiHttpService,
-        useClass: SYNDESIS_PROVIDERS.ApiHttpProviderService
+        useClass: SYNDESIS_API_PROVIDERS.ApiHttpProviderService
       },
       {
         provide: HTTP_INTERCEPTORS,
-        useClass: SYNDESIS_PROVIDERS.ApiHttpInterceptor,
+        useClass: SYNDESIS_API_PROVIDERS.ApiHttpInterceptor,
+        multi: true
+      },
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: SYNDESIS_API_PROVIDERS.ApiXsrfInterceptor,
         multi: true
       }
       ]
@@ -51,9 +61,9 @@ export class ApiModule {
         multi: true,
         useValue: apiEndpoints
       },
-      SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService,
+      SYNDESIS_API_PROVIDERS.ApiEndpointsLazyLoaderService,
       {
-        provide: SYNDESIS_PROVIDERS.ApiEndpointsLazyLoaderService,
+        provide: SYNDESIS_API_PROVIDERS.ApiEndpointsLazyLoaderService,
         useFactory: endpointsLazyLoaderFactory,
         deps: [API_ENDPOINTS, ApiConfigService]
       }]

--- a/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
+++ b/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
@@ -17,7 +17,7 @@ export class ApiXsrfInterceptor implements HttpInterceptor {
   intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     if (httpRequest.method !== 'HEAD' && httpRequest.method !== 'GET' && httpRequest.url.startsWith('http')) {
       const token = this.tokenExtractor.getToken();
-      const { headerName } = environment.csrf;
+      const { headerName } = environment.xsrf;
 
       if (!!token && !httpRequest.headers.has(headerName)) {
         httpRequest = httpRequest.clone({ headers: httpRequest.headers.set(headerName, token) });

--- a/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
+++ b/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpInterceptor,
+  HttpHandler,
+  HttpRequest,
+  HttpXsrfTokenExtractor
+} from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+
+import { environment } from '../../../environments/environment';
+
+@Injectable()
+export class ApiXsrfInterceptor implements HttpInterceptor {
+  constructor(private tokenExtractor: HttpXsrfTokenExtractor) { }
+
+  intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    if (httpRequest.method !== 'HEAD' && httpRequest.method !== 'GET' && httpRequest.url.startsWith('http')) {
+      const token = this.tokenExtractor.getToken();
+      const { headerName } = environment.csrf;
+
+      if (!!token && !httpRequest.headers.has(headerName)) {
+        httpRequest = httpRequest.clone({ headers: httpRequest.headers.set(headerName, token) });
+      }
+    }
+
+    return next.handle(httpRequest);
+  }
+}

--- a/app/ui/src/app/api/providers/index.ts
+++ b/app/ui/src/app/api/providers/index.ts
@@ -2,3 +2,4 @@ export * from './api-config-provider.service';
 export * from './api-endpoints-lazy-loader.service';
 export * from './api-http-provider.service';
 export * from './api-http-interceptor.service';
+export * from './api-xsrf-interceptor.service';

--- a/app/ui/src/environments/environment.prod.ts
+++ b/app/ui/src/environments/environment.prod.ts
@@ -5,5 +5,9 @@ export const environment = {
     localStorageKey: 'syndesis-i18n-locale',
     dictionaryFolderPath: '/assets/dictionary'
   },
+  csrf: {
+    headerName: 'SYNDESIS-XSRF-TOKEN',
+    cookieName: 'SYNDESIS-XSRF-COOKIE'
+  },
   config: {}
 };

--- a/app/ui/src/environments/environment.prod.ts
+++ b/app/ui/src/environments/environment.prod.ts
@@ -5,7 +5,7 @@ export const environment = {
     localStorageKey: 'syndesis-i18n-locale',
     dictionaryFolderPath: '/assets/dictionary'
   },
-  csrf: {
+  xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',
     cookieName: 'SYNDESIS-XSRF-COOKIE'
   },

--- a/app/ui/src/environments/environment.ts
+++ b/app/ui/src/environments/environment.ts
@@ -10,6 +10,10 @@ export const environment = Object.freeze({
     localStorageKey: 'syndesis-i18n-locale',
     dictionaryFolderPath: '/assets/dictionary'
   },
+  csrf: {
+    headerName: 'SYNDESIS-XSRF-TOKEN',
+    cookieName: 'SYNDESIS-XSRF-COOKIE'
+  },
   config: {
     apiEndpoint: 'http://localhost:8080/api/v1',
     title: 'DEVELOPMENT - Syndesis',

--- a/app/ui/src/environments/environment.ts
+++ b/app/ui/src/environments/environment.ts
@@ -10,7 +10,7 @@ export const environment = Object.freeze({
     localStorageKey: 'syndesis-i18n-locale',
     dictionaryFolderPath: '/assets/dictionary'
   },
-  csrf: {
+  xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',
     cookieName: 'SYNDESIS-XSRF-COOKIE'
   },


### PR DESCRIPTION
This PR covers up the UI parts for #2104

###
This PR leverages Angular's `HttpClientXsrfModule` and also implements a custom `HttpInterceptor` middleware that will incorporate the following functionality to Syndesis:

- The server can now send a XSFR token cookie to the frontend. The name for the cookie is fully configurable.
- Such token will be fetched from said cookie and appended in a custom header on every outgoing request made to the API. The name for the header is fully configurable.
- If no XSRF cookie is sent to the client, no XSFR token header will be sent back.

**Please note:** The token header is NOT appended on non-mutating requests (GET, HEAD).

### How to inform the UI about the cookie name or customize the header name
The UI [environments](https://github.com/syndesisio/syndesis/tree/master/app/ui/src/environments) folder contains the development and production setting files that Angular will use to customize the application setup after compilation. There is a new `xsrf` node in these files that contains two properties:

- `cookieName`: the name of the cookie saved by the browser containing the validation XSRF token.
- `headerName`: the name of the header contained the aforementioned token the server will expect.

Feel free to edit the names provided as needed to match the ones implemented in the backend.