### PR TITLE
fix: ensure the user is bounced back to the login page on logout

### DIFF
--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -151,7 +151,7 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   logout() {
     this.loggedIn = false;
-    return this.userService.logout().toPromise();
+    this.userService.logout();
   }
 
   /**
@@ -195,7 +195,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   handleAction($event: NotificationEvent): void {
     if ($event.action.id === 'reload') {
-      location.reload();
+      window.location.reload();
     }
   }
 

--- a/app/ui/src/app/core/providers/user-provider.service.ts
+++ b/app/ui/src/app/core/providers/user-provider.service.ts
@@ -1,16 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { UserService, ApiHttpService, User } from '@syndesis/ui/platform';
-import {
-  HttpClient,
-  HttpHeaders,
-  HttpRequest,
-  HttpEventType,
-  HttpProgressEvent,
-  HttpResponse,
-  HttpUrlEncodingCodec
-} from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class UserProviderService extends UserService {
@@ -20,7 +12,7 @@ export class UserProviderService extends UserService {
    * UserService constructor
    * @param {HttpClient} httpClient
    */
-  constructor(private httpClient: HttpClient, private apiHttpService: ApiHttpService) {
+  constructor(private httpClient: HttpClient, private apiHttpService: ApiHttpService, private ngZone: NgZone) {
     super();
   }
 
@@ -32,9 +24,11 @@ export class UserProviderService extends UserService {
   }
 
   /**
-   * Log the user out
+   * Triggers the logout flow and effectively returns the user to the login page
    */
-  logout(): Observable<any> {
-    return this.httpClient.get('/oauth/sign_out');
+  logout(): void {
+    this.ngZone.runOutsideAngular(() => {
+      window.location.href = '/oauth/sign_out';
+    });
   }
 }

--- a/app/ui/src/app/platform/types/user/user.service.ts
+++ b/app/ui/src/app/platform/types/user/user.service.ts
@@ -13,5 +13,5 @@ export abstract class UserService {
   /**
    * Log the user out
    */
-  abstract logout(): Observable<any>;
+  abstract logout(): void;
 }


### PR DESCRIPTION
fixes #2511 

the actual redirect would technically need to be handled by the oauth proxy, I don't think it currently supports a logout redirect URL or anything, but this at least ensures you wind up back at the login page, and you can log back in and things work normally.