### PR TITLE
feat(server): detailed version endpoint

### DIFF
--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -267,6 +267,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-manifests</artifactId>
+      <version>1.1</version>
+    </dependency>
+
     <!-- ===================================================================================== -->
 
     <!-- Atlasmap Data Mapper Services -->

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/Version.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/Version.java
@@ -15,17 +15,42 @@
  */
 package io.syndesis.server.endpoint;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+
+import com.jcabi.manifests.Manifests;
 
 public final class Version {
 
     private Version() {
     }
 
+    public static Map<String, String> getDetailed() {
+        final Map<String, String> detail = new HashMap<>();
+        detail.put("version", getVersion());
+        putManifestValueTo(detail, "commit-id", "Git-Commit-Id", "X-BasePOM-Git-Commit-Id");
+        putManifestValueTo(detail, "branch", "Git-Branch");
+        putManifestValueTo(detail, "build-time", "Build-Time");
+        putManifestValueTo(detail, "build-id", "X-BasePOM-Build-Id");
+
+        return Collections.unmodifiableMap(detail);
+    }
+
     public static String getVersion() {
         final String packageVersion = Version.class.getPackage().getImplementationVersion();
 
         return Optional.ofNullable(packageVersion).orElse("DEVELOPMENT");
+    }
+
+    static void putManifestValueTo(final Map<String, String> detail, final String key, final String... attributes) {
+        for (final String attribute : attributes) {
+            if (Manifests.exists(attribute)) {
+                detail.put(key, Manifests.read(attribute));
+                break;
+            }
+        }
     }
 
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/VersionEndpoint.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/VersionEndpoint.java
@@ -26,15 +26,22 @@ import org.springframework.stereotype.Component;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 
-@CacheFor(value=1, unit=HOURS)
+@CacheFor(value = 1, unit = HOURS)
 @Path("/version")
 @Component
 public class VersionEndpoint {
 
     @GET
+    @Produces("application/json")
+    @ApiOperation(value = "Get the version as JSON specification")
+    public Response doGetJson() {
+        return Response.ok(Version.getDetailed()).build();
+    }
+
+    @GET
     @Produces("text/plain")
     @ApiOperation(value = "Get the version")
-    public Response doGet() {
+    public Response doGetPlain() {
         return Response.ok(Version.getVersion()).build();
     }
 }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/VersionITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/VersionITCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.runtime;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VersionITCase extends BaseITCase {
+
+    private static final ParameterizedTypeReference<Map<String, String>> MAP_OF_STRINGS = new ParameterizedTypeReference<Map<String, String>>() {
+    };
+
+    @Test
+    public void shouldFetchDetailedVersion() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, "application/json");
+
+        final ResponseEntity<Map<String, String>> detailed = http(HttpMethod.GET, "/api/v1/version", null, MAP_OF_STRINGS,
+            tokenRule.validToken(), headers, HttpStatus.OK);
+
+        assertThat(detailed.getBody()).isNotEmpty();
+    }
+
+    @Test
+    public void shouldFetchPlainVersion() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, "text/plain");
+
+        final ResponseEntity<String> plainVersion = http(HttpMethod.GET, "/api/v1/version", null, String.class, tokenRule.validToken(),
+            headers, HttpStatus.OK);
+
+        assertThat(plainVersion.getBody()).isNotBlank();
+    }
+}


### PR DESCRIPTION
This adds a endpoint that in addition to the existing plain text version
information adds a more detailed version information. The response JSON
might contain the following:

 - `version` - same as the existing plain text version
 - `commit-id` - git commit id of the version
 - `branch` - git branch being built
 - `build-time` - time of the build
 - `build-id` - identifier of the build

Only the `version` property is guaranteed to be present, other
properties depend on how the build performed.