### PR TITLE
fix: trim strings by default except for secret fields

### DIFF
--- a/app/ui/src/app/connections/common/configuration/configuration.service.ts
+++ b/app/ui/src/app/connections/common/configuration/configuration.service.ts
@@ -3,10 +3,13 @@ import {
   DynamicFormControlModel,
   DynamicInputModel
 } from '@ng-dynamic-forms/core';
-import { Connection, Connector, FormFactoryService } from '@syndesis/ui/platform';
+import { Connection, Connector, FormFactoryService, StringMap, ConfigurationProperty } from '@syndesis/ui/platform';
 
 @Injectable()
 export class ConnectionConfigurationService {
+
+  formConfig: StringMap<ConfigurationProperty>;
+
   constructor(private formFactory: FormFactoryService) {}
 
   shouldValidate(connector: Connector) {
@@ -14,22 +17,15 @@ export class ConnectionConfigurationService {
     return tags.indexOf('verifier') != -1;
   }
 
-  sanitize(data: {}) {
-    const sanitized: any = {};
-    // strip out any null/empty values
-    for (const key of Object.keys(data)) {
-      const trimmed = key.trim();
-      const value = data[key] || '';
-      sanitized[trimmed] = value === '' ? undefined : value;
-    }
-    return sanitized;
+  sanitize(data: {}): any {
+    return this.formFactory.sanitizeValues(data, this.formConfig);
   }
 
   getFormModel(
     connection: Connection,
     readOnly: boolean
   ): DynamicFormControlModel[] {
-    const config = this.getFormConfig(connection);
+    const config = this.formConfig = this.getFormConfig(connection);
     let controls = ['*'];
     // TODO temporary client-side hack to tweak form ordering
     switch (connection.connectorId) {

--- a/app/ui/src/app/connections/create-page/configure-fields/configure-fields.component.ts
+++ b/app/ui/src/app/connections/create-page/configure-fields/configure-fields.component.ts
@@ -34,12 +34,7 @@ export class ConnectionsConfigureFieldsComponent
     this.formGroup = this.formService.createFormGroup(this.formModel);
     this.formChangesSubscription = this.formGroup.valueChanges.subscribe(
       data => {
-        Object.keys(data).forEach(key => {
-          if (data[key] === null) {
-            delete data[key];
-          }
-        });
-        this.connection.configuredProperties = data;
+        this.connection.configuredProperties = this.configurationService.sanitize(data);
       }
     );
 

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -58,7 +58,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   }
 
   buildData(data: any) {
-    const formValue = this.formFactory.supressNullValues(this.formGroup ? this.formGroup.value : {});
+    const formValue = this.formFactory.sanitizeValues(this.formGroup ? this.formGroup.value : {}, this.formConfig);
     return { ...this.step.configuredProperties, ...formValue, ...data };
   }
 

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -148,7 +148,7 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
   continue() {
     const step = this.currentFlowService.getStep(this.position);
     if (this.userDefined) {
-      const value = this.formGroup.value;
+      const value = this.formFactoryService.sanitizeValues(this.formGroup.value, DESCRIBE_DATA_FORM_CONFIG);
       const dataShape = this.getDataShape(this.direction, step);
       // normalize this to 'any'
       dataShape.kind = value.kind;

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -82,7 +82,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy, Aft
     this.currentFlowService.events.emit({
       kind: 'integration-set-properties',
       position: this.position,
-      properties: this.formFactory.supressNullValues({ ...data }),
+      properties: this.formFactory.sanitizeValues({ ...data }, this.formConfig),
       onSave: () => {
         this.router.navigate(['save-or-add-step'], {
           queryParams: { validate: true },

--- a/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
+++ b/app/ui/src/app/platform/types/form-factory/form-factory.service.ts
@@ -21,10 +21,48 @@ export abstract class FormFactoryService {
     controls?: Array<string>
   ): DynamicFormControlModel[];
 
-  supressNullValues(data: object): object {
+  sanitizeValues(
+    data: any,
+    properties:
+      | StringMap<ConfiguredConfigurationProperty>
+      | StringMap<ConfigurationProperty>
+      | StringMap<any>
+      | any): any {
+    data = this.supressNullValues(data);
+    data = this.trimStringValues(data, properties);
+    return data;
+  }
+
+  supressNullValues(data: any): any {
+    if (!data) {
+      return data;
+    }
     Object.keys(data).forEach(key => {
       if (data[key] === null) {
         delete data[key];
+      }
+    });
+    return data;
+  }
+
+  trimStringValues(
+    data: any,
+    properties:
+      | StringMap<ConfiguredConfigurationProperty>
+      | StringMap<ConfigurationProperty>
+      | StringMap<any>
+      | any): any {
+    if (!properties || !data) {
+      return data;
+    }
+    Object.keys(data).forEach(key => {
+      const prop = properties[key];
+      if (prop && prop.trim === false || prop.secret) {
+        return;
+      }
+      const value = data[key];
+      if (typeof value === 'string') {
+        data[key] = value.trim();
       }
     });
     return data;

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
@@ -35,6 +35,7 @@ const OAUTH_APP_FORM_CONFIG = {
   templateUrl: 'oauth-app-form.component.html'
 })
 export class OAuthAppFormComponent implements OnInit {
+  formConfig: any;
   @Input() item: any = {};
 
   loading = false;
@@ -51,7 +52,7 @@ export class OAuthAppFormComponent implements OnInit {
   ) {}
 
   save() {
-    const app = { ...this.item.client, ...this.formGroup.value };
+    const app = { ...this.item.client, ...this.formFactory.sanitizeValues(this.formGroup.value, this.formConfig) };
     this.formGroup.disable();
     this.loading = true;
     this.error = null;
@@ -85,7 +86,7 @@ export class OAuthAppFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    const formConfig = JSON.parse(JSON.stringify(OAUTH_APP_FORM_CONFIG));
+    const formConfig = this.formConfig = JSON.parse(JSON.stringify(OAUTH_APP_FORM_CONFIG));
     this.formModel = this.formFactory.createFormModel(
       formConfig,
       this.item.client,


### PR DESCRIPTION
fixes #2510 

Adds support for a `trim` field in config property definitions to control if a string value should be trimmed or not, also ensures that all the spots where the form factory is used sanitizes the data coming back from the form.