### PR TITLE
fix(ui): don't show properties that are hidden and secret

### DIFF
--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -145,7 +145,7 @@ export class FormFactoryProviderService extends FormFactoryService {
                       type: string,
                       validators: {},
                       errorMessages: {}) {
-    if (field.secret) {
+    if (field.secret && field.type !== 'hidden') {
       type = 'password';
     }
     return new DynamicInputModel({


### PR DESCRIPTION
Adds condition so that the property that is both hidden and secret is
not displayed.

Fixes #2494