### PR TITLE
Feat/218 better error handling

### DIFF
--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -151,7 +151,7 @@ export class ApiHttpProviderService extends ApiHttpService {
       .filter(requestEvent => requestEvent.type === HttpEventType.Response)
       .map(requestEvent => requestEvent as HttpResponse<T>)
       .map(requestEvent => requestEvent.body)
-      .catch(error => this.handleError(JSON.parse(error.error)));
+      .catch(error => this.handleError(error.error));
   }
 
   private emitProgressEvent(httpProgressEvent?: HttpProgressEvent): void {

--- a/app/ui/src/app/app.component.spec.ts
+++ b/app/ui/src/app/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { CoreModule } from './core/core.module';
 import { async, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CollapseModule, ModalModule } from 'ngx-bootstrap';
@@ -13,6 +14,7 @@ import { ConfigService } from './config.service';
 import { SyndesisStoreModule } from './store/store.module';
 import { TestSupportService } from './store/test-support.service';
 import { platformReducer } from './platform';
+import { ERROR_HANDLER_PROVIDERS } from './error-handler';
 
 describe('AppComponent', () => {
   const APP_NAME = 'Syndesis';
@@ -24,6 +26,7 @@ describe('AppComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
+        CoreModule.forRoot(),
         SyndesisStoreModule,
         SyndesisCommonModule.forRoot(),
         ModalModule.forRoot(),
@@ -34,6 +37,7 @@ describe('AppComponent', () => {
         NgRxStoreModule.forRoot(platformReducer),
       ],
       providers: [
+        ERROR_HANDLER_PROVIDERS,
         ConfigService,
         UserService,
         TestSupportService,

--- a/app/ui/src/app/app.module.ts
+++ b/app/ui/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, NgModule, InjectionToken, ErrorHandler } from '@angular/core';
+import { APP_INITIALIZER, NgModule, InjectionToken } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';

--- a/app/ui/src/app/app.module.ts
+++ b/app/ui/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, NgModule, InjectionToken } from '@angular/core';
+import { APP_INITIALIZER, NgModule, InjectionToken, ErrorHandler } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { DynamicFormsCoreModule } from '@ng-dynamic-forms/core';
@@ -15,6 +15,7 @@ import { SyndesisCommonModule } from './common';
 import { appConfigInitializer, ConfigService } from './config.service';
 import { SyndesisStoreModule } from './store/store.module';
 import { platformEndpoints, PlatformModule } from './platform';
+import { ERROR_HANDLER_PROVIDERS } from './error-handler';
 
 @NgModule({
   declarations: [AppComponent],
@@ -35,6 +36,7 @@ import { platformEndpoints, PlatformModule } from './platform';
     NotificationModule,
   ],
   providers: [
+    ERROR_HANDLER_PROVIDERS,
     ConfigService,
     {
       provide: APP_INITIALIZER,

--- a/app/ui/src/app/error-handler/exception-handler.service.ts
+++ b/app/ui/src/app/error-handler/exception-handler.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, ErrorHandler } from '@angular/core';
+
+const GENERIC_ERROR_MSG = '[Syndesis] Exception logged';
+
+@Injectable()
+export class ExceptionHandlerService extends ErrorHandler {
+  constructor() {
+    super();
+  }
+
+  handleError(error: any): void {
+    this.log(error);
+    super.handleError(error);
+  }
+
+  log(error: any): void {
+    /* tslint:disable no-console */
+    if (console && console.error) {
+      console.error(error || GENERIC_ERROR_MSG);
+    }
+  }
+}

--- a/app/ui/src/app/error-handler/http-error.interceptor.ts
+++ b/app/ui/src/app/error-handler/http-error.interceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { NotificationType } from 'patternfly-ng';
+
+import { NotificationService } from '@syndesis/ui/common';
+
+const GENERIC_HTTP_ERROR_MSG = '[Syndesis] HTTP Exception logged';
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor(private notificationService: NotificationService) { }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(request).do((event: HttpEvent<any>) => event, (error: any) => {
+      if (error instanceof HttpErrorResponse) {
+        this.notificationService.popNotification({
+          type: NotificationType.DANGER,
+          header: 'The server returned an error',
+          message: error && error.message ? error.message : 'Your request could not be completed. Please try again.'
+        });
+
+        /* tslint:disable no-console */
+        if (console && console.error) {
+          console.error(error || GENERIC_HTTP_ERROR_MSG);
+        }
+      }
+    });
+  }
+}

--- a/app/ui/src/app/error-handler/http-error.interceptor.ts
+++ b/app/ui/src/app/error-handler/http-error.interceptor.ts
@@ -1,23 +1,37 @@
 import { Injectable } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+import { combineLatest } from 'rxjs/observable/combineLatest';
 import { NotificationType } from 'patternfly-ng';
 
 import { NotificationService } from '@syndesis/ui/common';
+import { I18NService } from '@syndesis/ui/platform';
 
 const GENERIC_HTTP_ERROR_MSG = '[Syndesis] HTTP Exception logged';
 
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
-  constructor(private notificationService: NotificationService) { }
+  private errorMessages: {
+    httpError: string;
+    httpErrorMessage: string;
+  };
+
+  constructor(private notificationService: NotificationService, private i18NService: I18NService) {
+    combineLatest(
+      this.i18NService.getValue('errors.httperror'),
+      this.i18NService.getValue('errors.httperrordefaultmsg')
+    ).subscribe(([httpError, httpErrorMessage]) => {
+      this.errorMessages = { httpError, httpErrorMessage };
+    });
+  }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).do((event: HttpEvent<any>) => event, (error: any) => {
       if (error instanceof HttpErrorResponse) {
         this.notificationService.popNotification({
           type: NotificationType.DANGER,
-          header: 'The server returned an error',
-          message: error && error.message ? error.message : 'Your request could not be completed. Please try again.'
+          header: this.errorMessages.httpError,
+          message: error && error.message ? error.message : this.errorMessages.httpErrorMessage
         });
 
         /* tslint:disable no-console */

--- a/app/ui/src/app/error-handler/index.ts
+++ b/app/ui/src/app/error-handler/index.ts
@@ -5,7 +5,7 @@ import { ExceptionHandlerService } from './exception-handler.service';
 import { HttpErrorInterceptor } from './http-error.interceptor';
 import { OfflineHandlerService } from './offline-handler.service';
 
-function offlineHandlerInitializer(offlineHandlerService: OfflineHandlerService): () => Promise<OfflineHandlerService> {
+export function offlineHandlerInitializer(offlineHandlerService: OfflineHandlerService): () => Promise<OfflineHandlerService> {
   return () => offlineHandlerService.initialize(true);
 }
 

--- a/app/ui/src/app/error-handler/index.ts
+++ b/app/ui/src/app/error-handler/index.ts
@@ -1,0 +1,29 @@
+import { APP_INITIALIZER, ErrorHandler } from '@angular/core';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { ExceptionHandlerService } from './exception-handler.service';
+import { HttpErrorInterceptor } from './http-error.interceptor';
+import { OfflineHandlerService } from './offline-handler.service';
+
+function offlineHandlerInitializer(offlineHandlerService: OfflineHandlerService): () => Promise<OfflineHandlerService> {
+  return () => offlineHandlerService.initialize(true);
+}
+
+export const ERROR_HANDLER_PROVIDERS = [
+  {
+    provide: ErrorHandler,
+    useClass: ExceptionHandlerService
+  },
+  OfflineHandlerService,
+  {
+    provide: APP_INITIALIZER,
+    useFactory: offlineHandlerInitializer,
+    deps: [OfflineHandlerService],
+    multi: true
+  },
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: HttpErrorInterceptor,
+    multi: true
+  }
+];

--- a/app/ui/src/app/error-handler/offline-handler.service.ts
+++ b/app/ui/src/app/error-handler/offline-handler.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Observable } from 'rxjs/Observable';
+import { NotificationType } from 'patternfly-ng';
+
+import { NotificationService } from '@syndesis/ui/common';
+
+@Injectable()
+export class OfflineHandlerService {
+  online$: Observable<boolean>;
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: any,
+    private notificationService: NotificationService
+  ) { }
+
+  initialize(enablePopNotifications: boolean): Promise<any> {
+    return new Promise(resolve => {
+      if (isPlatformBrowser(this.platformId)) {
+        this.online$ = Observable.merge(
+          Observable.fromEvent(window, 'offline').map(() => false),
+          Observable.fromEvent(window, 'online').map(() => true),
+        );
+
+        if (enablePopNotifications) {
+          this.initializePopNotifications();
+        }
+      }
+
+      return resolve();
+    });
+  }
+
+  private initializePopNotifications(): void {
+    this.online$.subscribe(isOnline => {
+      this.notificationService.popNotification({
+        type: isOnline ? NotificationType.SUCCESS : NotificationType.DANGER,
+        header: isOnline ? 'You\'re back online' : 'You went offline',
+        message: isOnline ? 'Your internet connection has been restored' : 'Your internet connection has been interrupted'
+      });
+    });
+  }
+}

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -83,6 +83,14 @@
       }
     },
     "import-db-txt": "Please select the data file to import:",
+    "errors": {
+      "youareonline": "You're back online",
+      "youareoffline": "You went offline",
+      "networkonline": "Your internet connection has been restored",
+      "networkoffline": "Your internet connection has been interrupted",
+      "httperror": "The server returned an error",
+      "httperrordefaultmsg": "Your request could not be completed. Please try again."
+    },
     "shared": {
       "loading": "loading",
       "project": {

--- a/app/ui/src/polyfills.ts
+++ b/app/ui/src/polyfills.ts
@@ -62,6 +62,7 @@ import 'rxjs/add/observable/empty';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
+import 'rxjs/add/observable/fromEvent';
 
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/combineLatest';


### PR DESCRIPTION
Fixes #218 
Fixes #2315 too

This PR encompass the following new features:

- Application wide errors are now funneled through a centralized Exception Handler Service, allowing for easier logging and reporting.
- Http errors (HTTP 500 errors, API calls yielding a 404 error, etc) when communicating with the backend API are now handled and not propagated, ensuring that components keep being responsive, and also reported through a toast notification. This will enhance the overall UX on those (many) components/flows where no proper Http exception handling had been implemented.
- Network errors (WiFi lags, Internet downtimes) are now reported on realtime with a toast notification informing the user that his Internet connection has been interrupted or is back.

FYI, the error strings configured for each toast notification are fully managed through the i18n dictionary.