### PR TITLE
chore(install): Moved out generation of productised templates

### DIFF
--- a/doc/sdh/cli/cmd_release.adoc
+++ b/doc/sdh/cli/cmd_release.adoc
@@ -44,7 +44,6 @@ Options for release:
                               (and removed after the release)
     --docker-user <user>      Docker user for Docker Hub
     --docker-password <pwd>   Docker password for Docker Hub
-    --product-templates       Create templates for the productised version only and tag
     --no-git-push             Don't push the release tag (and symbolic major.minor tag)
     --git-remote              Name of the git remote to push to. If not given, its trying to be pushed
                               to the git remote to which the currently checked out branch is attached to.
@@ -243,22 +242,6 @@ syndesis release \
 <4> Docker credentials required for pushing to Docker Hub
 
 A daily Jenkins job with this configuration run on https://ci.fabric8.io for creating a daily snapshots.
-
-### Fuse Online Templates
-
-The templates checked in and tagged with _regular_ tags in pure numeric form (e.g. `1.2.8`) are always referencing upstream images that are available at Docker Hub.
-
-For a different setup to referencing different images (i.e. the images that are produced by the Red Hat productisation process), yet another set of templates can be generated.
-
-For this the option `--product-templates` can be used, which generates templates _without image stream definitions_, but referencing supposedly already existing image streams.
-
-These templates are created with a tag `fuse-ignite-<minor>` (e.g. `fuse-ignite-1.2`) in the Git repository and so directly accessed from GitHub.
-
-The product template support is currently very specific to the Fuse Ignite Cluster, which is used for the Technical Preview phase of Fuse Ignite.
-
-So it is likely that it might change in the future.
-
-NOTE: An extra step is required to import productised Syndesis Docker images into the Fuse Ignite cluster. This step should be documented here, and probably added to the release script.
 
 [[dev-release-troubleshooting]]
 ### Troubleshooting

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -205,7 +205,10 @@
           01_maven_central: https://repo1.maven.org/maven2
           02_redhat_ea_repository: https://maven.repository.redhat.com/earlyaccess/all
           03_jboss_ea: https://repository.jboss.org/nexus/content/groups/ea
-{{/Productized}}      openshift:
+{{/Productized}}{{#Ocp}}      controllers:
+        maxIntegrationsPerUser: 0
+        maxDeploymentsPerUser: 0
+{{/Ocp}}      openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}

--- a/install/generator/run.sh
+++ b/install/generator/run.sh
@@ -18,9 +18,9 @@ go get -u github.com/spf13/cobra github.com/spf13/pflag github.com/hoisie/mustac
 cd $dir
 
 echo "$MESSAGE" > ${targetdir}/syndesis.yml
-go run syndesis-template.go $* --name=syndesis >> ${targetdir}/syndesis.yml
+go run syndesis-template.go --name=syndesis $* >> ${targetdir}/syndesis.yml
 
 echo "$MESSAGE" > ${targetdir}/syndesis-dev.yml
-go run syndesis-template.go $* --name=syndesis-dev --allow-localhost --debug >> ${targetdir}/syndesis-dev.yml
+go run syndesis-template.go --name=syndesis-dev $* --allow-localhost --debug >> ${targetdir}/syndesis-dev.yml
 
 # For re-enabling plain Docker images, use --with-docker-images when generating the template

--- a/install/generator/syndesis-template.go
+++ b/install/generator/syndesis-template.go
@@ -70,6 +70,8 @@ type Context struct {
 	AllowLocalHost   bool
 	WithDockerImages bool
 	Productized      bool
+	Oso              bool
+	Ocp              bool
 	Tag              string
 	Registry         string
 	Images           images
@@ -138,7 +140,8 @@ func init() {
 	flags.BoolVar(&context.AllowLocalHost, "allow-localhost", false, "Allow localhost")
 	flags.BoolVar(&context.WithDockerImages, "with-docker-images", false, "With docker images")
 	flags.StringVar(&context.Tags.Syndesis, "syndesis-tag", "latest", "Syndesis Image tag to use")
-	flags.BoolVar(&context.Productized, "product", false, "Generate product templates?")
+	flags.BoolVar(&context.Oso, "oso", false, "Generate product templates for SO")
+	flags.BoolVar(&context.Ocp, "ocp", false, "Generate product templates for OCP")
 	flags.StringVar(&context.Registry, "registry", "docker.io", "Registry to use for imagestreams")
 	flags.BoolVar(&context.Debug, "debug", false, "Enable debug support")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -146,11 +149,14 @@ func init() {
 
 func install(cmd *cobra.Command, args []string) {
 
-	if context.Productized {
+	if context.Oso || context.Ocp {
+		context.Productized = true
 		if err := mergo.MergeWithOverwrite(&context, productContext); err != nil {
 			log.Fatal("Cannot merge in product image names")
 		}
-		context.Name = context.Name + "-fuse-ignite-" + context.Tags.Syndesis
+		if context.Oso {
+			context.Name = context.Name + "-" + context.Tags.Syndesis
+		}
 	}
 
 	files, err := ioutil.ReadDir("./")

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -30,7 +30,6 @@ release::usage() {
                               temporary directory will be used (and removed after the release)
     --docker-user <user>      Docker user for Docker Hub
     --docker-password <pwd>   Docker password for Docker Hub
-    --product-templates       Create templates for the productised version only and tag
     --no-git-push             Don't push the release tag (and symbolic major.minor tag) at the end
     --git-remote              Name of the git remote to push to. If not given, its trying to be pushed
                               to the git remote to which the currently checked out branch is attached to.
@@ -67,12 +66,6 @@ release::run() {
     # Get the Syndesis minor version (e.g. "1.3")
     local moving_tag=$(extract_minor_version $release_version)
     check_error $moving_tag
-
-    # Generate product templates only if desired
-    if [ $(hasflag --product-templates) ]; then
-        do_product_templates $topdir $moving_tag "fuse-ignite"
-        exit 0
-    fi
 
     # Write to logfile if requested
     if [ $(readopt --log) ]; then
@@ -367,27 +360,6 @@ git_push() {
 
 # =======================================================================
 # Side actions
-
-do_product_templates() {
-  local topdir=$1
-  local moving_tag=$2
-  local tag_prefix=${4:-fuse-ignite}
-
-  cd $topdir/install/generator
-
-  echo "==== Creating product templates for $moving_tag"
-  sh run.sh --product --syndesis-tag="$moving_tag"
-
-  echo "==== Committing"
-  cd $topdir
-  git_commit ^install/ "Update OpenShift templates for Syndesis $moving_tag"
-
-  echo "=== Tagging"
-  git tag -f "${tag_prefix}-${moving_tag}"
-
-  # Push release tag only
-  git_push "$topdir" "$release_version"
-}
 
 drop_staging_repo() {
     local topdir="$1"

--- a/tools/bin/install-syndesis
+++ b/tools/bin/install-syndesis
@@ -40,6 +40,8 @@ EOT
 
 recreate_project() {
     local project=$1
+    local dont_ask=${2:-false}
+
     if [ -z "$project" ]; then
         echo "No project given"
         exit 1
@@ -47,6 +49,17 @@ recreate_project() {
 
     # Delete project if existing
     if oc get project "${project}" >/dev/null 2>&1 ; then
+        if [ $dont_ask != "true" ]; then
+            echo =============== WARNING -- Going to delete project ${project}
+            oc get all -n $project
+            echo ============================================================
+            read -p "Do you really want to delete the existing project $project ? yes/[no] : " choice
+            echo
+            if [ "$choice" != "yes" ] && [ "$choice" != "y" ]; then
+                echo "Aborting on user's request"
+                exit 1
+            fi
+        fi
         echo "Deleting project ${project}"
         oc delete project "${project}"
     fi
@@ -72,7 +85,7 @@ create_oauthclient() {
 
 create_and_apply_template() {
     local route=$1
-    local console=$2
+    local console=${2:-}
     local template=${3:-syndesis}
     local tag=${4:-}
 
@@ -99,12 +112,14 @@ get_template_name() {
     local tag=${2:-}
     if [ -n "$tag" ]; then
         local candidate="$template-$tag"
-        local output=$(oc get template $candidate 2>&1)
-        if [[ $output = "*NotFound*" ]]; then
+        $(oc get template $candidate >/dev/null 2>&1)
+        if [ $? -eq 0 ]; then
           echo $candidate
           return
         fi
     fi
+
+
     echo $template
 }
 
@@ -232,10 +247,11 @@ tag=$(readopt --tag -t)
 route=$(readopt --route -r)
 console=$(readopt --console)
 
-# Main code
-if [ -z "$route" ] ||[ $(hasflag --help -h) ]; then
-    display_usage
-    exit 0
+# Get route
+route=$(readopt --route)
+if [ -z "${route}" ]; then
+    route="$(guess_route "$project")"
+    check_error $route
 fi
 
 # If a project is given, create it new or recreate it


### PR DESCRIPTION
These will be hosted in fuse-ignite-install repo for OSO and OCP
installations.

* Replaced --productize for the template generator with --oso and --ocp for the different environments.
* Added no limits wrt integrations for the OCP case