### PR TITLE
fix(donut-chart): prevent scrollbars from displaying on screen resize

### DIFF
--- a/app/ui/src/app/dashboard/dashboard_integrations/dashboard-integrations.component.html
+++ b/app/ui/src/app/dashboard/dashboard_integrations/dashboard-integrations.component.html
@@ -47,8 +47,7 @@
               </h2>
             </div>
             <div class="card-pf-body">
-              <div class="col-xs-12"
-                   *ngIf="!loading">
+              <div class="no-overflow" *ngIf="!loading">
                 <pfng-chart-donut [chartData]="integrationChartData" [config]="integrationsChartConfig"></pfng-chart-donut>
               </div>
             </div>

--- a/app/ui/src/scss/utils/_helpers.scss
+++ b/app/ui/src/scss/utils/_helpers.scss
@@ -129,3 +129,8 @@
     @include truncate(ellipsis);
   }
 }
+
+// Shared style rules
+.no-overflow {
+  overflow: hidden;
+}


### PR DESCRIPTION
This PR makes a minor styling adjustment for the dashboard integrations donut counter. We remove the bootstrap layout class as its not needed and add class which sets overflow content to "hidden", which in turn prevents the scroll bars from appearing.

fixes https://github.com/syndesisio/syndesis/issues/2374