### PR TITLE
fix(server): don't warn about missing properties on derived connections

### DIFF
--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/ConnectionUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/ConnectionUpdateHandler.java
@@ -91,7 +91,9 @@ public class ConnectionUpdateHandler extends AbstractResourceUpdateHandler<Conne
         List<LeveledMessage> messages = new ArrayList<>();
         messages.addAll(computeValidatorMessages(LeveledMessage.Builder::new, connection));
         messages.addAll(computePropertiesDiffMessages(LeveledMessage.Builder::new, oldConnector.getProperties(), newConnector.getProperties()));
-        messages.addAll(computeMissingMandatoryPropertiesMessages(LeveledMessage.Builder::new, newConnector.getProperties(), merge(newConnector.getConfiguredProperties(), connection.getConfiguredProperties())));
+        if (!connection.isDerived()) {
+            messages.addAll(computeMissingMandatoryPropertiesMessages(LeveledMessage.Builder::new, newConnector.getProperties(), merge(newConnector.getConfiguredProperties(), connection.getConfiguredProperties())));
+        }
         messages.addAll(computeSecretsUpdateMessages(LeveledMessage.Builder::new, newConnector.getProperties(), connection.getConfiguredProperties()));
 
         builder.errors(countMessagesWithLevel(LeveledMessage.Level.ERROR, messages));


### PR DESCRIPTION
For Salesforce Connector Connections we support multiple ways of
configuring the properties, when the connection is configured without
OAuth settings set, i.e. manually, the username and password fields are
required; with OAuth settings, i.e. using OAuth flow, username and
password are not set and not required.

Given that the warning SYNDESIS006 is issued if a required property is
not configured, a warning will be shown on Salesforce connections
created from OAuth flow. We can distinguish those by having their
`derived` flag set and filter out this warning.

Fixes #2532