### PR TITLE
chore: rework version formatting on support page

### DIFF
--- a/app/ui/src/app/support/support.component.html
+++ b/app/ui/src/app/support/support.component.html
@@ -9,8 +9,22 @@
       instructions for sending the zip file.</p>
 
     <h2>Version</h2>
-    <p id="productVersion">
-      <strong>Syndesis:</strong> {{ version | async }}</p>
+    <syndesis-loading [loading]="!(version$ | async)">
+      <div *ngIf="version$ | async as versionInfo">
+        <dl class="dl-horizontal" *ngIf="versionInfo.version">
+          <dt>{{ 'shared.project.name' | synI18n }}:</dt>
+          <dd>{{ versionInfo.version }}</dd>
+        </dl>
+        <dl class="dl-horizontal" *ngIf="versionInfo['build-id']">
+          <dt>{{ 'support.buildid' | synI18n }}:</dt>
+          <dd>{{ versionInfo['build-id'] }}</dd>
+        </dl>
+        <dl class="dl-horizontal" *ngIf="versionInfo['commit-id']">
+          <dt>{{ 'support.commitid' | synI18n }}:</dt>
+          <dd>{{ versionInfo['commit-id'] }}</dd>
+        </dl>
+      </div>
+    </syndesis-loading>
 
     <h2>Download Trobuleshooting Diagnostics</h2>
     <p>System level and application level diagnostics will be captured since both are required to troubleshoot any issues. Usernames

--- a/app/ui/src/app/support/support.component.ts
+++ b/app/ui/src/app/support/support.component.ts
@@ -1,5 +1,6 @@
 import { Component,  Input,  ViewChild, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators/map';
 import * as fileSaver from 'file-saver';
 
 import { ObjectPropertyFilterConfig } from '../common/object-property-filter.pipe';
@@ -46,7 +47,7 @@ export class SupportComponent implements OnInit {
   notificationType: NotificationType = NotificationType.DANGER;
   notificationHidden = true;
 
-  version = Observable.of('unknown');
+  version$: Observable<any>;
 
   constructor(
     public store: IntegrationStore,
@@ -267,8 +268,6 @@ export class SupportComponent implements OnInit {
       this.updateItems();
     });
     this.store.loadAll();
-    this.version = this.apiHttpService.get('/version', {
-      responseType: 'text'
-    });
+    this.version$ = this.apiHttpService.get('/version');
   }
 }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -82,6 +82,10 @@
         }
       }
     },
+    "support": {
+      "buildid": "Build ID",
+      "commitid": "Commit ID"
+    },
     "import-db-txt": "Please select the data file to import:",
     "errors": {
       "youareonline": "You're back online",


### PR DESCRIPTION
fixes #2384 though @zregvart did all the real work :-)

Example (fake build/commit ID):

![capture](https://user-images.githubusercontent.com/351660/38885286-80e2b782-4240-11e8-9a50-f5d2bc03b2b8.PNG)

build/commit IDs only appear if they're in the response