### PR TITLE
fix(UI): i18n string fetching can now be performed imperatively support i18n provider

### DIFF
--- a/app/ui/src/app/core/providers/i18n-provider.service.ts
+++ b/app/ui/src/app/core/providers/i18n-provider.service.ts
@@ -51,8 +51,7 @@ export class I18NProviderService extends I18NService {
     }
 
     let translation = this.getTranslatedTerm(this.dictionary, ...translateKeys);
-
-    if (translation !== fallbackValue)  {
+    if (translation !== fallbackValue) {
       translation = this.replaceLabelPlaceholders(translation, args);
       translation = this.replaceIndexPlaceholders(translation, args);
     }
@@ -77,8 +76,7 @@ export class I18NProviderService extends I18NService {
   getValue(dictionaryKey: string, args?: any[]): Observable<string> {
     return this.platformStore
       .select(selectI18NState)
-      .delay(0)
-      .switchMap(() => this.localize(dictionaryKey, args));
+      .map(() => this.localize(dictionaryKey, args));
   }
 
   private getTranslatedTerm(dictionary: DictionaryEntry, ...keys: string[]): string {
@@ -87,6 +85,7 @@ export class I18NProviderService extends I18NService {
     for (let index = 0; index < keys.length; index++) {
       const key = keys[index];
       translationMatch = translationMatch[key];
+
       if (!translationMatch) {
         return fallbackValue;
       }

--- a/app/ui/src/app/platform/types/i18n/README.md
+++ b/app/ui/src/app/platform/types/i18n/README.md
@@ -292,7 +292,7 @@ By doing the above we can handle as many links as we wish from inside a single c
 ## Using i18n values programmatically
 Up to now we've seen how we handle I18N features from within the templates and how we can edit the dictionary files. However, in our daily practice we might need to access a particular dictionary entry from within our code. This is more of an edge case, though.
 
-If you ever need to access specific keys from the I18N store, you can either subscribe to the store slice or use the `getValue(dictionaryKey: string, args?: any[]): Observable<string>` method available at the `I18NService` injectable class. Such method will return an observable string which will issue values every time the active locale is changed.
+If you ever need to access specific keys from the I18N store, you can leverage the `I18NService.getValue(dictionaryKey: string, args?: any[]): Observable<string>` method available at the `I18NService` injectable class. Such method will return an observable string which will issue values every time the active locale is changed.
 
 ### Switching to another I18N locale programmatically
 You can swap the active dictionary by triggering the `I18NFetch` action, properly populated with the locale you want to enable. Eg:

--- a/app/ui/src/polyfills.ts
+++ b/app/ui/src/polyfills.ts
@@ -73,7 +73,6 @@ import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/take';
-import 'rxjs/add/operator/delay';
 
 /***************************************************************************************************
  * APPLICATION IMPORTS


### PR DESCRIPTION
This fixes the `I18NService.getValue(dictionaryKey: string, args?: any[]): Observable<string>` method available at the `I18NService` injectable service class, allowing for harnessing the features of the I18N implementation imperatively within component controllers and services.