### PR TITLE
Fix connection leak in extension icon retrieval

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
@@ -159,9 +159,9 @@ public final class ConnectorIconHandler extends BaseHandler {
 
             if (extensionIcon.isPresent()) {
                 final StreamingOutput streamingOutput = (out) -> {
-                    final BufferedSink sink = Okio.buffer(Okio.sink(out));
-                    sink.writeAll(Okio.source(extensionIcon.get()));
-                    sink.close();
+                    try (BufferedSink sink = Okio.buffer(Okio.sink(out)); InputStream iconStream = extensionIcon.get()) {
+                        sink.writeAll(Okio.source(iconStream));
+                    }
                 };
                 return Response.ok(streamingOutput, extensionDataManager.getExtensionIconMediaType(iconFile)).build();
             } else {


### PR DESCRIPTION
Fix #2289
There was a input stream left behind that caused ultimately a connection leak.
Syndesis became unresponsive after reaching ~100 open connections.