### PR TITLE
fix(ui): handle swagger specifications with no tags

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
@@ -15,7 +15,7 @@ export class ApiConnectorReviewComponent {
   @Input() showNextButton: boolean;
   @Input() set apiConnectorData(value: ApiConnectorData) {
     this.validation = value;
-    const actionCountByTags = value.actionsSummary.actionCountByTags;
+    const actionCountByTags = value.actionsSummary.actionCountByTags || {};
     this.importedActions = Object.keys(actionCountByTags).map(key => ({
       tag: key,
       count: +actionCountByTags[key]


### PR DESCRIPTION
When no tags are provided `actionCountByTags` property might be
undefined and we need to support that for Swagger specifications that do
not offer any tags.

Fixes #2308