### PR TITLE
feat(server): additional oauth2 properties via vendor extensions

### DIFF
--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -73,6 +73,25 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     }
 
     @Test
+    public void shouldCreateSecurityConfigurationFromConcurSwagger() throws IOException {
+        final String specification = resource("/swagger/concur.swagger.json");
+
+        final ConnectorSettings connectorSettings = new ConnectorSettings.Builder()//
+            .name("Concur List API")//
+            .description("Invokes Concur List API")//
+            .icon("fa-globe")//
+            .putConfiguredProperty("specification", specification)//
+            .build();
+
+        final Connector generated = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+
+        assertThat(generated.getProperties().keySet()).contains("accessToken", "authorizationEndpoint", "tokenEndpoint", "clientId",
+            "clientSecret", "tokenStrategy", "authorizeUsingParameters");
+        assertThat(generated.getProperties().get("tokenStrategy").getDefaultValue()).isEqualTo("AUTHORIZATION_HEADER");
+        assertThat(generated.getProperties().get("authorizeUsingParameters").getDefaultValue()).isEqualTo("true");
+    }
+
+    @Test
     public void shouldCreateSecurityConfigurationFromReverbSwagger() throws IOException {
         final String specification = resource("/swagger/reverb.swagger.yaml");
 

--- a/app/server/connector-generator/src/test/resources/swagger/concur.swagger.json
+++ b/app/server/connector-generator/src/test/resources/swagger/concur.swagger.json
@@ -412,5 +412,18 @@
     "Void": {
       "properties": {}
     }
+  },
+  "securityDefinitions": {
+    "concur_oauth2": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "https://us-impl.api.concursolutions.com/oauth2/v0/authorize",
+      "tokenUrl": "https://us-impl.api.concursolutions.com/oauth2/v0/token",
+      "scopes": {
+        "LIST": "Access List API"
+      },
+      "x-token-strategy": "AUTHORIZATION_HEADER",
+      "x-authorize-using-parameters": true
+    }
   }
 }

--- a/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
+++ b/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
@@ -281,6 +281,36 @@
           "componentProperty": true,
           "description": "URL to fetch the OAuth Access token"
         },
+        "tokenStrategy": {
+          "kind": "property",
+          "displayName": "OAuth Token strategy",
+          "group": "producer",
+          "label": "producer",
+          "required": false,
+          "type": "hidden",
+          "javaType": "java.lang.String",
+          "tags": [
+            "oauth-token-strategy"
+          ],
+          "deprecated": false,
+          "secret": false,
+          "componentProperty": true
+        },
+        "authorizeUsingParameters": {
+          "kind": "property",
+          "displayName": "OAuth Token strategy",
+          "group": "producer",
+          "label": "producer",
+          "required": false,
+          "type": "hidden",
+          "javaType": "java.lang.String",
+          "tags": [
+            "oauth-authorize-using-parameters"
+          ],
+          "deprecated": false,
+          "secret": false,
+          "componentProperty": true
+        },
         "specification": {
           "kind": "property",
           "displayName": "Specification",


### PR DESCRIPTION
This adds support for `x-token-strategy` and
`x-authorize-using-parameters` vendor extensions. These control how the
OAuth2 flow is executed:
 - setting `x-token-strategy` vendor extension to:
    - AUTHORIZATION_HEADER (default): indicates that the access token
      should be carried in the Authorization header as an OAuth2 Bearer
      token
    - ACCESS_TOKEN_PARAMETER: indicates that the access token should be
      carried as a query parameter named "access_token"
    - OAUTH_TOKEN_PARAMETER: indicates that the access token should be
      carried as a query parameter named "oauth_token"
  - setting `x-authorize-using-parameters` to `true` (`false` is
    default) will pass client credentials to the provider as parameters
    instead of using HTTP Basic authentication.

Example Swagger specification:
```yaml
securityDefinitions:
  concur_oauth2:
    type: 'oauth2'
    flow: 'accessCode'
    authorizationUrl: 'https://us-impl.api.concursolutions.com/oauth2/v0/authorize'
    tokenUrl: 'https://us-impl.api.concursolutions.com/oauth2/v0/token'
    scopes:
      LIST: Access List API
    x-token-strategy: AUTHORIZATION_HEADER
    x-authorize-using-parameters: true
```

Fixes #2357