### PR TITLE
chore(build): Allow git plugin in "flash" profile

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -322,16 +322,6 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>pl.project13.maven</groupId>
-            <artifactId>git-commit-id-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default</id>
-                <phase />
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-enforcer-plugin</artifactId>
             <executions>
               <execution>

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -235,7 +235,7 @@ build_and_stage_artefacts() {
 
     if [ $(hasflag --no-maven-release) ]; then
         echo "==== Building locally (--no-maven-release)"
-        ./mvnw ${maven_opts} clean install
+        ./mvnw ${maven_opts} clean install -Pflash
     else
         echo "==== Building and staging Maven artefacts to Sonatype"
         ./mvnw ${maven_opts} -Prelease clean deploy -DstagingDescription="Staging Syndesis for $(readopt --release-version)"


### PR DESCRIPTION
This does not slow down the build considerably and is required
for getting git information into the version API endpoint.

Also, adapt the 'daily' release mode to run in flash, without tests,
to avoid sporadic test failures.
The rational is that its better to have daily releases which might have
some issues than having no such release because of test failures
(which might or might not be due to real errors)