### PR TITLE
chore(ui): always propagate http exceptions

### DIFF
--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -20,7 +20,7 @@ import {
 import { ConfigService } from '@syndesis/ui/config.service';
 
 const DEFAULT_ERROR_MSG = 'An unexpected HTTP error occured. Please check stack strace';
-const PROPAGATE_EXCEPTIONS = false;
+const PROPAGATE_EXCEPTIONS = true;
 
 @Injectable()
 export class ApiHttpProviderService extends ApiHttpService {


### PR DESCRIPTION
Since many components and services do not handle Http exceptions right, [this PR ](https://github.com/syndesisio/syndesis/pull/2349) introduced a new Http interceptor that offered a convenient toast notification when API errors (500, 401, etc) occur, catching all those exceptions and not allowing them to propagate.

But Redux effects do expect those exceptions to be propagated since that is the way that `XXXX_ERROR` actions are triggered. Therefore this PR reinstates Http exception propagation which, ultimately, is supposed to be harmless.

So long and thanks for the all fish!

https://youtu.be/ojydNb3Lrrs