### PR TITLE
feat(ui): display correct version on support page

### DIFF
--- a/app/ui/src/app/support/support.component.html
+++ b/app/ui/src/app/support/support.component.html
@@ -3,14 +3,14 @@
     <h1>Support</h1>
     <p>To obtain support, download diagnostic information through this page. If the downloaded zip file is less than 0.5 GB,
       attach it to an email message that requests help and send the message to
-      <a class="text-nowrap" href="mailto:{{ 'email' | synI18n }}">{{ 'email' | synI18n }}</a>. 
+      <a class="text-nowrap" href="mailto:{{ 'email' | synI18n }}">{{ 'email' | synI18n }}</a>.
       If the downloaded zip file is larger than 0.5 GB, send an email message that requests
       help, but do not attach the file, and indicate that the zip file is too large to attach. Technical support will provide
       instructions for sending the zip file.</p>
 
     <h2>Version</h2>
     <p id="productVersion">
-      <strong>Syndesis:</strong> v1.0</p>
+      <strong>Syndesis:</strong> {{ version | async }}</p>
 
     <h2>Download Trobuleshooting Diagnostics</h2>
     <p>System level and application level diagnostics will be captured since both are required to troubleshoot any issues. Usernames

--- a/app/ui/src/app/support/support.component.ts
+++ b/app/ui/src/app/support/support.component.ts
@@ -5,7 +5,7 @@ import * as fileSaver from 'file-saver';
 import { ObjectPropertyFilterConfig } from '../common/object-property-filter.pipe';
 import { ObjectPropertySortConfig } from '../common/object-property-sort.pipe';
 
-import { Integrations, Integration, IntegrationSupportService } from '@syndesis/ui/platform';
+import { Integrations, Integration, IntegrationSupportService, ApiHttpService } from '@syndesis/ui/platform';
 import { log, getCategory } from '@syndesis/ui/logging';
 import { IntegrationStore } from '@syndesis/ui/store';
 
@@ -46,9 +46,12 @@ export class SupportComponent implements OnInit {
   notificationType: NotificationType = NotificationType.DANGER;
   notificationHidden = true;
 
+  version = Observable.of('unknown');
+
   constructor(
     public store: IntegrationStore,
     public integrationSupportService: IntegrationSupportService,
+    private apiHttpService: ApiHttpService
   ) {}
 
   buildData(data: any = {}): void {
@@ -264,5 +267,8 @@ export class SupportComponent implements OnInit {
       this.updateItems();
     });
     this.store.loadAll();
+    this.version = this.apiHttpService.get('/version', {
+      responseType: 'text'
+    });
   }
 }


### PR DESCRIPTION
This uses the plain text endpoint at `/api/v1/version` to display the
correct version on the support page.

Fixes #2384