### PR TITLE
fix(server): use proper integration version

### DIFF
--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
@@ -223,9 +223,8 @@ public class PublishHandler extends BaseHandler implements StateChangeHandler {
         }
     }
 
-
-    private Integration integrationOf(IntegrationDeployment integrationDeployment) {
-        return dataManager.fetch(Integration.class, integrationDeployment.getIntegrationId().orElseThrow(() -> new IllegalStateException("IntegrationDeployment doesn't have integration id.")));
+    private static Integration integrationOf(IntegrationDeployment integrationDeployment) {
+        return integrationDeployment.getSpec();
     }
 
     /**


### PR DESCRIPTION
When generating OpenShift Secret we used the latest version of the
Integration. That meant that if we modified the order or added steps the
Secret would be misaligned with the image build used. For instance if we
removed a logging step (at position 2) between the two existing steps:
start at positon 1 and stop at position 3 steps, the id of the last step
would changed from 3 to 2, but the generated `application.properties` in
the Secret would still have the key with `-3`.

This prevented deployments of previous versions or deployments of newer
versions.

Fixes #2432