### PR TITLE
fix(server): operation summaries not shown as null

### DIFF
--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/OperationDescription.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/OperationDescription.java
@@ -23,9 +23,36 @@ public final class OperationDescription {
 
     public final String name;
 
+    private final int hashCode;
+
     public OperationDescription(final String name, final String description) {
         this.name = Objects.requireNonNull(name, "operation name");
         this.description = Objects.requireNonNull(description, "operation description");
+        hashCode = 31 * name.hashCode() + 7 * description.hashCode();
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (!(obj instanceof OperationDescription)) {
+            return false;
+        }
+
+        final OperationDescription other = (OperationDescription) obj;
+
+        return Objects.equals(name, other.name) && Objects.equals(description, other.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return "OperationDescription: " + name + ", description: " + description;
+    }
 }

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -18,6 +18,7 @@ package io.syndesis.server.connector.generator.swagger;
 import java.io.IOException;
 import java.util.Optional;
 
+import io.swagger.models.Info;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
@@ -28,6 +29,7 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSettings;
 import io.syndesis.common.model.connection.ConnectorSummary;
+import io.syndesis.server.connector.generator.swagger.util.SwaggerHelper;
 
 import org.junit.Test;
 
@@ -90,6 +92,34 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     }
 
     @Test
+    public void shouldDetermineConnectorDescription() {
+        final Swagger swagger = new Swagger();
+
+        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+
+        final Info info = new Info();
+        swagger.info(info);
+        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+
+        info.description("description");
+        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("description");
+    }
+
+    @Test
+    public void shouldDetermineConnectorName() {
+        final Swagger swagger = new Swagger();
+
+        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+
+        final Info info = new Info();
+        swagger.info(info);
+        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+
+        info.title("title");
+        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("title");
+    }
+
+    @Test
     public void shouldIncorporateGivenConfiguredProperties() throws IOException {
         final String specification = resource("/swagger/reverb.swagger.yaml");
 
@@ -143,4 +173,9 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
         assertThat(summary.getWarnings()).isEmpty();
     }
 
+    private static ConnectorSettings createSettingsFrom(final Swagger swagger) {
+        return new ConnectorSettings.Builder()//
+            .putConfiguredProperty("specification", SwaggerHelper.serialize(swagger))//
+            .build();
+    }
 }

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperOperationDescriptionGenerationTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperOperationDescriptionGenerationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.connector.generator.swagger.util;
+
+import java.util.Arrays;
+
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class SwaggerHelperOperationDescriptionGenerationTest {
+
+    private final OperationDescription expected;
+
+    private final Operation operation;
+
+    private final Swagger swagger;
+
+    public SwaggerHelperOperationDescriptionGenerationTest(final String operationSummary, final String operationDescription,
+        final String expectedName, final String expectedDescription) {
+        operation = new Operation().description(operationDescription).summary(operationSummary);
+        swagger = new Swagger().path("/test", new Path().get(operation));
+        expected = new OperationDescription(expectedName, expectedDescription);
+    }
+
+    @Test
+    public void shouldDetermineOperationDescriptions() {
+        assertThat(SwaggerHelper.operationDescriptionOf(swagger, operation)).isEqualTo(expected);
+    }
+
+    @Parameters
+    public static Iterable<Object[]> parameters() {
+        return Arrays.<Object[]>asList(//
+            new Object[] {null, null, "GET /test", "Send GET request to /test"}, //
+            new Object[] {null, "", "GET /test", "Send GET request to /test"}, //
+            new Object[] {"", null, "GET /test", "Send GET request to /test"}, //
+            new Object[] {"", "", "GET /test", "Send GET request to /test"}, //
+            new Object[] {"Test summary", "Test description", "Test summary", "Test description"}, //
+            new Object[] {"", "Test description", "GET /test", "Test description"}, //
+            new Object[] {null, "Test description", "GET /test", "Test description"}, //
+            new Object[] {"Test summary", "", "Test summary", "Send GET request to /test"}, //
+            new Object[] {"Test summary", null, "Test summary", "Send GET request to /test"});
+    }
+}

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperOperationDescriptionGenerationTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperOperationDescriptionGenerationTest.java
@@ -53,13 +53,19 @@ public class SwaggerHelperOperationDescriptionGenerationTest {
     public static Iterable<Object[]> parameters() {
         return Arrays.<Object[]>asList(//
             new Object[] {null, null, "GET /test", "Send GET request to /test"}, //
+            new Object[] {"null", "null", "GET /test", "Send GET request to /test"}, //
             new Object[] {null, "", "GET /test", "Send GET request to /test"}, //
+            new Object[] {"null", "", "GET /test", "Send GET request to /test"}, //
             new Object[] {"", null, "GET /test", "Send GET request to /test"}, //
+            new Object[] {"", "null", "GET /test", "Send GET request to /test"}, //
             new Object[] {"", "", "GET /test", "Send GET request to /test"}, //
             new Object[] {"Test summary", "Test description", "Test summary", "Test description"}, //
             new Object[] {"", "Test description", "GET /test", "Test description"}, //
             new Object[] {null, "Test description", "GET /test", "Test description"}, //
+            new Object[] {"null", "Test description", "GET /test", "Test description"}, //
             new Object[] {"Test summary", "", "Test summary", "Send GET request to /test"}, //
-            new Object[] {"Test summary", null, "Test summary", "Send GET request to /test"});
+            new Object[] {"Test summary", null, "Test summary", "Send GET request to /test"}, //
+            new Object[] {"Test summary", "null", "Test summary", "Send GET request to /test"});
     }
+
 }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/IntegrationsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/IntegrationsITCase.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.server.runtime;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Swagger parser interprets empty strings as literal `"null"` strings.
This results in having the string `"null"` as a name or description of a
operation. This checks if the parsed string is literal `"null"` string
and generates the proper name/description as if it was literal `null`
value.

The two other commits are adding tests and cleaning.

Fixes #2223