### PR TITLE
fix: Avoid parsing the error response, as it's an object

### DIFF
--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -150,7 +150,7 @@ export class ApiHttpProviderService extends ApiHttpService {
       .filter(requestEvent => requestEvent.type === HttpEventType.Response)
       .map(requestEvent => requestEvent as HttpResponse<T>)
       .map(requestEvent => requestEvent.body)
-      .catch(error => Observable.throw(this.catchError(JSON.parse(error.error))));
+      .catch(error => Observable.throw(this.catchError(error)));
   }
 
   private emitProgressEvent(httpProgressEvent?: HttpProgressEvent): void {


### PR DESCRIPTION
fixes #2315 

Though we should swap the messages in the returned error object so the right string is shown to the user.