### PR TITLE
fix(connector): proper data shape kind for mqtt

### DIFF
--- a/app/connector/mqtt/src/main/resources/META-INF/syndesis/connector/mqtt.json
+++ b/app/connector/mqtt/src/main/resources/META-INF/syndesis/connector/mqtt.json
@@ -82,8 +82,7 @@
             "actionType": "connector",
             "descriptor": {
                 "inputDataShape": {
-                    "kind": "java",
-                    "type": "java.lang.String"
+                    "kind": "any"
                 },
                 "outputDataShape": {
                     "kind": "none"
@@ -122,8 +121,7 @@
                     "kind": "none"
                 },
                 "outputDataShape": {
-                    "kind": "java",
-                    "type": "java.lang.String"
+                    "kind": "any"
                 },
                 "configuredProperties": {
                 },


### PR DESCRIPTION
This set the input/output data shape kind to `any` for the mqtt
connector, previously it was erroneously set to `kind: 'java'` and
`type: 'java.lang.String'`.

Fixes #2476