### PR TITLE
fix: On MySQL - Table name pattern can not be NULL or empty #2482

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DatabaseProduct.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DatabaseProduct.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.connector.sql.common;
 
+import java.util.Locale;
+
 /**
  * Enumeration of Database products we have tested, and for which we ship
  * drivers for. One caviat is the Oracle Driver which cannot be shipped due to
@@ -34,5 +36,9 @@ public enum DatabaseProduct {
      */
     public String nameWithSpaces() {
         return name().replaceAll("_", " ");
+    }
+
+    public static DatabaseProduct fromName(String databaseProductName) {
+        return valueOf(databaseProductName.toUpperCase(Locale.US).replaceAll(" ", "_"));
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
@@ -89,8 +89,8 @@ public class SqlMetadataAdapterTest {
                 }
             }
             Statement stmt = connection.createStatement();
-            String createTable = "CREATE TABLE NAME (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " +
-                    "lastName VARCHAR(255))";
+            String createTable = "CREATE TABLE NAME (ID INTEGER PRIMARY KEY, FIRSTNAME VARCHAR(255), " +
+                    "LASTNAME VARCHAR(255))";
             stmt.executeUpdate(createTable);
         } catch (SQLException ex) {
             fail("Exception", ex);
@@ -100,6 +100,8 @@ public class SqlMetadataAdapterTest {
     @AfterClass
     public static void afterClass() throws SQLException {
         if (connection!=null && !connection.isClosed()) {
+            Statement stmt = connection.createStatement();
+            stmt.execute("DROP TABLE NAME");
             connection.close();
         }
     }
@@ -157,14 +159,15 @@ public class SqlMetadataAdapterTest {
         SqlMetadataRetrieval adapter = new SqlMetadataRetrieval();
         SyndesisMetadata syndesisMetaData = adapter.adapt(camelContext, "sql", "sql-stored-connector", parameters, metadata.get());
 
-        String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = Json.writer();
+
+        String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
         String actualListOfProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
         assertEquals(expectedListOfProcedures, actualListOfProcedures, JSONCompareMode.STRICT);
 
         parameters.put(SqlMetadataRetrieval.PATTERN, SqlMetadataRetrieval.FROM_PATTERN);
         String expectedListOfStartProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
-                String actualListOfStartProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
+        String actualListOfStartProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
         assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures, JSONCompareMode.STRICT);
 
         parameters.put("procedureName", "DEMO_ADD");

--- a/app/connector/sql/src/test/resources/test-options.properties
+++ b/app/connector/sql/src/test/resources/test-options.properties
@@ -8,6 +8,11 @@
 #sql-connector.user=<user>
 #sql-connector.password=<password>
 
+# Mysql database configuration
+#sql-connector.url=jdbc:mysql://localhost:3306/test?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
+#sql-connector.user=test
+#sql-connector.password=password
+
 # Derby database configuration
 sql-connector.url=jdbc:derby:memory:testdb;create=true
 sql-connector.user=sa


### PR DESCRIPTION
Fixes https://github.com/syndesisio/syndesis/issues/2482. For MySQL a pattern of "%" should be used instead of null.