### PR TITLE
Toast notifications import/export

### DIFF
--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -2,7 +2,7 @@
   <div class="card-pf">
     <div class="card-pf-heading">
       <div class="card-pf-title">
-        <h1>Import Integration</h1>
+        <h1>{{ 'integrations.import-export.header' | synI18n }}</h1>
       </div>
     </div>
     <div class="card-pf-body">

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -33,7 +33,7 @@
                        class="text-muted">
                     <span *ngIf="item.isUploading"
                           class="spinner spinner-sm spinner-inline"></span>
-                    <em>Importing...</em>
+                    <em>{{ 'integrations.import-export.importing' | synI18n }}</em>
                   </div>
                   <div *ngIf="item.isUploaded">
                     <div *ngIf="item.isSuccess; else isError">
@@ -63,15 +63,12 @@
             <table class="table">
               <tbody>
               <ng-container *ngFor="let integration of importedOverviews$ | async">
-                <tr *ngIf="integration.name">
-                  <!--
-                  <th>{{ 'integrations.import-export.item-name' | synI18n: 'Integration' }} Name</th>
-                  -->
+                <tr>
                   <th>Integration Name</th>
                   <td>{{ integration.name }}</td>
                 </tr>
                 <tr *ngFor="let step of integration.steps">
-                  <th *ngIf="step.connection">Connection Name</th>
+                  <th>Connection Name</th>
                   <td>{{ step.connection.name }}</td>
                 </tr>
               </ng-container>

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -57,7 +57,7 @@
       <div class="results">
         <div *ngIf="showReviewStep">
           <div class="col-xs-2 text">
-            <h3>Import Results:</h3>
+            <h3>{{ 'integrations.import-export.import-results' | synI18n }}</h3>
           </div>
           <div class="col-xs-10">
             <table class="table">
@@ -84,12 +84,12 @@
           <button type="button"
                   class="btn btn-primary"
                   (click)="done(importedOverviews$)">
-            Done
+            {{ 'integrations.import-export.btn-done' | synI18n }}
           </button>
           <button type="button"
                   class="btn btn-default"
                   (click)="cancel()">
-            Cancel
+            {{ 'integrations.import-export.btn-cancel' | synI18n }}
           </button>
         </div>
       </div>

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -38,11 +38,11 @@
                   <div *ngIf="item.isUploaded">
                     <div *ngIf="item.isSuccess; else isError">
                       <span class="pficon-ok"></span>
-                      Successfully imported.
+                      {{ 'integrations.import-export.import-success' | synI18n }}
                     </div>
                     <ng-template #isError>
                       <span class="pficon-error-circle-o"></span>
-                      Unable to import this file.
+                      {{ 'integrations.import-export.import-fail' | synI18n }}
                     </ng-template>
                   </div>
                 </div>

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -15,7 +15,7 @@
            [ngClass]="{'syn-drop-zone--hover': isDragAndDropImport}"
            (fileOver)="onDropOverAndOut($event)"
            (onFileDrop)="onDropFile()">
-        <p>Drag and drop your integration files here or</p>
+        <p>{{ 'integrations.import-export.drag-and-drop' | synI18n }}</p>
         <div class="row syn-drop-zone__file-select">
           <div class="col-md-3">
             <input #fileSelect

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -7,7 +7,7 @@
     </div>
     <div class="card-pf-body">
       <div>
-        <p>Choose one or more zip files that contain exported integrations that you want to import.</p>
+        <p>{{ 'integrations.import-export.choose-files' | synI18n }}</p>
       </div>
       <div class="syn-drop-zone"
            ng2FileDrop

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.html
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.html
@@ -51,8 +51,7 @@
           </div>
         </div>
         <p class="help-block">
-          <em>Note: The imported integration will be in the draft state. If you previously imported and this
-            environment has a draft version of the integration, then that draft is lost.</em>
+          <em>{{ 'integrations.import-export.help-block' | synI18n }}</em>
         </p>
       </div>
       <div class="results">
@@ -65,6 +64,9 @@
               <tbody>
               <ng-container *ngFor="let integration of importedOverviews$ | async">
                 <tr *ngIf="integration.name">
+                  <!--
+                  <th>{{ 'integrations.import-export.item-name' | synI18n: 'Integration' }} Name</th>
+                  -->
                   <th>Integration Name</th>
                   <td>{{ integration.name }}</td>
                 </tr>

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.ts
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.ts
@@ -17,6 +17,8 @@ import {
 import { IntegrationStore } from '@syndesis/ui/store';
 import { environment } from '../../../../environments/environment';
 import { HttpXsrfTokenExtractor } from '@angular/common/http';
+import {NotificationType} from "patternfly-ng";
+import {NotificationService} from "@syndesis/ui/common";
 
 @Component({
   selector: 'syndesis-import-integration-component',
@@ -41,6 +43,7 @@ export class IntegrationImportComponent implements OnInit {
   constructor(private integrationSupportService: IntegrationSupportService,
               private integrationStore: IntegrationStore,
               private router: Router,
+              public notificationService: NotificationService,
               private tokenExtractor: HttpXsrfTokenExtractor) {
     // Do stuff here!
   }
@@ -100,6 +103,13 @@ export class IntegrationImportComponent implements OnInit {
     });
 
     this.uploader.onWhenAddingFileFailed = (item: FileLikeObject, filter: any, options: any): any => {
+      this.notificationService.popNotification({
+        type: NotificationType.DANGER,
+        header: 'Import Failed',
+        message: 'There was an issue importing your integration.',
+        isPersistent: true,
+      });
+
       this.error = this.getFileTypeError();
       this.fileSelect.nativeElement['value'] = '';
       this.uploader.clearQueue();
@@ -110,6 +120,13 @@ export class IntegrationImportComponent implements OnInit {
                                     status: number) => {
       if (status === 200) {
         this.fetchImportedIntegrations(JSON.parse(response));
+
+        this.notificationService.popNotification({
+          type: NotificationType.SUCCESS,
+          header: 'Successfully Imported',
+          message: 'Your integration has been imported',
+          isPersistent: true,
+        });
       }
     };
   }

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.ts
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.ts
@@ -17,8 +17,8 @@ import {
 import { IntegrationStore } from '@syndesis/ui/store';
 import { environment } from '../../../../environments/environment';
 import { HttpXsrfTokenExtractor } from '@angular/common/http';
-import {NotificationType} from "patternfly-ng";
-import {NotificationService} from "@syndesis/ui/common";
+import { NotificationType } from 'patternfly-ng';
+import { NotificationService } from '@syndesis/ui/common';
 
 @Component({
   selector: 'syndesis-import-integration-component',

--- a/app/ui/src/app/integration/import-export/import/integration-import.component.ts
+++ b/app/ui/src/app/integration/import-export/import/integration-import.component.ts
@@ -107,7 +107,7 @@ export class IntegrationImportComponent implements OnInit {
         type: NotificationType.DANGER,
         header: 'Import Failed',
         message: 'There was an issue importing your integration.',
-        isPersistent: true,
+        isPersistent: false,
       });
 
       this.error = this.getFileTypeError();
@@ -125,7 +125,7 @@ export class IntegrationImportComponent implements OnInit {
           type: NotificationType.SUCCESS,
           header: 'Successfully Imported',
           message: 'Your integration has been imported',
-          isPersistent: true,
+          isPersistent: false,
         });
       }
     };

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -6,9 +6,15 @@
       "integrations": "Integrations",
       "import-export": {
         "choose-file": "Choose one or more zip files that contain exported integrations that you want to import.",
-        "drag-and-drop": "",
+        "drag-and-drop": "Drag and drop your integration files here or",
         "help-block": "Note: The imported integration will be in the draft state. If you previously imported and this environment has a draft version of the integration, then that draft is lost.",
-        "item-name": "{{0}} Name"
+        "item-name": "{{0}} Name",
+        "importing": "Importing...",
+        "import-success": "Successfully imported.",
+        "import-fail": "Unable to import this file.",
+        "import-results": "Import Results:",
+        "btn-done": "Done",
+        "btn-cancel": "Cancel"
       }
     },
     "connections": {

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -3,7 +3,13 @@
   "dictionary": {
     "integrations": {
       "integration": "Integration",
-      "integrations": "Integrations"
+      "integrations": "Integrations",
+      "import-export": {
+        "choose-file": "Choose one or more zip files that contain exported integrations that you want to import.",
+        "drag-and-drop": "",
+        "help-block": "Note: The imported integration will be in the draft state. If you previously imported and this environment has a draft version of the integration, then that draft is lost.",
+        "item-name": "{{0}} Name"
+      }
     },
     "connections": {
       "connection": "Connection",

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -5,7 +5,8 @@
       "integration": "Integration",
       "integrations": "Integrations",
       "import-export": {
-        "choose-file": "Choose one or more zip files that contain exported integrations that you want to import.",
+        "header": "Import Integration",
+        "choose-files": "Choose one or more zip files that contain exported integrations that you want to import.",
         "drag-and-drop": "Drag and drop your integration files here or",
         "help-block": "Note: The imported integration will be in the draft state. If you previously imported and this environment has a draft version of the integration, then that draft is lost.",
         "item-name": "{{0}} Name",


### PR DESCRIPTION
Re-add toast notifications to import/export. Some improvements will be made for failed imports in an upcoming PR.

- i18n support (still need to remove text from component as well, done for template)
- Non-persistent notifications on success and fail

## Screenshots
<img width="1449" alt="screenshot 2018-05-07 17 37 54" src="https://user-images.githubusercontent.com/3844502/39726569-74ee0ed0-521d-11e8-87c8-f9afdf9790ad.png">


fix #1956 