### PR TITLE
fix(server): encrypt connection properties from oauth flow

### DIFF
--- a/app/server/credential/src/main/java/io/syndesis/server/credential/CredentialConfiguration.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/CredentialConfiguration.java
@@ -16,6 +16,7 @@
 package io.syndesis.server.credential;
 
 import io.syndesis.server.dao.manager.DataManager;
+import io.syndesis.server.dao.manager.EncryptionComponent;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +30,8 @@ public class CredentialConfiguration {
     }
 
     @Bean
-    public Credentials credentials(final CredentialProviderLocator connectionProviderLocator) {
-        return new Credentials(connectionProviderLocator);
+    public Credentials credentials(final CredentialProviderLocator connectionProviderLocator, final EncryptionComponent encryptionComponent,
+        final DataManager dataManager) {
+        return new Credentials(connectionProviderLocator, encryptionComponent, dataManager);
     }
 }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
@@ -111,7 +111,7 @@ public class CredentialITCase extends BaseITCase {
 
         final HttpHeaders cookies = persistAsCookie(flowState);
 
-        final Connection newConnection = new Connection.Builder().name("Test connection").connectorId("http").build();
+        final Connection newConnection = new Connection.Builder().name("Test connection").connectorId("test-provider").build();
         final ResponseEntity<Connection> connectionResponse = http(HttpMethod.POST, "/api/v1/connections",
             newConnection, Connection.class, tokenRule.validToken(), cookies, HttpStatus.OK);
 


### PR DESCRIPTION
This encrypts secret connection properties that are defined when the
OAuth flow completes by invoking the
`EncryptionComponent::encryptPropertyValues` when applying client side
state to the newly created Connection.

Fixes #2441