### PR TITLE
Dashboard connection spinner positioning

### DIFF
--- a/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
+++ b/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
@@ -10,7 +10,7 @@
 </div>
 
 <div class="syndesis-dashboard-connections">
-  <syndesis-loading [loading]="true">
+  <syndesis-loading [loading]="loading">
     <!-- Empty State -->
     <ng-container *ngIf="connections?.length === 0">
       <div class="blank-slate-pf">

--- a/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
+++ b/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
@@ -9,8 +9,8 @@
   </div>
 </div>
 
-<syndesis-loading [loading]="loading">
-  <div class="syndesis-dashboard-connections">
+<div class="syndesis-dashboard-connections">
+  <syndesis-loading [loading]="true">
     <!-- Empty State -->
     <ng-container *ngIf="connections?.length === 0">
       <div class="blank-slate-pf">
@@ -59,5 +59,5 @@
         </div>
       </div>
     </ng-container>
-  </div>
-</syndesis-loading>
+  </syndesis-loading>
+</div>

--- a/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.scss
+++ b/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.scss
@@ -1,6 +1,7 @@
 .syndesis-dashboard-connections {
-  .card {
+  position: relative;
 
+  .card {
     //----- Same as .card-pf-icon-circle except without the blue circle ----------------->>
     .card-pf-view .card-pf-top-element .card-pf-icon-large {
       display: block;


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/2199

**Please note** - this will just fix the spinner placement for the connection area on the dashboard. I also created another branch, [loader-ui](https://github.com/michael-coker/syndesis/tree/loader-ui), that contains the spinner icon within the `<syndesis-loading>` element across the app. This will change the position of the icon in a lot of places - not sure if that's good or bad. If you prefer the other approach, I can submit a PR for that branch instead.