### PR TITLE
fix(ui): api connector icon upload when providing url for swagger

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector.service.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector.service.ts
@@ -48,7 +48,13 @@ export class ApiConnectorService {
     const connectorSettings = this.sanitizeCustomConnectorRequest(rawConnectorSettings);
 
     if (specification || icon) {
-      const payload = specification && icon ? { specification, icon } : { specification } || { icon };
+      const payload = {};
+      if (specification) {
+        payload['specification'] = specification;
+      }
+      if (icon) {
+        payload['icon'] = icon;
+      }
       return apiHttpService.upload(payload, { connectorSettings });
     } else {
       return apiHttpService.post(connectorSettings);


### PR DESCRIPTION
When the user provides a URL to the Swagger specification and tries to
upload the icon the logic would not upload the icon. This refactors the
logic that decides what multipart types to upload to make it easier to
understand and corrects that issue.

Fixes #2287