### PR TITLE
fix(connector): proper basic authentication encoding

### DIFF
--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponent.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponent.java
@@ -106,7 +106,9 @@ public final class SwaggerConnectorComponent extends DefaultConnectorComponent {
             headers.put("Authorization", "Bearer " + accessToken);
         } else if (authenticationType == AuthenticationType.basic) {
             final String usernameAndPassword = username + ":" + password;
-            headers.put("Authorization", "Basic " + Base64.getEncoder().encode(usernameAndPassword.getBytes(StandardCharsets.UTF_8)));
+            final String usernameAndPasswordEncoded = Base64.getEncoder()
+                .encodeToString(usernameAndPassword.getBytes(StandardCharsets.UTF_8));
+            headers.put("Authorization", "Basic " + usernameAndPasswordEncoded);
         }
     }
 

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponentTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/SwaggerConnectorComponentTest.java
@@ -79,6 +79,20 @@ public class SwaggerConnectorComponentTest {
     }
 
     @Test
+    public void shouldSetBasicAuthorizationHeader() {
+        final SwaggerConnectorComponent component = new SwaggerConnectorComponent();
+
+        component.setAuthenticationType(AuthenticationType.basic);
+        component.setUsername("username");
+        component.setPassword("dolphins");
+
+        final HashMap<String, Object> headers = new HashMap<>();
+        component.addAuthenticationHeadersTo(headers);
+
+        assertThat(headers).containsEntry("Authorization", "Basic dXNlcm5hbWU6ZG9scGhpbnM=");
+    }
+
+    @Test
     public void shouldSetOAuth2AuthorizationHeader() {
         final SwaggerConnectorComponent component = new SwaggerConnectorComponent();
 


### PR DESCRIPTION
This fixes Base64 encoding of basic authentication in the
`Authorization` header for the `connector-rest-swagger` connector.

Fixes #2369