### PR TITLE
feat(s3): use duration control type for delay form field

### DIFF
--- a/app/connector/aws-s3/src/main/resources/META-INF/syndesis/connector/aws-s3.json
+++ b/app/connector/aws-s3/src/main/resources/META-INF/syndesis/connector/aws-s3.json
@@ -286,7 +286,7 @@
                     "group": "scheduler",
                     "label": "consumer,scheduler",
                     "required": false,
-                    "type": "integer",
+                    "type": "duration",
                     "javaType": "long",
                     "optionalPrefix": "consumer.",
                     "deprecated": false,


### PR DESCRIPTION
This PR changes the type of form control that's used for the delay field when configuring an S3 connection.

fixes https://github.com/syndesisio/syndesis/issues/2312

take advantage of new duration control when specifying amount of delay when polling an S3 bucket