### PR TITLE
user doc: Update references to callback URL to use URL at top of OAuth mgmt page

### DIFF
--- a/doc/integrating_applications/topics/creating_api_connectors.adoc
+++ b/doc/integrating_applications/topics/creating_api_connectors.adoc
@@ -61,6 +61,11 @@ the base URL is `/api/v1` then the connection endpoint is
 mapping steps. If the Swagger file supports more than one schema then {prodname}
 uses the TLS (HTTPS) schema.
 . Review the connector details and optionally upload an icon for the connector.
+If you do not upload an icon, {prodname} generates one.
+You can upload an icon at a later time. When {prodname} displays
+the flow of an integration, it displays a connector's icon
+to represent connections that are created from that connector.
++
 To override a value obtained from
 the Swagger file, edit the field value that you want to change.
 After {prodname} creates a connector,

--- a/doc/integrating_applications/topics/register_with_dropbox.adoc
+++ b/doc/integrating_applications/topics/register_with_dropbox.adoc
@@ -11,8 +11,8 @@ Perform these steps:
 
 . In {prodname}:
 .. In the left panel, click *Settings*.
-.. Under the page title, in the sentence that starts with *During
-registration*, copy the URL to the clipboard. 
+.. Under the page title, in the sentence that starts with `*During
+registration*``, copy the URL to the clipboard. 
 For example, the URL is something like this:
 `\https://app-proj9128.7b63.{prodnameinurl}.openshiftapps.com/api/v1/credentials/callback`.
 

--- a/doc/integrating_applications/topics/registering_with_rest_api.adoc
+++ b/doc/integrating_applications/topics/registering_with_rest_api.adoc
@@ -13,16 +13,12 @@ section and see <<create-rest-api-connection>>.
 
 To register {prodname} as an authorized API client:
 
-. Prepare the {prodname} callback URL that the API will use:
-.. In {prodname}, in the left panel, click *Home*.
-.. Copy the {prodname} URL from the browser address bar and paste it in
-a text file.
-.. In the text file, remove `dashboard` from the end of the URL.
-.. Append `api/v1/credentials/callback`. For example, your callback URL
-might look like this:
-`\https://app-proj9128.7b63.{prodnameinurl}.openshiftapps.com/api/v1/credentials/callback`.
-. In {prodname}, in the left panel, click *Settings*.
-. Look for the name of the API you want to connect to and click its
+. In {prodname}:
+.. In the left panel, click *Settings*.
+.. Near the top of the *OAuth Application Management* page, where you see
+`*During registration, enter this callback URL:*`, copy that URL to the
+clipboard.
+.. Look for the name of the API you want to connect to and click its
 *Register* button to display its client ID and client secret fields.
 
 . In another browser window, you must register {prodname} as an OAuth
@@ -30,9 +26,14 @@ client of the API you want to connect to. The exact steps for doing this
 vary for each API service. Typically, the API service provides an OAuth
 custom application setting page. Go to that page.
 
-. On that page,
-provide the {prodname} callback URL and obtain the API service's
-client ID and client secret that {prodname} will use to access the API.
-. Paste the client ID and the client secret into their
-respective fields in the {prodname} *Settings* page.
+. On that page:
+.. Provide the {prodname} callback URL, which you copied at the beginning
+of this procedure.
+.. Obtain the client ID and client secret that the API service assigns to
+your installation of {prodname}.
+
+. In the {prodname} *Settings* page, in the entry for the 
+API service you are registering with, 
+paste the assigned client ID and the client secret.
+
 . Click *Save*.

--- a/doc/shared/register_with_sf.adoc
+++ b/doc/shared/register_with_sf.adoc
@@ -23,11 +23,11 @@ endif::[]
 Perform these steps to register {prodname} as a Salesforce client:
 
 . In {prodname}:
-.. In the left panel, click *Home*.
-.. Copy the {prodname} URL from the browser address bar so it is in the
-clipboard.
 .. In the left panel, click *Settings*.
-.. In the *OAuth Application Management* page, to the right of *Salesforce*,
+.. Near the top of the *OAuth Application Management* page, where you see
+`*During registration, enter this callback URL:*`, copy that URL to the
+clipboard.
+.. To the right of the *Salesforce* entry,
 click *Register* to display the *Client ID* and *Client Secret* fields.
 . In another browser tab, log in to your Salesforce account and
 follow the steps below to create a connected app.
@@ -42,9 +42,8 @@ https://help.salesforce.com/articleView?id=connected_app_create.htm[Create a Con
 .. Scroll down to *Connected Apps* and click *New*.
 .. Enter the required information and then select *Enable OAuth Settings*.
 .. In the *Callback URL* field, paste your
-{prodname} URL, which you copied in step 2.
-Remove `dashboard` from the end of the URL
-and append `api/v1/credentials/callback`. For example:
+{prodname} URL, which you copied at the beginning of this procedure.
+For example:
 `\https://app-proj9128.7b63.{prodnameinurl}.openshiftapps.com/api/v1/credentials/callback`.
 .. For *OAuth Scopes*, add:
 ** *Access and manage your data*

--- a/doc/shared/register_with_twitter.adoc
+++ b/doc/shared/register_with_twitter.adoc
@@ -10,13 +10,13 @@ installation of {prodname} with Twitter only once.
 Perform these steps:
 
 . In {prodname}:
-.. In the left panel, click *Home*.
-.. Copy the {prodname} URL from the browser address bar so it is in the
-clipboard.
 .. In the left panel, click *Settings*.
-.. In the *OAuth Application Management* page, to the right of *Twitter*,
+.. Near the top of the *OAuth Application Management* page, where you see
+`*During registration, enter this callback URL:*`, copy that URL to the
+clipboard.
+.. To the right of the *Twitter* entry,
 click *Register* to display the *Client ID* and *Client Secret* fields.
-. In another browser tab, go  to `http://apps.twitter.com` and do
+. In another browser tab, go to http://apps.twitter.com and do
 the following:
 .. If you are not already logged in to Twitter, log in.
 .. Click *Create New App*.
@@ -24,11 +24,11 @@ the following:
 must be unique among all names of apps registered with Twitter.
 .. In the *Description* field, enter helpful information.
 Twitter requires some input in this field.
-.. Paste your {prodname} URL into the *Website* and
-*Callback URL* fields.
-.. In the *Callback URL* field, remove `dashboard` from the end
-of the URL and append `api/v1/credentials/callback`.
-For example:
+.. In the *Website* field, paste the URL that you copied at the beginning
+of this procedure and remove `api/v1/credentials/callback` from the end
+of the URL.
+.. In the *Callback URL* field, paste the URL again. It should be
+something like this:
 `\https://app-proj9128.7b63.{prodnameinurl}.openshiftapps.com/api/v1/credentials/callback`.
 .. Click *Yes* to agree to the Twitter developer agreement.
 .. Click *Create your Twitter application*.


### PR DESCRIPTION
Updated instructions for obtaining the callback URL. Ready to merge. 