### PR TITLE
Add Xsrf protection in syndesis backend

### DIFF
--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
@@ -42,6 +42,15 @@ import org.springframework.security.web.authentication.preauth.RequestHeaderAuth
 @EnableWebSecurity
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    private static final String[] COMMON_NON_SECURED_PATHS = {
+        "/api/v1/swagger.*",
+        "/api/v1/index.html",
+        "/api/v1/internal/swagger.*",
+        "/api/v1/internal/index.html",
+        "/api/v1/version",
+        "/health"
+    };
+
     @Override
     protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
         authenticationManagerBuilder.authenticationProvider(authenticationProvider());
@@ -56,16 +65,16 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .addFilter(new AnonymousAuthenticationFilter("anonymous"))
             .authorizeRequests()
             .antMatchers(HttpMethod.OPTIONS).permitAll()
-            .antMatchers("/api/v1/swagger.*").permitAll()
-            .antMatchers("/api/v1/index.html").permitAll()
-            .antMatchers("/api/v1/internal/swagger.*").permitAll()
-            .antMatchers("/api/v1/internal/index.html").permitAll()
-            .antMatchers("/api/v1/version").permitAll()
+            .antMatchers(COMMON_NON_SECURED_PATHS).permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/credentials/callback").permitAll()
             .antMatchers("/api/v1/**").hasRole("AUTHENTICATED")
             .anyRequest().permitAll();
 
-        http.csrf().disable();
+        http.csrf()
+            .ignoringAntMatchers(COMMON_NON_SECURED_PATHS)
+            .ignoringAntMatchers("/api/v1/credentials/callback")
+            .ignoringAntMatchers("/api/v1/atlas/**")
+            .csrfTokenRepository(new SyndesisCsrfRepository());
     }
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCsrfRepository.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCsrfRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.runtime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+public class SyndesisCsrfRepository implements CsrfTokenRepository {
+
+    private static final String XSRF_HEADER_NAME = "SYNDESIS-XSRF-TOKEN";
+    private static final String XSRF_HEADER_VALUE = "awesome";
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyndesisCsrfRepository.class);
+
+    @Override
+    public CsrfToken generateToken(HttpServletRequest httpServletRequest) {
+        return new DefaultCsrfToken(XSRF_HEADER_NAME, XSRF_HEADER_NAME, XSRF_HEADER_VALUE);
+    }
+
+    @Override
+    public void saveToken(CsrfToken csrfToken, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        if (csrfToken != null && csrfToken.getHeaderName() != null && csrfToken.getToken() != null) {
+            httpServletResponse.setHeader(csrfToken.getHeaderName(), csrfToken.getToken());
+        }
+    }
+
+    @Override
+    public CsrfToken loadToken(HttpServletRequest httpServletRequest) {
+        Optional<String> token = extractToken(httpServletRequest);
+        if (token.isPresent()) {
+            LOG.trace("Xsrf token found in request to uri {}. Value is: {}", httpServletRequest.getRequestURI(), token.get());
+        } else {
+            LOG.trace("Xsrf token not found in request to uri {}", httpServletRequest.getRequestURI());
+        }
+        return token.map(val -> new DefaultCsrfToken(XSRF_HEADER_NAME, XSRF_HEADER_NAME, val)).orElse(null);
+    }
+
+    private Optional<String> extractToken(HttpServletRequest request) {
+        String token = request.getHeader(XSRF_HEADER_NAME);
+        return Optional.ofNullable(token);
+    }
+}

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
@@ -280,6 +280,7 @@ public abstract class BaseITCase {
         }
         headers.set("X-Forwarded-User", "someone_important");
         headers.set("X-Forwarded-Access-Token", token);
+        headers.set("SYNDESIS-XSRF-TOKEN", "awesome");
     }
 
     static final class YamlJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {

--- a/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
+++ b/app/ui/src/app/api/providers/api-xsrf-interceptor.service.ts
@@ -15,11 +15,11 @@ export class ApiXsrfInterceptor implements HttpInterceptor {
   constructor(private tokenExtractor: HttpXsrfTokenExtractor) { }
 
   intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (httpRequest.method !== 'HEAD' && httpRequest.method !== 'GET' && httpRequest.url.startsWith('http')) {
-      const token = this.tokenExtractor.getToken();
+    if (httpRequest.url.startsWith('http')) {
+      const token = this.tokenExtractor.getToken() || environment.xsrf.defaultTokenValue;
       const { headerName } = environment.xsrf;
 
-      if (!!token && !httpRequest.headers.has(headerName)) {
+      if (!httpRequest.headers.has(headerName)) {
         httpRequest = httpRequest.clone({ headers: httpRequest.headers.set(headerName, token) });
       }
     }

--- a/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
+++ b/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
@@ -16,7 +16,7 @@ import { NotificationService } from '@syndesis/ui/common';
 import { ExtensionStore } from '@syndesis/ui/store/extension/extension.store';
 
 import { environment } from '../../../../environments/environment';
-import {HttpXsrfTokenExtractor} from "@angular/common/http";
+import { HttpXsrfTokenExtractor } from '@angular/common/http';
 
 interface FileError {
   level: string;

--- a/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
+++ b/app/ui/src/app/customizations/tech-extensions/import/tech-extension-import.component.ts
@@ -15,6 +15,9 @@ import { Extension } from '@syndesis/ui/platform';
 import { NotificationService } from '@syndesis/ui/common';
 import { ExtensionStore } from '@syndesis/ui/store/extension/extension.store';
 
+import { environment } from '../../../../environments/environment';
+import {HttpXsrfTokenExtractor} from "@angular/common/http";
+
 interface FileError {
   level: string;
   message: string;
@@ -46,7 +49,8 @@ export class TechExtensionImportComponent implements OnInit {
   constructor(private extensionStore: ExtensionStore,
               private notificationService: NotificationService,
               private router: Router,
-              private route: ActivatedRoute) {
+              private route: ActivatedRoute,
+              private tokenExtractor: HttpXsrfTokenExtractor) {
     this.extension$ = this.extensionStore.resource;
   }
 
@@ -93,6 +97,12 @@ export class TechExtensionImportComponent implements OnInit {
     const uploadUrl = this.extensionStore.getUploadUrl(this.extensionId);
     this.uploader = new FileUploader({
       url: uploadUrl,
+      headers: [
+        {
+          name: environment.xsrf.headerName,
+          value: this.tokenExtractor.getToken() || environment.xsrf.defaultTokenValue,
+        }
+      ],
       disableMultipart: false,
       autoUpload: true,
       removeAfterUpload: true,

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.ts
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.ts
@@ -15,8 +15,8 @@ import {
   FileUploaderOptions
 } from 'ng2-file-upload';
 import { IntegrationStore } from '@syndesis/ui/store';
-import {environment} from "../../../../environments/environment";
-import {HttpXsrfTokenExtractor} from "@angular/common/http";
+import { environment } from '../../../../environments/environment';
+import { HttpXsrfTokenExtractor } from '@angular/common/http';
 
 @Component({
   selector: 'syndesis-import-integration-component',

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.ts
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.ts
@@ -15,6 +15,8 @@ import {
   FileUploaderOptions
 } from 'ng2-file-upload';
 import { IntegrationStore } from '@syndesis/ui/store';
+import {environment} from "../../../../environments/environment";
+import {HttpXsrfTokenExtractor} from "@angular/common/http";
 
 @Component({
   selector: 'syndesis-import-integration-component',
@@ -38,7 +40,8 @@ export class IntegrationImportComponent implements OnInit {
 
   constructor(private integrationSupportService: IntegrationSupportService,
               private integrationStore: IntegrationStore,
-              private router: Router) {
+              private router: Router,
+              private tokenExtractor: HttpXsrfTokenExtractor) {
     // Do stuff here!
   }
 
@@ -78,6 +81,12 @@ export class IntegrationImportComponent implements OnInit {
   ngOnInit() {
     this.uploader = new FileUploader({
       url: this.integrationSupportService.importIntegrationURL(),
+      headers: [
+        {
+          name: environment.xsrf.headerName,
+          value: this.tokenExtractor.getToken() || environment.xsrf.defaultTokenValue,
+        }
+      ],
       disableMultipart: true,
       autoUpload: true,
       filters: [

--- a/app/ui/src/app/integration/list-page/list-page.component.ts
+++ b/app/ui/src/app/integration/list-page/list-page.component.ts
@@ -11,6 +11,8 @@ import {
   FileItem,
   ParsedResponseHeaders
 } from 'ng2-file-upload';
+import {environment} from "../../../environments/environment";
+import {HttpXsrfTokenExtractor} from "@angular/common/http";
 
 @Component({
   selector: 'syndesis-integration-list-page',
@@ -44,6 +46,7 @@ export class IntegrationListPage implements OnInit {
     private modalService: ModalService,
     private integrationSupportService: IntegrationSupportService,
     private integrationStore: IntegrationStore,
+    private tokenExtractor: HttpXsrfTokenExtractor,
     public notificationService: NotificationService,
   ) {
     this.integrations$ = integrationStore.list;
@@ -54,6 +57,12 @@ export class IntegrationListPage implements OnInit {
     this.integrationStore.loadAll();
     this.uploader = new FileUploader({
       url: this.integrationSupportService.importIntegrationURL(),
+      headers: [
+        {
+          name: environment.xsrf.headerName,
+          value: this.tokenExtractor.getToken() || environment.xsrf.defaultTokenValue,
+        }
+      ],
       disableMultipart: true,
       autoUpload: true
     });

--- a/app/ui/src/app/integration/list-page/list-page.component.ts
+++ b/app/ui/src/app/integration/list-page/list-page.component.ts
@@ -11,8 +11,8 @@ import {
   FileItem,
   ParsedResponseHeaders
 } from 'ng2-file-upload';
-import {environment} from "../../../environments/environment";
-import {HttpXsrfTokenExtractor} from "@angular/common/http";
+import { environment } from '../../../environments/environment';
+import { HttpXsrfTokenExtractor } from '@angular/common/http';
 
 @Component({
   selector: 'syndesis-integration-list-page',

--- a/app/ui/src/environments/environment.prod.ts
+++ b/app/ui/src/environments/environment.prod.ts
@@ -7,7 +7,8 @@ export const environment = {
   },
   xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',
-    cookieName: 'SYNDESIS-XSRF-COOKIE'
+    cookieName: 'SYNDESIS-XSRF-COOKIE',
+    defaultTokenValue: 'awesome'
   },
   config: {}
 };

--- a/app/ui/src/environments/environment.ts
+++ b/app/ui/src/environments/environment.ts
@@ -12,7 +12,8 @@ export const environment = Object.freeze({
   },
   xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',
-    cookieName: 'SYNDESIS-XSRF-COOKIE'
+    cookieName: 'SYNDESIS-XSRF-COOKIE',
+    defaultTokenValue: 'awesome',
   },
   config: {
     apiEndpoint: 'http://localhost:8080/api/v1',

--- a/app/ui/src/environments/environment.ts
+++ b/app/ui/src/environments/environment.ts
@@ -13,7 +13,7 @@ export const environment = Object.freeze({
   xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',
     cookieName: 'SYNDESIS-XSRF-COOKIE',
-    defaultTokenValue: 'awesome',
+    defaultTokenValue: 'awesome'
   },
   config: {
     apiEndpoint: 'http://localhost:8080/api/v1',


### PR DESCRIPTION
Adding xsrf protection using spring security.
I changed the ui part to use the token on each request (also `GET` and `TRACE`) and to use the `awesome` token value by default unless the server asks to use a different one (the server will not, for now).
Multipart requests were ok, the problem was in the angular FileUploader that required a ad hoc config (fixed it).

Spring-security validates the token header twice under the hood, so I used a shared constant value for ui and server.

This can be merged. I put the wip flag until we decide if we want to protect Atlasmap endpoints too (cc: @igarashitm).
