### PR TITLE
chore(server): swagger specification parsing robustness

### DIFF
--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -37,12 +37,6 @@ import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.RefParameter;
-import io.syndesis.server.connector.generator.ConnectorGenerator;
-import io.syndesis.server.connector.generator.swagger.util.JsonSchemaHelper;
-import io.syndesis.server.connector.generator.swagger.util.OperationDescription;
-import io.syndesis.server.connector.generator.swagger.util.SwaggerHelper;
-import io.syndesis.server.connector.generator.util.ActionComparator;
-import io.syndesis.common.util.SyndesisServerException;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.Action;
@@ -55,6 +49,12 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSettings;
 import io.syndesis.common.model.connection.ConnectorSummary;
 import io.syndesis.common.model.connection.ConnectorTemplate;
+import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.server.connector.generator.ConnectorGenerator;
+import io.syndesis.server.connector.generator.swagger.util.JsonSchemaHelper;
+import io.syndesis.server.connector.generator.swagger.util.OperationDescription;
+import io.syndesis.server.connector.generator.swagger.util.SwaggerHelper;
+import io.syndesis.server.connector.generator.util.ActionComparator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +103,7 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
             final Map<String, Integer> tagCounts = paths.entrySet().stream()//
                 .flatMap(p -> p.getValue().getOperations().stream())//
                 .peek(o -> total.incrementAndGet())//
-                .flatMap(o -> o.getTags().stream().distinct())//
+                .flatMap(o -> ofNullable(o.getTags()).orElse(Collections.emptyList()).stream().distinct())//
                 .collect(//
                     Collectors.groupingBy(//
                         Function.identity(), //

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/AbstractSwaggerConnectorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/AbstractSwaggerConnectorTest.java
@@ -17,8 +17,8 @@ package io.syndesis.server.connector.generator.swagger;
 
 import java.util.List;
 
-import io.syndesis.common.util.Json;
 import io.syndesis.common.model.connection.ConnectorTemplate;
+import io.syndesis.common.util.Json;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -136,6 +136,27 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     }
 
     @Test
+    public void shouldNotFailOnEmptySwagger() {
+        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder()//
+            .putConfiguredProperty("specification", "{}")//
+            .build();
+
+        final ConnectorSummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        assertThat(summary).isNotNull();
+    }
+
+    @Test
+    public void shouldNotFailOnTrivialyEmptyOperations() {
+        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder()//
+            .putConfiguredProperty("specification",
+                "{\"swagger\": \"2.0\",\"info\": {\"version\": \"0.0.0\",\"title\": \"title\",\"description\": \"description\"},\"paths\": {\"/operation\": {\"get\": {\"responses\": {\"200\": {\"description\": \"OK\"}}}}}}")//
+            .build();
+
+        final ConnectorSummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        assertThat(summary).isNotNull();
+    }
+
+    @Test
     public void shouldProvideInfoFromPetstoreSwagger() throws IOException {
         final String specification = resource("/swagger/petstore.swagger.json");
 
@@ -170,7 +191,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
         final ConnectorSummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(summary.getErrors()).hasSize(1);
-        assertThat(summary.getWarnings()).isEmpty();
+        assertThat(summary.getWarnings()).hasSize(1);
     }
 
     private static ConnectorSettings createSettingsFrom(final Swagger swagger) {

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/PropertyGeneratorsTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/PropertyGeneratorsTest.java
@@ -26,7 +26,6 @@ import static io.syndesis.server.connector.generator.swagger.PropertyGenerators.
 import static io.syndesis.server.connector.generator.swagger.PropertyGenerators.determineHost;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class PropertyGeneratorsTest {
 
@@ -56,19 +55,14 @@ public class PropertyGeneratorsTest {
     }
 
     @Test
-    public void shouldFailIfNoHttpSchemesFound() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> determineHost(new Swagger().scheme(Scheme.WS).scheme(Scheme.WSS)))
-            .withMessageStartingWith("Unable to find a supported scheme");
+    public void shouldReturnNullIfNoHostGivenAnywhere() {
+        assertThat(determineHost(new Swagger())).isNull();
+        assertThat(determineHost(new Swagger().scheme(Scheme.HTTP))).isNull();
+        assertThat(determineHost(new Swagger().host("host"))).isNull();
     }
 
     @Test
-    public void shouldFailToDetermineIfNoHostGivenAnywhere() {
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> determineHost(new Swagger()))
-            .withMessageStartingWith("Swagger specification does not provide");
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> determineHost(new Swagger().scheme(Scheme.HTTP)))
-            .withMessageStartingWith("Swagger specification does not provide");
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> determineHost(new Swagger().host("host")))
-            .withMessageStartingWith("Swagger specification does not provide");
+    public void shouldReturnNullIfNoHttpSchemesFound() {
+        assertThat(determineHost(new Swagger().scheme(Scheme.WS).scheme(Scheme.WSS))).isNull();
     }
 }

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/TestHelper.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/TestHelper.java
@@ -52,8 +52,8 @@ public final class TestHelper {
 
         final Map<?, ?> tree = Json.reader().forType(Map.class).readValue(json);
 
-        return Json.copyObjectMapperConfiguration().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).writerWithDefaultPrettyPrinter()
-            .writeValueAsString(tree);
+        return Json.copyObjectMapperConfiguration().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .writerWithDefaultPrettyPrinter().writeValueAsString(tree);
     }
 
     static String resource(final String path, final String alternative) throws IOException {

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelperTest.java
@@ -59,10 +59,13 @@ public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
         final SwaggerModelInfo info = SwaggerHelper.parse(specification, true);
 
         assertThat(info.getErrors()).hasSize(1);
-        assertThat(info.getWarnings()).isEmpty();
+        assertThat(info.getWarnings()).hasSize(1);
         assertThat(info.getErrors().get(0).message()).startsWith("instance value (\"httpz\") not found in enum");
         assertThat(info.getErrors().get(0).property()).contains("/schemes/0");
         assertThat(info.getErrors().get(0).error()).contains("validation");
+        assertThat(info.getWarnings().get(0).message()).startsWith("Unable to determine the scheme");
+        assertThat(info.getWarnings().get(0).property()).contains("/schemes");
+        assertThat(info.getWarnings().get(0).error()).contains("missing-schemes");
     }
 
     @Test


### PR DESCRIPTION
This replaces throwing exceptions from property generators to Swagger
specification validation thereby increases the robustness of Swagger
specification parsing/handling.

With this for minimal valid Swagger files we should be able to present
the user with issues that are identified in the validation of the
Swagger specification.

Fixes #2307