### PR TITLE
fix(ui): remove the oauth settings by setting values to null

### DIFF
--- a/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
@@ -47,7 +47,7 @@ export class OAuthAppModalComponent {
 
   // Clear the store credentials for the selected oauth app
   removeCredentials() {
-    const app = { ...this.item.client, clientId: '', clientSecret: '' };
+    const app = { ...this.item.client, clientId: null, clientSecret: null };
     return this.store
       .update(app)
       .take(1)


### PR DESCRIPTION
Syndesis server used to consider properties that are empty or contain
only whitespace as `null` (_trim to null_), this is no longer the case
and the property value needs to be specified as `null`.

Removing OAuth settings would only change the value to an empty string
(`""`) and thus would be still remain as configured.

Fixes #2533