### PR TITLE
chore(install): declare accept header for liveness probe

### DIFF
--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateAutoConfiguration.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateAutoConfiguration.java
@@ -52,7 +52,7 @@ public class ResourceUpdateAutoConfiguration {
         return new ResourceUpdateController(
             configuration,
             eventBus,
-            Arrays.asList(
+            Arrays.<ResourceUpdateHandler>asList(
                 new ConnectionUpdateHandler(dataManager, encryptionComponent, validator),
                 new IntegrationUpdateHandler(dataManager, encryptionComponent,validator)
             )

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -104,6 +104,9 @@
             httpGet:
               port: 8080
               path: /api/v1/version
+              httpHeaders:
+              - name: Accept
+                value: 'text/plain'
             initialDelaySeconds: 300
             periodSeconds: 20
             failureThreshold: 5

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -1006,6 +1006,9 @@ objects:
             httpGet:
               port: 8080
               path: /api/v1/version
+              httpHeaders:
+              - name: Accept
+                value: 'text/plain'
             initialDelaySeconds: 300
             periodSeconds: 20
             failureThreshold: 5

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1002,6 +1002,9 @@ objects:
             httpGet:
               port: 8080
               path: /api/v1/version
+              httpHeaders:
+              - name: Accept
+                value: 'text/plain'
             initialDelaySeconds: 300
             periodSeconds: 20
             failureThreshold: 5


### PR DESCRIPTION
This declares the `Accept: text/plain` for the liveness probe and with that removes the messages in the log as now the handler that produces `text/plain` for `/api/v1/version` is narrowly selected.

Fixes #2423
