### PR TITLE
fix(upgrade): Scale replicas to 0 before updating DeploymentConfigs

### DIFF
--- a/tools/upgrade/steps/prep_40_process_template
+++ b/tools/upgrade/steps/prep_40_process_template
@@ -19,6 +19,8 @@ Ideally, all such objects are annotated with `io.syndesis/upgrade-mode: keep` an
 
 The files created are stored locally and are applied in a later <<step-apply-upgrade-json, step>>.
 
+All `DeployemntConfig`s replicas are set to 0 so that they do not startup right after the update because a config trigger change.
+
 .Rollback
 Only the locally created object definitions need to be cleaned up (or kept for a later manual rollback).
 EOT
@@ -49,6 +51,12 @@ process_template::run() {
         local name=$(cat $res | jq -r '.metadata.name')
         [ -d ${workdir}/resources/${kind} ] || mkdir -p ${workdir}/resources/${kind}
 
+        if [ "$kind" = "DeploymentConfig" ]; then
+          # Set replica to 0 to avoid redeployment when patching the resource
+          local temp_dc=$(mktemp)
+          cat $res | jq -M '.spec.replicas |= 0' > $temp_dc
+          mv $temp_dc $res
+        fi
         if [ -n "${anno}" ] && [ "${anno}" = "keep" ]; then
             echo "      - Not updating $name"
         else

--- a/tools/upgrade/steps/upgrade_40_update_resources
+++ b/tools/upgrade/steps/upgrade_40_update_resources
@@ -39,7 +39,7 @@ EOT
 # All resources which should be update by force (delete/create) because
 # an in-place update is not possible
 # * Service and Route can't be replaced because there are immutable datat in the spec (like clusterip)
-# * ServiceAccounts are force replace so that hoopefully the associated secrets are cleaned up, too.
+# * ServiceAccounts are force replaced so that hopefully the associated secrets are cleaned up, too.
 FORCE_UPGRADE_RESOURCES="Service Route ServiceAccount"
 
 # Document which resource shouldn't be updated


### PR DESCRIPTION
Supposed to fix #2462

As discussed in #2475, we make an update with 0 replicas. This works for me
locally, so hopefully also in general.