### PR TITLE
chore(server): support diverse swagger specifications

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/Json.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/Json.java
@@ -107,4 +107,8 @@ public final class Json {
         }
         return rc;
     }
+
+    public static <T> T convertValue(final Object fromValue, final Class<T> toValueType) {
+        return OBJECT_MAPPER.convertValue(fromValue, toValueType);
+    }
 }

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseDataShapeGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseDataShapeGenerator.java
@@ -33,6 +33,6 @@ abstract class BaseDataShapeGenerator implements DataShapeGenerator {
     }
 
     static Optional<Response> findResponse(final Operation operation) {
-        return operation.getResponses().values().stream().filter(r -> r.getSchema() != null).findFirst();
+        return operation.getResponses().values().stream().filter(r -> r.getResponseSchema() != null).findFirst();
     }
 }

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -60,6 +60,8 @@ import io.syndesis.server.connector.generator.util.ActionComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
@@ -129,7 +131,7 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
         }
     }
 
-    abstract ConnectorDescriptor.Builder createDescriptor(String specification, Swagger swagger, Operation operation);
+    abstract ConnectorDescriptor.Builder createDescriptor(ObjectNode json, Swagger swagger, Operation operation);
 
     protected final Connector basicConnector(final ConnectorTemplate connectorTemplate, final ConnectorSettings connectorSettings) {
         final Swagger swagger = parseSpecification(connectorSettings, false).getModel();
@@ -209,7 +211,7 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
                     }
                 }
 
-                final ConnectorDescriptor descriptor = createDescriptor(info.getResolvedSpecification(), swagger, operation)//
+                final ConnectorDescriptor descriptor = createDescriptor(info.getResolvedJsonGraph(), swagger, operation)//
                     .camelConnectorGAV(connectorGav)//
                     .camelConnectorPrefix(connectorScheme)//
                     .connectorId(connectorId)//

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -18,6 +18,7 @@ package io.syndesis.server.connector.generator.swagger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -180,6 +181,7 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
         final String connectorScheme = connectorTemplate.getCamelConnectorPrefix();
 
         final List<ConnectorAction> actions = new ArrayList<>();
+        final Map<String, Integer> operationIdCounts = new HashMap<>();
         int idx = 0;
         for (final Entry<String, Path> pathEntry : paths.entrySet()) {
             final Path path = pathEntry.getValue();
@@ -188,8 +190,23 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
 
             for (final Entry<HttpMethod, Operation> entry : operationMap.entrySet()) {
                 final Operation operation = entry.getValue();
-                if (operation.getOperationId() == null) {
+                final String operationId = operation.getOperationId();
+                if (operationId == null) {
                     operation.operationId("operation-" + idx++);
+                } else {
+                    // we tolerate that some operations might have the same
+                    // operationId, if that's the case we generate a unique
+                    // operationId by appending the count of the duplicates,
+                    // e.g. operation ids for non unique operation id "foo" will
+                    // be "foo", "foo1", "foo2", ... this will be reflected in
+                    // the Swagger specification stored in `specification`
+                    // property
+                    final Integer count = operationIdCounts.compute(operationId,
+                        (id, currentCount) -> ofNullable(currentCount).map(c -> ++c).orElse(0));
+
+                    if (count > 0) {
+                        operation.operationId(operationId + count);
+                    }
                 }
 
                 final ConnectorDescriptor descriptor = createDescriptor(info.getResolvedSpecification(), swagger, operation)//

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/DataShapeGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/DataShapeGenerator.java
@@ -20,12 +20,14 @@ import io.swagger.models.Swagger;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public interface DataShapeGenerator {
 
     DataShape DATA_SHAPE_NONE = new DataShape.Builder().kind(DataShapeKinds.NONE).build();
 
-    DataShape createShapeFromRequest(String specification, Swagger swagger, Operation operation);
+    DataShape createShapeFromRequest(ObjectNode json, Swagger swagger, Operation operation);
 
-    DataShape createShapeFromResponse(String specification, Swagger swagger, Operation operation);
+    DataShape createShapeFromResponse(ObjectNode json, Swagger swagger, Operation operation);
 
 }

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/SwaggerModelInfo.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/SwaggerModelInfo.java
@@ -15,15 +15,19 @@
  */
 package io.syndesis.server.connector.generator.swagger;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 import io.swagger.models.Swagger;
 import io.syndesis.common.model.Violation;
+import io.syndesis.common.util.Json;
+import io.syndesis.server.connector.generator.swagger.util.JsonSchemaHelper;
 
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Class holding information about a swagger model and related validations.
@@ -42,6 +46,17 @@ public interface SwaggerModelInfo {
     }
 
     Swagger getModel();
+
+    @Value.Lazy
+    default ObjectNode getResolvedJsonGraph() {
+        try {
+            final ObjectNode json = (ObjectNode) Json.reader().readTree(getResolvedSpecification());
+
+            return JsonSchemaHelper.resolvableNodeForSpecification(json);
+        } catch (final IOException e) {
+            throw new IllegalStateException("Unable to parse Swagger resolved specification as JSON", e);
+        }
+    }
 
     String getResolvedSpecification();
 

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
@@ -20,6 +20,8 @@ import io.swagger.models.Swagger;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.action.ConnectorDescriptor;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConnectorGenerator {
 
     private final DataShapeGenerator dataShapeGenerator;
@@ -29,13 +31,13 @@ public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConn
     }
 
     @Override
-    ConnectorDescriptor.Builder createDescriptor(final String specification, final Swagger swagger, final Operation operation) {
+    ConnectorDescriptor.Builder createDescriptor(final ObjectNode json, final Swagger swagger, final Operation operation) {
         final ConnectorDescriptor.Builder actionDescriptor = new ConnectorDescriptor.Builder();
 
-        final DataShape inputDataShape = dataShapeGenerator.createShapeFromRequest(specification, swagger, operation);
+        final DataShape inputDataShape = dataShapeGenerator.createShapeFromRequest(json, swagger, operation);
         actionDescriptor.inputDataShape(inputDataShape);
 
-        final DataShape outputDataShape = dataShapeGenerator.createShapeFromResponse(specification, swagger, operation);
+        final DataShape outputDataShape = dataShapeGenerator.createShapeFromResponse(json, swagger, operation);
         actionDescriptor.outputDataShape(outputDataShape);
 
         actionDescriptor.putConfiguredProperty("operationId", operation.getOperationId());

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/UnifiedDataShapeGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/UnifiedDataShapeGenerator.java
@@ -21,6 +21,8 @@ import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.syndesis.common.model.DataShape;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public final class UnifiedDataShapeGenerator implements DataShapeGenerator {
 
     private static final String APPLICATION_JSON = "application/json";
@@ -32,28 +34,28 @@ public final class UnifiedDataShapeGenerator implements DataShapeGenerator {
     private static final DataShapeGenerator XML = new UnifiedXmlDataShapeGenerator();
 
     @Override
-    public DataShape createShapeFromRequest(final String specification, final Swagger swagger, final Operation operation) {
+    public DataShape createShapeFromRequest(final ObjectNode json, final Swagger swagger, final Operation operation) {
         if (supports(APPLICATION_JSON, swagger.getConsumes(), operation.getConsumes())) {
-            return JSON.createShapeFromRequest(specification, swagger, operation);
+            return JSON.createShapeFromRequest(json, swagger, operation);
         } else if (supports(APPLICATION_XML, swagger.getConsumes(), operation.getConsumes())) {
-            return XML.createShapeFromRequest(specification, swagger, operation);
+            return XML.createShapeFromRequest(json, swagger, operation);
         } else {
             // most likely a body-less request, i.e. only with parameters, we'll
             // use JSON to define those parameters
-            return JSON.createShapeFromRequest(specification, swagger, operation);
+            return JSON.createShapeFromRequest(json, swagger, operation);
         }
     }
 
     @Override
-    public DataShape createShapeFromResponse(final String specification, final Swagger swagger, final Operation operation) {
+    public DataShape createShapeFromResponse(final ObjectNode json, final Swagger swagger, final Operation operation) {
         if (supports(APPLICATION_JSON, swagger.getProduces(), operation.getProduces())) {
-            return JSON.createShapeFromResponse(specification, swagger, operation);
+            return JSON.createShapeFromResponse(json, swagger, operation);
         } else if (supports(APPLICATION_XML, swagger.getProduces(), operation.getProduces())) {
-            return XML.createShapeFromResponse(specification, swagger, operation);
+            return XML.createShapeFromResponse(json, swagger, operation);
         } else {
             // most likely a body-less request, i.e. only with parameters, we'll
             // use JSON to define those parameters
-            return JSON.createShapeFromResponse(specification, swagger, operation);
+            return JSON.createShapeFromResponse(json, swagger, operation);
         }
     }
 

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/UnifiedXmlDataShapeGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/UnifiedXmlDataShapeGenerator.java
@@ -41,14 +41,16 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
-import io.syndesis.server.connector.generator.swagger.util.XmlSchemaHelper;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.server.connector.generator.swagger.util.XmlSchemaHelper;
 
 import org.apache.commons.lang3.ClassUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import static io.syndesis.server.connector.generator.swagger.util.SwaggerHelper.dereference;
 import static io.syndesis.server.connector.generator.swagger.util.XmlSchemaHelper.addElement;
@@ -87,7 +89,7 @@ public class UnifiedXmlDataShapeGenerator extends BaseDataShapeGenerator {
     }
 
     @Override
-    public DataShape createShapeFromRequest(final String specification, final Swagger swagger, final Operation operation) {
+    public DataShape createShapeFromRequest(final ObjectNode json, final Swagger swagger, final Operation operation) {
         final Document document = DocumentHelper.createDocument();
 
         final Element schemaSet = document.addElement("d:SchemaSet", SCHEMA_SET_NS);
@@ -152,7 +154,7 @@ public class UnifiedXmlDataShapeGenerator extends BaseDataShapeGenerator {
     }
 
     @Override
-    public DataShape createShapeFromResponse(final String specification, final Swagger swagger, final Operation operation) {
+    public DataShape createShapeFromResponse(final ObjectNode json, final Swagger swagger, final Operation operation) {
         final Optional<Response> maybeResponse = findResponse(operation);
 
         if (!maybeResponse.isPresent()) {

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/DummyStreamHandler.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/DummyStreamHandler.java
@@ -15,33 +15,29 @@
  */
 package io.syndesis.server.connector.generator.swagger.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.nio.charset.StandardCharsets;
 
-final class InMemoryUrlStreamHandler extends URLStreamHandler {
-    private final String specification;
+final class DummyStreamHandler extends URLStreamHandler {
 
-    InMemoryUrlStreamHandler(final String specification) {
-        this.specification = specification;
+    static final URL DUMMY_URL;
+    static {
+        try {
+            DUMMY_URL = new URL("dummy", null, 0, "part", new DummyStreamHandler());
+        } catch (final MalformedURLException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private DummyStreamHandler() {
+        // only needed for `DUMMY_URL`
     }
 
     @Override
-    protected URLConnection openConnection(final URL u) throws IOException {
-        return new URLConnection(u) {
-            @Override
-            public void connect() throws IOException {
-                // NOP
-            }
-
-            @Override
-            public InputStream getInputStream() throws IOException {
-                return new ByteArrayInputStream(specification.getBytes(StandardCharsets.UTF_8));
-            }
-        };
+    protected URLConnection openConnection(final URL url) throws IOException {
+        return null;
     }
 }

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelper.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/util/SwaggerHelper.java
@@ -45,7 +45,6 @@ import org.yaml.snakeyaml.Yaml;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
@@ -55,8 +54,6 @@ import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 public final class SwaggerHelper {
-
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerHelper.class);
 
@@ -148,9 +145,9 @@ public final class SwaggerHelper {
     static JsonNode convertToJson(final String specification) throws IOException, JsonProcessingException {
         final JsonNode specRoot;
         if (specification.matches("\\s+\\{")) {
-            specRoot = JSON_MAPPER.readTree(specification);
+            specRoot = Json.reader().readTree(specification);
         } else {
-            specRoot = JSON_MAPPER.convertValue(YAML_PARSER.load(specification), JsonNode.class);
+            specRoot = Json.convertValue(YAML_PARSER.load(specification), JsonNode.class);
         }
         return specRoot;
     }

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -16,14 +16,17 @@
 package io.syndesis.server.connector.generator.swagger;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import io.swagger.models.Info;
 import io.swagger.models.Operation;
+import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.parser.SwaggerParser;
 import io.syndesis.common.model.action.ActionsSummary;
+import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
@@ -152,6 +155,20 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
         final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(connector.getConfiguredProperties()).containsEntry("tokenEndpoint", "http://some.token.url");
+    }
+
+    @Test
+    public void shouldMakeNonUniqueOperationIdsUnique() {
+        final Swagger swagger = new Swagger().path("/path", new Path().get(new Operation().operationId("foo"))
+            .post(new Operation().operationId("foo")).put(new Operation().operationId("bar")));
+
+        final Connector generated = generator.configureConnector(SWAGGER_TEMPLATE, new Connector.Builder().id("connector1").build(),
+            createSettingsFrom(swagger));
+        final List<ConnectorAction> actions = generated.getActions();
+        assertThat(actions).hasSize(3);
+        assertThat(actions.get(0).getId()).hasValueSatisfying(id -> assertThat(id).endsWith("foo"));
+        assertThat(actions.get(1).getId()).hasValueSatisfying(id -> assertThat(id).endsWith("foo1"));
+        assertThat(actions.get(2).getId()).hasValueSatisfying(id -> assertThat(id).endsWith("bar"));
     }
 
     @Test

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -36,6 +36,8 @@ import io.syndesis.server.connector.generator.swagger.util.SwaggerHelper;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import static io.syndesis.server.connector.generator.swagger.TestHelper.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,7 +46,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
 
     private final BaseSwaggerConnectorGenerator generator = new BaseSwaggerConnectorGenerator() {
         @Override
-        ConnectorDescriptor.Builder createDescriptor(final String specification, final Swagger swagger, final Operation operation) {
+        ConnectorDescriptor.Builder createDescriptor(final ObjectNode json, final Swagger swagger, final Operation operation) {
             return new ConnectorDescriptor.Builder();
         }
     };

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/SwaggerUnifiedShapeGeneratorExampleTests.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/SwaggerUnifiedShapeGeneratorExampleTests.java
@@ -45,7 +45,7 @@ public class SwaggerUnifiedShapeGeneratorExampleTests extends BaseSwaggerGenerat
 
     @Parameters(name = "{0}")
     public static Iterable<String> parameters() {
-        return Arrays.asList("reverb", "petstore", "petstore_xml", "basic_auth", "todo", "complex_xml");
+        return Arrays.asList("reverb", "petstore", "petstore_xml", "basic_auth", "todo", "complex_xml", "kie-server");
     }
 
 }

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/SyndesisSwaggerValidationRulesTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/SyndesisSwaggerValidationRulesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.connector.generator.swagger;
+
+import java.util.List;
+
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+import io.syndesis.common.model.Violation;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SyndesisSwaggerValidationRulesTest {
+
+    @Test
+    public void shouldValidateOperationUniqueness() {
+        final Swagger swagger = new Swagger()
+            .path("/path", new Path().get(new Operation().operationId("o1")).post(new Operation().operationId("o2")))
+            .path("/other", new Path().patch(new Operation().operationId("o2")).put(new Operation().operationId("o3")))
+            .path("/more", new Path().options(new Operation().operationId("o4")).delete(new Operation().operationId("o3")));
+        final SwaggerModelInfo info = new SwaggerModelInfo.Builder().model(swagger).build();
+        final SwaggerModelInfo validated = SyndesisSwaggerValidationRules.validateUniqueOperationIds(info);
+
+        final List<Violation> warnings = validated.getWarnings();
+        assertThat(warnings).hasSize(1);
+        final Violation nonUniqueWarning = warnings.get(0);
+        assertThat(nonUniqueWarning.error()).isEqualTo("non-unique-operation-ids");
+        assertThat(nonUniqueWarning.property()).isNull();
+        assertThat(nonUniqueWarning.message()).isEqualTo("Found operations with non unique operationIds: o2, o3");
+    }
+}

--- a/app/server/connector-generator/src/test/resources/swagger/expected-pet-schema.json
+++ b/app/server/connector-generator/src/test/resources/swagger/expected-pet-schema.json
@@ -2,7 +2,7 @@
   "xml": {
     "name": "Pet"
   },
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Pet",
   "required": [
     "name",

--- a/app/server/connector-generator/src/test/resources/swagger/kie-server.swagger.json
+++ b/app/server/connector-generator/src/test/resources/swagger/kie-server.swagger.json
@@ -1,0 +1,11748 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Kie Server API",
+        "description": "All endpoints that can be used with the Kie Server",
+        "version": "7.0.0"
+    },
+    "basePath": "/kie-server/services/rest",
+    "tags": [{
+        "name": "Administration of cases :: Case Management"
+    }, {
+        "name": "Queries - case definitions and instances :: Case Management"
+    }, {
+        "name": "Case instances :: Case Management"
+    }, {
+        "name": "KIE Server Script :: Core"
+    }, {
+        "name": "KIE Server :: Core"
+    }, {
+        "name": "Decision Service :: DMN"
+    }, {
+        "name": "Rules evaluation :: BRM"
+    }, {
+        "name": "Process and task definitions :: BPM"
+    }, {
+        "name": "Documents :: BPM"
+    }, {
+        "name": "Asynchronous jobs :: BPM"
+    }, {
+        "name": "Process instances :: BPM"
+    }, {
+        "name": "Custom queries :: BPM"
+    }, {
+        "name": "Queries - processes, nodes, variables and tasks :: BPM"
+    }, {
+        "name": "User task operations and queries :: BPM"
+    }, {
+        "name": "Process instances administration :: BPM"
+    }, {
+        "name": "User tasks administration :: BPM"
+    }, {
+        "name": "Process and task forms :: BPM"
+    }, {
+        "name": "Process definition and instance images :: BPM"
+    }, {
+        "name": "Planning and solvers :: BRP"
+    }],
+    "paths": {
+        "/server/admin/cases/instances": {
+            "get": {
+                "tags": ["Administration of cases :: Case Management"],
+                "summary": "Retrieves case instances without authntication checks and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional case instance status (open, closed, canceled) - defaults ot open (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["open", "closed", "cancelled"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/processes": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves process definitions with filtering by name or id of the process definition and applies pagination",
+                "description": "",
+                "operationId": "getProcessDefinitions",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "filter",
+                    "in": "query",
+                    "description": "process definition id or name that process definitions will be filtered by",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/instances": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instances with authntication checks and applies pagination, allows to filter by data (case file) name and value, owner and case instance status",
+                "description": "",
+                "operationId": "getCaseInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "dataItemName",
+                    "in": "query",
+                    "description": "data item name that case instances will be filtered by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "dataItemValue",
+                    "in": "query",
+                    "description": "data item value that case instances will be filtered by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "owner",
+                    "in": "query",
+                    "description": "case instance owner that case instances will be filtered by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional case instance status (open, closed, canceled) - defaults ot open (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["open", "closed", "cancelled"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/{caseRoleName}/instances": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instances where given user is involed in given role and applies pagination, allows to filter by case instance status",
+                "description": "",
+                "operationId": "getCaseInstancesByRole",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "caseRoleName",
+                    "in": "path",
+                    "description": "case role that instances should be found for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional case instance status (open, closed, canceled) - defaults ot open (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["open", "closed", "cancelled"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/instances/{caseId}/caseFile": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instance data items, allows to filter by name or type of data and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstanceDataItems",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "case instance identifier that data items should belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "optionally filter by data item names",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "type",
+                    "in": "query",
+                    "description": "optionally filter by data item types",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/{id}/processes": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves process definitions that belong to given container and applies pagination",
+                "description": "",
+                "operationId": "getProcessDefinitionsByContainer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process definitions should be filtered by",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/instances/{caseId}/tasks/instances/pot-owners": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instance tasks assigned as potential owner, allows to filter by task status and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstanceTasksAsPotentialOwner",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "case instance identifier that tasks should belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/instances/{caseId}/tasks/instances/admins": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instance tasks assigned as business admin, allows to filter by task status and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstanceTasksAsAdmin",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "case instance identifier that tasks should belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases/instances/{caseId}/tasks/instances/stakeholders": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case instance tasks assigned as stakeholder, allows to filter by task status and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstanceTasksAsStakeholder",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "case instance identifier that tasks should belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/cases": {
+            "get": {
+                "tags": ["Queries - case definitions and instances :: Case Management"],
+                "summary": "Retrieves case definitions with filtering by name or id of the case definition and applies pagination",
+                "description": "",
+                "operationId": "getCaseDefinitions",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "filter",
+                    "in": "query",
+                    "description": "case definition id or name that case definitions will be filtered by",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/{caseDefId}/instances": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case instances for given case definition only, allows to filter by case instance status and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstancesByDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that should be used to filter case instances",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseDefId",
+                    "in": "path",
+                    "description": "case definition id that should be used to filter case instances",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional case instance status (open, closed, canceled) - defaults ot open (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["open", "closed", "cancelled"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Starts new case instance of given case definition within given container with optional initial CaseFile (that provides variables and case role assignment)",
+                "description": "",
+                "operationId": "startCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the case definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseDefId",
+                    "in": "path",
+                    "description": "case definition id that new instance should be created from",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional CaseFile with variables and/or case role assignments",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case definition or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves active case instance by given identifier (case id) with optionally loading data, roles, milestones and stages",
+                "description": "",
+                "operationId": "getCaseInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "withData",
+                    "in": "query",
+                    "description": "optional flag to load data when loading case instance",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "withRoles",
+                    "in": "query",
+                    "description": "optional flag to load roles when loading case instance",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "withMilestones",
+                    "in": "query",
+                    "description": "optional flag to load milestones when loading case instance",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "withStages",
+                    "in": "query",
+                    "description": "optional flag to load stages when loading case instance",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Closes case instance with given identifier (case id) optionally with comment",
+                "description": "",
+                "operationId": "closeCaseInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional comment when closing a case instance as String",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Cancels case instance with given identifier (case id) it can also when intructed permanently destroy the case instance",
+                "description": "",
+                "operationId": "cancelCaseInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "destroy",
+                    "in": "query",
+                    "description": "allows to destroy (permanently) case instance as part of the cancel operation, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/{caseDefId}/instances/{caseId}": {
+            "put": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Reopens case instance with given identifier (case id) by initiating given case definition",
+                "description": "",
+                "operationId": "reopenCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the case definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseDefId",
+                    "in": "path",
+                    "description": "case definition id that new instance should be created from",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional CaseFile with variables and/or case role assignments",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/milestones": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves milestones from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceMilestones",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "achievedOnly",
+                    "in": "query",
+                    "description": "optional flag that allows to control which milestones to load - achieved only or actives ones too, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-milestone-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/stages": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves stages from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceStages",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "activeOnly",
+                    "in": "query",
+                    "description": "optional flag that allows to control which stages to load - active only or completed ones too, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-stage-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/caseFile": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case instance data as map where key is the name of data item and value is actual instance of the data item from case file",
+                "description": "",
+                "operationId": "getCaseInstanceData",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "optional name(s) of the data items to retrieve",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Puts new data (map of variables) into case instance's case file",
+                "description": "",
+                "operationId": "putCaseInstanceData",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "restrictedTo",
+                    "in": "query",
+                    "description": "optional role name(s) that given data should be restricted to",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "map of data to be placed in case file as Map",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Removes data items identified by name(s) from case instance's case file",
+                "description": "",
+                "operationId": "deleteCaseInstanceData",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "dataId",
+                    "in": "query",
+                    "description": "one or more names of the data items to be removed from case file",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/caseFile/{dataId}": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case instance data by data item name",
+                "description": "",
+                "operationId": "getCaseInstanceDataByName",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "dataId",
+                    "in": "path",
+                    "description": "name of the data item within case file to retrieve",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Puts new data (single data identified by name) into case instance's case file",
+                "description": "",
+                "operationId": "putCaseInstanceDataByName",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "dataId",
+                    "in": "path",
+                    "description": "name of the data item to be added to case file",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "restrictedTo",
+                    "in": "query",
+                    "description": "optional role name(s) that given data should be restricted to",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data to be placed in case file, any type can be provided",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/tasks": {
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds dynamic task (user or service depending on the payload) to case instance",
+                "description": "",
+                "operationId": "addDynamicTaskToCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data for dynamic task (it represents task specification that drives the selection of the type of task)",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks": {
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds dynamic task (user or service depending on the payload) to given stage within case instance",
+                "description": "",
+                "operationId": "addDynamicTaskToCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseStageId",
+                    "in": "path",
+                    "description": "identifier of the stage within case instance where dynamic task should be added",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data for dynamic task (it represents task specification that drives the selection of the type of task)",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/processes/{pId}": {
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds dynamic subprocess identified by process id to case instance",
+                "description": "",
+                "operationId": "addDynamicProcessToCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id of the subprocess to be added",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data for dynamic subprocess",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/processes/{pId}": {
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds dynamic subprocess identified by process id to stage within case instance",
+                "description": "",
+                "operationId": "addDynamicProcessToCase",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseStageId",
+                    "in": "path",
+                    "description": "identifier of the stage within case instance where dynamic subprocess should be added",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id of the subprocess to be added",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data for dynamic subprocess",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks/{nodeName}": {
+            "put": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Triggers ad hoc fragment in stage within case instance with optional data",
+                "description": "",
+                "operationId": "triggerAdHocNodeInStage",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseStageId",
+                    "in": "path",
+                    "description": "identifier of the stage within case instance where adhoc fragment should be triggered",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "nodeName",
+                    "in": "path",
+                    "description": "name of the adhoc fragment to be triggered",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional data to be given when triggering adhoc fragment",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/adhocfragments": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves adhoc fragments from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceAdHocFragments",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-adhoc-fragment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/processes/instances": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves process isntances that compose complete case instance",
+                "description": "",
+                "operationId": "getCaseInstanceProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/nodes/instances": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves node instances from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceActiveNodes",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "completed",
+                    "in": "query",
+                    "description": "optional flag that allows to control which node instances to load - active or completed, defaults to false loading only active ones",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/roles": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves role assignments from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceRoleAssignments",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-role-assignment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/roles/{caseRoleName}": {
+            "put": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds new role assignment for given case, it can be either user or group based assignment",
+                "description": "",
+                "operationId": "addRoleAssignment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseRoleName",
+                    "in": "path",
+                    "description": "name of the case role the assignment should be set",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "user to be aded to case role for given case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "group",
+                    "in": "query",
+                    "description": "group to be aded to case role for given case instance",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Removes role assignment from user or group for given case instance",
+                "description": "",
+                "operationId": "removeRoleAssignment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseRoleName",
+                    "in": "path",
+                    "description": "name of the case role the assignment should be removed",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "user to be removed from case role for given case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "group",
+                    "in": "query",
+                    "description": "group to be removed from case role for given case instance",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/comments": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves comments from case instance",
+                "description": "",
+                "operationId": "getCaseInstanceComments",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-comment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Adds new comment to given case instance",
+                "description": "",
+                "operationId": "addComment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "author",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "restrictedTo",
+                    "in": "query",
+                    "description": "optional role name(s) that given comment should be restricted to",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "actual content of the comment to be added as String",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/definitions/{caseDefId}": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case definition for given container and case definition id",
+                "description": "",
+                "operationId": "getCaseDefinitionsByDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that should be used to filter case definitions",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseDefId",
+                    "in": "path",
+                    "description": "case definition id that should be loaded",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-definition"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/comments/{caseCommentId}": {
+            "put": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Updates comment within case instance",
+                "description": "",
+                "operationId": "updateComment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseCommentId",
+                    "in": "path",
+                    "description": "identifier of the comment to be updated",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "author",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "restrictedTo",
+                    "in": "query",
+                    "description": "optional role name(s) that given comment should be restricted to",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "actual content of the comment to be updated to as String",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Removes given comment from case instance",
+                "description": "",
+                "operationId": "removeComment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseCommentId",
+                    "in": "path",
+                    "description": "identifier of the comment to be removed",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances/{caseId}/tasks/{nodeName}": {
+            "put": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Triggers ad hoc fragment in case instance with optional data",
+                "description": "",
+                "operationId": "triggerAdHocNode",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that case instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "caseId",
+                    "in": "path",
+                    "description": "identifier of the case instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "nodeName",
+                    "in": "path",
+                    "description": "name of the adhoc fragment to be triggered",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional data to be given when triggering adhoc fragment",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Case instance not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/instances": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case instances for given container only, allows to filter by case instance status and applies pagination",
+                "description": "",
+                "operationId": "getCaseInstancesByContainer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that should be used to filter case instances",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional case instance status (open, closed, canceled) - defaults ot open (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["open", "closed", "cancelled"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/cases/definitions": {
+            "get": {
+                "tags": ["Case instances :: Case Management"],
+                "summary": "Retrieves case definition for given container only, applies pagination",
+                "description": "",
+                "operationId": "getCaseDefinitionsByContainer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that should be used to filter case definitions",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/case-definition-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/config": {
+            "post": {
+                "tags": ["KIE Server Script :: Core"],
+                "summary": "Executes command script on execution server, usually used as a batch to configure KIE Server",
+                "description": "",
+                "operationId": "executeCommands",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "in": "body",
+                    "name": "body",
+                    "description": "command script payload",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/responses"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves KIE Server information - id, name, location, capabilities, messages",
+                "description": "",
+                "operationId": "getInfo",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/scanner": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves stanner information for given container",
+                "description": "",
+                "operationId": "getScannerInfo",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id for scanner to be loaded",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Updates scanner for given container",
+                "description": "",
+                "operationId": "updateScanner",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id for scanner to be updated",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "Scanner information given as KieScannerResource type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves containers deployed to this server, optionally filtered by group, artifact, version or status",
+                "description": "",
+                "operationId": "listContainers",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "groupId",
+                    "in": "query",
+                    "description": "optional groupId to filter containers by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "artifactId",
+                    "in": "query",
+                    "description": "optional artifactId to filter containers by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "version",
+                    "in": "query",
+                    "description": "optional version to filter containers by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional status to filter containers by",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves container with given id",
+                "description": "",
+                "operationId": "getContainerInfo",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id to be retrieved",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Creates (deploys) new KIE container to this server",
+                "description": "",
+                "operationId": "createContainer",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id to be assigned to deployed KIE Container",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "KIE Container resource to be deployed as KieContainerResource",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "400": {
+                        "description": "container could not be created"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Disposes (undeploys) container with given id",
+                "description": "",
+                "operationId": "disposeContainer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id to be disposed (undeployed)",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/state": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves server state - configuration that the server is currently running with",
+                "description": "",
+                "operationId": "getServerState",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/release-id": {
+            "get": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Retrieves release id of the KIE container with given id",
+                "description": "",
+                "operationId": "getReleaseId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id that release id should be loaded from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["KIE Server :: Core"],
+                "summary": "Updates release id of the KIE container with given id to provided release id",
+                "description": "",
+                "operationId": "updateReleaseId",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id that release id should be upgraded",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "Release Id to be upgraded to as ReleaseId type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/dmn": {
+            "get": {
+                "tags": ["Decision Service :: DMN"],
+                "summary": "Retrieves DMN model for given container",
+                "description": "",
+                "operationId": "getModels",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id that modesl should be loaded from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Models or container not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Decision Service :: DMN"],
+                "summary": "Evaluates decisions for given imput",
+                "description": "",
+                "operationId": "evaluateDecisions",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id to be used to evaluate decisions on",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "DMN context to be used while evaluation decisions as DMNContextKS type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/instances/{id}": {
+            "post": {
+                "tags": ["Rules evaluation :: BRM"],
+                "summary": "Evaluates rules by executing commands on the rule session",
+                "description": "",
+                "operationId": "manageContainer",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "Container id where rules should be evaluated on",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "Commands to be executed on rule engine given as BatchExecutionCommand type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/response"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/variables": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves process variables definitions that are present in given process and container",
+                "description": "",
+                "operationId": "getProcessVariables",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that the variable definitions should be retrieved from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-variables"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/tasks/service": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves service tasks definitions that are present in given process and container",
+                "description": "",
+                "operationId": "getServiceTasks",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that the service task definitions should be retrieved from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-service-tasks"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/entities": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves actors and groups that are involved in given process and container",
+                "description": "",
+                "operationId": "getAssociatedEntities",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that the involved actors and groups should be retrieved from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-associated-entities"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/tasks/users": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves user tasks definitions that are present in given process and container",
+                "description": "",
+                "operationId": "getTasksDefinitions",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that the user task definitions should be retrieved from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/user-task-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/inputs": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves input variables defined on a given user task",
+                "description": "",
+                "operationId": "getTaskInputMappings",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that given task belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "taskName",
+                    "in": "path",
+                    "description": "task name that input variable definitions should be retrieved for",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-task-inputs"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves process definition identified by given process id within given container",
+                "description": "",
+                "operationId": "getProcessDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that the definition should be retrieved for",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definition"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/subprocesses": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves sub process definitions that are defined in given process within given container",
+                "description": "",
+                "operationId": "getReusableSubProcesses",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that subprocesses should be retrieved from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-subprocesses"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/outputs": {
+            "get": {
+                "tags": ["Process and task definitions :: BPM"],
+                "summary": "Retrieves output variables defined on a given user task",
+                "description": "",
+                "operationId": "getTaskOutputMappings",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that given task belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "taskName",
+                    "in": "path",
+                    "description": "task name that output variable definitions should be retrieved for",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-task-outputs"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/documents/{documentId}": {
+            "get": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Retrieves document identified by given documentId",
+                "description": "",
+                "operationId": "getDocument",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "documentId",
+                    "in": "path",
+                    "description": "document id of a document that should be retruned",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/document-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Document with given id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Updates document identified by given document id based on given content (body)",
+                "description": "",
+                "operationId": "updateDocument",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "documentId",
+                    "in": "path",
+                    "description": "document id of a document that should be updated",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "document content represented as DocumentInstance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Document with given id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Deletes document identified by given document id",
+                "description": "",
+                "operationId": "deleteDocument",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "documentId",
+                    "in": "path",
+                    "description": "document id of a document that should be deleted",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Document with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/documents": {
+            "get": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Retrieves documents that are stored in the system, with pagination",
+                "description": "",
+                "operationId": "listDocuments",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/document-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Creates new document based on given content (body)",
+                "description": "",
+                "operationId": "createDocument",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "in": "body",
+                    "name": "body",
+                    "description": "document content represented as DocumentInstance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/documents/{documentId}/content": {
+            "get": {
+                "tags": ["Documents :: BPM"],
+                "summary": "Retrieves document's content identified by given documentId",
+                "description": "",
+                "operationId": "getDocumentContent",
+                "produces": ["application/octet-stream"],
+                "parameters": [{
+                    "name": "documentId",
+                    "in": "path",
+                    "description": "document id of a document that content should be retruned from",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "byte"
+                            }
+                        },
+                        "headers": {}
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Document with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/jobs/{jobId}": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous job by given jobId",
+                "description": "",
+                "operationId": "getRequestById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "jobId",
+                    "in": "path",
+                    "description": "identifier of the asynchronous job to be retrieved",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "withErrors",
+                    "in": "query",
+                    "description": "optional flag that indicats if errors should be loaded as well",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "withData",
+                    "in": "query",
+                    "description": "optional flag that indicats if input/output data should be loaded as well",
+                    "required": false,
+                    "type": "boolean"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Requeues failed asynchronous job identified by given jobId",
+                "description": "",
+                "operationId": "requeueRequest",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "jobId",
+                    "in": "path",
+                    "description": "identifier of the asynchronous job to be requeued",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Cancels active asynchronous job identified by given jobId",
+                "description": "",
+                "operationId": "cancelRequest",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "jobId",
+                    "in": "path",
+                    "description": "identifier of the asynchronous job to be canceled",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs/keys/{key}": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous jobs by business key",
+                "description": "",
+                "operationId": "getRequestsByBusinessKey",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "key",
+                    "in": "path",
+                    "description": "identifier of the business key that asynchornous jobs should be found for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["QUEUED", "DONE", "CANCELLED", "ERROR", "RETRYING", "RUNNING"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs/commands/{cmd}": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous jobs by command",
+                "description": "",
+                "operationId": "getRequestsByCommand",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "cmd",
+                    "in": "path",
+                    "description": "name of the command that asynchornous jobs should be found for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["QUEUED", "DONE", "CANCELLED", "ERROR", "RETRYING", "RUNNING"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs/processes/instances/{pInstanceId}": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous jobs by process instance id",
+                "description": "",
+                "operationId": "getRequestsByProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that asynchornous jobs should be found for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["QUEUED", "DONE", "CANCELLED", "ERROR", "RETRYING", "RUNNING"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous jobs filtered by status",
+                "description": "",
+                "operationId": "getRequestsByStatus",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["QUEUED", "DONE", "CANCELLED", "ERROR", "RETRYING", "RUNNING"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Schedules new asynchronous job based on given body",
+                "description": "",
+                "operationId": "scheduleRequest",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "containerId",
+                    "in": "query",
+                    "description": "optional container id that the job should be associated with",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "asynchronous job definition represented as JobRequestInstance",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs/containers/{id}": {
+            "get": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Retrieves asynchronous jobs by container",
+                "description": "",
+                "operationId": "getRequestsByContainer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "identifier of the container that asynchornous jobs should be found for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["QUEUED", "DONE", "CANCELLED", "ERROR", "RETRYING", "RUNNING"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/request-info-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/jobs/{jobId}/data": {
+            "post": {
+                "tags": ["Asynchronous jobs :: BPM"],
+                "summary": "Updates active asynchronous job's data (identified by given jobId)",
+                "description": "",
+                "operationId": "updateRequestData",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "jobId",
+                    "in": "path",
+                    "description": "identifier of the asynchronous job to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "containerId",
+                    "in": "query",
+                    "description": "optional container id that the job should be associated with",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "data to be updated on the asynchronous job represented as Map",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/{pId}/instances/correlation/{correlationKey}": {
+            "post": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Starts new process instance with correlation key of given process definition within given container with optional variables",
+                "description": "",
+                "operationId": "startProcessWithCorrelation",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that new instance should be created from",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "correlationKey",
+                    "in": "path",
+                    "description": "correlation key to be assigned to process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional map of process variables",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process ID or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/nodes/instances": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes",
+                "description": "",
+                "operationId": "getProcessInstanceHistory",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that history should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "activeOnly",
+                    "in": "query",
+                    "description": "instructs if active nodes only should be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "completedOnly",
+                    "in": "query",
+                    "description": "instructs if completed nodes only should be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves process instances that belong to given container",
+                "description": "",
+                "operationId": "getProcessInstancesByDeploymentId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Aborts active process instances identified by given list of identifiers",
+                "description": "",
+                "operationId": "abortProcessInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "instanceId",
+                    "in": "query",
+                    "description": "list of identifiers of the process instances to be aborted",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/signal/{sName}": {
+            "post": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Signals active process instance identified by given id with singal name and optional event data",
+                "description": "",
+                "operationId": "signalProcessInstance",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance to be signaled",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "sName",
+                    "in": "path",
+                    "description": "signal name to be send to process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional event data - any type can be provided",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/signal/{sName}": {
+            "post": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Signals active process instances identified by given ids with singal name and optional event data",
+                "description": "",
+                "operationId": "signalProcessInstances",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "instanceId",
+                    "in": "query",
+                    "description": "list of identifiers of the process instances to be signaled",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "sName",
+                    "in": "path",
+                    "description": "signal name to be send to process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional event data - any type can be provided",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/variable/{varName}": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves active process instance's (identified by given id) variable given as variable name",
+                "description": "",
+                "operationId": "getProcessInstanceVariable",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that variable should be retrieved from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "varName",
+                    "in": "path",
+                    "description": "variable name to be retrieved",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Updates active process instance's (identified by given id) variable with given name",
+                "description": "",
+                "operationId": "setProcessVariable",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "varName",
+                    "in": "path",
+                    "description": "name of the variable to be set/updated",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "variable data - any type can be provided",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/variables": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves active process instance's (identified by given id) variables, variables are returned as map where key is the variable name (string) and value is variable value (any type)",
+                "description": "",
+                "operationId": "getProcessInstanceVariables",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that variables should be retrieved from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Updates active process instance's (identified by given id) variables given as map in the body",
+                "description": "",
+                "operationId": "setProcessVariables",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "variable data give as map",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/signals": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves active process instance's (identified by given id) active signals",
+                "description": "",
+                "operationId": "getAvailableSignals",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that signals should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/workitems": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves work items within process instance and container",
+                "description": "",
+                "operationId": "getWorkItemByProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that work items belong to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/work-item-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, Work Item or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/variables/instances": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves variables last value (from audit logs) for given process instance",
+                "description": "",
+                "operationId": "getVariablesCurrentState",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that variables state should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/variable-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/variables/instances/{varName}": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves variable history (from audit logs) for given variable name that belongs to process instance",
+                "description": "",
+                "operationId": "getVariableHistory",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that variable history should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "varName",
+                    "in": "path",
+                    "description": "name of the variables that history should be collected for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/variable-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves process definitions that belong to given container",
+                "description": "",
+                "operationId": "getProcessesByDeploymentId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/processes": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves process instances that belong to given container and have given parent process instance, optionally allow to filter by process instance state.",
+                "description": "",
+                "operationId": "getProcessInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the parent process instance that process instances should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves process instance identified by given id optionally with variables (variables will be loaded only for active process instance)",
+                "description": "",
+                "operationId": "getProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance to be fetched",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "withVars",
+                    "in": "query",
+                    "description": "indicates if process instance variables should be loaded or not",
+                    "required": false,
+                    "type": "boolean"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Aborts active process instance identified by given id",
+                "description": "",
+                "operationId": "abortProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance to be aborted",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/{pId}/instances": {
+            "post": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Starts new process instance of given process definition within given container with optional variables",
+                "description": "",
+                "operationId": "startProcess",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the process definition resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id that new instance should be created from",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional map of process variables",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process ID or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/completed": {
+            "put": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Completes work item identified by workItemId within process instance and container. Optionally completion can provide outcome data - as map",
+                "description": "",
+                "operationId": "completeWorkItem",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that work item belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "workItemId",
+                    "in": "path",
+                    "description": "identifier of the work item to complete",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional outcome data give as map",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, Work Item or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/aborted": {
+            "put": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Aborts work item identified by workItemId within process instance and container",
+                "description": "",
+                "operationId": "abortWorkItem",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that work item belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "workItemId",
+                    "in": "path",
+                    "description": "identifier of the work item to abort",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, Work Item or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}": {
+            "get": {
+                "tags": ["Process instances :: BPM"],
+                "summary": "Retrieves work item identified by workItemId within process instance and container",
+                "description": "",
+                "operationId": "getWorkItem",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that work item belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "workItemId",
+                    "in": "path",
+                    "description": "identifier of the work item to retrieve",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/work-item-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, Work Item or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/queries/definitions": {
+            "get": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Retruns all custom queries defined in the system",
+                "description": "",
+                "operationId": "getQueries",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/query-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/definitions/{queryName}": {
+            "get": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Retrieves existing query definition from the system with given queryName",
+                "description": "",
+                "operationId": "getQuery",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be retrieved",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/query-definition"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Query definition with given name not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Registers new query definition in the system with given queryName",
+                "description": "",
+                "operationId": "createQueryDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be registered",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "query definition represented as QueryDefinition",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "409": {
+                        "description": "Query with given name already exists"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Replaces existing query definition or registers new if not exists in the system with given queryName",
+                "description": "",
+                "operationId": "replaceQueryDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be replaced",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "query definition represented as QueryDefinition",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Deletes existing query definition from the system with given queryName",
+                "description": "",
+                "operationId": "dropQueryDefinition",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be deleted",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Query definition with given name not found"
+                    }
+                }
+            }
+        },
+        "/server/queries/definitions/{queryName}/data": {
+            "get": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper.",
+                "description": "",
+                "operationId": "runQuery",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be used for query",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "mapper",
+                    "in": "query",
+                    "description": "identifier of the query mapper to be used when transforming results",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "orderBy",
+                    "in": "query",
+                    "description": "optional sort order",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Query definition with given name not found"
+                    }
+                }
+            }
+        },
+        "/server/queries/definitions/{queryName}/filtered-data": {
+            "post": {
+                "tags": ["Custom queries :: BPM"],
+                "summary": "Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper. Query is additional altered by the filter spec and/or builder",
+                "description": "",
+                "operationId": "runQueryFiltered",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "queryName",
+                    "in": "path",
+                    "description": "identifier of the query definition to be used for query",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "mapper",
+                    "in": "query",
+                    "description": "identifier of the query mapper to be used when transforming results",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "builder",
+                    "in": "query",
+                    "description": "optional identifier of the query builder to be used for query conditions",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional query filter specification represented as QueryFilterSpec",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "400": {
+                        "description": "Query parameters or filter spec provide invalid conditions"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/variables/{varName}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instances filtered by by variable or by variable and its value. Applies pagination by default and allows to specify sorting",
+                "description": "",
+                "operationId": "getProcessInstanceByVariables",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "varName",
+                    "in": "path",
+                    "description": "variable name to filter process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "varValue",
+                    "in": "query",
+                    "description": "variable value to filter process instance, optional when filtering by name only required when filtering by name and value",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/variables/{varName}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks by variable name and optionally by variable value, optionally filters by status and applies pagination",
+                "description": "",
+                "operationId": "getTasksByVariables",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "varName",
+                    "in": "path",
+                    "description": "name of the variable used to fiter tasks",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "varValue",
+                    "in": "query",
+                    "description": "value of the variable used to fiter tasks, optional when filtering only by name, required when filtering by both name and value",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/{pInstanceId}/nodes/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes",
+                "description": "",
+                "operationId": "getProcessInstanceHistory",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id to to retrive history for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "activeOnly",
+                    "in": "query",
+                    "description": "include active nodes only",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "completedOnly",
+                    "in": "query",
+                    "description": "include completed nodes only",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/{tInstanceId}/events": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves task events for given task id and applies pagination",
+                "description": "",
+                "operationId": "getTaskEvents",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "task id to load task events for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-event-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/containers/{id}/process/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instances filtered by container. Applies pagination by default and allows to specify sorting",
+                "description": "",
+                "operationId": "getProcessInstancesByDeploymentId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id to filter process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/{pId}/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instances filtered by process id. Applies pagination by default and allows to specify sorting",
+                "description": "",
+                "operationId": "getProcessInstancesByProcessId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id to filter process instance",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "initiator",
+                    "in": "query",
+                    "description": "optinal process instance initiator - user who started process instance to filtr process instances",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/{pInstanceId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instance for given process instance id and optionally loads its variables",
+                "description": "",
+                "operationId": "getProcessInstanceById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id to retrieve process instance",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "withVars",
+                    "in": "query",
+                    "description": "load process instance variables or not, defaults to false",
+                    "required": false,
+                    "type": "boolean"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance id not found"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instance/correlation/{correlationKey}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instance by exactly matched correlation key",
+                "description": "",
+                "operationId": "getProcessInstanceByCorrelationKey",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "correlationKey",
+                    "in": "path",
+                    "description": "correlation key associated with process instance",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/correlation/{correlationKey}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instances filtered by correlation key, retrieves all process instances that match correlationkey*. Applies pagination by default and allows to specify sorting",
+                "description": "",
+                "operationId": "getProcessInstancesByCorrelationKey",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "correlationKey",
+                    "in": "path",
+                    "description": "correlation key to filter process instance, can be given as partial correlation key like in starts with approach",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/{pInstanceId}/wi-nodes/instances/{workItemId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves node instance for given process instance id and work item id",
+                "description": "",
+                "operationId": "getNodeInstanceForWorkItem",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id that work item belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "workItemId",
+                    "in": "path",
+                    "description": "work item id to retrieve node instance for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Node instance id not found"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/{pInstanceId}/variables/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves variables last value (from audit logs) for given process instance",
+                "description": "",
+                "operationId": "getVariablesCurrentState",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id to load variables current state (latest value) for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/variable-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances/{pInstanceId}/variables/instances/{varName}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves variable history (from audit logs) for given variable name that belongs to process instance",
+                "description": "",
+                "operationId": "getVariableHistory",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id to load variable history for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "varName",
+                    "in": "path",
+                    "description": "variable name that history should be loaded for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/variable-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/containers/{id}/processes/definitions": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process definitions that belong to given container",
+                "description": "",
+                "operationId": "getProcessesByDeploymentId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id to filter process definitions",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/definitions": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process definitions filtered by process id or name",
+                "description": "",
+                "operationId": "getProcessesByFilter",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "filter",
+                    "in": "query",
+                    "description": "process id or name to filter process definitions",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/definitions/{pId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process definitions filtered by process id",
+                "description": "",
+                "operationId": "getProcessesById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id to load process definition",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definitions"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/containers/{id}/processes/definitions/{pId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process definition that belong to given container and has matching process id",
+                "description": "",
+                "operationId": "getProcessesByDeploymentIdProcessId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process definition belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "process id to load process definition",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-definition"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks, optionally filters by status and applies pagination",
+                "description": "",
+                "operationId": "getAllAuditTask",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/workitem/{workItemId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves task by associated work item id",
+                "description": "",
+                "operationId": "getTaskByWorkItemId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "workItemId",
+                    "in": "path",
+                    "description": "work item id to load task associated with",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task not found for given work item id"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/pot-owners": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks assigned as potential owner, optionally filters by status and given groups and applies pagination",
+                "description": "",
+                "operationId": "getTasksAssignedAsPotentialOwner",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "groups",
+                    "in": "query",
+                    "description": "optional group names to include in the query",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }, {
+                    "name": "filter",
+                    "in": "query",
+                    "description": "optional custom filter for task data",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/owners": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks owned, optionally filters by status and applies pagination",
+                "description": "",
+                "operationId": "getTasksOwnedByStatus",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/process/{pInstanceId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks associated with given process instance, optionally filters by status and applies pagination",
+                "description": "",
+                "operationId": "getTasksByStatusByProcessInstanceId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "process instance id to filter task instances",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/{tInstanceId}": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves task by task id",
+                "description": "",
+                "operationId": "getTaskById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "task id to load task instance",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task not found for given id"
+                    }
+                }
+            }
+        },
+        "/server/queries/processes/instances": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves process instances filtered by status, initiator, processName - depending what query parameters are given. Applies pagination by default and allows to specify sorting",
+                "description": "",
+                "operationId": "getProcessInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional process instance status (active, completed, aborted) - defaults ot active (1) only",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int32",
+                        "enum": [1, 2, 3]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "initiator",
+                    "in": "query",
+                    "description": "optional process instance initiator - user who started process instance to filter process instances",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "processName",
+                    "in": "query",
+                    "description": "optional process name to filter process instances",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/queries/tasks/instances/admins": {
+            "get": {
+                "tags": ["Queries - processes, nodes, variables and tasks :: BPM"],
+                "summary": "Retrieves tasks assigned as business administrator, optionally filters by status and applies pagination",
+                "description": "",
+                "operationId": "getTasksAssignedAsBusinessAdministratorByStatus",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)",
+                    "required": false,
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Created", "Ready", "Reserved", "InProgress", "Suspended", "Completed", "Failed", "Error", "Exited", "Obsolete"]
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-summary-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/released": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Releases task with given id that belongs to given container",
+                "description": "",
+                "operationId": "release",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be released",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/delegated": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Delegates task with given id that belongs to given container",
+                "description": "",
+                "operationId": "delegate",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be delegated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "targetUser",
+                    "in": "query",
+                    "description": "user that task should be dalegated to",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/completed": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Completes task with given id that belongs to given container, optionally it can claim and start task when auto-progress is used",
+                "description": "",
+                "operationId": "complete",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be completed",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "auto-progress",
+                    "in": "query",
+                    "description": "optional flag that allows to directlu claim and start task (if needed) before completion",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional map of output variables",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves task with given id that belongs to given container, optionally loads its input, output data and assignments",
+                "description": "",
+                "operationId": "getTask",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be loaded",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "withInputData",
+                    "in": "query",
+                    "description": "optionally loads task input data",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "withOutputData",
+                    "in": "query",
+                    "description": "optionally loads task output data",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "withAssignments",
+                    "in": "query",
+                    "description": "optionally loads task people assignments",
+                    "required": false,
+                    "type": "boolean"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Updates task with given id that belongs to given container with given task instance details in body, updates name, description, priority, expiration date, form name, input and output variables",
+                "description": "",
+                "operationId": "update",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "task instance with updates as TaskInstance type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/attachments": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves attachments from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getAttachmentsByTaskId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that attachments should be loaded for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-attachment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Adds attachment to task with given id that belongs to given container",
+                "description": "",
+                "operationId": "addAttachment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that attachment should be added to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "name of the attachment to be added",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "attachment content, any type can be provided",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/claimed": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Claims task with given id that belongs to given container",
+                "description": "",
+                "operationId": "claim",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be claimed",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/forwarded": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Forwards task with given id that belongs to given container",
+                "description": "",
+                "operationId": "forward",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be forwarded",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "targetUser",
+                    "in": "query",
+                    "description": "user that the task should be forwarded to",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/activated": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Activates task with given id that belongs to given container",
+                "description": "",
+                "operationId": "activate",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be activated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/description": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Sets description on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "setDescription",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance where description should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "description as String",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/events": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves task events for given task id and applies pagination",
+                "description": "",
+                "operationId": "getTaskEvents",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that events should be loaded for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-event-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/contents/output": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves output date from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getTaskOutputContentByTaskId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that output data should be loaded from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Saves content on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "saveContent",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that data should be saved into",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "output data to be saved as Map ",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/contents/input": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves input date from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getTaskInputContentByTaskId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that input data should be loaded from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/comments": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves comments from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getCommentsByTaskId",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that comments should be loaded for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-comment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Adds comment to task with given id that belongs to given container",
+                "description": "",
+                "operationId": "addComment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that comment should be added to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "comment data as TaskComment",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}/content": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves attachment's content with given id from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getAttachmentContentById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that attachment belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "attachmentId",
+                    "in": "path",
+                    "description": "identifier of the attachment that content should be loaded from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/nominated": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Nominates task with given id that belongs to given container",
+                "description": "",
+                "operationId": "nominate",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be nominated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "potOwner",
+                    "in": "query",
+                    "description": "list of users that the task should be nominated to",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves attachment with given id from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getAttachmentById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that attachment belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "attachmentId",
+                    "in": "path",
+                    "description": "identifier of the attachment to be loaded",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-attachment"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Deletes attachment from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "deleteAttachment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that attachment belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "attachmentId",
+                    "in": "path",
+                    "description": "identifier of the attachment to be deleted",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/comments/{commentId}": {
+            "get": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Retrieves comment with given id from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "getCommentById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that comment belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "commentId",
+                    "in": "path",
+                    "description": "identifier of the comment to be loaded",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-comment"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Deletes comment from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "deleteComment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that comment belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "commentId",
+                    "in": "path",
+                    "description": "identifier of the comment to be deleted",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/expiration": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Sets expiration date on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "setExpirationDate",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance where expiration date should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "expiration date as Date",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/skipable": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Sets skipable flag on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "setSkipable",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance where skipable flag should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "skipable flag as Boolean",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/contents/{contentId}": {
+            "delete": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Deletes content from task with given id that belongs to given container",
+                "description": "",
+                "operationId": "deleteContent",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that content belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "contentId",
+                    "in": "path",
+                    "description": "identifier of the content to be deleted",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/exited": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Exists task with given id that belongs to given container",
+                "description": "",
+                "operationId": "exit",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be exited",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/started": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Starts task with given id that belongs to given container",
+                "description": "",
+                "operationId": "start",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be started",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/priority": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Sets priority on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "setPriority",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance where priority should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "priority as Integer",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/stopped": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Stops task with given id that belongs to given container",
+                "description": "",
+                "operationId": "stop",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be stopped",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/suspended": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Suspends task with given id that belongs to given container",
+                "description": "",
+                "operationId": "suspend",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be suspended",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/resumed": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Resumes task with given id that belongs to given container",
+                "description": "",
+                "operationId": "resume",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be resumed",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/name": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Sets name on task with given id that belongs to given container",
+                "description": "",
+                "operationId": "setName",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance where name should be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "name as String",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/failed": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Fails task with given id that belongs to given container",
+                "description": "",
+                "operationId": "fail",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be failed",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "optional map of output variables",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/tasks/{tInstanceId}/states/skipped": {
+            "put": {
+                "tags": ["User task operations and queries :: BPM"],
+                "summary": "Skips task with given id that belongs to given container",
+                "description": "",
+                "operationId": "skip",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that should be skipped",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "user",
+                    "in": "query",
+                    "description": "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled",
+                    "required": false,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task with given id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieves all nodes from process instance and container",
+                "description": "",
+                "operationId": "getNodes",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that process nodes should be collected from",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/process-node-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances/{nodeInstanceId}": {
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retriggers given node instance within process instance and container",
+                "description": "",
+                "operationId": "retriggerNodeInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that node instance belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "nodeInstanceId",
+                    "in": "path",
+                    "description": "identifier of node instance that should be retriggered",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, node instance or Container Id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Cancels given node instance within process instance and container",
+                "description": "",
+                "operationId": "cancelNodeInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that node instance belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "nodeInstanceId",
+                    "in": "path",
+                    "description": "identifier of node instance that should be canceled",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, node instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieves all active node instances from process instance and container",
+                "description": "",
+                "operationId": "getActiveNodeInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that active nodes instances should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/timers/{timerId}": {
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Updates timer instance within process instance and container",
+                "description": "",
+                "operationId": "updateTimer",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that timer belongs to",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "timerId",
+                    "in": "path",
+                    "description": "identifier of timer instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "relative",
+                    "in": "query",
+                    "description": "optional flag that indicates if the time expression is relative to the current date or not, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "Map of timer expressions - deplay, perios and repeat are allowed values in the map",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, node instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/timers": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieves all active timer instance from process instance and container",
+                "description": "",
+                "operationId": "getTimerInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that timer instances should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/timer-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes/{nodeId}": {
+            "post": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Triggers node within process instance and container",
+                "description": "",
+                "operationId": "triggerNode",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance where node should be triggered",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "nodeId",
+                    "in": "path",
+                    "description": "identifier of the node to be triggered",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, node instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/errors/{errorId}": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieve execution error by its identifier",
+                "description": "",
+                "operationId": "getExecutionErrorById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process error belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "path",
+                    "description": "identifier of error to be loaded",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/execution-error"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Acknowledge execution error by given id",
+                "description": "",
+                "operationId": "acknowledgeError",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that error belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "path",
+                    "description": "identifier of error to be acknowledged",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Execution error or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}": {
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Migrates process instance to new container and process definition with optional node mapping",
+                "description": "",
+                "operationId": "migrateProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance to be migrated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "targetContainerId",
+                    "in": "query",
+                    "description": "container id that new process definition belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "targetProcessId",
+                    "in": "query",
+                    "description": "process definition that process instance should be migrated to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "node mapping - unique ids of old definition to new definition given as Map",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/migration-report-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances": {
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Migrates process instances to new container and process definition with optional node mapping",
+                "description": "",
+                "operationId": "migrateProcessInstances",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instances belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "query",
+                    "description": "list of identifiers of process instance to be migrated",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "collectionFormat": "multi"
+                }, {
+                    "name": "targetContainerId",
+                    "in": "query",
+                    "description": "container id that new process definition belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "targetProcessId",
+                    "in": "query",
+                    "description": "process definition that process instances should be migrated to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "node mapping - unique ids of old definition to new definition given as Map",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/migration-report-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/errors": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieves execution errors for container, applies pagination",
+                "description": "",
+                "operationId": "getExecutionErrors",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that errors belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "includeAck",
+                    "in": "query",
+                    "description": "optional flag that indicates if acknowledged errors should also be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/node-instance-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance or Container Id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Acknowledges given execution errors",
+                "description": "",
+                "operationId": "acknowledgeErrors",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that errors belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "query",
+                    "description": "list of error identifiers to be acknowledged",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Execution error or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/processes/instances/{pInstanceId}/errors": {
+            "get": {
+                "tags": ["Process instances administration :: BPM"],
+                "summary": "Retrieves execution errors for process instance and container, applies pagination",
+                "description": "",
+                "operationId": "getExecutionErrorsByProcessInstance",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of process instance that errors should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "includeAck",
+                    "in": "query",
+                    "description": "optional flag that indicates if acknowledged errors should also be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "node",
+                    "in": "query",
+                    "description": "optional name of the node in the process instance to filter by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/execution-error-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/errors/{errorId}": {
+            "get": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Retrieve execution error by its identifier",
+                "description": "",
+                "operationId": "getExecutionErrorById",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that error belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "path",
+                    "description": "identifier of the execution error to load",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/execution-error"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Acknowledges given execution error",
+                "description": "",
+                "operationId": "acknowledgeError",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that error belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "path",
+                    "description": "identifier of the execution error to be acknowledged",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners": {
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Adds potential owners to given task instance, optionally removing existing ones",
+                "description": "",
+                "operationId": "addPotentialOwners",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "remove",
+                    "in": "query",
+                    "description": "optional flag that indicates if existing potential owners should be removed, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "list of users/groups to be added as potential owners, as OrgEntities type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners": {
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Adds excluded owners to given task instance, optionally removing existing ones",
+                "description": "",
+                "operationId": "addExcludedOwners",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "remove",
+                    "in": "query",
+                    "description": "optional flag that indicates if existing excluded owners should be removed, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "list of users/groups to be added as excluded owners, as OrgEntities type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/contents/input": {
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Adds task inputs to given task instance",
+                "description": "",
+                "operationId": "addTaskInputs",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "map of data to be set as task inputs, as Map",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes task inputs referenced by names from given task instance",
+                "description": "",
+                "operationId": "removeTaskInputs",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "one or more names of task inputs to be removed",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/contents/output": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes task outputs referenced by names from given task instance",
+                "description": "",
+                "operationId": "removeTaskOutputs",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "one or more names of task outputs to be removed",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/reassignments": {
+            "get": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Retrieves reassignments for given task",
+                "description": "",
+                "operationId": "getTaskReassignments",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "activeOnly",
+                    "in": "query",
+                    "description": "optional flag that indicates if active only reassignmnets should be collected, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-reassignment-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Schedules new reassign of given task instance",
+                "description": "",
+                "operationId": "reassign",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "expiresAt",
+                    "in": "query",
+                    "description": "time expression for reassignmnet",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "whenNotStarted",
+                    "in": "query",
+                    "description": "optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "whenNotCompleted",
+                    "in": "query",
+                    "description": "optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "list of users/groups that task should be reassined to, as OrgEntities type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/notifications": {
+            "get": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Retrieves notifications for given task",
+                "description": "",
+                "operationId": "getTaskNotifications",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "activeOnly",
+                    "in": "query",
+                    "description": "optional flag that indicates if active only notifications should be collected, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/task-notification-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            },
+            "post": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Schedules new notification for given task instance",
+                "description": "",
+                "operationId": "notify",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "expiresAt",
+                    "in": "query",
+                    "description": "time expression for notification",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "whenNotStarted",
+                    "in": "query",
+                    "description": "optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "whenNotCompleted",
+                    "in": "query",
+                    "description": "optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "email notification details, as EmailNotification type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/notifications/{notificationId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Cancels notification for given task instance",
+                "description": "",
+                "operationId": "cancelNotification",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "notificationId",
+                    "in": "path",
+                    "description": "identifier of notification to be canceled",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/reassignments/{reassignmentId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Cancels reassignment for given task instance",
+                "description": "",
+                "operationId": "cancelReassignment",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "reassignmentId",
+                    "in": "path",
+                    "description": "identifier of reassignment to be canceled",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/errors": {
+            "get": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Retrieves execution errors for container, allows to filter by task name and/or process id, applies pagination",
+                "description": "",
+                "operationId": "getExecutionErrors",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "includeAck",
+                    "in": "query",
+                    "description": "optional flag that indicates if acknowledged errors should also be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "optional name of the task to filter by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "process",
+                    "in": "query",
+                    "description": "optional process id that the task belongs to to filter by",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/execution-error-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container Id not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Acknowledges given execution errors",
+                "description": "",
+                "operationId": "acknowledgeErrors",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that errors belong to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "errorId",
+                    "in": "query",
+                    "description": "list of identifiers of execution errors to be acknowledged",
+                    "required": true,
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "collectionFormat": "multi"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/admins/users/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes business admins from given task instance",
+                "description": "",
+                "operationId": "removeAdminsUsers",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of users to be removed from business admin list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/groups/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes potential owner groups from given task instance",
+                "description": "",
+                "operationId": "removePotentialOwnersGroups",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of groups to be removed from potantial owners list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/groups/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes excluded owners groups from given task instance",
+                "description": "",
+                "operationId": "removeExcludedOwnersGroups",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of groups to be removed from excluded owners list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/admins/groups/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes business admin groups from given task instance",
+                "description": "",
+                "operationId": "removeAdminsGroups",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of groups to be removed from business admin list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/admins": {
+            "put": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Adds business admins to given task instance, optionally removing existing ones",
+                "description": "",
+                "operationId": "addAdmins",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "remove",
+                    "in": "query",
+                    "description": "optional flag that indicates if existing business admins should be removed, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "list of users/groups to be added as business admins, as OrgEntities type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/users/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes potential owners from given task instance",
+                "description": "",
+                "operationId": "removePotentialOwnersUsers",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of users to be removed from potantial owners list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/users/{entityId}": {
+            "delete": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Removes excluded owners from given task instance",
+                "description": "",
+                "operationId": "removeExcludedOwnersUsers",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance to be updated",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "entityId",
+                    "in": "path",
+                    "description": "list of users to be removed from excluded owners list",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task instance or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/admin/containers/{id}/tasks/{tInstanceId}/errors": {
+            "get": {
+                "tags": ["User tasks administration :: BPM"],
+                "summary": "Retrieves execution errors for task instance and container, applies pagination",
+                "description": "",
+                "operationId": "getExecutionErrorsByTask",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of the task instance that errors should be collected for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "includeAck",
+                    "in": "query",
+                    "description": "optional flag that indicates if acknowledged errors should also be collected, defaults to false",
+                    "required": false,
+                    "type": "boolean",
+                    "default": false
+                }, {
+                    "name": "page",
+                    "in": "query",
+                    "description": "optional pagination - at which page to start, defaults to 0 (meaning first)",
+                    "required": false,
+                    "type": "integer",
+                    "default": 0,
+                    "format": "int32"
+                }, {
+                    "name": "pageSize",
+                    "in": "query",
+                    "description": "optional pagination - size of the result, defaults to 10",
+                    "required": false,
+                    "type": "integer",
+                    "default": 10,
+                    "format": "int32"
+                }, {
+                    "name": "sort",
+                    "in": "query",
+                    "description": "optional sort column, no default",
+                    "required": false,
+                    "type": "string"
+                }, {
+                    "name": "sortOrder",
+                    "in": "query",
+                    "description": "optional sort direction (asc, desc) - defaults to asc",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/execution-error-list"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/forms/tasks/{tInstanceId}": {
+            "get": {
+                "tags": ["Process and task forms :: BPM"],
+                "summary": "Retrieves form for task instance within a container",
+                "description": "",
+                "operationId": "getTaskForm",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that task instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "tInstanceId",
+                    "in": "path",
+                    "description": "identifier of task instance that form should be fetched for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }, {
+                    "name": "lang",
+                    "in": "query",
+                    "description": "optional language that the form should be found for",
+                    "required": false,
+                    "type": "string",
+                    "default": "en"
+                }, {
+                    "name": "filter",
+                    "in": "query",
+                    "description": "optional filter flag if form should be filtered or returned as is",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "type",
+                    "in": "query",
+                    "description": "optional type of the form, defaults to ANY so system will find the most current one",
+                    "required": false,
+                    "type": "string",
+                    "default": "ANY"
+                }, {
+                    "name": "marshallContent",
+                    "in": "query",
+                    "description": "optional marshall content flag if the content should be transformed or not, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Task, form or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/forms/processes/{pId}": {
+            "get": {
+                "tags": ["Process and task forms :: BPM"],
+                "summary": "Retrieves form for process definition within a container",
+                "description": "",
+                "operationId": "getProcessForm",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process definition belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "identifier of process definition that form should be fetched for",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "lang",
+                    "in": "query",
+                    "description": "optional language that the form should be found for",
+                    "required": false,
+                    "type": "string",
+                    "default": "en"
+                }, {
+                    "name": "filter",
+                    "in": "query",
+                    "description": "optional filter flag if form should be filtered or returned as is",
+                    "required": false,
+                    "type": "boolean"
+                }, {
+                    "name": "type",
+                    "in": "query",
+                    "description": "optional type of the form, defaults to ANY so system will find the most current one",
+                    "required": false,
+                    "type": "string",
+                    "default": "ANY"
+                }, {
+                    "name": "marshallContent",
+                    "in": "query",
+                    "description": "optional marshall content flag if the content should be transformed or not, defaults to true",
+                    "required": false,
+                    "type": "boolean",
+                    "default": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process definition, form or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/images/processes/instances/{pInstanceId}": {
+            "get": {
+                "tags": ["Process definition and instance images :: BPM"],
+                "summary": "Retrieves process instance image",
+                "description": "",
+                "operationId": "getProcessInstanceImage",
+                "produces": ["application/svg+xml"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process instance belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pInstanceId",
+                    "in": "path",
+                    "description": "identifier of the process instance that image should be loaded for",
+                    "required": true,
+                    "type": "integer",
+                    "format": "int64"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process instance, image or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/images/processes/{pId}": {
+            "get": {
+                "tags": ["Process definition and instance images :: BPM"],
+                "summary": "Retrieves process definition image",
+                "description": "",
+                "operationId": "getProcessImage",
+                "produces": ["application/svg+xml"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id that process definition belongs to",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "pId",
+                    "in": "path",
+                    "description": "identifier of the process definition that image should be loaded for",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Process definition, image or Container Id not found"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}/problemfactchanges/processed": {
+            "get": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Retrieves status if problem fact changes have been processed in given solver",
+                "description": "",
+                "operationId": "isEveryProblemFactChangeProcessed",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}/state/solving": {
+            "post": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Solves given planning problem with given solver",
+                "description": "",
+                "operationId": "solvePlanningProblem",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "planning problem",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}/state/terminating-early": {
+            "post": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Terminates early running solver with given id within container",
+                "description": "",
+                "operationId": "terminateSolverEarly",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "400": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}/problemfactchanges": {
+            "post": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Adds problem fact changes to given solver",
+                "description": "",
+                "operationId": "addProblemFactChanges",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "Problem fact changes, either single one or a list of them",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "400": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}": {
+            "get": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Retrieves solver by its identifier from given container",
+                "description": "",
+                "operationId": "getSolver",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/solver-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Creates solver within given container",
+                "description": "",
+                "operationId": "createSolver",
+                "consumes": ["application/xml", "application/json"],
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver config resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver to create",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "in": "body",
+                    "name": "body",
+                    "description": "solver instance details as SolverInstance type",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/solver-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "400": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Disposes given solver",
+                "description": "",
+                "operationId": "disposeSolver",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers": {
+            "get": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Retrieves solvers from given container",
+                "description": "",
+                "operationId": "getSolvers",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solvers reside",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/solvers"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        },
+        "/server/containers/{id}/solvers/{solverId}/bestsolution": {
+            "get": {
+                "tags": ["Planning and solvers :: BRP"],
+                "summary": "Retrieves best solution from solver within container",
+                "description": "",
+                "operationId": "getSolverWithBestSolution",
+                "produces": ["application/xml", "application/json"],
+                "parameters": [{
+                    "name": "id",
+                    "in": "path",
+                    "description": "container id where the solver resides",
+                    "required": true,
+                    "type": "string"
+                }, {
+                    "name": "solverId",
+                    "in": "path",
+                    "description": "identifier of the solver",
+                    "required": true,
+                    "type": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/solver-instance"
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected error"
+                    },
+                    "404": {
+                        "description": "Container does not exist or failure in creating solver"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "case-adhoc-fragment": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "case-adhoc-fragment"
+            }
+        },
+        "case-file": {
+            "type": "object",
+            "properties": {
+                "case-data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                },
+                "case-user-assignments": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "case-group-assignments": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "case-data-restrictions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-file"
+            }
+        },
+        "case-instance": {
+            "type": "object",
+            "properties": {
+                "case-id": {
+                    "type": "string"
+                },
+                "case-description": {
+                    "type": "string"
+                },
+                "case-owner": {
+                    "type": "string"
+                },
+                "case-status": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "case-definition-id": {
+                    "type": "string"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "case-started-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "case-completed-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "case-completion-msg": {
+                    "type": "string"
+                },
+                "case-file": {
+                    "$ref": "#/definitions/case-file"
+                },
+                "case-milestones": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "case-milestones"
+                        },
+                        "$ref": "#/definitions/case-milestone"
+                    }
+                },
+                "case-stages": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "case-stages"
+                        },
+                        "$ref": "#/definitions/case-stage"
+                    }
+                },
+                "case-roles": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "case-roles"
+                        },
+                        "$ref": "#/definitions/case-role-assignment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-instance"
+            }
+        },
+        "case-instance-list": {
+            "type": "object",
+            "properties": {
+                "instances": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "instances"
+                        },
+                        "$ref": "#/definitions/case-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-instance-list"
+            }
+        },
+        "case-milestone": {
+            "type": "object",
+            "properties": {
+                "milestone-name": {
+                    "type": "string"
+                },
+                "milestone-id": {
+                    "type": "string"
+                },
+                "milestone-achieved": {
+                    "type": "boolean"
+                },
+                "milestone-achieved-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "milestone-status": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "case-milestone"
+            }
+        },
+        "case-role-assignment": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "users"
+                        }
+                    }
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "groups"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-role-assignment"
+            }
+        },
+        "case-stage": {
+            "type": "object",
+            "properties": {
+                "stage-name": {
+                    "type": "string"
+                },
+                "stage-id": {
+                    "type": "string"
+                },
+                "stage-status": {
+                    "type": "string"
+                },
+                "adhoc-fragments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "adhoc-fragments"
+                        },
+                        "$ref": "#/definitions/case-adhoc-fragment"
+                    }
+                },
+                "active-nodes": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "active-nodes"
+                        },
+                        "$ref": "#/definitions/node-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-stage"
+            }
+        },
+        "node-instance": {
+            "type": "object",
+            "properties": {
+                "node-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "node-name": {
+                    "type": "string"
+                },
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "work-item-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "start-date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "node-id": {
+                    "type": "string"
+                },
+                "node-type": {
+                    "type": "string"
+                },
+                "node-connection": {
+                    "type": "string"
+                },
+                "node-completed": {
+                    "type": "boolean"
+                },
+                "reference-id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "xml": {
+                "name": "node-instance"
+            }
+        },
+        "case-milestone-list": {
+            "type": "object",
+            "properties": {
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "milestones"
+                        },
+                        "$ref": "#/definitions/case-milestone"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-milestone-list"
+            }
+        },
+        "case-stage-list": {
+            "type": "object",
+            "properties": {
+                "stages": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "stages"
+                        },
+                        "$ref": "#/definitions/case-stage"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-stage-list"
+            }
+        },
+        "case-adhoc-fragment-list": {
+            "type": "object",
+            "properties": {
+                "fragments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "fragments"
+                        },
+                        "$ref": "#/definitions/case-adhoc-fragment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-adhoc-fragment-list"
+            }
+        },
+        "process-instance": {
+            "type": "object",
+            "properties": {
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "process-id": {
+                    "type": "string"
+                },
+                "process-name": {
+                    "type": "string"
+                },
+                "process-version": {
+                    "type": "string"
+                },
+                "process-instance-state": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "initiator": {
+                    "type": "string"
+                },
+                "start-date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "process-instance-desc": {
+                    "type": "string"
+                },
+                "correlation-key": {
+                    "type": "string"
+                },
+                "parent-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "active-user-tasks": {
+                    "$ref": "#/definitions/task-summary-list"
+                },
+                "process-instance-variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-instance"
+            }
+        },
+        "process-instance-list": {
+            "type": "object",
+            "properties": {
+                "process-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "process-instance"
+                        },
+                        "$ref": "#/definitions/process-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-instance-list"
+            }
+        },
+        "task-summary": {
+            "type": "object",
+            "properties": {
+                "task-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-name": {
+                    "type": "string"
+                },
+                "task-subject": {
+                    "type": "string"
+                },
+                "task-description": {
+                    "type": "string"
+                },
+                "task-status": {
+                    "type": "string"
+                },
+                "task-priority": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "task-is-skipable": {
+                    "type": "boolean"
+                },
+                "task-actual-owner": {
+                    "type": "string"
+                },
+                "task-created-by": {
+                    "type": "string"
+                },
+                "task-created-on": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-activation-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-expiration-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-proc-inst-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-proc-def-id": {
+                    "type": "string"
+                },
+                "task-container-id": {
+                    "type": "string"
+                },
+                "task-parent-id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "xml": {
+                "name": "task-summary"
+            }
+        },
+        "task-summary-list": {
+            "type": "object",
+            "properties": {
+                "task-summary": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-summary"
+                        },
+                        "$ref": "#/definitions/task-summary"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-summary-list"
+            }
+        },
+        "node-instance-list": {
+            "type": "object",
+            "properties": {
+                "node-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "node-instance"
+                        },
+                        "$ref": "#/definitions/node-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "node-instance-list"
+            }
+        },
+        "case-role-assignment-list": {
+            "type": "object",
+            "properties": {
+                "role-assignments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "role-assignments"
+                        },
+                        "$ref": "#/definitions/case-role-assignment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-role-assignment-list"
+            }
+        },
+        "case-comment": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "author": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "added-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "restricted-to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "restricted-to"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-comment"
+            }
+        },
+        "case-comment-list": {
+            "type": "object",
+            "properties": {
+                "comments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "comments"
+                        },
+                        "$ref": "#/definitions/case-comment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-comment-list"
+            }
+        },
+        "case-definition": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "case-id-prefix": {
+                    "type": "string"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "adhoc-fragments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "adhoc-fragments"
+                        },
+                        "$ref": "#/definitions/case-adhoc-fragment"
+                    }
+                },
+                "roles": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "milestones"
+                        },
+                        "$ref": "#/definitions/case-milestone-def"
+                    }
+                },
+                "stages": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "stages"
+                        },
+                        "$ref": "#/definitions/case-stage-def"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-definition"
+            }
+        },
+        "case-milestone-def": {
+            "type": "object",
+            "properties": {
+                "milestone-name": {
+                    "type": "string"
+                },
+                "milestone-id": {
+                    "type": "string"
+                },
+                "milestone-mandatory": {
+                    "type": "boolean"
+                }
+            },
+            "xml": {
+                "name": "case-milestone-def"
+            }
+        },
+        "case-stage-def": {
+            "type": "object",
+            "properties": {
+                "stage-name": {
+                    "type": "string"
+                },
+                "stage-id": {
+                    "type": "string"
+                },
+                "adhoc-fragments": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "adhoc-fragments"
+                        },
+                        "$ref": "#/definitions/case-adhoc-fragment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-stage-def"
+            }
+        },
+        "case-definition-list": {
+            "type": "object",
+            "properties": {
+                "definitions": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "definitions"
+                        },
+                        "$ref": "#/definitions/case-definition"
+                    }
+                }
+            },
+            "xml": {
+                "name": "case-definition-list"
+            }
+        },
+        "response": {
+            "type": "object",
+            "xml": {
+                "name": "response"
+            }
+        },
+        "responses": {
+            "type": "object",
+            "properties": {
+                "response": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "response"
+                        },
+                        "$ref": "#/definitions/response"
+                    }
+                }
+            },
+            "xml": {
+                "name": "responses"
+            }
+        },
+        "process-variables": {
+            "type": "object",
+            "properties": {
+                "variables": {
+                    "type": "object",
+                    "xml": {
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-variables"
+            }
+        },
+        "process-service-tasks": {
+            "type": "object",
+            "properties": {
+                "serviceTasks": {
+                    "type": "object",
+                    "xml": {
+                        "name": "tasks",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-service-tasks"
+            }
+        },
+        "process-associated-entities": {
+            "type": "object",
+            "properties": {
+                "associatedEntities": {
+                    "type": "object",
+                    "xml": {
+                        "name": "associated-entities",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-associated-entities"
+            }
+        },
+        "user-task-definition": {
+            "type": "object",
+            "properties": {
+                "associatedEntities": {
+                    "type": "array",
+                    "xml": {
+                        "name": "associated-entities",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "taskInputMappings": {
+                    "type": "object",
+                    "xml": {
+                        "name": "task-inputs",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "taskOutputMappings": {
+                    "type": "object",
+                    "xml": {
+                        "name": "task-outputs",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "task-id": {
+                    "type": "string"
+                },
+                "task-name": {
+                    "type": "string"
+                },
+                "task-priority": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "task-comment": {
+                    "type": "string"
+                },
+                "task-created-by": {
+                    "type": "string"
+                },
+                "task-skippable": {
+                    "type": "boolean"
+                },
+                "task-form-name": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "user-task-definition"
+            }
+        },
+        "user-task-definitions": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task"
+                        },
+                        "$ref": "#/definitions/user-task-definition"
+                    }
+                }
+            },
+            "xml": {
+                "name": "user-task-definitions"
+            }
+        },
+        "process-task-inputs": {
+            "type": "object",
+            "properties": {
+                "taskInputs": {
+                    "type": "object",
+                    "xml": {
+                        "name": "inputs",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-task-inputs"
+            }
+        },
+        "process-definition": {
+            "type": "object",
+            "properties": {
+                "associatedEntities": {
+                    "type": "object",
+                    "xml": {
+                        "name": "associated-entities",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceTasks": {
+                    "type": "object",
+                    "xml": {
+                        "name": "service-tasks",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "processVariables": {
+                    "type": "object",
+                    "xml": {
+                        "name": "process-variables",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "reusableSubProcesses": {
+                    "type": "array",
+                    "xml": {
+                        "name": "process-subprocesses",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "process-id": {
+                    "type": "string"
+                },
+                "process-name": {
+                    "type": "string"
+                },
+                "process-version": {
+                    "type": "string"
+                },
+                "package": {
+                    "type": "string"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "dynamic": {
+                    "type": "boolean"
+                }
+            },
+            "xml": {
+                "name": "process-definition"
+            }
+        },
+        "process-subprocesses": {
+            "type": "object",
+            "properties": {
+                "subProcesses": {
+                    "type": "array",
+                    "xml": {
+                        "name": "subprocesses",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-subprocesses"
+            }
+        },
+        "process-task-outputs": {
+            "type": "object",
+            "properties": {
+                "taskOutputs": {
+                    "type": "object",
+                    "xml": {
+                        "name": "outputs",
+                        "wrapped": true
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-task-outputs"
+            }
+        },
+        "document-instance": {
+            "type": "object",
+            "properties": {
+                "document-id": {
+                    "type": "string"
+                },
+                "document-name": {
+                    "type": "string"
+                },
+                "document-link": {
+                    "type": "string"
+                },
+                "document-size": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "document-last-mod": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "document-content": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "byte",
+                        "xml": {
+                            "name": "document-content"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "document-instance"
+            }
+        },
+        "document-instance-list": {
+            "type": "object",
+            "properties": {
+                "document-instances": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "document-instances"
+                        },
+                        "$ref": "#/definitions/document-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "document-instance-list"
+            }
+        },
+        "error-info-instance": {
+            "type": "object",
+            "properties": {
+                "error-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "request-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "error-message": {
+                    "type": "string"
+                },
+                "error-stacktrace": {
+                    "type": "string"
+                },
+                "error-date": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "xml": {
+                "name": "error-info-instance"
+            }
+        },
+        "error-info-instance-list": {
+            "type": "object",
+            "properties": {
+                "error-info-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "error-info-instance"
+                        },
+                        "$ref": "#/definitions/error-info-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "error-info-instance-list"
+            }
+        },
+        "request-info-instance": {
+            "type": "object",
+            "properties": {
+                "request-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "request-status": {
+                    "type": "string"
+                },
+                "request-business-key": {
+                    "type": "string"
+                },
+                "request-message": {
+                    "type": "string"
+                },
+                "request-retries": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "request-executions": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "request-command": {
+                    "type": "string"
+                },
+                "request-scheduled-date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "request-data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                },
+                "response-data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                },
+                "request-errors": {
+                    "$ref": "#/definitions/error-info-instance-list"
+                },
+                "request-container-id": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "request-info-instance"
+            }
+        },
+        "request-info-instance-list": {
+            "type": "object",
+            "properties": {
+                "request-info-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "request-info-instance"
+                        },
+                        "$ref": "#/definitions/request-info-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "request-info-instance-list"
+            }
+        },
+        "work-item-instance": {
+            "type": "object",
+            "properties": {
+                "work-item-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "work-item-name": {
+                    "type": "string"
+                },
+                "work-item-state": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "work-item-params": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                },
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "node-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "node-id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "xml": {
+                "name": "work-item-instance"
+            }
+        },
+        "work-item-instance-list": {
+            "type": "object",
+            "properties": {
+                "work-item-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "work-item-instance"
+                        },
+                        "$ref": "#/definitions/work-item-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "work-item-instance-list"
+            }
+        },
+        "variable-instance": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "old-value": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "modification-date": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "xml": {
+                "name": "variable-instance"
+            }
+        },
+        "variable-instance-list": {
+            "type": "object",
+            "properties": {
+                "variable-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "variable-instance"
+                        },
+                        "$ref": "#/definitions/variable-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "variable-instance-list"
+            }
+        },
+        "process-definitions": {
+            "type": "object",
+            "properties": {
+                "processes": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "processes"
+                        },
+                        "$ref": "#/definitions/process-definition"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-definitions"
+            }
+        },
+        "query-definition": {
+            "type": "object",
+            "properties": {
+                "query-name": {
+                    "type": "string"
+                },
+                "query-source": {
+                    "type": "string"
+                },
+                "query-expression": {
+                    "type": "string"
+                },
+                "query-target": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "query-definition"
+            }
+        },
+        "query-definitions": {
+            "type": "object",
+            "properties": {
+                "queries": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "queries"
+                        },
+                        "$ref": "#/definitions/query-definition"
+                    }
+                }
+            },
+            "xml": {
+                "name": "query-definitions"
+            }
+        },
+        "task-event-instance": {
+            "type": "object",
+            "properties": {
+                "task-event-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-event-type": {
+                    "type": "string"
+                },
+                "task-event-user": {
+                    "type": "string"
+                },
+                "task-event-date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-work-item-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-event-message": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "task-event-instance"
+            }
+        },
+        "task-event-instance-list": {
+            "type": "object",
+            "properties": {
+                "task-event-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-event-instance"
+                        },
+                        "$ref": "#/definitions/task-event-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-event-instance-list"
+            }
+        },
+        "task-instance": {
+            "type": "object",
+            "properties": {
+                "task-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-priority": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "task-name": {
+                    "type": "string"
+                },
+                "task-subject": {
+                    "type": "string"
+                },
+                "task-description": {
+                    "type": "string"
+                },
+                "task-type": {
+                    "type": "string"
+                },
+                "task-form": {
+                    "type": "string"
+                },
+                "task-status": {
+                    "type": "string"
+                },
+                "task-actual-owner": {
+                    "type": "string"
+                },
+                "task-created-by": {
+                    "type": "string"
+                },
+                "task-created-on": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-activation-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-expiration-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-skippable": {
+                    "type": "boolean"
+                },
+                "task-workitem-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-parent-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "task-process-id": {
+                    "type": "string"
+                },
+                "task-container-id": {
+                    "type": "string"
+                },
+                "task-last-modification-user": {
+                    "type": "string"
+                },
+                "task-last-modificaiton-date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "task-correlation-key": {
+                    "type": "string"
+                },
+                "task-pot-owners": {
+                    "type": "array",
+                    "xml": {
+                        "name": "potential-owners",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "task-pot-owners"
+                        }
+                    }
+                },
+                "task-excl-owners": {
+                    "type": "array",
+                    "xml": {
+                        "name": "excluded-owners",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "task-excl-owners"
+                        }
+                    }
+                },
+                "task-business-admins": {
+                    "type": "array",
+                    "xml": {
+                        "name": "business-admins",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "task-business-admins"
+                        }
+                    }
+                },
+                "task-input-data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                },
+                "task-output-data": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-instance"
+            }
+        },
+        "task-attachment": {
+            "type": "object",
+            "properties": {
+                "attachment-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "attachment-name": {
+                    "type": "string"
+                },
+                "attachment-added-by": {
+                    "type": "string"
+                },
+                "attachment-added-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "attachment-type": {
+                    "type": "string"
+                },
+                "attachment-size": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "attachment-content-id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "xml": {
+                "name": "task-attachment"
+            }
+        },
+        "task-attachment-list": {
+            "type": "object",
+            "properties": {
+                "task-attachment": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-attachment"
+                        },
+                        "$ref": "#/definitions/task-attachment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-attachment-list"
+            }
+        },
+        "task-comment": {
+            "type": "object",
+            "properties": {
+                "comment-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "comment-added-by": {
+                    "type": "string"
+                },
+                "comment-added-at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "xml": {
+                "name": "task-comment"
+            }
+        },
+        "task-comment-list": {
+            "type": "object",
+            "properties": {
+                "task-comment": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-comment"
+                        },
+                        "$ref": "#/definitions/task-comment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-comment-list"
+            }
+        },
+        "process-node": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "process-id": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "process-node"
+            }
+        },
+        "process-node-list": {
+            "type": "object",
+            "properties": {
+                "process-node": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "process-node"
+                        },
+                        "$ref": "#/definitions/process-node"
+                    }
+                }
+            },
+            "xml": {
+                "name": "process-node-list"
+            }
+        },
+        "timer-instance": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "activation-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "last-fire-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "next-fire-time": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "delay": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "period": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "repeat-limit": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "session-id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "xml": {
+                "name": "timer-instance"
+            }
+        },
+        "timer-instance-list": {
+            "type": "object",
+            "properties": {
+                "timer-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "timer-instance"
+                        },
+                        "$ref": "#/definitions/timer-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "timer-instance-list"
+            }
+        },
+        "migration-report-instance": {
+            "type": "object",
+            "properties": {
+                "migration-successful": {
+                    "type": "boolean"
+                },
+                "migration-start": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "migration-end": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "migration-logs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "migration-logs"
+                        }
+                    }
+                }
+            },
+            "xml": {
+                "name": "migration-report-instance"
+            }
+        },
+        "migration-report-instance-list": {
+            "type": "object",
+            "properties": {
+                "migration-report-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "migration-report-instance"
+                        },
+                        "$ref": "#/definitions/migration-report-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "migration-report-instance-list"
+            }
+        },
+        "execution-error": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "container-id": {
+                    "type": "string"
+                },
+                "process-instance-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "process-id": {
+                    "type": "string"
+                },
+                "activity-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "activity-name": {
+                    "type": "string"
+                },
+                "job-id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "error-msg": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "acknowledged": {
+                    "type": "boolean"
+                },
+                "acknowledged-by": {
+                    "type": "string"
+                },
+                "acknowledged-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "error-date": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "xml": {
+                "name": "execution-error"
+            }
+        },
+        "execution-error-list": {
+            "type": "object",
+            "properties": {
+                "error-instance": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "error-instance"
+                        },
+                        "$ref": "#/definitions/execution-error"
+                    }
+                }
+            },
+            "xml": {
+                "name": "execution-error-list"
+            }
+        },
+        "task-reassignment": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "reassign-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "users"
+                        }
+                    }
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "groups"
+                        }
+                    }
+                },
+                "active": {
+                    "type": "boolean"
+                }
+            },
+            "xml": {
+                "name": "task-reassignment"
+            }
+        },
+        "task-reassignment-list": {
+            "type": "object",
+            "properties": {
+                "task-reassignment": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-reassignment"
+                        },
+                        "$ref": "#/definitions/task-reassignment"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-reassignment-list"
+            }
+        },
+        "task-notification": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notify-at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "users"
+                        }
+                    }
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "xml": {
+                            "name": "groups"
+                        }
+                    }
+                },
+                "active": {
+                    "type": "boolean"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "task-notification"
+            }
+        },
+        "task-notification-list": {
+            "type": "object",
+            "properties": {
+                "task-notification": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "task-notification"
+                        },
+                        "$ref": "#/definitions/task-notification"
+                    }
+                }
+            },
+            "xml": {
+                "name": "task-notification-list"
+            }
+        },
+        "ScoreWrapper": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "solver-instance": {
+            "type": "object",
+            "properties": {
+                "container-id": {
+                    "type": "string"
+                },
+                "solver-id": {
+                    "type": "string"
+                },
+                "solver-config-file": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["NOT_SOLVING", "TERMINATING_EARLY", "SOLVING"]
+                },
+                "score": {
+                    "$ref": "#/definitions/ScoreWrapper"
+                },
+                "best-solution": {
+                    "type": "object"
+                }
+            },
+            "xml": {
+                "name": "solver-instance"
+            }
+        },
+        "solvers": {
+            "type": "object",
+            "properties": {
+                "solver": {
+                    "type": "array",
+                    "items": {
+                        "xml": {
+                            "name": "solver"
+                        },
+                        "$ref": "#/definitions/solver-instance"
+                    }
+                }
+            },
+            "xml": {
+                "name": "solvers"
+            }
+        }
+    }
+}

--- a/app/server/connector-generator/src/test/resources/swagger/kie-server.unified_connector.json
+++ b/app/server/connector-generator/src/test/resources/swagger/kie-server.unified_connector.json
@@ -1,0 +1,7681 @@
+{
+  "connectorGroup": {
+    "id": "swagger-connector-template"
+  },
+  "connectorGroupId": "swagger-connector-template",
+  "description": "All endpoints that can be used with the Kie Server",
+  "version": 1,
+  "actions": [
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstances",
+      "name": "Retrieves case instances without authntication checks and applies pagination",
+      "description": "Send GET request to /server/admin/cases/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstances"
+        }
+      },
+      "tags": [
+        "Administration of cases :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:cancelRequest",
+      "name": "Cancels active asynchronous job identified by given jobId",
+      "description": "Send DELETE request to /server/jobs/{jobId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be canceled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "cancelRequest"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:requeueRequest",
+      "name": "Requeues failed asynchronous job identified by given jobId",
+      "description": "Send PUT request to /server/jobs/{jobId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be requeued\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "requeueRequest"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestById",
+      "name": "Retrieves asynchronous job by given jobId",
+      "description": "Send GET request to /server/jobs/{jobId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be retrieved\"},\"withErrors\":{\"type\":\"boolean\",\"title\":\"withErrors\",\"description\":\"optional flag that indicats if errors should be loaded as well\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag that indicats if input/output data should be loaded as well\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestById"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestsByBusinessKey",
+      "name": "Retrieves asynchronous jobs by business key",
+      "description": "Send GET request to /server/jobs/keys/{key}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\",\"title\":\"key\",\"description\":\"identifier of the business key that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance-list\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}}},\"xml\":{\"name\":\"request-info-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestsByBusinessKey"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestsByCommand",
+      "name": "Retrieves asynchronous jobs by command",
+      "description": "Send GET request to /server/jobs/commands/{cmd}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"cmd\":{\"type\":\"string\",\"title\":\"cmd\",\"description\":\"name of the command that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance-list\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}}},\"xml\":{\"name\":\"request-info-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestsByCommand"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestsByContainer",
+      "name": "Retrieves asynchronous jobs by container",
+      "description": "Send GET request to /server/jobs/containers/{id}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"identifier of the container that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance-list\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}}},\"xml\":{\"name\":\"request-info-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestsByContainer"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestsByProcessInstance",
+      "name": "Retrieves asynchronous jobs by process instance id",
+      "description": "Send GET request to /server/jobs/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance-list\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}}},\"xml\":{\"name\":\"request-info-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestsByProcessInstance"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getRequestsByStatus",
+      "name": "Retrieves asynchronous jobs filtered by status",
+      "description": "Send GET request to /server/jobs",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"request-info-instance-list\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}}}},\"xml\":{\"name\":\"request-info-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getRequestsByStatus"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:scheduleRequest",
+      "name": "Schedules new asynchronous job based on given body",
+      "description": "Send POST request to /server/jobs",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "scheduleRequest"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateRequestData",
+      "name": "Updates active asynchronous job's data (identified by given jobId)",
+      "description": "Send POST request to /server/jobs/{jobId}/data",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be updated\"},\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "updateRequestData"
+        }
+      },
+      "tags": [
+        "Asynchronous jobs :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addDynamicProcessToCase",
+      "name": "Adds dynamic subprocess identified by process id to case instance",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/processes/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addDynamicProcessToCase"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addDynamicProcessToCase1",
+      "name": "Adds dynamic subprocess identified by process id to stage within case instance",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/processes/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic subprocess should be added\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addDynamicProcessToCase1"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addDynamicTaskToCase",
+      "name": "Adds dynamic task (user or service depending on the payload) to case instance",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/tasks",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addDynamicTaskToCase"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addDynamicTaskToCase1",
+      "name": "Adds dynamic task (user or service depending on the payload) to given stage within case instance",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic task should be added\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addDynamicTaskToCase1"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addComment",
+      "name": "Adds new comment to given case instance",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/comments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addComment"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addRoleAssignment",
+      "name": "Adds new role assignment for given case, it can be either user or group based assignment",
+      "description": "Send PUT request to /server/containers/{id}/cases/instances/{caseId}/roles/{caseRoleName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be set\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be aded to case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be aded to case role for given case instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addRoleAssignment"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:cancelCaseInstance",
+      "name": "Cancels case instance with given identifier (case id) it can also when intructed permanently destroy the case instance",
+      "description": "Send DELETE request to /server/containers/{id}/cases/instances/{caseId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"destroy\":{\"type\":\"boolean\",\"title\":\"destroy\",\"description\":\"allows to destroy (permanently) case instance as part of the cancel operation, defaults to false\",\"default\":\"false\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "cancelCaseInstance"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:closeCaseInstance",
+      "name": "Closes case instance with given identifier (case id) optionally with comment",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "closeCaseInstance"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:putCaseInstanceData",
+      "name": "Puts new data (map of variables) into case instance's case file",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/caseFile",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "putCaseInstanceData"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:putCaseInstanceDataByName",
+      "name": "Puts new data (single data identified by name) into case instance's case file",
+      "description": "Send POST request to /server/containers/{id}/cases/instances/{caseId}/caseFile/{dataId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item to be added to case file\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "putCaseInstanceDataByName"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:deleteCaseInstanceData",
+      "name": "Removes data items identified by name(s) from case instance's case file",
+      "description": "Send DELETE request to /server/containers/{id}/cases/instances/{caseId}/caseFile",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"array\",\"title\":\"dataId\",\"description\":\"one or more names of the data items to be removed from case file\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "deleteCaseInstanceData"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeComment",
+      "name": "Removes given comment from case instance",
+      "description": "Send DELETE request to /server/containers/{id}/cases/instances/{caseId}/comments/{caseCommentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be removed\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeComment"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeRoleAssignment",
+      "name": "Removes role assignment from user or group for given case instance",
+      "description": "Send DELETE request to /server/containers/{id}/cases/instances/{caseId}/roles/{caseRoleName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be removed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be removed from case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be removed from case role for given case instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeRoleAssignment"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:reopenCase",
+      "name": "Reopens case instance with given identifier (case id) by initiating given case definition",
+      "description": "Send PUT request to /server/containers/{id}/cases/{caseDefId}/instances/{caseId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "reopenCase"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstance",
+      "name": "Retrieves active case instance by given identifier (case id) with optionally loading data, roles, milestones and stages",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag to load data when loading case instance\",\"default\":\"false\"},\"withRoles\":{\"type\":\"boolean\",\"title\":\"withRoles\",\"description\":\"optional flag to load roles when loading case instance\",\"default\":\"false\"},\"withMilestones\":{\"type\":\"boolean\",\"title\":\"withMilestones\",\"description\":\"optional flag to load milestones when loading case instance\",\"default\":\"false\"},\"withStages\":{\"type\":\"boolean\",\"title\":\"withStages\",\"description\":\"optional flag to load stages when loading case instance\",\"default\":\"false\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstance"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceAdHocFragments",
+      "name": "Retrieves adhoc fragments from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/adhocfragments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-adhoc-fragment-list\",\"properties\":{\"fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}}},\"xml\":{\"name\":\"case-adhoc-fragment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceAdHocFragments"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseDefinitionsByDefinition",
+      "name": "Retrieves case definition for given container and case definition id",
+      "description": "Send GET request to /server/containers/{id}/cases/definitions/{caseDefId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be loaded\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-definition\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"roles\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\",\"format\":\"int32\"}},\"milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"case-milestone-def\"}}},\"stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}}},\"xml\":{\"name\":\"case-stage-def\"}}}},\"xml\":{\"name\":\"case-definition\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseDefinitionsByDefinition"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseDefinitionsByContainer",
+      "name": "Retrieves case definition for given container only, applies pagination",
+      "description": "Send GET request to /server/containers/{id}/cases/definitions",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-definition-list\",\"properties\":{\"definitions\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"roles\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\",\"format\":\"int32\"}},\"milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"case-milestone-def\"}}},\"stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}}},\"xml\":{\"name\":\"case-stage-def\"}}}},\"xml\":{\"name\":\"case-definition\"}}}},\"xml\":{\"name\":\"case-definition-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseDefinitionsByContainer"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceData",
+      "name": "Retrieves case instance data as map where key is the name of data item and value is actual instance of the data item from case file",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/caseFile",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optional name(s) of the data items to retrieve\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\",\"additionalProperties\":{\"type\":\"object\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceData"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceDataByName",
+      "name": "Retrieves case instance data by data item name",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/caseFile/{dataId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item within case file to retrieve\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceDataByName"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstancesByDefinition",
+      "name": "Retrieves case instances for given case definition only, allows to filter by case instance status and applies pagination",
+      "description": "Send GET request to /server/containers/{id}/cases/{caseDefId}/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstancesByDefinition"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstancesByContainer",
+      "name": "Retrieves case instances for given container only, allows to filter by case instance status and applies pagination",
+      "description": "Send GET request to /server/containers/{id}/cases/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstancesByContainer"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceComments",
+      "name": "Retrieves comments from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/comments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-comment-list\",\"properties\":{\"comments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"author\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"},\"added-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"restricted-to\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"restricted-to\"}}}},\"xml\":{\"name\":\"case-comment\"}}}},\"xml\":{\"name\":\"case-comment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceComments"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceMilestones",
+      "name": "Retrieves milestones from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/milestones",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"achievedOnly\":{\"type\":\"boolean\",\"title\":\"achievedOnly\",\"description\":\"optional flag that allows to control which milestones to load - achieved only or actives ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-milestone-list\",\"properties\":{\"milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}}},\"xml\":{\"name\":\"case-milestone-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceMilestones"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceActiveNodes",
+      "name": "Retrieves node instances from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/nodes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"completed\":{\"type\":\"boolean\",\"title\":\"completed\",\"description\":\"optional flag that allows to control which node instances to load - active or completed, defaults to false loading only active ones\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance-list\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"node-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceActiveNodes"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceProcessInstance",
+      "name": "Retrieves process isntances that compose complete case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/processes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceProcessInstance"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceRoleAssignments",
+      "name": "Retrieves role assignments from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/roles",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-role-assignment-list\",\"properties\":{\"role-assignments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-role-assignment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceRoleAssignments"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceStages",
+      "name": "Retrieves stages from case instance",
+      "description": "Send GET request to /server/containers/{id}/cases/instances/{caseId}/stages",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that allows to control which stages to load - active only or completed ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-stage-list\",\"properties\":{\"stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}}},\"xml\":{\"name\":\"case-stage-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceStages"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:startCase",
+      "name": "Starts new case instance of given case definition within given container with optional initial CaseFile (that provides variables and case role assignment)",
+      "description": "Send POST request to /server/containers/{id}/cases/{caseDefId}/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "startCase"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:triggerAdHocNode",
+      "name": "Triggers ad hoc fragment in case instance with optional data",
+      "description": "Send PUT request to /server/containers/{id}/cases/instances/{caseId}/tasks/{nodeName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "triggerAdHocNode"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:triggerAdHocNodeInStage",
+      "name": "Triggers ad hoc fragment in stage within case instance with optional data",
+      "description": "Send PUT request to /server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks/{nodeName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where adhoc fragment should be triggered\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "triggerAdHocNodeInStage"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateComment",
+      "name": "Updates comment within case instance",
+      "description": "Send PUT request to /server/containers/{id}/cases/instances/{caseId}/comments/{caseCommentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be updated\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "updateComment"
+        }
+      },
+      "tags": [
+        "Case instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:dropQueryDefinition",
+      "name": "Deletes existing query definition from the system with given queryName",
+      "description": "Send DELETE request to /server/queries/definitions/{queryName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be deleted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "dropQueryDefinition"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:runQuery",
+      "name": "Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper.",
+      "description": "Send GET request to /server/queries/definitions/{queryName}/data",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"orderBy\":{\"type\":\"string\",\"title\":\"orderBy\",\"description\":\"optional sort order\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"type\":\"object\"}"
+        },
+        "configuredProperties": {
+          "operationId": "runQuery"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:runQueryFiltered",
+      "name": "Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper. Query is additional altered by the filter spec and/or builder",
+      "description": "Send POST request to /server/queries/definitions/{queryName}/filtered-data",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"builder\":{\"type\":\"string\",\"title\":\"builder\",\"description\":\"optional identifier of the query builder to be used for query conditions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "runQueryFiltered"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:createQueryDefinition",
+      "name": "Registers new query definition in the system with given queryName",
+      "description": "Send POST request to /server/queries/definitions/{queryName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be registered\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "createQueryDefinition"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:replaceQueryDefinition",
+      "name": "Replaces existing query definition or registers new if not exists in the system with given queryName",
+      "description": "Send PUT request to /server/queries/definitions/{queryName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be replaced\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "replaceQueryDefinition"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getQuery",
+      "name": "Retrieves existing query definition from the system with given queryName",
+      "description": "Send GET request to /server/queries/definitions/{queryName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be retrieved\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"query-definition\",\"properties\":{\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-expression\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"xml\":{\"name\":\"query-definition\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getQuery"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getQueries",
+      "name": "Retruns all custom queries defined in the system",
+      "description": "Send GET request to /server/queries/definitions",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"query-definitions\",\"properties\":{\"queries\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-expression\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"xml\":{\"name\":\"query-definition\"}}}},\"xml\":{\"name\":\"query-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getQueries"
+        }
+      },
+      "tags": [
+        "Custom queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:evaluateDecisions",
+      "name": "Evaluates decisions for given imput",
+      "description": "Send POST request to /server/containers/{id}/dmn",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be used to evaluate decisions on\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "evaluateDecisions"
+        }
+      },
+      "tags": [
+        "Decision Service :: DMN"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getModels",
+      "name": "Retrieves DMN model for given container",
+      "description": "Send GET request to /server/containers/{id}/dmn",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that modesl should be loaded from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getModels"
+        }
+      },
+      "tags": [
+        "Decision Service :: DMN"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:createDocument",
+      "name": "Creates new document based on given content (body)",
+      "description": "Send POST request to /server/documents",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "createDocument"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:deleteDocument",
+      "name": "Deletes document identified by given document id",
+      "description": "Send DELETE request to /server/documents/{documentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be deleted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "deleteDocument"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getDocument",
+      "name": "Retrieves document identified by given documentId",
+      "description": "Send GET request to /server/documents/{documentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be retruned\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"document-instance\",\"properties\":{\"document-id\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\",\"format\":\"int64\"},\"document-last-mod\":{\"type\":\"string\",\"format\":\"date-time\"},\"document-content\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"byte\",\"xml\":{\"name\":\"document-content\"}}}},\"xml\":{\"name\":\"document-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getDocument"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getDocumentContent",
+      "name": "Retrieves document's content identified by given documentId",
+      "description": "Send GET request to /server/documents/{documentId}/content",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that content should be retruned from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "null"
+        },
+        "configuredProperties": {
+          "operationId": "getDocumentContent"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:listDocuments",
+      "name": "Retrieves documents that are stored in the system, with pagination",
+      "description": "Send GET request to /server/documents",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"document-instance-list\",\"properties\":{\"document-instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"document-id\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\",\"format\":\"int64\"},\"document-last-mod\":{\"type\":\"string\",\"format\":\"date-time\"},\"document-content\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"byte\",\"xml\":{\"name\":\"document-content\"}}}},\"xml\":{\"name\":\"document-instance\"}}}},\"xml\":{\"name\":\"document-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "listDocuments"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateDocument",
+      "name": "Updates document identified by given document id based on given content (body)",
+      "description": "Send PUT request to /server/documents/{documentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "updateDocument"
+        }
+      },
+      "tags": [
+        "Documents :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:createContainer",
+      "name": "Creates (deploys) new KIE container to this server",
+      "description": "Send PUT request to /server/containers/{id}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be assigned to deployed KIE Container\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "createContainer"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:disposeContainer",
+      "name": "Disposes (undeploys) container with given id",
+      "description": "Send DELETE request to /server/containers/{id}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be disposed (undeployed)\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "disposeContainer"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getInfo",
+      "name": "Retrieves KIE Server information - id, name, location, capabilities, messages",
+      "description": "Send GET request to /server",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "kind": "none"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getInfo"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getContainerInfo",
+      "name": "Retrieves container with given id",
+      "description": "Send GET request to /server/containers/{id}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be retrieved\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getContainerInfo"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:listContainers",
+      "name": "Retrieves containers deployed to this server, optionally filtered by group, artifact, version or status",
+      "description": "Send GET request to /server/containers",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"groupId\":{\"type\":\"string\",\"title\":\"groupId\",\"description\":\"optional groupId to filter containers by\"},\"artifactId\":{\"type\":\"string\",\"title\":\"artifactId\",\"description\":\"optional artifactId to filter containers by\"},\"version\":{\"type\":\"string\",\"title\":\"version\",\"description\":\"optional version to filter containers by\"},\"status\":{\"type\":\"string\",\"title\":\"status\",\"description\":\"optional status to filter containers by\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "listContainers"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getReleaseId",
+      "name": "Retrieves release id of the KIE container with given id",
+      "description": "Send GET request to /server/containers/{id}/release-id",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be loaded from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getReleaseId"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getServerState",
+      "name": "Retrieves server state - configuration that the server is currently running with",
+      "description": "Send GET request to /server/state",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "kind": "none"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getServerState"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getScannerInfo",
+      "name": "Retrieves stanner information for given container",
+      "description": "Send GET request to /server/containers/{id}/scanner",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be loaded\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getScannerInfo"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateReleaseId",
+      "name": "Updates release id of the KIE container with given id to provided release id",
+      "description": "Send POST request to /server/containers/{id}/release-id",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be upgraded\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "updateReleaseId"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateScanner",
+      "name": "Updates scanner for given container",
+      "description": "Send POST request to /server/containers/{id}/scanner",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "updateScanner"
+        }
+      },
+      "tags": [
+        "KIE Server :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:executeCommands",
+      "name": "Executes command script on execution server, usually used as a batch to configure KIE Server",
+      "description": "Send POST request to /server/config",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"responses\",\"properties\":{\"response\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}},\"xml\":{\"name\":\"responses\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "executeCommands"
+        }
+      },
+      "tags": [
+        "KIE Server Script :: Core"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addProblemFactChanges",
+      "name": "Adds problem fact changes to given solver",
+      "description": "Send POST request to /server/containers/{id}/solvers/{solverId}/problemfactchanges",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addProblemFactChanges"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:createSolver",
+      "name": "Creates solver within given container",
+      "description": "Send PUT request to /server/containers/{id}/solvers/{solverId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver config resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver to create\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"solver-instance\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"solver-config-file\":{\"type\":\"string\"},\"status\":{\"type\":\"string\",\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"]},\"score\":{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}},\"best-solution\":{\"type\":\"object\"}},\"xml\":{\"name\":\"solver-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "createSolver"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:disposeSolver",
+      "name": "Disposes given solver",
+      "description": "Send DELETE request to /server/containers/{id}/solvers/{solverId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "disposeSolver"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getSolverWithBestSolution",
+      "name": "Retrieves best solution from solver within container",
+      "description": "Send GET request to /server/containers/{id}/solvers/{solverId}/bestsolution",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"solver-instance\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"solver-config-file\":{\"type\":\"string\"},\"status\":{\"type\":\"string\",\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"]},\"score\":{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}},\"best-solution\":{\"type\":\"object\"}},\"xml\":{\"name\":\"solver-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getSolverWithBestSolution"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getSolver",
+      "name": "Retrieves solver by its identifier from given container",
+      "description": "Send GET request to /server/containers/{id}/solvers/{solverId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"solver-instance\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"solver-config-file\":{\"type\":\"string\"},\"status\":{\"type\":\"string\",\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"]},\"score\":{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}},\"best-solution\":{\"type\":\"object\"}},\"xml\":{\"name\":\"solver-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getSolver"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getSolvers",
+      "name": "Retrieves solvers from given container",
+      "description": "Send GET request to /server/containers/{id}/solvers",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solvers reside\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"solvers\",\"properties\":{\"solver\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"solver-config-file\":{\"type\":\"string\"},\"status\":{\"type\":\"string\",\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"]},\"score\":{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}},\"best-solution\":{\"type\":\"object\"}},\"xml\":{\"name\":\"solver-instance\"}}}},\"xml\":{\"name\":\"solvers\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getSolvers"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:isEveryProblemFactChangeProcessed",
+      "name": "Retrieves status if problem fact changes have been processed in given solver",
+      "description": "Send GET request to /server/containers/{id}/solvers/{solverId}/problemfactchanges/processed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"boolean\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "isEveryProblemFactChangeProcessed"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:solvePlanningProblem",
+      "name": "Solves given planning problem with given solver",
+      "description": "Send POST request to /server/containers/{id}/solvers/{solverId}/state/solving",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "solvePlanningProblem"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:terminateSolverEarly",
+      "name": "Terminates early running solver with given id within container",
+      "description": "Send POST request to /server/containers/{id}/solvers/{solverId}/state/terminating-early",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "terminateSolverEarly"
+        }
+      },
+      "tags": [
+        "Planning and solvers :: BRP"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAssociatedEntities",
+      "name": "Retrieves actors and groups that are involved in given process and container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/entities",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the involved actors and groups should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-associated-entities\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"process-associated-entities\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getAssociatedEntities"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskInputMappings",
+      "name": "Retrieves input variables defined on a given user task",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/inputs",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that input variable definitions should be retrieved for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-task-inputs\",\"properties\":{\"taskInputs\":{\"type\":\"object\",\"xml\":{\"name\":\"inputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-task-inputs\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskInputMappings"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskOutputMappings",
+      "name": "Retrieves output variables defined on a given user task",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/outputs",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that output variable definitions should be retrieved for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-task-outputs\",\"properties\":{\"taskOutputs\":{\"type\":\"object\",\"xml\":{\"name\":\"outputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-task-outputs\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskOutputMappings"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessDefinition",
+      "name": "Retrieves process definition identified by given process id within given container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the definition should be retrieved for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definition\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessDefinition"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessVariables",
+      "name": "Retrieves process variables definitions that are present in given process and container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/variables",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the variable definitions should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-variables\",\"properties\":{\"variables\":{\"type\":\"object\",\"xml\":{\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-variables\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessVariables"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getServiceTasks",
+      "name": "Retrieves service tasks definitions that are present in given process and container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/tasks/service",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the service task definitions should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-service-tasks\",\"properties\":{\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-service-tasks\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getServiceTasks"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getReusableSubProcesses",
+      "name": "Retrieves sub process definitions that are defined in given process within given container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/subprocesses",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that subprocesses should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-subprocesses\",\"properties\":{\"subProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-subprocesses\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getReusableSubProcesses"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksDefinitions",
+      "name": "Retrieves user tasks definitions that are present in given process and container",
+      "description": "Send GET request to /server/containers/{id}/processes/definitions/{pId}/tasks/users",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the user task definitions should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"user-task-definitions\",\"properties\":{\"task\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"array\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"taskInputMappings\":{\"type\":\"object\",\"xml\":{\"name\":\"task-inputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"taskOutputMappings\":{\"type\":\"object\",\"xml\":{\"name\":\"task-outputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"task-id\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-comment\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-form-name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"user-task-definition\"}}}},\"xml\":{\"name\":\"user-task-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksDefinitions"
+        }
+      },
+      "tags": [
+        "Process and task definitions :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessForm",
+      "name": "Retrieves form for process definition within a container",
+      "description": "Send GET request to /server/containers/{id}/forms/processes/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of process definition that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessForm"
+        }
+      },
+      "tags": [
+        "Process and task forms :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskForm",
+      "name": "Retrieves form for task instance within a container",
+      "description": "Send GET request to /server/containers/{id}/forms/tasks/{tInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskForm"
+        }
+      },
+      "tags": [
+        "Process and task forms :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessImage",
+      "name": "Retrieves process definition image",
+      "description": "Send GET request to /server/containers/{id}/images/processes/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of the process definition that image should be loaded for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessImage"
+        }
+      },
+      "tags": [
+        "Process definition and instance images :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceImage",
+      "name": "Retrieves process instance image",
+      "description": "Send GET request to /server/containers/{id}/images/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that image should be loaded for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceImage"
+        }
+      },
+      "tags": [
+        "Process definition and instance images :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:abortProcessInstance",
+      "name": "Aborts active process instance identified by given id",
+      "description": "Send DELETE request to /server/containers/{id}/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be aborted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "abortProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:abortProcessInstances",
+      "name": "Aborts active process instances identified by given list of identifiers",
+      "description": "Send DELETE request to /server/containers/{id}/processes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be aborted\",\"items\":{\"type\":\"integer\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "abortProcessInstances"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:abortWorkItem",
+      "name": "Aborts work item identified by workItemId within process instance and container",
+      "description": "Send PUT request to /server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/aborted",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to abort\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "abortWorkItem"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:completeWorkItem",
+      "name": "Completes work item identified by workItemId within process instance and container. Optionally completion can provide outcome data - as map",
+      "description": "Send PUT request to /server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/completed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to complete\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "completeWorkItem"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAvailableSignals",
+      "name": "Retrieves active process instance's (identified by given id) active signals",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/signals",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that signals should be collected for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "null"
+        },
+        "configuredProperties": {
+          "operationId": "getAvailableSignals"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceVariable",
+      "name": "Retrieves active process instance's (identified by given id) variable given as variable name",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/variable/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable should be retrieved from\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to be retrieved\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceVariable"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceVariables",
+      "name": "Retrieves active process instance's (identified by given id) variables, variables are returned as map where key is the variable name (string) and value is variable value (any type)",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/variables",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables should be retrieved from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\",\"additionalProperties\":{\"type\":\"object\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceVariables"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceHistory",
+      "name": "Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/nodes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that history should be collected for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"instructs if active nodes only should be collected, defaults to false\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"instructs if completed nodes only should be collected, defaults to false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance-list\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"node-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceHistory"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessesByDeploymentId",
+      "name": "Retrieves process definitions that belong to given container",
+      "description": "Send GET request to /server/containers/{id}/processes",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definitions\",\"properties\":{\"processes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}}},\"xml\":{\"name\":\"process-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessesByDeploymentId"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstance",
+      "name": "Retrieves process instance identified by given id optionally with variables (variables will be loaded only for active process instance)",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be fetched\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"indicates if process instance variables should be loaded or not\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstancesByDeploymentId",
+      "name": "Retrieves process instances that belong to given container",
+      "description": "Send GET request to /server/containers/{id}/processes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstancesByDeploymentId"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstances",
+      "name": "Retrieves process instances that belong to given container and have given parent process instance, optionally allow to filter by process instance state.",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/processes",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the parent process instance that process instances should be collected for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstances"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getVariableHistory",
+      "name": "Retrieves variable history (from audit logs) for given variable name that belongs to process instance",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/variables/instances/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable history should be collected for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variables that history should be collected for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"variable-instance-list\",\"properties\":{\"variable-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"modification-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"variable-instance\"}}}},\"xml\":{\"name\":\"variable-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getVariableHistory"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getVariablesCurrentState",
+      "name": "Retrieves variables last value (from audit logs) for given process instance",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/variables/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables state should be collected for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"variable-instance-list\",\"properties\":{\"variable-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"modification-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"variable-instance\"}}}},\"xml\":{\"name\":\"variable-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getVariablesCurrentState"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getWorkItem",
+      "name": "Retrieves work item identified by workItemId within process instance and container",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to retrieve\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"work-item-instance\",\"properties\":{\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"work-item-params\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"work-item-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getWorkItem"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getWorkItemByProcessInstance",
+      "name": "Retrieves work items within process instance and container",
+      "description": "Send GET request to /server/containers/{id}/processes/instances/{pInstanceId}/workitems",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work items belong to\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"work-item-instance-list\",\"properties\":{\"work-item-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"work-item-params\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"work-item-instance\"}}}},\"xml\":{\"name\":\"work-item-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getWorkItemByProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:signalProcessInstance",
+      "name": "Signals active process instance identified by given id with singal name and optional event data",
+      "description": "Send POST request to /server/containers/{id}/processes/instances/{pInstanceId}/signal/{sName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be signaled\"},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "signalProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:signalProcessInstances",
+      "name": "Signals active process instances identified by given ids with singal name and optional event data",
+      "description": "Send POST request to /server/containers/{id}/processes/instances/signal/{sName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be signaled\",\"items\":{\"type\":\"integer\"}},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "signalProcessInstances"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:startProcess",
+      "name": "Starts new process instance of given process definition within given container with optional variables",
+      "description": "Send POST request to /server/containers/{id}/processes/{pId}/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "startProcess"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:startProcessWithCorrelation",
+      "name": "Starts new process instance with correlation key of given process definition within given container with optional variables",
+      "description": "Send POST request to /server/containers/{id}/processes/{pId}/instances/correlation/{correlationKey}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"},\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to be assigned to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "startProcessWithCorrelation"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setProcessVariable",
+      "name": "Updates active process instance's (identified by given id) variable with given name",
+      "description": "Send PUT request to /server/containers/{id}/processes/instances/{pInstanceId}/variable/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable to be set/updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setProcessVariable"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setProcessVariables",
+      "name": "Updates active process instance's (identified by given id) variables given as map in the body",
+      "description": "Send POST request to /server/containers/{id}/processes/instances/{pInstanceId}/variables",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setProcessVariables"
+        }
+      },
+      "tags": [
+        "Process instances :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:acknowledgeError",
+      "name": "Acknowledge execution error by given id",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/errors/{errorId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be acknowledged\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "acknowledgeError"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:acknowledgeErrors",
+      "name": "Acknowledges given execution errors",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of error identifiers to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "acknowledgeErrors"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:cancelNodeInstance",
+      "name": "Cancels given node instance within process instance and container",
+      "description": "Send DELETE request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances/{nodeInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be canceled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "cancelNodeInstance"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:migrateProcessInstance",
+      "name": "Migrates process instance to new container and process definition with optional node mapping",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance to be migrated\"},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instance should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"migration-report-instance\",\"properties\":{\"migration-successful\":{\"type\":\"boolean\"},\"migration-start\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-end\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-logs\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}}}},\"xml\":{\"name\":\"migration-report-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "migrateProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:migrateProcessInstances",
+      "name": "Migrates process instances to new container and process definition with optional node mapping",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instances belongs to\"},\"pInstanceId\":{\"type\":\"array\",\"title\":\"pInstanceId\",\"description\":\"list of identifiers of process instance to be migrated\",\"items\":{\"type\":\"integer\"}},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instances should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"migration-report-instance-list\",\"properties\":{\"migration-report-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"migration-successful\":{\"type\":\"boolean\"},\"migration-start\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-end\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-logs\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}}}},\"xml\":{\"name\":\"migration-report-instance\"}}}},\"xml\":{\"name\":\"migration-report-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "migrateProcessInstances"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrorById",
+      "name": "Retrieve execution error by its identifier",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/errors/{errorId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be loaded\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"execution-error\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrorById"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getActiveNodeInstances",
+      "name": "Retrieves all active node instances from process instance and container",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that active nodes instances should be collected for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance-list\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"node-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getActiveNodeInstances"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTimerInstances",
+      "name": "Retrieves all active timer instance from process instance and container",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/timers",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer instances should be collected for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"timer-instance-list\",\"properties\":{\"timer-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"last-fire-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"next-fire-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"delay\":{\"type\":\"integer\",\"format\":\"int64\"},\"period\":{\"type\":\"integer\",\"format\":\"int64\"},\"repeat-limit\":{\"type\":\"integer\",\"format\":\"int32\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"session-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"timer-instance\"}}}},\"xml\":{\"name\":\"timer-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTimerInstances"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getNodes",
+      "name": "Retrieves all nodes from process instance and container",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that process nodes should be collected from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-node-list\",\"properties\":{\"process-node\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"type\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"process-node\"}}}},\"xml\":{\"name\":\"process-node-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getNodes"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrors",
+      "name": "Retrieves execution errors for container, applies pagination",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance-list\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"node-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrors"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrorsByProcessInstance",
+      "name": "Retrieves execution errors for process instance and container, applies pagination",
+      "description": "Send GET request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"node\":{\"type\":\"string\",\"title\":\"node\",\"description\":\"optional name of the node in the process instance to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"execution-error-list\",\"properties\":{\"error-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}}}},\"xml\":{\"name\":\"execution-error-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrorsByProcessInstance"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:retriggerNodeInstance",
+      "name": "Retriggers given node instance within process instance and container",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances/{nodeInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be retriggered\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "retriggerNodeInstance"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:triggerNode",
+      "name": "Triggers node within process instance and container",
+      "description": "Send POST request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes/{nodeId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance where node should be triggered\"},\"nodeId\":{\"type\":\"integer\",\"title\":\"nodeId\",\"description\":\"identifier of the node to be triggered\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "triggerNode"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:updateTimer",
+      "name": "Updates timer instance within process instance and container",
+      "description": "Send PUT request to /server/admin/containers/{id}/processes/instances/{pInstanceId}/timers/{timerId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer belongs to\"},\"timerId\":{\"type\":\"integer\",\"title\":\"timerId\",\"description\":\"identifier of timer instance to be updated\"},\"relative\":{\"type\":\"boolean\",\"title\":\"relative\",\"description\":\"optional flag that indicates if the time expression is relative to the current date or not, defaults to true\",\"default\":\"true\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "updateTimer"
+        }
+      },
+      "tags": [
+        "Process instances administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseDefinitions",
+      "name": "Retrieves case definitions with filtering by name or id of the case definition and applies pagination",
+      "description": "Send GET request to /server/queries/cases",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"case definition id or name that case definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseDefinitions"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceDataItems",
+      "name": "Retrieves case instance data items, allows to filter by name or type of data and applies pagination",
+      "description": "Send GET request to /server/queries/cases/instances/{caseId}/caseFile",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that data items should belong to\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optionally filter by data item names\",\"items\":{\"type\":\"string\"}},\"type\":{\"type\":\"array\",\"title\":\"type\",\"description\":\"optionally filter by data item types\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceDataItems"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceTasksAsAdmin",
+      "name": "Retrieves case instance tasks assigned as business admin, allows to filter by task status and applies pagination",
+      "description": "Send GET request to /server/queries/cases/instances/{caseId}/tasks/instances/admins",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceTasksAsAdmin"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceTasksAsPotentialOwner",
+      "name": "Retrieves case instance tasks assigned as potential owner, allows to filter by task status and applies pagination",
+      "description": "Send GET request to /server/queries/cases/instances/{caseId}/tasks/instances/pot-owners",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceTasksAsPotentialOwner"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstanceTasksAsStakeholder",
+      "name": "Retrieves case instance tasks assigned as stakeholder, allows to filter by task status and applies pagination",
+      "description": "Send GET request to /server/queries/cases/instances/{caseId}/tasks/instances/stakeholders",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstanceTasksAsStakeholder"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstancesByRole",
+      "name": "Retrieves case instances where given user is involed in given role and applies pagination, allows to filter by case instance status",
+      "description": "Send GET request to /server/queries/cases/{caseRoleName}/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"case role that instances should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstancesByRole"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCaseInstances1",
+      "name": "Retrieves case instances with authntication checks and applies pagination, allows to filter by data (case file) name and value, owner and case instance status",
+      "description": "Send GET request to /server/queries/cases/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"dataItemName\":{\"type\":\"string\",\"title\":\"dataItemName\",\"description\":\"data item name that case instances will be filtered by\"},\"dataItemValue\":{\"type\":\"string\",\"title\":\"dataItemValue\",\"description\":\"data item value that case instances will be filtered by\"},\"owner\":{\"type\":\"string\",\"title\":\"owner\",\"description\":\"case instance owner that case instances will be filtered by\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCaseInstances1"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessDefinitionsByContainer",
+      "name": "Retrieves process definitions that belong to given container and applies pagination",
+      "description": "Send GET request to /server/queries/cases/{id}/processes",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definitions should be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessDefinitionsByContainer"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessDefinitions",
+      "name": "Retrieves process definitions with filtering by name or id of the process definition and applies pagination",
+      "description": "Send GET request to /server/queries/cases/processes",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process definition id or name that process definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"case-instance-list\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-milestones\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}}},\"case-stages\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"case-stage\"}}},\"case-roles\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}}}},\"xml\":{\"name\":\"case-instance\"}}}},\"xml\":{\"name\":\"case-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessDefinitions"
+        }
+      },
+      "tags": [
+        "Queries - case definitions and instances :: Case Management"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getNodeInstanceForWorkItem",
+      "name": "Retrieves node instance for given process instance id and work item id",
+      "description": "Send GET request to /server/queries/processes/instances/{pInstanceId}/wi-nodes/instances/{workItemId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to retrieve node instance for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getNodeInstanceForWorkItem"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceHistory1",
+      "name": "Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes",
+      "description": "Send GET request to /server/queries/processes/instances/{pInstanceId}/nodes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to to retrive history for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"include active nodes only\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"include completed nodes only\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"node-instance-list\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}}}},\"xml\":{\"name\":\"node-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceHistory1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessesByDeploymentIdProcessId",
+      "name": "Retrieves process definition that belong to given container and has matching process id",
+      "description": "Send GET request to /server/queries/containers/{id}/processes/definitions/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definition\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessesByDeploymentIdProcessId"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessesById",
+      "name": "Retrieves process definitions filtered by process id",
+      "description": "Send GET request to /server/queries/processes/definitions/{pId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definitions\",\"properties\":{\"processes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}}},\"xml\":{\"name\":\"process-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessesById"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessesByFilter",
+      "name": "Retrieves process definitions filtered by process id or name",
+      "description": "Send GET request to /server/queries/processes/definitions",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process id or name to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definitions\",\"properties\":{\"processes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}}},\"xml\":{\"name\":\"process-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessesByFilter"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessesByDeploymentId1",
+      "name": "Retrieves process definitions that belong to given container",
+      "description": "Send GET request to /server/queries/containers/{id}/processes/definitions",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-definitions\",\"properties\":{\"processes\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}}}},\"xml\":{\"name\":\"process-definitions\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessesByDeploymentId1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceByCorrelationKey",
+      "name": "Retrieves process instance by exactly matched correlation key",
+      "description": "Send GET request to /server/queries/processes/instance/correlation/{correlationKey}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key associated with process instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceByCorrelationKey"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceById",
+      "name": "Retrieves process instance for given process instance id and optionally loads its variables",
+      "description": "Send GET request to /server/queries/processes/instances/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to retrieve process instance\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"load process instance variables or not, defaults to false\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceById"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstanceByVariables",
+      "name": "Retrieves process instances filtered by by variable or by variable and its value. Applies pagination by default and allows to specify sorting",
+      "description": "Send GET request to /server/queries/processes/instances/variables/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to filter process instance\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"variable value to filter process instance, optional when filtering by name only required when filtering by name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstanceByVariables"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstancesByDeploymentId1",
+      "name": "Retrieves process instances filtered by container. Applies pagination by default and allows to specify sorting",
+      "description": "Send GET request to /server/queries/containers/{id}/process/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstancesByDeploymentId1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstancesByCorrelationKey",
+      "name": "Retrieves process instances filtered by correlation key, retrieves all process instances that match correlationkey*. Applies pagination by default and allows to specify sorting",
+      "description": "Send GET request to /server/queries/processes/instances/correlation/{correlationKey}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to filter process instance, can be given as partial correlation key like in starts with approach\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstancesByCorrelationKey"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstancesByProcessId",
+      "name": "Retrieves process instances filtered by process id. Applies pagination by default and allows to specify sorting",
+      "description": "Send GET request to /server/queries/processes/{pId}/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optinal process instance initiator - user who started process instance to filtr process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstancesByProcessId"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getProcessInstances1",
+      "name": "Retrieves process instances filtered by status, initiator, processName - depending what query parameters are given. Applies pagination by default and allows to specify sorting",
+      "description": "Send GET request to /server/queries/processes/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optional process instance initiator - user who started process instance to filter process instances\"},\"processName\":{\"type\":\"string\",\"title\":\"processName\",\"description\":\"optional process name to filter process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"process-instance-list\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}}}},\"xml\":{\"name\":\"process-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getProcessInstances1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskByWorkItemId",
+      "name": "Retrieves task by associated work item id",
+      "description": "Send GET request to /server/queries/tasks/instances/workitem/{workItemId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to load task associated with\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-instance\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-workitem-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-last-modificaiton-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-pot-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}}},\"task-excl-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}}},\"task-business-admins\":{\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}}},\"task-input-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"task-output-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"task-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskByWorkItemId"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskById",
+      "name": "Retrieves task by task id",
+      "description": "Send GET request to /server/queries/tasks/instances/{tInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task instance\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-instance\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-workitem-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-last-modificaiton-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-pot-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}}},\"task-excl-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}}},\"task-business-admins\":{\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}}},\"task-input-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"task-output-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"task-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskById"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskEvents",
+      "name": "Retrieves task events for given task id and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/{tInstanceId}/events",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task events for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-event-instance-list\",\"properties\":{\"task-event-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-event-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-event-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-message\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-event-instance\"}}}},\"xml\":{\"name\":\"task-event-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskEvents"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksAssignedAsBusinessAdministratorByStatus",
+      "name": "Retrieves tasks assigned as business administrator, optionally filters by status and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/admins",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksAssignedAsBusinessAdministratorByStatus"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksAssignedAsPotentialOwner",
+      "name": "Retrieves tasks assigned as potential owner, optionally filters by status and given groups and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/pot-owners",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"groups\":{\"type\":\"array\",\"title\":\"groups\",\"description\":\"optional group names to include in the query\",\"items\":{\"type\":\"string\"}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"},\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"optional custom filter for task data\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksAssignedAsPotentialOwner"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksByStatusByProcessInstanceId",
+      "name": "Retrieves tasks associated with given process instance, optionally filters by status and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/process/{pInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to filter task instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksByStatusByProcessInstanceId"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksByVariables",
+      "name": "Retrieves tasks by variable name and optionally by variable value, optionally filters by status and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/variables/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable used to fiter tasks\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"value of the variable used to fiter tasks, optional when filtering only by name, required when filtering by both name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksByVariables"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTasksOwnedByStatus",
+      "name": "Retrieves tasks owned, optionally filters by status and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances/owners",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTasksOwnedByStatus"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAllAuditTask",
+      "name": "Retrieves tasks, optionally filters by status and applies pagination",
+      "description": "Send GET request to /server/queries/tasks/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-summary-list\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}}}},\"xml\":{\"name\":\"task-summary-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getAllAuditTask"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getVariableHistory1",
+      "name": "Retrieves variable history (from audit logs) for given variable name that belongs to process instance",
+      "description": "Send GET request to /server/queries/processes/instances/{pInstanceId}/variables/instances/{varName}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variable history for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name that history should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"variable-instance-list\",\"properties\":{\"variable-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"modification-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"variable-instance\"}}}},\"xml\":{\"name\":\"variable-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getVariableHistory1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getVariablesCurrentState1",
+      "name": "Retrieves variables last value (from audit logs) for given process instance",
+      "description": "Send GET request to /server/queries/processes/instances/{pInstanceId}/variables/instances",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variables current state (latest value) for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"variable-instance-list\",\"properties\":{\"variable-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"modification-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"variable-instance\"}}}},\"xml\":{\"name\":\"variable-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getVariablesCurrentState1"
+        }
+      },
+      "tags": [
+        "Queries - processes, nodes, variables and tasks :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:manageContainer",
+      "name": "Evaluates rules by executing commands on the rule session",
+      "description": "Send POST request to /server/containers/instances/{id}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id where rules should be evaluated on\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"response\",\"xml\":{\"name\":\"response\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "manageContainer"
+        }
+      },
+      "tags": [
+        "Rules evaluation :: BRM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:activate",
+      "name": "Activates task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/activated",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be activated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "activate"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addAttachment",
+      "name": "Adds attachment to task with given id that belongs to given container",
+      "description": "Send POST request to /server/containers/{id}/tasks/{tInstanceId}/attachments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment should be added to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"name of the attachment to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "addAttachment"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addComment1",
+      "name": "Adds comment to task with given id that belongs to given container",
+      "description": "Send POST request to /server/containers/{id}/tasks/{tInstanceId}/comments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment should be added to\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "addComment1"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:claim",
+      "name": "Claims task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/claimed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be claimed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "claim"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:complete",
+      "name": "Completes task with given id that belongs to given container, optionally it can claim and start task when auto-progress is used",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/completed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be completed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"auto-progress\":{\"type\":\"boolean\",\"title\":\"auto-progress\",\"description\":\"optional flag that allows to directlu claim and start task (if needed) before completion\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "complete"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:delegate",
+      "name": "Delegates task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/delegated",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be delegated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that task should be dalegated to\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "delegate"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:deleteAttachment",
+      "name": "Deletes attachment from task with given id that belongs to given container",
+      "description": "Send DELETE request to /server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be deleted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "deleteAttachment"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:deleteComment",
+      "name": "Deletes comment from task with given id that belongs to given container",
+      "description": "Send DELETE request to /server/containers/{id}/tasks/{tInstanceId}/comments/{commentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be deleted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "deleteComment"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:deleteContent",
+      "name": "Deletes content from task with given id that belongs to given container",
+      "description": "Send DELETE request to /server/containers/{id}/tasks/{tInstanceId}/contents/{contentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that content belongs to\"},\"contentId\":{\"type\":\"integer\",\"title\":\"contentId\",\"description\":\"identifier of the content to be deleted\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "deleteContent"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:exit",
+      "name": "Exists task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/exited",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be exited\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "exit"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:fail",
+      "name": "Fails task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/failed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be failed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "fail"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:forward",
+      "name": "Forwards task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/forwarded",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be forwarded\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that the task should be forwarded to\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "forward"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:nominate",
+      "name": "Nominates task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/nominated",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be nominated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"potOwner\":{\"type\":\"array\",\"title\":\"potOwner\",\"description\":\"list of users that the task should be nominated to\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "nominate"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:release",
+      "name": "Releases task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/released",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be released\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "release"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:resume",
+      "name": "Resumes task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/resumed",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be resumed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "resume"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAttachmentById",
+      "name": "Retrieves attachment with given id from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be loaded\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-attachment\",\"properties\":{\"attachment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"attachment-type\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\",\"format\":\"int32\"},\"attachment-content-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-attachment\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getAttachmentById"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAttachmentContentById",
+      "name": "Retrieves attachment's content with given id from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}/content",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment that content should be loaded from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\"}"
+        },
+        "configuredProperties": {
+          "operationId": "getAttachmentContentById"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getAttachmentsByTaskId",
+      "name": "Retrieves attachments from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/attachments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachments should be loaded for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-attachment-list\",\"properties\":{\"task-attachment\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"attachment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"attachment-type\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\",\"format\":\"int32\"},\"attachment-content-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-attachment\"}}}},\"xml\":{\"name\":\"task-attachment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getAttachmentsByTaskId"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCommentById",
+      "name": "Retrieves comment with given id from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/comments/{commentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be loaded\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-comment\",\"properties\":{\"comment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"comment\":{\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"task-comment\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCommentById"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getCommentsByTaskId",
+      "name": "Retrieves comments from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/comments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comments should be loaded for\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-comment-list\",\"properties\":{\"task-comment\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"comment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"comment\":{\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"task-comment\"}}}},\"xml\":{\"name\":\"task-comment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getCommentsByTaskId"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskInputContentByTaskId",
+      "name": "Retrieves input date from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/contents/input",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that input data should be loaded from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\",\"additionalProperties\":{\"type\":\"object\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskInputContentByTaskId"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskOutputContentByTaskId",
+      "name": "Retrieves output date from task with given id that belongs to given container",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/contents/output",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that output data should be loaded from\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"successful operation\",\"additionalProperties\":{\"type\":\"object\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskOutputContentByTaskId"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskEvents1",
+      "name": "Retrieves task events for given task id and applies pagination",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}/events",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that events should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-event-instance-list\",\"properties\":{\"task-event-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"task-event-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-event-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-message\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-event-instance\"}}}},\"xml\":{\"name\":\"task-event-instance-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskEvents1"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTask",
+      "name": "Retrieves task with given id that belongs to given container, optionally loads its input, output data and assignments",
+      "description": "Send GET request to /server/containers/{id}/tasks/{tInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be loaded\"},\"withInputData\":{\"type\":\"boolean\",\"title\":\"withInputData\",\"description\":\"optionally loads task input data\"},\"withOutputData\":{\"type\":\"boolean\",\"title\":\"withOutputData\",\"description\":\"optionally loads task output data\"},\"withAssignments\":{\"type\":\"boolean\",\"title\":\"withAssignments\",\"description\":\"optionally loads task people assignments\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-instance\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-workitem-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-last-modificaiton-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-pot-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}}},\"task-excl-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}}},\"task-business-admins\":{\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}}},\"task-input-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"task-output-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"task-instance\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTask"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:saveContent",
+      "name": "Saves content on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/contents/output",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that data should be saved into\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "saveContent"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setDescription",
+      "name": "Sets description on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/description",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where description should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setDescription"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setExpirationDate",
+      "name": "Sets expiration date on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/expiration",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where expiration date should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setExpirationDate"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setName",
+      "name": "Sets name on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/name",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where name should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setName"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setPriority",
+      "name": "Sets priority on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/priority",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where priority should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setPriority"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:setSkipable",
+      "name": "Sets skipable flag on task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/skipable",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where skipable flag should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "setSkipable"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:skip",
+      "name": "Skips task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/skipped",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be skipped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "skip"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:start",
+      "name": "Starts task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/started",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be started\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "start"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:stop",
+      "name": "Stops task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/stopped",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be stopped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "stop"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:suspend",
+      "name": "Suspends task with given id that belongs to given container",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}/states/suspended",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be suspended\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "suspend"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:update",
+      "name": "Updates task with given id that belongs to given container with given task instance details in body, updates name, description, priority, expiration date, form name, input and output variables",
+      "description": "Send PUT request to /server/containers/{id}/tasks/{tInstanceId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be updated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "update"
+        }
+      },
+      "tags": [
+        "User task operations and queries :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:acknowledgeError1",
+      "name": "Acknowledges given execution error",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/errors/{errorId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to be acknowledged\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "acknowledgeError1"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:acknowledgeErrors1",
+      "name": "Acknowledges given execution errors",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of identifiers of execution errors to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "acknowledgeErrors1"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addAdmins",
+      "name": "Adds business admins to given task instance, optionally removing existing ones",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/{tInstanceId}/admins",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing business admins should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addAdmins"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addExcludedOwners",
+      "name": "Adds excluded owners to given task instance, optionally removing existing ones",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing excluded owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addExcludedOwners"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addPotentialOwners",
+      "name": "Adds potential owners to given task instance, optionally removing existing ones",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing potential owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addPotentialOwners"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:addTaskInputs",
+      "name": "Adds task inputs to given task instance",
+      "description": "Send PUT request to /server/admin/containers/{id}/tasks/{tInstanceId}/contents/input",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "addTaskInputs"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:cancelNotification",
+      "name": "Cancels notification for given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/notifications/{notificationId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"notificationId\":{\"type\":\"integer\",\"title\":\"notificationId\",\"description\":\"identifier of notification to be canceled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "cancelNotification"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:cancelReassignment",
+      "name": "Cancels reassignment for given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/reassignments/{reassignmentId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"reassignmentId\":{\"type\":\"integer\",\"title\":\"reassignmentId\",\"description\":\"identifier of reassignment to be canceled\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "cancelReassignment"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeAdminsGroups",
+      "name": "Removes business admin groups from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/admins/groups/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from business admin list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeAdminsGroups"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeAdminsUsers",
+      "name": "Removes business admins from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/admins/users/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from business admin list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeAdminsUsers"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeExcludedOwnersUsers",
+      "name": "Removes excluded owners from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/users/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from excluded owners list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeExcludedOwnersUsers"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeExcludedOwnersGroups",
+      "name": "Removes excluded owners groups from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/groups/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from excluded owners list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeExcludedOwnersGroups"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removePotentialOwnersGroups",
+      "name": "Removes potential owner groups from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/groups/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from potantial owners list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removePotentialOwnersGroups"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removePotentialOwnersUsers",
+      "name": "Removes potential owners from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/users/{entityId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from potantial owners list\"}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removePotentialOwnersUsers"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeTaskInputs",
+      "name": "Removes task inputs referenced by names from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/contents/input",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task inputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeTaskInputs"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:removeTaskOutputs",
+      "name": "Removes task outputs referenced by names from given task instance",
+      "description": "Send DELETE request to /server/admin/containers/{id}/tasks/{tInstanceId}/contents/output",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task outputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "configuredProperties": {
+          "operationId": "removeTaskOutputs"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrorById1",
+      "name": "Retrieve execution error by its identifier",
+      "description": "Send GET request to /server/admin/containers/{id}/tasks/errors/{errorId}",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to load\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"execution-error\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrorById1"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrors1",
+      "name": "Retrieves execution errors for container, allows to filter by task name and/or process id, applies pagination",
+      "description": "Send GET request to /server/admin/containers/{id}/tasks/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"optional name of the task to filter by\"},\"process\":{\"type\":\"string\",\"title\":\"process\",\"description\":\"optional process id that the task belongs to to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"execution-error-list\",\"properties\":{\"error-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}}}},\"xml\":{\"name\":\"execution-error-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrors1"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getExecutionErrorsByTask",
+      "name": "Retrieves execution errors for task instance and container, applies pagination",
+      "description": "Send GET request to /server/admin/containers/{id}/tasks/{tInstanceId}/errors",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"execution-error-list\",\"properties\":{\"error-instance\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}}}},\"xml\":{\"name\":\"execution-error-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getExecutionErrorsByTask"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskNotifications",
+      "name": "Retrieves notifications for given task",
+      "description": "Send GET request to /server/admin/containers/{id}/tasks/{tInstanceId}/notifications",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only notifications should be collected, defaults to true\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-notification-list\",\"properties\":{\"task-notification\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"},\"notify-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}},\"active\":{\"type\":\"boolean\"},\"subject\":{\"type\":\"string\"},\"content\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-notification\"}}}},\"xml\":{\"name\":\"task-notification-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskNotifications"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:getTaskReassignments",
+      "name": "Retrieves reassignments for given task",
+      "description": "Send GET request to /server/admin/containers/{id}/tasks/{tInstanceId}/reassignments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only reassignmnets should be collected, defaults to true\",\"default\":\"true\"}}}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"title\":\"task-reassignment-list\",\"properties\":{\"task-reassignment\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"},\"reassign-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}},\"active\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"task-reassignment\"}}}},\"xml\":{\"name\":\"task-reassignment-list\"}}"
+        },
+        "configuredProperties": {
+          "operationId": "getTaskReassignments"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:notify",
+      "name": "Schedules new notification for given task instance",
+      "description": "Send POST request to /server/admin/containers/{id}/tasks/{tInstanceId}/notifications",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for notification\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "notify"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    },
+    {
+      "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:reassign",
+      "name": "Schedules new reassign of given task instance",
+      "description": "Send POST request to /server/admin/containers/{id}/tasks/{tInstanceId}/reassignments",
+      "descriptor": {
+        "connectorId": "_id_",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
+        "camelConnectorPrefix": "swagger-operation",
+        "inputDataShape": {
+          "name": "Request",
+          "description": "API request payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for reassignmnet\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+        },
+        "outputDataShape": {
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"integer\",\"title\":\"successful operation\",\"format\":\"int64\"}"
+        },
+        "configuredProperties": {
+          "operationId": "reassign"
+        }
+      },
+      "tags": [
+        "User tasks administration :: BPM"
+      ],
+      "actionType": "connector",
+      "dependencies": [
+        {
+          "type": "MAVEN",
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
+        }
+      ],
+      "pattern": "To"
+    }
+  ],
+  "name": "Kie Server API",
+  "properties": {
+    "host": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "Scheme hostname and port to direct the HTTP requests to in the form of https://hostname:port. Can be configured at the endpoint component or in the correspoding REST configuration in the Camel Context. If you give this component a name (e.g. petstore) that REST configuration is consulted first rest-swagger next and global configuration last. If set overrides any value found in the Swagger specification RestConfiguration. Can be overriden in endpoint configuration.",
+      "displayName": "Host",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": true,
+      "secret": false,
+      "type": "string",
+      "order": 10
+    },
+    "basePath": {
+      "componentProperty": true,
+      "defaultValue": "/kie-server/services/rest",
+      "deprecated": false,
+      "description": "API basePath for example /v2. Default is unset if set overrides the value present in Swagger specification.",
+      "displayName": "Base path",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": true,
+      "secret": false,
+      "type": "string",
+      "order": 11
+    },
+    "authenticationType": {
+      "componentProperty": true,
+      "defaultValue": "none",
+      "deprecated": false,
+      "description": "Type of authentication used to connect to the API",
+      "displayName": "Authentication Type",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": false,
+      "secret": false,
+      "type": "string",
+      "tags": [
+        "authentication-type"
+      ],
+      "enum": [
+        {
+          "label": "No Security",
+          "value": "none"
+        }
+      ],
+      "order": 1
+    },
+    "specification": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "Swagger specification of the service",
+      "displayName": "Specification",
+      "group": "producer",
+      "javaType": "java.lang.String",
+      "kind": "property",
+      "label": "producer",
+      "required": true,
+      "secret": false,
+      "type": "hidden",
+      "tags": [
+        "upload",
+        "url"
+      ]
+    }
+  },
+  "configuredProperties": {
+    "specification": "{\"swagger\":\"2.0\",\"info\":{\"description\":\"All endpoints that can be used with the Kie Server\",\"version\":\"7.0.0\",\"title\":\"Kie Server API\"},\"basePath\":\"/kie-server/services/rest\",\"tags\":[{\"name\":\"Administration of cases :: Case Management\"},{\"name\":\"Queries - case definitions and instances :: Case Management\"},{\"name\":\"Case instances :: Case Management\"},{\"name\":\"KIE Server Script :: Core\"},{\"name\":\"KIE Server :: Core\"},{\"name\":\"Decision Service :: DMN\"},{\"name\":\"Rules evaluation :: BRM\"},{\"name\":\"Process and task definitions :: BPM\"},{\"name\":\"Documents :: BPM\"},{\"name\":\"Asynchronous jobs :: BPM\"},{\"name\":\"Process instances :: BPM\"},{\"name\":\"Custom queries :: BPM\"},{\"name\":\"Queries - processes, nodes, variables and tasks :: BPM\"},{\"name\":\"User task operations and queries :: BPM\"},{\"name\":\"Process instances administration :: BPM\"},{\"name\":\"User tasks administration :: BPM\"},{\"name\":\"Process and task forms :: BPM\"},{\"name\":\"Process definition and instance images :: BPM\"},{\"name\":\"Planning and solvers :: BRP\"}],\"paths\":{\"/server/admin/cases/instances\":{\"get\":{\"tags\":[\"Administration of cases :: Case Management\"],\"summary\":\"Retrieves case instances without authntication checks and applies pagination\",\"operationId\":\"getCaseInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/processes\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves process definitions with filtering by name or id of the process definition and applies pagination\",\"operationId\":\"getProcessDefinitions\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"filter\",\"in\":\"query\",\"description\":\"process definition id or name that process definitions will be filtered by\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/instances\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instances with authntication checks and applies pagination, allows to filter by data (case file) name and value, owner and case instance status\",\"operationId\":\"getCaseInstances1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"dataItemName\",\"in\":\"query\",\"description\":\"data item name that case instances will be filtered by\",\"required\":false,\"type\":\"string\"},{\"name\":\"dataItemValue\",\"in\":\"query\",\"description\":\"data item value that case instances will be filtered by\",\"required\":false,\"type\":\"string\"},{\"name\":\"owner\",\"in\":\"query\",\"description\":\"case instance owner that case instances will be filtered by\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/{caseRoleName}/instances\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instances where given user is involed in given role and applies pagination, allows to filter by case instance status\",\"operationId\":\"getCaseInstancesByRole\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"caseRoleName\",\"in\":\"path\",\"description\":\"case role that instances should be found for\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/instances/{caseId}/caseFile\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instance data items, allows to filter by name or type of data and applies pagination\",\"operationId\":\"getCaseInstanceDataItems\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"case instance identifier that data items should belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"name\",\"in\":\"query\",\"description\":\"optionally filter by data item names\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"name\":\"type\",\"in\":\"query\",\"description\":\"optionally filter by data item types\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/{id}/processes\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves process definitions that belong to given container and applies pagination\",\"operationId\":\"getProcessDefinitionsByContainer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process definitions should be filtered by\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/instances/{caseId}/tasks/instances/pot-owners\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instance tasks assigned as potential owner, allows to filter by task status and applies pagination\",\"operationId\":\"getCaseInstanceTasksAsPotentialOwner\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"case instance identifier that tasks should belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/instances/{caseId}/tasks/instances/admins\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instance tasks assigned as business admin, allows to filter by task status and applies pagination\",\"operationId\":\"getCaseInstanceTasksAsAdmin\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"case instance identifier that tasks should belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases/instances/{caseId}/tasks/instances/stakeholders\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case instance tasks assigned as stakeholder, allows to filter by task status and applies pagination\",\"operationId\":\"getCaseInstanceTasksAsStakeholder\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"case instance identifier that tasks should belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/cases\":{\"get\":{\"tags\":[\"Queries - case definitions and instances :: Case Management\"],\"summary\":\"Retrieves case definitions with filtering by name or id of the case definition and applies pagination\",\"operationId\":\"getCaseDefinitions\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"filter\",\"in\":\"query\",\"description\":\"case definition id or name that case definitions will be filtered by\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/{caseDefId}/instances\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case instances for given case definition only, allows to filter by case instance status and applies pagination\",\"operationId\":\"getCaseInstancesByDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that should be used to filter case instances\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseDefId\",\"in\":\"path\",\"description\":\"case definition id that should be used to filter case instances\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Starts new case instance of given case definition within given container with optional initial CaseFile (that provides variables and case role assignment)\",\"operationId\":\"startCase\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the case definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseDefId\",\"in\":\"path\",\"description\":\"case definition id that new instance should be created from\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional CaseFile with variables and/or case role assignments\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"404\":{\"description\":\"Case definition or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves active case instance by given identifier (case id) with optionally loading data, roles, milestones and stages\",\"operationId\":\"getCaseInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"withData\",\"in\":\"query\",\"description\":\"optional flag to load data when loading case instance\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"withRoles\",\"in\":\"query\",\"description\":\"optional flag to load roles when loading case instance\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"withMilestones\",\"in\":\"query\",\"description\":\"optional flag to load milestones when loading case instance\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"withStages\",\"in\":\"query\",\"description\":\"optional flag to load stages when loading case instance\",\"required\":false,\"type\":\"boolean\",\"default\":false}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Closes case instance with given identifier (case id) optionally with comment\",\"operationId\":\"closeCaseInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional comment when closing a case instance as String\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Cancels case instance with given identifier (case id) it can also when intructed permanently destroy the case instance\",\"operationId\":\"cancelCaseInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"destroy\",\"in\":\"query\",\"description\":\"allows to destroy (permanently) case instance as part of the cancel operation, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/{caseDefId}/instances/{caseId}\":{\"put\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Reopens case instance with given identifier (case id) by initiating given case definition\",\"operationId\":\"reopenCase\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the case definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseDefId\",\"in\":\"path\",\"description\":\"case definition id that new instance should be created from\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional CaseFile with variables and/or case role assignments\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/milestones\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves milestones from case instance\",\"operationId\":\"getCaseInstanceMilestones\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"achievedOnly\",\"in\":\"query\",\"description\":\"optional flag that allows to control which milestones to load - achieved only or actives ones too, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-milestone-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-milestone-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/stages\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves stages from case instance\",\"operationId\":\"getCaseInstanceStages\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"activeOnly\",\"in\":\"query\",\"description\":\"optional flag that allows to control which stages to load - active only or completed ones too, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-stage-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-stage-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/caseFile\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case instance data as map where key is the name of data item and value is actual instance of the data item from case file\",\"operationId\":\"getCaseInstanceData\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"name\",\"in\":\"query\",\"description\":\"optional name(s) of the data items to retrieve\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"responseSchema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Puts new data (map of variables) into case instance's case file\",\"operationId\":\"putCaseInstanceData\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"restrictedTo\",\"in\":\"query\",\"description\":\"optional role name(s) that given data should be restricted to\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"map of data to be placed in case file as Map\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Removes data items identified by name(s) from case instance's case file\",\"operationId\":\"deleteCaseInstanceData\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"dataId\",\"in\":\"query\",\"description\":\"one or more names of the data items to be removed from case file\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/caseFile/{dataId}\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case instance data by data item name\",\"operationId\":\"getCaseInstanceDataByName\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"dataId\",\"in\":\"path\",\"description\":\"name of the data item within case file to retrieve\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\"},\"responseSchema\":{\"type\":\"object\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Puts new data (single data identified by name) into case instance's case file\",\"operationId\":\"putCaseInstanceDataByName\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"dataId\",\"in\":\"path\",\"description\":\"name of the data item to be added to case file\",\"required\":true,\"type\":\"string\"},{\"name\":\"restrictedTo\",\"in\":\"query\",\"description\":\"optional role name(s) that given data should be restricted to\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data to be placed in case file, any type can be provided\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/tasks\":{\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds dynamic task (user or service depending on the payload) to case instance\",\"operationId\":\"addDynamicTaskToCase\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data for dynamic task (it represents task specification that drives the selection of the type of task)\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks\":{\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds dynamic task (user or service depending on the payload) to given stage within case instance\",\"operationId\":\"addDynamicTaskToCase1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseStageId\",\"in\":\"path\",\"description\":\"identifier of the stage within case instance where dynamic task should be added\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data for dynamic task (it represents task specification that drives the selection of the type of task)\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/processes/{pId}\":{\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds dynamic subprocess identified by process id to case instance\",\"operationId\":\"addDynamicProcessToCase\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id of the subprocess to be added\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data for dynamic subprocess\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/processes/{pId}\":{\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds dynamic subprocess identified by process id to stage within case instance\",\"operationId\":\"addDynamicProcessToCase1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseStageId\",\"in\":\"path\",\"description\":\"identifier of the stage within case instance where dynamic subprocess should be added\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id of the subprocess to be added\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data for dynamic subprocess\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/stages/{caseStageId}/tasks/{nodeName}\":{\"put\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Triggers ad hoc fragment in stage within case instance with optional data\",\"operationId\":\"triggerAdHocNodeInStage\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseStageId\",\"in\":\"path\",\"description\":\"identifier of the stage within case instance where adhoc fragment should be triggered\",\"required\":true,\"type\":\"string\"},{\"name\":\"nodeName\",\"in\":\"path\",\"description\":\"name of the adhoc fragment to be triggered\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional data to be given when triggering adhoc fragment\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/adhocfragments\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves adhoc fragments from case instance\",\"operationId\":\"getCaseInstanceAdHocFragments\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-adhoc-fragment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-adhoc-fragment-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/processes/instances\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves process isntances that compose complete case instance\",\"operationId\":\"getCaseInstanceProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/nodes/instances\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves node instances from case instance\",\"operationId\":\"getCaseInstanceActiveNodes\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"completed\",\"in\":\"query\",\"description\":\"optional flag that allows to control which node instances to load - active or completed, defaults to false loading only active ones\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/roles\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves role assignments from case instance\",\"operationId\":\"getCaseInstanceRoleAssignments\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-role-assignment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-role-assignment-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/roles/{caseRoleName}\":{\"put\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds new role assignment for given case, it can be either user or group based assignment\",\"operationId\":\"addRoleAssignment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseRoleName\",\"in\":\"path\",\"description\":\"name of the case role the assignment should be set\",\"required\":true,\"type\":\"string\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"user to be aded to case role for given case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"group\",\"in\":\"query\",\"description\":\"group to be aded to case role for given case instance\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Removes role assignment from user or group for given case instance\",\"operationId\":\"removeRoleAssignment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseRoleName\",\"in\":\"path\",\"description\":\"name of the case role the assignment should be removed\",\"required\":true,\"type\":\"string\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"user to be removed from case role for given case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"group\",\"in\":\"query\",\"description\":\"group to be removed from case role for given case instance\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/comments\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves comments from case instance\",\"operationId\":\"getCaseInstanceComments\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-comment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-comment-list\"}},\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Adds new comment to given case instance\",\"operationId\":\"addComment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"author\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"restrictedTo\",\"in\":\"query\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"actual content of the comment to be added as String\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/definitions/{caseDefId}\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case definition for given container and case definition id\",\"operationId\":\"getCaseDefinitionsByDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that should be used to filter case definitions\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseDefId\",\"in\":\"path\",\"description\":\"case definition id that should be loaded\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-definition\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-definition\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/comments/{caseCommentId}\":{\"put\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Updates comment within case instance\",\"operationId\":\"updateComment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseCommentId\",\"in\":\"path\",\"description\":\"identifier of the comment to be updated\",\"required\":true,\"type\":\"string\"},{\"name\":\"author\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"restrictedTo\",\"in\":\"query\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"actual content of the comment to be updated to as String\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Removes given comment from case instance\",\"operationId\":\"removeComment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseCommentId\",\"in\":\"path\",\"description\":\"identifier of the comment to be removed\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances/{caseId}/tasks/{nodeName}\":{\"put\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Triggers ad hoc fragment in case instance with optional data\",\"operationId\":\"triggerAdHocNode\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that case instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"caseId\",\"in\":\"path\",\"description\":\"identifier of the case instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"nodeName\",\"in\":\"path\",\"description\":\"name of the adhoc fragment to be triggered\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional data to be given when triggering adhoc fragment\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Case instance not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/instances\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case instances for given container only, allows to filter by case instance status and applies pagination\",\"operationId\":\"getCaseInstancesByContainer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that should be used to filter case instances\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/cases/definitions\":{\"get\":{\"tags\":[\"Case instances :: Case Management\"],\"summary\":\"Retrieves case definition for given container only, applies pagination\",\"operationId\":\"getCaseDefinitionsByContainer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that should be used to filter case definitions\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/case-definition-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/case-definition-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/config\":{\"post\":{\"tags\":[\"KIE Server Script :: Core\"],\"summary\":\"Executes command script on execution server, usually used as a batch to configure KIE Server\",\"operationId\":\"executeCommands\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"in\":\"body\",\"name\":\"body\",\"description\":\"command script payload\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/responses\"},\"responseSchema\":{\"$ref\":\"#/definitions/responses\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves KIE Server information - id, name, location, capabilities, messages\",\"operationId\":\"getInfo\",\"produces\":[\"application/xml\",\"application/json\"],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/scanner\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves stanner information for given container\",\"operationId\":\"getScannerInfo\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id for scanner to be loaded\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Updates scanner for given container\",\"operationId\":\"updateScanner\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id for scanner to be updated\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"Scanner information given as KieScannerResource type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves containers deployed to this server, optionally filtered by group, artifact, version or status\",\"operationId\":\"listContainers\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"groupId\",\"in\":\"query\",\"description\":\"optional groupId to filter containers by\",\"required\":false,\"type\":\"string\"},{\"name\":\"artifactId\",\"in\":\"query\",\"description\":\"optional artifactId to filter containers by\",\"required\":false,\"type\":\"string\"},{\"name\":\"version\",\"in\":\"query\",\"description\":\"optional version to filter containers by\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional status to filter containers by\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves container with given id\",\"operationId\":\"getContainerInfo\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id to be retrieved\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Creates (deploys) new KIE container to this server\",\"operationId\":\"createContainer\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id to be assigned to deployed KIE Container\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"KIE Container resource to be deployed as KieContainerResource\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"400\":{\"description\":\"container could not be created\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Disposes (undeploys) container with given id\",\"operationId\":\"disposeContainer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id to be disposed (undeployed)\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/state\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves server state - configuration that the server is currently running with\",\"operationId\":\"getServerState\",\"produces\":[\"application/xml\",\"application/json\"],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/release-id\":{\"get\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Retrieves release id of the KIE container with given id\",\"operationId\":\"getReleaseId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id that release id should be loaded from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"KIE Server :: Core\"],\"summary\":\"Updates release id of the KIE container with given id to provided release id\",\"operationId\":\"updateReleaseId\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id that release id should be upgraded\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"Release Id to be upgraded to as ReleaseId type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/dmn\":{\"get\":{\"tags\":[\"Decision Service :: DMN\"],\"summary\":\"Retrieves DMN model for given container\",\"operationId\":\"getModels\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id that modesl should be loaded from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"404\":{\"description\":\"Models or container not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Decision Service :: DMN\"],\"summary\":\"Evaluates decisions for given imput\",\"operationId\":\"evaluateDecisions\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id to be used to evaluate decisions on\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"DMN context to be used while evaluation decisions as DMNContextKS type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"404\":{\"description\":\"Container not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/instances/{id}\":{\"post\":{\"tags\":[\"Rules evaluation :: BRM\"],\"summary\":\"Evaluates rules by executing commands on the rule session\",\"operationId\":\"manageContainer\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"Container id where rules should be evaluated on\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"Commands to be executed on rule engine given as BatchExecutionCommand type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/response\"},\"responseSchema\":{\"$ref\":\"#/definitions/response\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/variables\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves process variables definitions that are present in given process and container\",\"operationId\":\"getProcessVariables\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that the variable definitions should be retrieved from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-variables\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-variables\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/tasks/service\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves service tasks definitions that are present in given process and container\",\"operationId\":\"getServiceTasks\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that the service task definitions should be retrieved from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-service-tasks\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-service-tasks\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/entities\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves actors and groups that are involved in given process and container\",\"operationId\":\"getAssociatedEntities\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that the involved actors and groups should be retrieved from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-associated-entities\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-associated-entities\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/tasks/users\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves user tasks definitions that are present in given process and container\",\"operationId\":\"getTasksDefinitions\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that the user task definitions should be retrieved from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/user-task-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/user-task-definitions\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/inputs\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves input variables defined on a given user task\",\"operationId\":\"getTaskInputMappings\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that given task belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"taskName\",\"in\":\"path\",\"description\":\"task name that input variable definitions should be retrieved for\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-task-inputs\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-task-inputs\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves process definition identified by given process id within given container\",\"operationId\":\"getProcessDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that the definition should be retrieved for\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definition\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definition\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/subprocesses\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves sub process definitions that are defined in given process within given container\",\"operationId\":\"getReusableSubProcesses\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that subprocesses should be retrieved from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-subprocesses\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-subprocesses\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/definitions/{pId}/tasks/users/{taskName}/outputs\":{\"get\":{\"tags\":[\"Process and task definitions :: BPM\"],\"summary\":\"Retrieves output variables defined on a given user task\",\"operationId\":\"getTaskOutputMappings\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that given task belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"taskName\",\"in\":\"path\",\"description\":\"task name that output variable definitions should be retrieved for\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-task-outputs\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-task-outputs\"}},\"404\":{\"description\":\"Process or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/documents/{documentId}\":{\"get\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Retrieves document identified by given documentId\",\"operationId\":\"getDocument\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"documentId\",\"in\":\"path\",\"description\":\"document id of a document that should be retruned\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/document-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/document-instance\"}},\"404\":{\"description\":\"Document with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Updates document identified by given document id based on given content (body)\",\"operationId\":\"updateDocument\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"documentId\",\"in\":\"path\",\"description\":\"document id of a document that should be updated\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"document content represented as DocumentInstance\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Document with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Deletes document identified by given document id\",\"operationId\":\"deleteDocument\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"documentId\",\"in\":\"path\",\"description\":\"document id of a document that should be deleted\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Document with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/documents\":{\"get\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Retrieves documents that are stored in the system, with pagination\",\"operationId\":\"listDocuments\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/document-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/document-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Creates new document based on given content (body)\",\"operationId\":\"createDocument\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"in\":\"body\",\"name\":\"body\",\"description\":\"document content represented as DocumentInstance\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/documents/{documentId}/content\":{\"get\":{\"tags\":[\"Documents :: BPM\"],\"summary\":\"Retrieves document's content identified by given documentId\",\"operationId\":\"getDocumentContent\",\"produces\":[\"application/octet-stream\"],\"parameters\":[{\"name\":\"documentId\",\"in\":\"path\",\"description\":\"document id of a document that content should be retruned from\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"byte\",\"pattern\":\"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$\"}},\"responseSchema\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"byte\",\"pattern\":\"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$\"}}},\"404\":{\"description\":\"Document with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/{jobId}\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous job by given jobId\",\"operationId\":\"getRequestById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"jobId\",\"in\":\"path\",\"description\":\"identifier of the asynchronous job to be retrieved\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"withErrors\",\"in\":\"query\",\"description\":\"optional flag that indicats if errors should be loaded as well\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"withData\",\"in\":\"query\",\"description\":\"optional flag that indicats if input/output data should be loaded as well\",\"required\":false,\"type\":\"boolean\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Requeues failed asynchronous job identified by given jobId\",\"operationId\":\"requeueRequest\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"jobId\",\"in\":\"path\",\"description\":\"identifier of the asynchronous job to be requeued\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Cancels active asynchronous job identified by given jobId\",\"operationId\":\"cancelRequest\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"jobId\",\"in\":\"path\",\"description\":\"identifier of the asynchronous job to be canceled\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/keys/{key}\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous jobs by business key\",\"operationId\":\"getRequestsByBusinessKey\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"key\",\"in\":\"path\",\"description\":\"identifier of the business key that asynchornous jobs should be found for\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/commands/{cmd}\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous jobs by command\",\"operationId\":\"getRequestsByCommand\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"cmd\",\"in\":\"path\",\"description\":\"name of the command that asynchornous jobs should be found for\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/processes/instances/{pInstanceId}\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous jobs by process instance id\",\"operationId\":\"getRequestsByProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that asynchornous jobs should be found for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous jobs filtered by status\",\"operationId\":\"getRequestsByStatus\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Schedules new asynchronous job based on given body\",\"operationId\":\"scheduleRequest\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"containerId\",\"in\":\"query\",\"description\":\"optional container id that the job should be associated with\",\"required\":false,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"asynchronous job definition represented as JobRequestInstance\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/containers/{id}\":{\"get\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Retrieves asynchronous jobs by container\",\"operationId\":\"getRequestsByContainer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"identifier of the container that asynchornous jobs should be found for\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/request-info-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/request-info-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/jobs/{jobId}/data\":{\"post\":{\"tags\":[\"Asynchronous jobs :: BPM\"],\"summary\":\"Updates active asynchronous job's data (identified by given jobId)\",\"operationId\":\"updateRequestData\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"jobId\",\"in\":\"path\",\"description\":\"identifier of the asynchronous job to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"containerId\",\"in\":\"query\",\"description\":\"optional container id that the job should be associated with\",\"required\":false,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"data to be updated on the asynchronous job represented as Map\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/{pId}/instances/correlation/{correlationKey}\":{\"post\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Starts new process instance with correlation key of given process definition within given container with optional variables\",\"operationId\":\"startProcessWithCorrelation\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that new instance should be created from\",\"required\":true,\"type\":\"string\"},{\"name\":\"correlationKey\",\"in\":\"path\",\"description\":\"correlation key to be assigned to process instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional map of process variables\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Process ID or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/nodes/instances\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes\",\"operationId\":\"getProcessInstanceHistory\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that history should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"activeOnly\",\"in\":\"query\",\"description\":\"instructs if active nodes only should be collected, defaults to false\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"completedOnly\",\"in\":\"query\",\"description\":\"instructs if completed nodes only should be collected, defaults to false\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves process instances that belong to given container\",\"operationId\":\"getProcessInstancesByDeploymentId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Aborts active process instances identified by given list of identifiers\",\"operationId\":\"abortProcessInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"instanceId\",\"in\":\"query\",\"description\":\"list of identifiers of the process instances to be aborted\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int64\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/signal/{sName}\":{\"post\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Signals active process instance identified by given id with singal name and optional event data\",\"operationId\":\"signalProcessInstance\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance to be signaled\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"sName\",\"in\":\"path\",\"description\":\"signal name to be send to process instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional event data - any type can be provided\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/signal/{sName}\":{\"post\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Signals active process instances identified by given ids with singal name and optional event data\",\"operationId\":\"signalProcessInstances\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"instanceId\",\"in\":\"query\",\"description\":\"list of identifiers of the process instances to be signaled\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int64\"},\"collectionFormat\":\"multi\"},{\"name\":\"sName\",\"in\":\"path\",\"description\":\"signal name to be send to process instance\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional event data - any type can be provided\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/variable/{varName}\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves active process instance's (identified by given id) variable given as variable name\",\"operationId\":\"getProcessInstanceVariable\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that variable should be retrieved from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"varName\",\"in\":\"path\",\"description\":\"variable name to be retrieved\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\"},\"responseSchema\":{\"type\":\"object\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Updates active process instance's (identified by given id) variable with given name\",\"operationId\":\"setProcessVariable\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"varName\",\"in\":\"path\",\"description\":\"name of the variable to be set/updated\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"variable data - any type can be provided\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/variables\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves active process instance's (identified by given id) variables, variables are returned as map where key is the variable name (string) and value is variable value (any type)\",\"operationId\":\"getProcessInstanceVariables\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that variables should be retrieved from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"responseSchema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Updates active process instance's (identified by given id) variables given as map in the body\",\"operationId\":\"setProcessVariables\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"variable data give as map\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/signals\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves active process instance's (identified by given id) active signals\",\"operationId\":\"getAvailableSignals\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that signals should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"responseSchema\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/workitems\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves work items within process instance and container\",\"operationId\":\"getWorkItemByProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that work items belong to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/work-item-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/work-item-instance-list\"}},\"404\":{\"description\":\"Process instance, Work Item or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/variables/instances\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves variables last value (from audit logs) for given process instance\",\"operationId\":\"getVariablesCurrentState\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that variables state should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/variable-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/variable-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/variables/instances/{varName}\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves variable history (from audit logs) for given variable name that belongs to process instance\",\"operationId\":\"getVariableHistory\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that variable history should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"varName\",\"in\":\"path\",\"description\":\"name of the variables that history should be collected for\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/variable-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/variable-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves process definitions that belong to given container\",\"operationId\":\"getProcessesByDeploymentId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definitions\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/processes\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves process instances that belong to given container and have given parent process instance, optionally allow to filter by process instance state.\",\"operationId\":\"getProcessInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the parent process instance that process instances should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves process instance identified by given id optionally with variables (variables will be loaded only for active process instance)\",\"operationId\":\"getProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance to be fetched\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"withVars\",\"in\":\"query\",\"description\":\"indicates if process instance variables should be loaded or not\",\"required\":false,\"type\":\"boolean\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Aborts active process instance identified by given id\",\"operationId\":\"abortProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance to be aborted\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/{pId}/instances\":{\"post\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Starts new process instance of given process definition within given container with optional variables\",\"operationId\":\"startProcess\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the process definition resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id that new instance should be created from\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional map of process variables\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Process ID or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/completed\":{\"put\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Completes work item identified by workItemId within process instance and container. Optionally completion can provide outcome data - as map\",\"operationId\":\"completeWorkItem\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that work item belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"workItemId\",\"in\":\"path\",\"description\":\"identifier of the work item to complete\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional outcome data give as map\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance, Work Item or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}/aborted\":{\"put\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Aborts work item identified by workItemId within process instance and container\",\"operationId\":\"abortWorkItem\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that work item belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"workItemId\",\"in\":\"path\",\"description\":\"identifier of the work item to abort\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Process instance, Work Item or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/processes/instances/{pInstanceId}/workitems/{workItemId}\":{\"get\":{\"tags\":[\"Process instances :: BPM\"],\"summary\":\"Retrieves work item identified by workItemId within process instance and container\",\"operationId\":\"getWorkItem\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that work item belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"workItemId\",\"in\":\"path\",\"description\":\"identifier of the work item to retrieve\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/work-item-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/work-item-instance\"}},\"404\":{\"description\":\"Process instance, Work Item or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/definitions\":{\"get\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Retruns all custom queries defined in the system\",\"operationId\":\"getQueries\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/query-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/query-definitions\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/definitions/{queryName}\":{\"get\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Retrieves existing query definition from the system with given queryName\",\"operationId\":\"getQuery\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be retrieved\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/query-definition\"},\"responseSchema\":{\"$ref\":\"#/definitions/query-definition\"}},\"404\":{\"description\":\"Query definition with given name not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Registers new query definition in the system with given queryName\",\"operationId\":\"createQueryDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be registered\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"query definition represented as QueryDefinition\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"409\":{\"description\":\"Query with given name already exists\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Replaces existing query definition or registers new if not exists in the system with given queryName\",\"operationId\":\"replaceQueryDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be replaced\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"query definition represented as QueryDefinition\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Deletes existing query definition from the system with given queryName\",\"operationId\":\"dropQueryDefinition\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be deleted\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Query definition with given name not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/definitions/{queryName}/data\":{\"get\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper.\",\"operationId\":\"runQuery\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be used for query\",\"required\":true,\"type\":\"string\"},{\"name\":\"mapper\",\"in\":\"query\",\"description\":\"identifier of the query mapper to be used when transforming results\",\"required\":true,\"type\":\"string\"},{\"name\":\"orderBy\",\"in\":\"query\",\"description\":\"optional sort order\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"array\",\"items\":{\"type\":\"object\"}},\"responseSchema\":{\"type\":\"array\",\"items\":{\"type\":\"object\"}}},\"404\":{\"description\":\"Query definition with given name not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/definitions/{queryName}/filtered-data\":{\"post\":{\"tags\":[\"Custom queries :: BPM\"],\"summary\":\"Queries using query definition identified by queryName. Maps the result to concrete objects based on provided mapper. Query is additional altered by the filter spec and/or builder\",\"operationId\":\"runQueryFiltered\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"queryName\",\"in\":\"path\",\"description\":\"identifier of the query definition to be used for query\",\"required\":true,\"type\":\"string\"},{\"name\":\"mapper\",\"in\":\"query\",\"description\":\"identifier of the query mapper to be used when transforming results\",\"required\":true,\"type\":\"string\"},{\"name\":\"builder\",\"in\":\"query\",\"description\":\"optional identifier of the query builder to be used for query conditions\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional query filter specification represented as QueryFilterSpec\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\"},\"responseSchema\":{\"type\":\"object\"}},\"400\":{\"description\":\"Query parameters or filter spec provide invalid conditions\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/variables/{varName}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instances filtered by by variable or by variable and its value. Applies pagination by default and allows to specify sorting\",\"operationId\":\"getProcessInstanceByVariables\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"varName\",\"in\":\"path\",\"description\":\"variable name to filter process instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"varValue\",\"in\":\"query\",\"description\":\"variable value to filter process instance, optional when filtering by name only required when filtering by name and value\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/variables/{varName}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks by variable name and optionally by variable value, optionally filters by status and applies pagination\",\"operationId\":\"getTasksByVariables\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"varName\",\"in\":\"path\",\"description\":\"name of the variable used to fiter tasks\",\"required\":true,\"type\":\"string\"},{\"name\":\"varValue\",\"in\":\"query\",\"description\":\"value of the variable used to fiter tasks, optional when filtering only by name, required when filtering by both name and value\",\"required\":false,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/{pInstanceId}/nodes/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves node instances for given process instance. Depending on provided query parameters (activeOnly or completedOnly) will return active and/or completes nodes\",\"operationId\":\"getProcessInstanceHistory1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id to to retrive history for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"activeOnly\",\"in\":\"query\",\"description\":\"include active nodes only\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"completedOnly\",\"in\":\"query\",\"description\":\"include completed nodes only\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/{tInstanceId}/events\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves task events for given task id and applies pagination\",\"operationId\":\"getTaskEvents\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"task id to load task events for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-event-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-event-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/containers/{id}/process/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instances filtered by container. Applies pagination by default and allows to specify sorting\",\"operationId\":\"getProcessInstancesByDeploymentId1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id to filter process instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/{pId}/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instances filtered by process id. Applies pagination by default and allows to specify sorting\",\"operationId\":\"getProcessInstancesByProcessId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id to filter process instance\",\"required\":true,\"type\":\"string\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"initiator\",\"in\":\"query\",\"description\":\"optinal process instance initiator - user who started process instance to filtr process instances\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/{pInstanceId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instance for given process instance id and optionally loads its variables\",\"operationId\":\"getProcessInstanceById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id to retrieve process instance\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"withVars\",\"in\":\"query\",\"description\":\"load process instance variables or not, defaults to false\",\"required\":false,\"type\":\"boolean\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance\"}},\"404\":{\"description\":\"Process instance id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instance/correlation/{correlationKey}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instance by exactly matched correlation key\",\"operationId\":\"getProcessInstanceByCorrelationKey\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"correlationKey\",\"in\":\"path\",\"description\":\"correlation key associated with process instance\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/correlation/{correlationKey}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instances filtered by correlation key, retrieves all process instances that match correlationkey*. Applies pagination by default and allows to specify sorting\",\"operationId\":\"getProcessInstancesByCorrelationKey\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"correlationKey\",\"in\":\"path\",\"description\":\"correlation key to filter process instance, can be given as partial correlation key like in starts with approach\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/{pInstanceId}/wi-nodes/instances/{workItemId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves node instance for given process instance id and work item id\",\"operationId\":\"getNodeInstanceForWorkItem\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id that work item belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"workItemId\",\"in\":\"path\",\"description\":\"work item id to retrieve node instance for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance\"}},\"404\":{\"description\":\"Node instance id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/{pInstanceId}/variables/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves variables last value (from audit logs) for given process instance\",\"operationId\":\"getVariablesCurrentState1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id to load variables current state (latest value) for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/variable-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/variable-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances/{pInstanceId}/variables/instances/{varName}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves variable history (from audit logs) for given variable name that belongs to process instance\",\"operationId\":\"getVariableHistory1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id to load variable history for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"varName\",\"in\":\"path\",\"description\":\"variable name that history should be loaded for\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/variable-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/variable-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/containers/{id}/processes/definitions\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process definitions that belong to given container\",\"operationId\":\"getProcessesByDeploymentId1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id to filter process definitions\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definitions\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/definitions\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process definitions filtered by process id or name\",\"operationId\":\"getProcessesByFilter\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"filter\",\"in\":\"query\",\"description\":\"process id or name to filter process definitions\",\"required\":true,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definitions\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/definitions/{pId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process definitions filtered by process id\",\"operationId\":\"getProcessesById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id to load process definition\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definitions\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definitions\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/containers/{id}/processes/definitions/{pId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process definition that belong to given container and has matching process id\",\"operationId\":\"getProcessesByDeploymentIdProcessId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process definition belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"process id to load process definition\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-definition\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-definition\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks, optionally filters by status and applies pagination\",\"operationId\":\"getAllAuditTask\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/workitem/{workItemId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves task by associated work item id\",\"operationId\":\"getTaskByWorkItemId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"workItemId\",\"in\":\"path\",\"description\":\"work item id to load task associated with\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-instance\"}},\"404\":{\"description\":\"Task not found for given work item id\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/pot-owners\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks assigned as potential owner, optionally filters by status and given groups and applies pagination\",\"operationId\":\"getTasksAssignedAsPotentialOwner\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"groups\",\"in\":\"query\",\"description\":\"optional group names to include in the query\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true},{\"name\":\"filter\",\"in\":\"query\",\"description\":\"optional custom filter for task data\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/owners\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks owned, optionally filters by status and applies pagination\",\"operationId\":\"getTasksOwnedByStatus\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/process/{pInstanceId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks associated with given process instance, optionally filters by status and applies pagination\",\"operationId\":\"getTasksByStatusByProcessInstanceId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"process instance id to filter task instances\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/{tInstanceId}\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves task by task id\",\"operationId\":\"getTaskById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"task id to load task instance\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-instance\"}},\"404\":{\"description\":\"Task not found for given id\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/processes/instances\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves process instances filtered by status, initiator, processName - depending what query parameters are given. Applies pagination by default and allows to specify sorting\",\"operationId\":\"getProcessInstances1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2,3]},\"collectionFormat\":\"multi\"},{\"name\":\"initiator\",\"in\":\"query\",\"description\":\"optional process instance initiator - user who started process instance to filter process instances\",\"required\":false,\"type\":\"string\"},{\"name\":\"processName\",\"in\":\"query\",\"description\":\"optional process name to filter process instances\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/queries/tasks/instances/admins\":{\"get\":{\"tags\":[\"Queries - processes, nodes, variables and tasks :: BPM\"],\"summary\":\"Retrieves tasks assigned as business administrator, optionally filters by status and applies pagination\",\"operationId\":\"getTasksAssignedAsBusinessAdministratorByStatus\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"status\",\"in\":\"query\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"required\":false,\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]},\"collectionFormat\":\"multi\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-summary-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-summary-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/released\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Releases task with given id that belongs to given container\",\"operationId\":\"release\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be released\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/delegated\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Delegates task with given id that belongs to given container\",\"operationId\":\"delegate\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be delegated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"targetUser\",\"in\":\"query\",\"description\":\"user that task should be dalegated to\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/completed\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Completes task with given id that belongs to given container, optionally it can claim and start task when auto-progress is used\",\"operationId\":\"complete\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be completed\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"auto-progress\",\"in\":\"query\",\"description\":\"optional flag that allows to directlu claim and start task (if needed) before completion\",\"required\":false,\"type\":\"boolean\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional map of output variables\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves task with given id that belongs to given container, optionally loads its input, output data and assignments\",\"operationId\":\"getTask\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be loaded\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"withInputData\",\"in\":\"query\",\"description\":\"optionally loads task input data\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"withOutputData\",\"in\":\"query\",\"description\":\"optionally loads task output data\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"withAssignments\",\"in\":\"query\",\"description\":\"optionally loads task people assignments\",\"required\":false,\"type\":\"boolean\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-instance\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Updates task with given id that belongs to given container with given task instance details in body, updates name, description, priority, expiration date, form name, input and output variables\",\"operationId\":\"update\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"task instance with updates as TaskInstance type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/attachments\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves attachments from task with given id that belongs to given container\",\"operationId\":\"getAttachmentsByTaskId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that attachments should be loaded for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-attachment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-attachment-list\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Adds attachment to task with given id that belongs to given container\",\"operationId\":\"addAttachment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that attachment should be added to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"name\",\"in\":\"query\",\"description\":\"name of the attachment to be added\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"attachment content, any type can be provided\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/claimed\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Claims task with given id that belongs to given container\",\"operationId\":\"claim\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be claimed\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/forwarded\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Forwards task with given id that belongs to given container\",\"operationId\":\"forward\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be forwarded\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"targetUser\",\"in\":\"query\",\"description\":\"user that the task should be forwarded to\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/activated\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Activates task with given id that belongs to given container\",\"operationId\":\"activate\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be activated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/description\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Sets description on task with given id that belongs to given container\",\"operationId\":\"setDescription\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance where description should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"description as String\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/events\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves task events for given task id and applies pagination\",\"operationId\":\"getTaskEvents1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that events should be loaded for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-event-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-event-instance-list\"}},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/contents/output\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves output date from task with given id that belongs to given container\",\"operationId\":\"getTaskOutputContentByTaskId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that output data should be loaded from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"responseSchema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Saves content on task with given id that belongs to given container\",\"operationId\":\"saveContent\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that data should be saved into\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"output data to be saved as Map \",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/contents/input\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves input date from task with given id that belongs to given container\",\"operationId\":\"getTaskInputContentByTaskId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that input data should be loaded from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"responseSchema\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/comments\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves comments from task with given id that belongs to given container\",\"operationId\":\"getCommentsByTaskId\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that comments should be loaded for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-comment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-comment-list\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Adds comment to task with given id that belongs to given container\",\"operationId\":\"addComment1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that comment should be added to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"comment data as TaskComment\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}/content\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves attachment's content with given id from task with given id that belongs to given container\",\"operationId\":\"getAttachmentContentById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that attachment belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"attachmentId\",\"in\":\"path\",\"description\":\"identifier of the attachment that content should be loaded from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"object\"},\"responseSchema\":{\"type\":\"object\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/nominated\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Nominates task with given id that belongs to given container\",\"operationId\":\"nominate\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be nominated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"name\":\"potOwner\",\"in\":\"query\",\"description\":\"list of users that the task should be nominated to\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/attachments/{attachmentId}\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves attachment with given id from task with given id that belongs to given container\",\"operationId\":\"getAttachmentById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that attachment belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"attachmentId\",\"in\":\"path\",\"description\":\"identifier of the attachment to be loaded\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-attachment\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-attachment\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Deletes attachment from task with given id that belongs to given container\",\"operationId\":\"deleteAttachment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that attachment belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"attachmentId\",\"in\":\"path\",\"description\":\"identifier of the attachment to be deleted\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/comments/{commentId}\":{\"get\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Retrieves comment with given id from task with given id that belongs to given container\",\"operationId\":\"getCommentById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that comment belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"commentId\",\"in\":\"path\",\"description\":\"identifier of the comment to be loaded\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-comment\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-comment\"}},\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Deletes comment from task with given id that belongs to given container\",\"operationId\":\"deleteComment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that comment belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"commentId\",\"in\":\"path\",\"description\":\"identifier of the comment to be deleted\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/expiration\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Sets expiration date on task with given id that belongs to given container\",\"operationId\":\"setExpirationDate\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance where expiration date should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"expiration date as Date\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/skipable\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Sets skipable flag on task with given id that belongs to given container\",\"operationId\":\"setSkipable\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance where skipable flag should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"skipable flag as Boolean\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/contents/{contentId}\":{\"delete\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Deletes content from task with given id that belongs to given container\",\"operationId\":\"deleteContent\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that content belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"contentId\",\"in\":\"path\",\"description\":\"identifier of the content to be deleted\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/exited\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Exists task with given id that belongs to given container\",\"operationId\":\"exit\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be exited\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/started\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Starts task with given id that belongs to given container\",\"operationId\":\"start\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be started\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/priority\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Sets priority on task with given id that belongs to given container\",\"operationId\":\"setPriority\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance where priority should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"priority as Integer\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/stopped\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Stops task with given id that belongs to given container\",\"operationId\":\"stop\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be stopped\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/suspended\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Suspends task with given id that belongs to given container\",\"operationId\":\"suspend\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be suspended\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/resumed\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Resumes task with given id that belongs to given container\",\"operationId\":\"resume\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be resumed\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/name\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Sets name on task with given id that belongs to given container\",\"operationId\":\"setName\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance where name should be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"name as String\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/failed\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Fails task with given id that belongs to given container\",\"operationId\":\"fail\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be failed\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"optional map of output variables\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/tasks/{tInstanceId}/states/skipped\":{\"put\":{\"tags\":[\"User task operations and queries :: BPM\"],\"summary\":\"Skips task with given id that belongs to given container\",\"operationId\":\"skip\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that should be skipped\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"user\",\"in\":\"query\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\",\"required\":false,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task with given id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieves all nodes from process instance and container\",\"operationId\":\"getNodes\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that process nodes should be collected from\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/process-node-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/process-node-list\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances/{nodeInstanceId}\":{\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retriggers given node instance within process instance and container\",\"operationId\":\"retriggerNodeInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that node instance belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"nodeInstanceId\",\"in\":\"path\",\"description\":\"identifier of node instance that should be retriggered\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Process instance, node instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Cancels given node instance within process instance and container\",\"operationId\":\"cancelNodeInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that node instance belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"nodeInstanceId\",\"in\":\"path\",\"description\":\"identifier of node instance that should be canceled\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Process instance, node instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodeinstances\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieves all active node instances from process instance and container\",\"operationId\":\"getActiveNodeInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that active nodes instances should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance-list\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/timers/{timerId}\":{\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Updates timer instance within process instance and container\",\"operationId\":\"updateTimer\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that timer belongs to\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"timerId\",\"in\":\"path\",\"description\":\"identifier of timer instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"relative\",\"in\":\"query\",\"description\":\"optional flag that indicates if the time expression is relative to the current date or not, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true},{\"in\":\"body\",\"name\":\"body\",\"description\":\"Map of timer expressions - deplay, perios and repeat are allowed values in the map\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Process instance, node instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/timers\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieves all active timer instance from process instance and container\",\"operationId\":\"getTimerInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that timer instances should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/timer-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/timer-instance-list\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/nodes/{nodeId}\":{\"post\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Triggers node within process instance and container\",\"operationId\":\"triggerNode\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance where node should be triggered\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"nodeId\",\"in\":\"path\",\"description\":\"identifier of the node to be triggered\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Process instance, node instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/errors/{errorId}\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieve execution error by its identifier\",\"operationId\":\"getExecutionErrorById\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process error belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"path\",\"description\":\"identifier of error to be loaded\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/execution-error\"},\"responseSchema\":{\"$ref\":\"#/definitions/execution-error\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Acknowledge execution error by given id\",\"operationId\":\"acknowledgeError\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that error belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"path\",\"description\":\"identifier of error to be acknowledged\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Execution error or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}\":{\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Migrates process instance to new container and process definition with optional node mapping\",\"operationId\":\"migrateProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance to be migrated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"targetContainerId\",\"in\":\"query\",\"description\":\"container id that new process definition belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"targetProcessId\",\"in\":\"query\",\"description\":\"process definition that process instance should be migrated to\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"node mapping - unique ids of old definition to new definition given as Map\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/migration-report-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/migration-report-instance\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances\":{\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Migrates process instances to new container and process definition with optional node mapping\",\"operationId\":\"migrateProcessInstances\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instances belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"query\",\"description\":\"list of identifiers of process instance to be migrated\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"integer\",\"format\":\"int64\"},\"collectionFormat\":\"multi\"},{\"name\":\"targetContainerId\",\"in\":\"query\",\"description\":\"container id that new process definition belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"targetProcessId\",\"in\":\"query\",\"description\":\"process definition that process instances should be migrated to\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"node mapping - unique ids of old definition to new definition given as Map\",\"required\":false,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/migration-report-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/migration-report-instance-list\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/errors\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieves execution errors for container, applies pagination\",\"operationId\":\"getExecutionErrors\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that errors belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"includeAck\",\"in\":\"query\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/node-instance-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/node-instance-list\"}},\"404\":{\"description\":\"Process instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Acknowledges given execution errors\",\"operationId\":\"acknowledgeErrors\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that errors belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"query\",\"description\":\"list of error identifiers to be acknowledged\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Execution error or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/processes/instances/{pInstanceId}/errors\":{\"get\":{\"tags\":[\"Process instances administration :: BPM\"],\"summary\":\"Retrieves execution errors for process instance and container, applies pagination\",\"operationId\":\"getExecutionErrorsByProcessInstance\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of process instance that errors should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"includeAck\",\"in\":\"query\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"node\",\"in\":\"query\",\"description\":\"optional name of the node in the process instance to filter by\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/execution-error-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/execution-error-list\"}},\"404\":{\"description\":\"Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/errors/{errorId}\":{\"get\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Retrieve execution error by its identifier\",\"operationId\":\"getExecutionErrorById1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that error belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"path\",\"description\":\"identifier of the execution error to load\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/execution-error\"},\"responseSchema\":{\"$ref\":\"#/definitions/execution-error\"}},\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Acknowledges given execution error\",\"operationId\":\"acknowledgeError1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that error belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"path\",\"description\":\"identifier of the execution error to be acknowledged\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners\":{\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Adds potential owners to given task instance, optionally removing existing ones\",\"operationId\":\"addPotentialOwners\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"remove\",\"in\":\"query\",\"description\":\"optional flag that indicates if existing potential owners should be removed, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"in\":\"body\",\"name\":\"body\",\"description\":\"list of users/groups to be added as potential owners, as OrgEntities type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners\":{\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Adds excluded owners to given task instance, optionally removing existing ones\",\"operationId\":\"addExcludedOwners\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"remove\",\"in\":\"query\",\"description\":\"optional flag that indicates if existing excluded owners should be removed, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"in\":\"body\",\"name\":\"body\",\"description\":\"list of users/groups to be added as excluded owners, as OrgEntities type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/contents/input\":{\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Adds task inputs to given task instance\",\"operationId\":\"addTaskInputs\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"map of data to be set as task inputs, as Map\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes task inputs referenced by names from given task instance\",\"operationId\":\"removeTaskInputs\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"name\",\"in\":\"query\",\"description\":\"one or more names of task inputs to be removed\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/contents/output\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes task outputs referenced by names from given task instance\",\"operationId\":\"removeTaskOutputs\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"name\",\"in\":\"query\",\"description\":\"one or more names of task outputs to be removed\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/reassignments\":{\"get\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Retrieves reassignments for given task\",\"operationId\":\"getTaskReassignments\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"activeOnly\",\"in\":\"query\",\"description\":\"optional flag that indicates if active only reassignmnets should be collected, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-reassignment-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-reassignment-list\"}},\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Schedules new reassign of given task instance\",\"operationId\":\"reassign\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"expiresAt\",\"in\":\"query\",\"description\":\"time expression for reassignmnet\",\"required\":true,\"type\":\"string\"},{\"name\":\"whenNotStarted\",\"in\":\"query\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"whenNotCompleted\",\"in\":\"query\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"in\":\"body\",\"name\":\"body\",\"description\":\"list of users/groups that task should be reassined to, as OrgEntities type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/notifications\":{\"get\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Retrieves notifications for given task\",\"operationId\":\"getTaskNotifications\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"activeOnly\",\"in\":\"query\",\"description\":\"optional flag that indicates if active only notifications should be collected, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/task-notification-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/task-notification-list\"}},\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"post\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Schedules new notification for given task instance\",\"operationId\":\"notify\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"expiresAt\",\"in\":\"query\",\"description\":\"time expression for notification\",\"required\":true,\"type\":\"string\"},{\"name\":\"whenNotStarted\",\"in\":\"query\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"whenNotCompleted\",\"in\":\"query\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"in\":\"body\",\"name\":\"body\",\"description\":\"email notification details, as EmailNotification type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"201\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"integer\",\"format\":\"int64\"},\"responseSchema\":{\"type\":\"integer\",\"format\":\"int64\"}},\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/notifications/{notificationId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Cancels notification for given task instance\",\"operationId\":\"cancelNotification\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"notificationId\",\"in\":\"path\",\"description\":\"identifier of notification to be canceled\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/reassignments/{reassignmentId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Cancels reassignment for given task instance\",\"operationId\":\"cancelReassignment\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"reassignmentId\",\"in\":\"path\",\"description\":\"identifier of reassignment to be canceled\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/errors\":{\"get\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Retrieves execution errors for container, allows to filter by task name and/or process id, applies pagination\",\"operationId\":\"getExecutionErrors1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"includeAck\",\"in\":\"query\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"name\",\"in\":\"query\",\"description\":\"optional name of the task to filter by\",\"required\":false,\"type\":\"string\"},{\"name\":\"process\",\"in\":\"query\",\"description\":\"optional process id that the task belongs to to filter by\",\"required\":false,\"type\":\"string\"},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/execution-error-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/execution-error-list\"}},\"404\":{\"description\":\"Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Acknowledges given execution errors\",\"operationId\":\"acknowledgeErrors1\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that errors belong to\",\"required\":true,\"type\":\"string\"},{\"name\":\"errorId\",\"in\":\"query\",\"description\":\"list of identifiers of execution errors to be acknowledged\",\"required\":true,\"type\":\"array\",\"items\":{\"type\":\"string\"},\"collectionFormat\":\"multi\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/admins/users/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes business admins from given task instance\",\"operationId\":\"removeAdminsUsers\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of users to be removed from business admin list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/groups/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes potential owner groups from given task instance\",\"operationId\":\"removePotentialOwnersGroups\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of groups to be removed from potantial owners list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/groups/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes excluded owners groups from given task instance\",\"operationId\":\"removeExcludedOwnersGroups\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of groups to be removed from excluded owners list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/admins/groups/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes business admin groups from given task instance\",\"operationId\":\"removeAdminsGroups\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of groups to be removed from business admin list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/admins\":{\"put\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Adds business admins to given task instance, optionally removing existing ones\",\"operationId\":\"addAdmins\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"remove\",\"in\":\"query\",\"description\":\"optional flag that indicates if existing business admins should be removed, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"in\":\"body\",\"name\":\"body\",\"description\":\"list of users/groups to be added as business admins, as OrgEntities type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/pot-owners/users/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes potential owners from given task instance\",\"operationId\":\"removePotentialOwnersUsers\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of users to be removed from potantial owners list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/exl-owners/users/{entityId}\":{\"delete\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Removes excluded owners from given task instance\",\"operationId\":\"removeExcludedOwnersUsers\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance to be updated\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"entityId\",\"in\":\"path\",\"description\":\"list of users to be removed from excluded owners list\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Task instance or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/admin/containers/{id}/tasks/{tInstanceId}/errors\":{\"get\":{\"tags\":[\"User tasks administration :: BPM\"],\"summary\":\"Retrieves execution errors for task instance and container, applies pagination\",\"operationId\":\"getExecutionErrorsByTask\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of the task instance that errors should be collected for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"includeAck\",\"in\":\"query\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"required\":false,\"type\":\"boolean\",\"default\":false},{\"name\":\"page\",\"in\":\"query\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"required\":false,\"type\":\"integer\",\"default\":0,\"format\":\"int32\"},{\"name\":\"pageSize\",\"in\":\"query\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"required\":false,\"type\":\"integer\",\"default\":10,\"format\":\"int32\"},{\"name\":\"sort\",\"in\":\"query\",\"description\":\"optional sort column, no default\",\"required\":false,\"type\":\"string\"},{\"name\":\"sortOrder\",\"in\":\"query\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/execution-error-list\"},\"responseSchema\":{\"$ref\":\"#/definitions/execution-error-list\"}},\"404\":{\"description\":\"Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/forms/tasks/{tInstanceId}\":{\"get\":{\"tags\":[\"Process and task forms :: BPM\"],\"summary\":\"Retrieves form for task instance within a container\",\"operationId\":\"getTaskForm\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that task instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"tInstanceId\",\"in\":\"path\",\"description\":\"identifier of task instance that form should be fetched for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"},{\"name\":\"lang\",\"in\":\"query\",\"description\":\"optional language that the form should be found for\",\"required\":false,\"type\":\"string\",\"default\":\"en\"},{\"name\":\"filter\",\"in\":\"query\",\"description\":\"optional filter flag if form should be filtered or returned as is\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"type\",\"in\":\"query\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"required\":false,\"type\":\"string\",\"default\":\"ANY\"},{\"name\":\"marshallContent\",\"in\":\"query\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"404\":{\"description\":\"Task, form or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/forms/processes/{pId}\":{\"get\":{\"tags\":[\"Process and task forms :: BPM\"],\"summary\":\"Retrieves form for process definition within a container\",\"operationId\":\"getProcessForm\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process definition belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"identifier of process definition that form should be fetched for\",\"required\":true,\"type\":\"string\"},{\"name\":\"lang\",\"in\":\"query\",\"description\":\"optional language that the form should be found for\",\"required\":false,\"type\":\"string\",\"default\":\"en\"},{\"name\":\"filter\",\"in\":\"query\",\"description\":\"optional filter flag if form should be filtered or returned as is\",\"required\":false,\"type\":\"boolean\"},{\"name\":\"type\",\"in\":\"query\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"required\":false,\"type\":\"string\",\"default\":\"ANY\"},{\"name\":\"marshallContent\",\"in\":\"query\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"required\":false,\"type\":\"boolean\",\"default\":true}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"404\":{\"description\":\"Process definition, form or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/images/processes/instances/{pInstanceId}\":{\"get\":{\"tags\":[\"Process definition and instance images :: BPM\"],\"summary\":\"Retrieves process instance image\",\"operationId\":\"getProcessInstanceImage\",\"produces\":[\"application/svg+xml\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process instance belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pInstanceId\",\"in\":\"path\",\"description\":\"identifier of the process instance that image should be loaded for\",\"required\":true,\"type\":\"integer\",\"format\":\"int64\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"404\":{\"description\":\"Process instance, image or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/images/processes/{pId}\":{\"get\":{\"tags\":[\"Process definition and instance images :: BPM\"],\"summary\":\"Retrieves process definition image\",\"operationId\":\"getProcessImage\",\"produces\":[\"application/svg+xml\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id that process definition belongs to\",\"required\":true,\"type\":\"string\"},{\"name\":\"pId\",\"in\":\"path\",\"description\":\"identifier of the process definition that image should be loaded for\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"string\"},\"responseSchema\":{\"type\":\"string\"}},\"404\":{\"description\":\"Process definition, image or Container Id not found\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}/problemfactchanges/processed\":{\"get\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Retrieves status if problem fact changes have been processed in given solver\",\"operationId\":\"isEveryProblemFactChangeProcessed\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"type\":\"boolean\"},\"responseSchema\":{\"type\":\"boolean\"}},\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}/state/solving\":{\"post\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Solves given planning problem with given solver\",\"operationId\":\"solvePlanningProblem\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"planning problem\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}/state/terminating-early\":{\"post\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Terminates early running solver with given id within container\",\"operationId\":\"terminateSolverEarly\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"400\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}/problemfactchanges\":{\"post\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Adds problem fact changes to given solver\",\"operationId\":\"addProblemFactChanges\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"Problem fact changes, either single one or a list of them\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"400\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}\":{\"get\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Retrieves solver by its identifier from given container\",\"operationId\":\"getSolver\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/solver-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/solver-instance\"}},\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}},\"put\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Creates solver within given container\",\"operationId\":\"createSolver\",\"consumes\":[\"application/xml\",\"application/json\"],\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver config resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver to create\",\"required\":true,\"type\":\"string\"},{\"in\":\"body\",\"name\":\"body\",\"description\":\"solver instance details as SolverInstance type\",\"required\":true,\"schema\":{\"type\":\"string\"}}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/solver-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/solver-instance\"}},\"400\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}},\"delete\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Disposes given solver\",\"operationId\":\"disposeSolver\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers\":{\"get\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Retrieves solvers from given container\",\"operationId\":\"getSolvers\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solvers reside\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/solvers\"},\"responseSchema\":{\"$ref\":\"#/definitions/solvers\"}},\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}},\"/server/containers/{id}/solvers/{solverId}/bestsolution\":{\"get\":{\"tags\":[\"Planning and solvers :: BRP\"],\"summary\":\"Retrieves best solution from solver within container\",\"operationId\":\"getSolverWithBestSolution\",\"produces\":[\"application/xml\",\"application/json\"],\"parameters\":[{\"name\":\"id\",\"in\":\"path\",\"description\":\"container id where the solver resides\",\"required\":true,\"type\":\"string\"},{\"name\":\"solverId\",\"in\":\"path\",\"description\":\"identifier of the solver\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"successful operation\",\"schema\":{\"$ref\":\"#/definitions/solver-instance\"},\"responseSchema\":{\"$ref\":\"#/definitions/solver-instance\"}},\"404\":{\"description\":\"Container does not exist or failure in creating solver\"},\"500\":{\"description\":\"Unexpected error\"}}}}},\"definitions\":{\"case-adhoc-fragment\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"case-file\":{\"type\":\"object\",\"properties\":{\"case-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"case-user-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-group-assignments\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}},\"case-data-restrictions\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"case-file\"}},\"case-instance\":{\"type\":\"object\",\"properties\":{\"case-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-owner\":{\"type\":\"string\"},\"case-status\":{\"type\":\"integer\",\"format\":\"int32\"},\"case-definition-id\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"case-started-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completed-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-file\":{\"$ref\":\"#/definitions/case-file\"},\"case-milestones\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"case-milestones\"},\"$ref\":\"#/definitions/case-milestone\"}},\"case-stages\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"case-stages\"},\"$ref\":\"#/definitions/case-stage\"}},\"case-roles\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"case-roles\"},\"$ref\":\"#/definitions/case-role-assignment\"}}},\"xml\":{\"name\":\"case-instance\"}},\"case-instance-list\":{\"type\":\"object\",\"properties\":{\"instances\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"instances\"},\"$ref\":\"#/definitions/case-instance\"}}},\"xml\":{\"name\":\"case-instance-list\"}},\"case-milestone\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"milestone-status\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-milestone\"}},\"case-role-assignment\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}}},\"xml\":{\"name\":\"case-role-assignment\"}},\"case-stage\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"adhoc-fragments\"},\"$ref\":\"#/definitions/case-adhoc-fragment\"}},\"active-nodes\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"active-nodes\"},\"$ref\":\"#/definitions/node-instance\"}}},\"xml\":{\"name\":\"case-stage\"}},\"node-instance\":{\"type\":\"object\",\"properties\":{\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-name\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"node-id\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"node-connection\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"reference-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"node-instance\"}},\"case-milestone-list\":{\"type\":\"object\",\"properties\":{\"milestones\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"milestones\"},\"$ref\":\"#/definitions/case-milestone\"}}},\"xml\":{\"name\":\"case-milestone-list\"}},\"case-stage-list\":{\"type\":\"object\",\"properties\":{\"stages\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"stages\"},\"$ref\":\"#/definitions/case-stage\"}}},\"xml\":{\"name\":\"case-stage-list\"}},\"case-adhoc-fragment-list\":{\"type\":\"object\",\"properties\":{\"fragments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"fragments\"},\"$ref\":\"#/definitions/case-adhoc-fragment\"}}},\"xml\":{\"name\":\"case-adhoc-fragment-list\"}},\"process-instance\":{\"type\":\"object\",\"properties\":{\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"process-instance-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"container-id\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"start-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"process-instance-desc\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"active-user-tasks\":{\"$ref\":\"#/definitions/task-summary-list\"},\"process-instance-variables\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"process-instance\"}},\"process-instance-list\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"process-instance\"},\"$ref\":\"#/definitions/process-instance\"}}},\"xml\":{\"name\":\"process-instance-list\"}},\"task-summary\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-proc-inst-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-summary\"}},\"task-summary-list\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-summary\"},\"$ref\":\"#/definitions/task-summary\"}}},\"xml\":{\"name\":\"task-summary-list\"}},\"node-instance-list\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"node-instance\"},\"$ref\":\"#/definitions/node-instance\"}}},\"xml\":{\"name\":\"node-instance-list\"}},\"case-role-assignment-list\":{\"type\":\"object\",\"properties\":{\"role-assignments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"role-assignments\"},\"$ref\":\"#/definitions/case-role-assignment\"}}},\"xml\":{\"name\":\"case-role-assignment-list\"}},\"case-comment\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"author\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"},\"added-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"restricted-to\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"restricted-to\"}}}},\"xml\":{\"name\":\"case-comment\"}},\"case-comment-list\":{\"type\":\"object\",\"properties\":{\"comments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"comments\"},\"$ref\":\"#/definitions/case-comment\"}}},\"xml\":{\"name\":\"case-comment-list\"}},\"case-definition\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"adhoc-fragments\"},\"$ref\":\"#/definitions/case-adhoc-fragment\"}},\"roles\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\",\"format\":\"int32\"}},\"milestones\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"milestones\"},\"$ref\":\"#/definitions/case-milestone-def\"}},\"stages\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"stages\"},\"$ref\":\"#/definitions/case-stage-def\"}}},\"xml\":{\"name\":\"case-definition\"}},\"case-milestone-def\":{\"type\":\"object\",\"properties\":{\"milestone-name\":{\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"case-milestone-def\"}},\"case-stage-def\":{\"type\":\"object\",\"properties\":{\"stage-name\":{\"type\":\"string\"},\"stage-id\":{\"type\":\"string\"},\"adhoc-fragments\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"adhoc-fragments\"},\"$ref\":\"#/definitions/case-adhoc-fragment\"}}},\"xml\":{\"name\":\"case-stage-def\"}},\"case-definition-list\":{\"type\":\"object\",\"properties\":{\"definitions\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"definitions\"},\"$ref\":\"#/definitions/case-definition\"}}},\"xml\":{\"name\":\"case-definition-list\"}},\"response\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}},\"responses\":{\"type\":\"object\",\"properties\":{\"response\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"response\"},\"$ref\":\"#/definitions/response\"}}},\"xml\":{\"name\":\"responses\"}},\"process-variables\":{\"type\":\"object\",\"properties\":{\"variables\":{\"type\":\"object\",\"xml\":{\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-variables\"}},\"process-service-tasks\":{\"type\":\"object\",\"properties\":{\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-service-tasks\"}},\"process-associated-entities\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}},\"xml\":{\"name\":\"process-associated-entities\"}},\"user-task-definition\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"array\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"taskInputMappings\":{\"type\":\"object\",\"xml\":{\"name\":\"task-inputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"taskOutputMappings\":{\"type\":\"object\",\"xml\":{\"name\":\"task-outputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"task-id\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-comment\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-form-name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"user-task-definition\"}},\"user-task-definitions\":{\"type\":\"object\",\"properties\":{\"task\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task\"},\"$ref\":\"#/definitions/user-task-definition\"}}},\"xml\":{\"name\":\"user-task-definitions\"}},\"process-task-inputs\":{\"type\":\"object\",\"properties\":{\"taskInputs\":{\"type\":\"object\",\"xml\":{\"name\":\"inputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-task-inputs\"}},\"process-definition\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}},\"serviceTasks\":{\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"processVariables\":{\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}},\"reusableSubProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"package\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"process-definition\"}},\"process-subprocesses\":{\"type\":\"object\",\"properties\":{\"subProcesses\":{\"type\":\"array\",\"xml\":{\"name\":\"subprocesses\",\"wrapped\":true},\"items\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-subprocesses\"}},\"process-task-outputs\":{\"type\":\"object\",\"properties\":{\"taskOutputs\":{\"type\":\"object\",\"xml\":{\"name\":\"outputs\",\"wrapped\":true},\"additionalProperties\":{\"type\":\"string\"}}},\"xml\":{\"name\":\"process-task-outputs\"}},\"document-instance\":{\"type\":\"object\",\"properties\":{\"document-id\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\",\"format\":\"int64\"},\"document-last-mod\":{\"type\":\"string\",\"format\":\"date-time\"},\"document-content\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"format\":\"byte\",\"xml\":{\"name\":\"document-content\"},\"pattern\":\"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$\"}}},\"xml\":{\"name\":\"document-instance\"}},\"document-instance-list\":{\"type\":\"object\",\"properties\":{\"document-instances\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"document-instances\"},\"$ref\":\"#/definitions/document-instance\"}}},\"xml\":{\"name\":\"document-instance-list\"}},\"error-info-instance\":{\"type\":\"object\",\"properties\":{\"error-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"error-info-instance\"}},\"error-info-instance-list\":{\"type\":\"object\",\"properties\":{\"error-info-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"error-info-instance\"},\"$ref\":\"#/definitions/error-info-instance\"}}},\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-info-instance\":{\"type\":\"object\",\"properties\":{\"request-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"request-status\":{\"type\":\"string\"},\"request-business-key\":{\"type\":\"string\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-executions\":{\"type\":\"integer\",\"format\":\"int32\"},\"request-command\":{\"type\":\"string\"},\"request-scheduled-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"request-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"response-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"request-errors\":{\"$ref\":\"#/definitions/error-info-instance-list\"},\"request-container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"request-info-instance\"}},\"request-info-instance-list\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"request-info-instance\"},\"$ref\":\"#/definitions/request-info-instance\"}}},\"xml\":{\"name\":\"request-info-instance-list\"}},\"work-item-instance\":{\"type\":\"object\",\"properties\":{\"work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-state\":{\"type\":\"integer\",\"format\":\"int32\"},\"work-item-params\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"container-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"node-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"work-item-instance\"}},\"work-item-instance-list\":{\"type\":\"object\",\"properties\":{\"work-item-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"work-item-instance\"},\"$ref\":\"#/definitions/work-item-instance\"}}},\"xml\":{\"name\":\"work-item-instance-list\"}},\"variable-instance\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"modification-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"variable-instance\"}},\"variable-instance-list\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"variable-instance\"},\"$ref\":\"#/definitions/variable-instance\"}}},\"xml\":{\"name\":\"variable-instance-list\"}},\"process-definitions\":{\"type\":\"object\",\"properties\":{\"processes\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"processes\"},\"$ref\":\"#/definitions/process-definition\"}}},\"xml\":{\"name\":\"process-definitions\"}},\"query-definition\":{\"type\":\"object\",\"properties\":{\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-expression\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"xml\":{\"name\":\"query-definition\"}},\"query-definitions\":{\"type\":\"object\",\"properties\":{\"queries\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"queries\"},\"$ref\":\"#/definitions/query-definition\"}}},\"xml\":{\"name\":\"query-definitions\"}},\"task-event-instance\":{\"type\":\"object\",\"properties\":{\"task-event-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-event-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-work-item-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-event-message\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-event-instance\"}},\"task-event-instance-list\":{\"type\":\"object\",\"properties\":{\"task-event-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-event-instance\"},\"$ref\":\"#/definitions/task-event-instance\"}}},\"xml\":{\"name\":\"task-event-instance-list\"}},\"task-instance\":{\"type\":\"object\",\"properties\":{\"task-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-priority\":{\"type\":\"integer\",\"format\":\"int32\"},\"task-name\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-status\":{\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-expiration-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-workitem-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-parent-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"task-process-id\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-last-modificaiton-date\":{\"type\":\"string\",\"format\":\"date-time\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-pot-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}}},\"task-excl-owners\":{\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}}},\"task-business-admins\":{\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true},\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}}},\"task-input-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}},\"task-output-data\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}},\"xml\":{\"name\":\"task-instance\"}},\"task-attachment\":{\"type\":\"object\",\"properties\":{\"attachment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"attachment-type\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\",\"format\":\"int32\"},\"attachment-content-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"task-attachment\"}},\"task-attachment-list\":{\"type\":\"object\",\"properties\":{\"task-attachment\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-attachment\"},\"$ref\":\"#/definitions/task-attachment\"}}},\"xml\":{\"name\":\"task-attachment-list\"}},\"task-comment\":{\"type\":\"object\",\"properties\":{\"comment-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"comment\":{\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-added-at\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"task-comment\"}},\"task-comment-list\":{\"type\":\"object\",\"properties\":{\"task-comment\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-comment\"},\"$ref\":\"#/definitions/task-comment\"}}},\"xml\":{\"name\":\"task-comment-list\"}},\"process-node\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"type\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"process-node\"}},\"process-node-list\":{\"type\":\"object\",\"properties\":{\"process-node\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"process-node\"},\"$ref\":\"#/definitions/process-node\"}}},\"xml\":{\"name\":\"process-node-list\"}},\"timer-instance\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activation-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"last-fire-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"next-fire-time\":{\"type\":\"string\",\"format\":\"date-time\"},\"delay\":{\"type\":\"integer\",\"format\":\"int64\"},\"period\":{\"type\":\"integer\",\"format\":\"int64\"},\"repeat-limit\":{\"type\":\"integer\",\"format\":\"int32\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"session-id\":{\"type\":\"integer\",\"format\":\"int64\"}},\"xml\":{\"name\":\"timer-instance\"}},\"timer-instance-list\":{\"type\":\"object\",\"properties\":{\"timer-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"timer-instance\"},\"$ref\":\"#/definitions/timer-instance\"}}},\"xml\":{\"name\":\"timer-instance-list\"}},\"migration-report-instance\":{\"type\":\"object\",\"properties\":{\"migration-successful\":{\"type\":\"boolean\"},\"migration-start\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-end\":{\"type\":\"string\",\"format\":\"date-time\"},\"migration-logs\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}}}},\"xml\":{\"name\":\"migration-report-instance\"}},\"migration-report-instance-list\":{\"type\":\"object\",\"properties\":{\"migration-report-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"migration-report-instance\"},\"$ref\":\"#/definitions/migration-report-instance\"}}},\"xml\":{\"name\":\"migration-report-instance-list\"}},\"execution-error\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"process-id\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"activity-name\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\",\"format\":\"int64\"},\"error-msg\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-by\":{\"type\":\"string\"},\"acknowledged-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"error-date\":{\"type\":\"string\",\"format\":\"date-time\"}},\"xml\":{\"name\":\"execution-error\"}},\"execution-error-list\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"error-instance\"},\"$ref\":\"#/definitions/execution-error\"}}},\"xml\":{\"name\":\"execution-error-list\"}},\"task-reassignment\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"},\"reassign-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}},\"active\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"task-reassignment\"}},\"task-reassignment-list\":{\"type\":\"object\",\"properties\":{\"task-reassignment\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-reassignment\"},\"$ref\":\"#/definitions/task-reassignment\"}}},\"xml\":{\"name\":\"task-reassignment-list\"}},\"task-notification\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"},\"notify-at\":{\"type\":\"string\",\"format\":\"date-time\"},\"users\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}}},\"groups\":{\"type\":\"array\",\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}}},\"active\":{\"type\":\"boolean\"},\"subject\":{\"type\":\"string\"},\"content\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-notification\"}},\"task-notification-list\":{\"type\":\"object\",\"properties\":{\"task-notification\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"task-notification\"},\"$ref\":\"#/definitions/task-notification\"}}},\"xml\":{\"name\":\"task-notification-list\"}},\"ScoreWrapper\":{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}},\"solver-instance\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"solver-config-file\":{\"type\":\"string\"},\"status\":{\"type\":\"string\",\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"]},\"score\":{\"$ref\":\"#/definitions/ScoreWrapper\"},\"best-solution\":{\"type\":\"object\"}},\"xml\":{\"name\":\"solver-instance\"}},\"solvers\":{\"type\":\"object\",\"properties\":{\"solver\":{\"type\":\"array\",\"items\":{\"xml\":{\"name\":\"solver\"},\"$ref\":\"#/definitions/solver-instance\"}}},\"xml\":{\"name\":\"solvers\"}}}}",
+    "basePath": "/kie-server/services/rest",
+    "authenticationType": "none"
+  }
+}

--- a/app/server/connector-generator/src/test/resources/swagger/petstore.unified_connector.json
+++ b/app/server/connector-generator/src/test/resources/swagger/petstore.unified_connector.json
@@ -204,7 +204,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"category\": {\"properties\": {\"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Category\"}}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"example\": \"doggie\", \"type\": \"string\"}, \"photoUrls\": {\"items\": {\"type\": \"string\"}, \"type\": \"array\", \"xml\": {\"name\": \"photoUrl\", \"wrapped\": true}}, \"status\": {\"description\": \"pet status in the store\", \"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\": \"string\"}, \"tags\": {\"items\": {\"properties\": {\"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Tag\"}}, \"type\": \"array\", \"xml\": {\"name\": \"tag\", \"wrapped\": true}}}, \"required\": [ \"name\", \"photoUrls\" ], \"title\": \"Pet\", \"type\": \"object\", \"xml\": {\"name\": \"Pet\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"category\": {\"properties\": {\"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Category\"}}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"example\": \"doggie\", \"type\": \"string\"}, \"photoUrls\": {\"items\": {\"type\": \"string\"}, \"type\": \"array\", \"xml\": {\"name\": \"photoUrl\", \"wrapped\": true}}, \"status\": {\"description\": \"pet status in the store\", \"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\": \"string\"}, \"tags\": {\"items\": {\"properties\": {\"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Tag\"}}, \"type\": \"array\", \"xml\": {\"name\": \"tag\", \"wrapped\": true}}}, \"required\": [ \"name\", \"photoUrls\" ], \"type\": \"object\", \"xml\": {\"name\": \"Pet\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -230,7 +230,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\" : {\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"], \"type\" : \"string\"}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Pet\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\" : {\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"], \"type\" : \"string\"}},\"xml\":{\"name\":\"Pet\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -262,7 +262,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Pet\"}"
+          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Pet\"}"
         },
         "configuredProperties": {
           "operationId": "findPetsByStatus"
@@ -291,7 +291,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Pet\"}"
+          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Pet\"}"
         },
         "configuredProperties": {
           "operationId": "findPetsByTags"
@@ -320,7 +320,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Pet\"}"
+          "specification": "{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Pet\"}"
         },
         "configuredProperties": {
           "operationId": "getPetById"
@@ -401,7 +401,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"integer\",\"format\":\"int32\"},\"type\":{\"type\":\"string\"},\"message\":{\"type\":\"string\"}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"ApiResponse\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"integer\",\"format\":\"int32\"},\"type\":{\"type\":\"string\"},\"message\":{\"type\":\"string\"}},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"ApiResponse\"}"
         },
         "configuredProperties": {
           "operationId": "uploadFile"
@@ -427,7 +427,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\",\"format\":\"int32\"}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"title\": \"successful operation\",\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\",\"format\":\"int32\"}}"
         },
         "configuredProperties": {
           "operationId": "getInventory"
@@ -450,13 +450,13 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"complete\": {\"default\": false, \"type\": \"boolean\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"petId\": {\"format\": \"int64\", \"type\": \"integer\"}, \"quantity\": {\"format\": \"int32\", \"type\": \"integer\"}, \"shipDate\": {\"format\": \"date-time\", \"type\": \"string\"}, \"status\": {\"description\": \"Order Status\", \"enum\": [ \"placed\", \"approved\", \"delivered\" ], \"type\": \"string\"}}, \"title\": \"Order\", \"type\": \"object\", \"xml\": {\"name\": \"Order\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"complete\": {\"default\": false, \"type\": \"boolean\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"petId\": {\"format\": \"int64\", \"type\": \"integer\"}, \"quantity\": {\"format\": \"int32\", \"type\": \"integer\"}, \"shipDate\": {\"format\": \"date-time\", \"type\": \"string\"}, \"status\": {\"description\": \"Order Status\", \"enum\": [ \"placed\", \"approved\", \"delivered\" ], \"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Order\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Order\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Order\"}"
         },
         "configuredProperties": {
           "operationId": "placeOrder"
@@ -485,7 +485,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Order\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Order\"}"
         },
         "configuredProperties": {
           "operationId": "getOrderById"
@@ -534,7 +534,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"title\": \"User\", \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -560,7 +560,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"title\": \"User\", \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}},\"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -586,7 +586,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"title\": \"User\", \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -615,7 +615,10 @@
           "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"parameters\": {\"properties\": {\"password\": {\"description\": \"The password for login in clear text\", \"title\": \"password\", \"type\": \"string\"}, \"username\": {\"description\": \"The user name for login\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
-          "kind": "none"
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
         },
         "configuredProperties": {
           "operationId": "loginUser"
@@ -667,7 +670,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"User\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"User\"}"
         },
         "configuredProperties": {
           "operationId": "getUserByName"
@@ -690,7 +693,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"$schema\": \"http://json-schema.org/schema#\", \"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"title\": \"User\", \"type\": \"object\", \"xml\": {\"name\": \"User\"}}, \"parameters\": {\"properties\": {\"username\": {\"description\": \"name that need to be updated\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": {\"format\": \"int64\", \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\", \"format\": \"int32\", \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}},\"type\": \"object\", \"xml\": {\"name\": \"User\"}}, \"parameters\": {\"properties\": {\"username\": {\"description\": \"name that need to be updated\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/connector-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
+++ b/app/server/connector-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
@@ -362,7 +362,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Order\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"}}}}"
         },
         "outputDataShape": {
           "name": "Response",
@@ -428,7 +428,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"User\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -461,7 +461,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"User\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -494,7 +494,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"User\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -629,7 +629,10 @@
           "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The user name for login\"},\"password\":{\"type\":\"string\",\"title\":\"password\",\"description\":\"The password for login in clear text\"}}}}}"
         },
         "outputDataShape": {
-          "kind": "none"
+          "name": "Response",
+          "description": "API response payload",
+          "kind": "json-schema",
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"string\",\"title\":\"successful operation\"}"
         },
         "configuredProperties": {
           "operationId": "loginUser"
@@ -659,7 +662,7 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"name that need to be updated\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"User\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"name that need to be updated\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/connector-generator/src/test/resources/swagger/reverb.unified_connector.json
+++ b/app/server/connector-generator/src/test/resources/swagger/reverb.unified_connector.json
@@ -11,7 +11,7 @@
       "description": "Send GET request to /articles",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -35,7 +35,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -46,7 +46,7 @@
       "description": "Full taxonomy tree of categories including middle categories",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -70,7 +70,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -81,7 +81,7 @@
       "description": "Send GET request to /categories/flat",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -105,7 +105,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -116,7 +116,7 @@
       "description": "Get category details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -140,7 +140,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -151,7 +151,7 @@
       "description": "Get subcategory details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -175,7 +175,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -186,7 +186,7 @@
       "description": "List of supported product categories",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -210,7 +210,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -221,7 +221,7 @@
       "description": "Send GET request to /comparison_shopping_pages/{id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -245,7 +245,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -256,7 +256,7 @@
       "description": "Return new or used listings for a comparison shopping page",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -280,7 +280,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -291,7 +291,7 @@
       "description": "Returns a set of comparison shopping pages based on the current params",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -315,7 +315,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -326,7 +326,7 @@
       "description": "Show comparison shopping page",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -350,7 +350,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -361,7 +361,7 @@
       "description": "View reviews of a comparison shopping page",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -385,7 +385,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -396,7 +396,7 @@
       "description": "Make an offer to the other participant in the conversation",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -420,7 +420,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -431,7 +431,7 @@
       "description": "Retrieve a list of country codes with corresponding subregions",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -455,7 +455,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -466,7 +466,7 @@
       "description": "Send GET request to /curated_sets/{slug}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -490,7 +490,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -501,7 +501,7 @@
       "description": "List of supported display currencies for browsing listings",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -525,7 +525,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -536,7 +536,7 @@
       "description": "List of supported listing currencies for shops",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -560,7 +560,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -571,7 +571,7 @@
       "description": "Feedback details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -595,7 +595,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -606,7 +606,7 @@
       "description": "Get results from a handpicked collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -630,7 +630,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -641,7 +641,7 @@
       "description": "List of supported product conditions",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -665,7 +665,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -676,7 +676,7 @@
       "description": "All listings including used, handmade, and brand new",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -700,7 +700,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -711,7 +711,7 @@
       "description": "Bump a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -735,7 +735,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -746,7 +746,7 @@
       "description": "Create a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -770,7 +770,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -781,7 +781,7 @@
       "description": "Create a review for a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -805,7 +805,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -816,7 +816,7 @@
       "description": "Default search of listings includes only used & handmade. Add a filter to view all listings or use the /listings/all endpoint.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -840,7 +840,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -851,7 +851,7 @@
       "description": "Delete a draft listing. Cannot be used on non-drafts.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -875,7 +875,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -886,7 +886,7 @@
       "description": "Delete an image from a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -910,7 +910,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -921,7 +921,7 @@
       "description": "Edit listing.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -945,7 +945,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -956,7 +956,7 @@
       "description": "Find a product bundle attached to a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -980,7 +980,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -991,7 +991,7 @@
       "description": "Flag a listing for inappropriate content or fraud",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1015,7 +1015,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1026,7 +1026,7 @@
       "description": "Individual facets",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1050,7 +1050,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1061,7 +1061,7 @@
       "description": "Listing details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1085,7 +1085,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1096,7 +1096,7 @@
       "description": "Listing details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1120,7 +1120,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1131,7 +1131,7 @@
       "description": "Make an offer to the seller of a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1155,7 +1155,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1166,7 +1166,7 @@
       "description": "Returns the latest negotiation for the requesting user given a listing id",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1190,7 +1190,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1201,7 +1201,7 @@
       "description": "See all sales that include a listing.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1225,7 +1225,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1236,7 +1236,7 @@
       "description": "Start a conversation with a seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1260,7 +1260,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1271,7 +1271,7 @@
       "description": "Update a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1295,7 +1295,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1306,7 +1306,7 @@
       "description": "View available bump tiers and stats for a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1330,7 +1330,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1341,7 +1341,7 @@
       "description": "View reviews of a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1365,7 +1365,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1376,7 +1376,7 @@
       "description": "View the images associated with a particular listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1400,7 +1400,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1411,7 +1411,7 @@
       "description": "Accept an offer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1435,7 +1435,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1446,7 +1446,7 @@
       "description": "Add a listing to your wishlist",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1470,7 +1470,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1481,7 +1481,7 @@
       "description": "Counter an offer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1505,7 +1505,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1516,7 +1516,7 @@
       "description": "Create a new address in your address book",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1540,7 +1540,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1551,7 +1551,7 @@
       "description": "Send DELETE request to /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1575,7 +1575,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1586,7 +1586,7 @@
       "description": "Send DELETE request to /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1610,7 +1610,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1621,7 +1621,7 @@
       "description": "Decline an offer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1645,7 +1645,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1656,7 +1656,7 @@
       "description": "Delete a follow",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1680,7 +1680,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1691,7 +1691,7 @@
       "description": "Delete an existing address in your address book",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1715,7 +1715,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1726,7 +1726,7 @@
       "description": "Display conversation details with messages in natural time order (oldest to newest)",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1750,7 +1750,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1761,7 +1761,7 @@
       "description": "End a listing",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1785,7 +1785,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1796,7 +1796,7 @@
       "description": "Follow a brand",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1820,7 +1820,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1831,7 +1831,7 @@
       "description": "Follow a category",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1855,7 +1855,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1866,7 +1866,7 @@
       "description": "Follow a collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1890,7 +1890,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1901,7 +1901,7 @@
       "description": "Follow a handpicked collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1925,7 +1925,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1936,7 +1936,7 @@
       "description": "Follow a search",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1960,7 +1960,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -1971,7 +1971,7 @@
       "description": "Follow a shop",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -1995,7 +1995,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2006,7 +2006,7 @@
       "description": "Follow a subcategory",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2030,7 +2030,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2041,7 +2041,7 @@
       "description": "Follow status for a brand",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2065,7 +2065,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2076,7 +2076,7 @@
       "description": "Follow status for a category",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2100,7 +2100,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2111,7 +2111,7 @@
       "description": "Follow status for a collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2135,7 +2135,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2146,7 +2146,7 @@
       "description": "Follow status for a handpicked collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2170,7 +2170,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2181,7 +2181,7 @@
       "description": "Follow status for a search",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2205,7 +2205,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2216,7 +2216,7 @@
       "description": "Follow status for a shop",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2240,7 +2240,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2251,7 +2251,7 @@
       "description": "Follow status for a subcategory",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2275,7 +2275,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2286,7 +2286,7 @@
       "description": "Get a list of active negotiations as a buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2310,7 +2310,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2321,7 +2321,7 @@
       "description": "Get a list of active negotiations as a seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2345,7 +2345,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2356,7 +2356,7 @@
       "description": "Get a list of payouts",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2380,7 +2380,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2391,7 +2391,7 @@
       "description": "Get a list of refund requests as a seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2415,7 +2415,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2426,7 +2426,7 @@
       "description": "Get a list of wishlisted items",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2450,7 +2450,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2461,7 +2461,7 @@
       "description": "Get a list of your conversations",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2485,7 +2485,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2496,7 +2496,7 @@
       "description": "Get a list of your lists (wishlist, watch list, etc)",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2520,7 +2520,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2531,7 +2531,7 @@
       "description": "Get a list of your recently viewed listings.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2555,7 +2555,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2566,7 +2566,7 @@
       "description": "Get account details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2590,7 +2590,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2601,7 +2601,7 @@
       "description": "Get all seller orders, newest first.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2625,7 +2625,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2636,7 +2636,7 @@
       "description": "Get listings from your feed",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2660,7 +2660,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2671,7 +2671,7 @@
       "description": "Get offer details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2695,7 +2695,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2706,7 +2706,7 @@
       "description": "Get payment",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2730,7 +2730,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2741,7 +2741,7 @@
       "description": "Get payments",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2765,7 +2765,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2776,7 +2776,7 @@
       "description": "Get seller orders awaiting shipment, newest first.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2800,7 +2800,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2811,7 +2811,7 @@
       "description": "Get unpaid seller orders, newest first.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2835,7 +2835,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2846,7 +2846,7 @@
       "description": "Get your actionable status counts",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2870,7 +2870,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2881,7 +2881,7 @@
       "description": "Initiate a refund for a sold order",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2905,7 +2905,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2916,7 +2916,7 @@
       "description": "List of orders that need feedback",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2940,7 +2940,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2951,7 +2951,7 @@
       "description": "List of received feedback",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -2975,7 +2975,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -2986,7 +2986,7 @@
       "description": "List of sent feedback",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3010,7 +3010,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3021,7 +3021,7 @@
       "description": "Mark a conversation read/unread",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3045,7 +3045,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3056,7 +3056,7 @@
       "description": "Marks an order as picked up",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3080,7 +3080,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3091,7 +3091,7 @@
       "description": "Marks an order as received by the buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3115,7 +3115,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3126,7 +3126,7 @@
       "description": "Marks an order as shipped",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3150,7 +3150,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3161,7 +3161,7 @@
       "description": "Send POST request to /my/curated_set/product/{product_id}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3185,7 +3185,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3196,7 +3196,7 @@
       "description": "Send POST request to /my/follows/{follow_id}/alert",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3220,7 +3220,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3231,7 +3231,7 @@
       "description": "Read the line items of a payout",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3255,7 +3255,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3266,7 +3266,7 @@
       "description": "Remove a listing from your wishlist",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3290,7 +3290,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3301,7 +3301,7 @@
       "description": "Retrieve a list of live listings for the seller. To search all listings specify state=all",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3325,7 +3325,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3336,7 +3336,7 @@
       "description": "Retrieve a list your draft listings",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3360,7 +3360,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3371,7 +3371,7 @@
       "description": "Returns a user's ArticleCategoryFollows",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3395,7 +3395,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3406,7 +3406,7 @@
       "description": "Returns all orders, newest first.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3430,7 +3430,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3441,7 +3441,7 @@
       "description": "Returns order details for a buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3465,7 +3465,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3476,7 +3476,7 @@
       "description": "Returns order details for a seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3500,7 +3500,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3511,7 +3511,7 @@
       "description": "Returns unpaid orders, newest first.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3535,7 +3535,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3546,7 +3546,7 @@
       "description": "See all addresses in your address book",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3570,7 +3570,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3581,7 +3581,7 @@
       "description": "See previous orders from buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3605,7 +3605,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3616,7 +3616,7 @@
       "description": "See what the user is following",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3640,7 +3640,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3651,7 +3651,7 @@
       "description": "Send a message",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3675,7 +3675,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3686,7 +3686,7 @@
       "description": "Set a user's ArticleCategoryFollows",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3710,7 +3710,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3721,7 +3721,7 @@
       "description": "Start a conversation",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3745,7 +3745,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3756,7 +3756,7 @@
       "description": "Unfollow a brand",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3780,7 +3780,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3791,7 +3791,7 @@
       "description": "Unfollow a category",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3815,7 +3815,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3826,7 +3826,7 @@
       "description": "Unfollow a collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3850,7 +3850,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3861,7 +3861,7 @@
       "description": "Unfollow a handpicked collection",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3885,7 +3885,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3896,7 +3896,7 @@
       "description": "Unfollow a shop",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3920,7 +3920,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3931,7 +3931,7 @@
       "description": "Unfollow a subcategory",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3955,7 +3955,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -3966,7 +3966,7 @@
       "description": "Update a refund request for a sold order",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -3990,7 +3990,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4001,7 +4001,7 @@
       "description": "Update account details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4025,7 +4025,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4036,7 +4036,7 @@
       "description": "Update an existing address in your address book",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4060,7 +4060,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4071,7 +4071,7 @@
       "description": "get your feed",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4095,7 +4095,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4106,7 +4106,7 @@
       "description": "get your feed customization options",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4130,7 +4130,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4141,7 +4141,7 @@
       "description": "Add feedback about an order's buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4165,7 +4165,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4176,7 +4176,7 @@
       "description": "Add feedback about an order's seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4200,7 +4200,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4211,7 +4211,7 @@
       "description": "Feedback details for an order's buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4235,7 +4235,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4246,7 +4246,7 @@
       "description": "Feedback details for an order's seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4270,7 +4270,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4281,7 +4281,7 @@
       "description": "Get list of payment methods",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4305,7 +4305,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4316,7 +4316,7 @@
       "description": "Get a list of paginated transactions for a price guide.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4340,7 +4340,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4351,7 +4351,7 @@
       "description": "Get a summary of transactions for a given price guide",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4375,7 +4375,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4386,7 +4386,7 @@
       "description": "Retrieve a Price Guide",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4410,7 +4410,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4421,7 +4421,7 @@
       "description": "Create a review for a product",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4445,7 +4445,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4456,7 +4456,7 @@
       "description": "Update a review",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4480,7 +4480,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4491,7 +4491,7 @@
       "description": "View a review",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4515,7 +4515,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4526,7 +4526,7 @@
       "description": "View reviews of a comparison shopping page",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4550,7 +4550,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4561,7 +4561,7 @@
       "description": "Add listings to a sale",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4585,7 +4585,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4596,7 +4596,7 @@
       "description": "Send GET request to /sales/{slug}",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4620,7 +4620,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4631,7 +4631,7 @@
       "description": "Remove a listing from a sale",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4655,7 +4655,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4666,7 +4666,7 @@
       "description": "View upcoming and live Reverb official sales.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4690,7 +4690,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4701,7 +4701,7 @@
       "description": "View your created sales.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4725,7 +4725,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4736,7 +4736,7 @@
       "description": "Send GET request to /shipping/regions",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4760,7 +4760,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4771,7 +4771,7 @@
       "description": "List of supported shipping providers",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4795,7 +4795,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4806,7 +4806,7 @@
       "description": "Disable vacation mode. All listings will be re-enabled.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4830,7 +4830,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4841,7 +4841,7 @@
       "description": "Enable vacation mode. All listings will be unavailable until vacation mode is turned off.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4865,7 +4865,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4876,7 +4876,7 @@
       "description": "Get accepted payment methods",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4900,7 +4900,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4911,7 +4911,7 @@
       "description": "Get your own shop details",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4935,7 +4935,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4946,7 +4946,7 @@
       "description": "List of supported product conditions",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -4970,7 +4970,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -4981,7 +4981,7 @@
       "description": "Returns shop vacation status",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5005,7 +5005,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5016,7 +5016,7 @@
       "description": "Update your shop profile",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5040,7 +5040,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5051,7 +5051,7 @@
       "description": "Get details on a shop.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5075,7 +5075,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5086,7 +5086,7 @@
       "description": "Get seller's feedback",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5110,7 +5110,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5121,7 +5121,7 @@
       "description": "Get seller's feedback as a buyer",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5145,7 +5145,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5156,7 +5156,7 @@
       "description": "Get seller's feedback as a seller",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5180,7 +5180,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5191,7 +5191,7 @@
       "description": "List of shipping profiles for your shop",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5215,7 +5215,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5226,7 +5226,7 @@
       "description": "A list of wanted items by the user",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5250,7 +5250,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5261,7 +5261,7 @@
       "description": "Mark an item wanted. Returns 200 on success or 422 on failure.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5285,7 +5285,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5296,7 +5296,7 @@
       "description": "Unmark an item wanted.",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5320,7 +5320,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5331,7 +5331,7 @@
       "description": "Get details of a webhook registration",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5355,7 +5355,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5366,7 +5366,7 @@
       "description": "Get webhook registrations",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5390,7 +5390,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5401,7 +5401,7 @@
       "description": "Register a webhook",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5425,7 +5425,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"
@@ -5436,7 +5436,7 @@
       "description": "Remove a webhook",
       "descriptor": {
         "connectorId": "-L2zJ-vC2AeqDvkcOlH5",
-        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT",
+        "camelConnectorGAV": "io.syndesis.connector:connector-rest-swagger:@project.version@",
         "camelConnectorPrefix": "swagger-operation",
         "connectorCustomizers": [],
         "inputDataShape": {
@@ -5460,7 +5460,7 @@
       "dependencies": [
         {
           "type": "MAVEN",
-          "id": "io.syndesis.connector:connector-rest-swagger:1.2-SNAPSHOT"
+          "id": "io.syndesis.connector:connector-rest-swagger:@project.version@"
         }
       ],
       "pattern": "To"

--- a/app/server/connector-generator/src/test/resources/swagger/todo.unified_connector.json
+++ b/app/server/connector-generator/src/test/resources/swagger/todo.unified_connector.json
@@ -127,7 +127,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Task\"}"
         },
         "configuredProperties": {
           "operationId": "operation-0"
@@ -151,13 +151,13 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         },
         "outputDataShape": {
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Task\"}"
         },
         "configuredProperties": {
           "operationId": "operation-1"
@@ -187,7 +187,7 @@
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Task\"}"
         },
         "configuredProperties": {
           "operationId": "operation-2"
@@ -211,13 +211,13 @@
           "name": "Request",
           "description": "API request payload",
           "kind": "json-schema",
-          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}}}"
+          "specification": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         },
         "outputDataShape": {
           "name": "Response",
           "description": "API response payload",
           "kind": "json-schema",
-          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Task\"}"
+          "specification": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}},\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Task\"}"
         },
         "configuredProperties": {
           "operationId": "operation-3"


### PR DESCRIPTION
This optimizes the way API connectors based on Swagger specifications are generated by greatly reducing the number of serialization/deserializations performed to or from JSON.

Also fixes a number of smaller edge cases, and cleans up the implementation to remove unnecessary JSON schema properties, such as duplicate schema declarations on merged input data shapes.

Also allows for certain, not entirely valid, Swagger specifications might define operation ids in a non-unique way. We can tolerate that and make them unique by adding a suffix on the operation id equal to the non-unique occurrence.

Fixes #2319