### PR TITLE
fix(ui): highlight step 3 in new connection wizard

### DIFF
--- a/app/ui/src/app/connections/create-page/create-page.component.ts
+++ b/app/ui/src/app/connections/create-page/create-page.component.ts
@@ -164,8 +164,9 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
         if (
           this.current.oauthStatus &&
           this.current.oauthStatus.status === 'SUCCESS' &&
-          page === 'configure-fields'
+          page === 'review'
         ) {
+          this.currentActiveStep++;
           this.goForward();
           return;
         }

--- a/app/ui/src/app/store/connector/connector.service.ts
+++ b/app/ui/src/app/store/connector/connector.service.ts
@@ -53,7 +53,7 @@ export class ConnectorService extends RESTService<Connector, Connectors> {
         });
 
         setTimeout(() => {
-          const returnUrl = `${window.location.pathname}#${id}`;
+          const returnUrl = `${window.location.pathname.replace(/[^/]*$/, 'review')}#${id}`;
           this.apiHttpService
             .setEndpointUrl(`/connectors/${id}/credentials`)
             .post<AcquisitionResponse>({ returnUrl })


### PR DESCRIPTION
When landing from the OAuth callback we would present the
_Name Connection_ form and the wizard would highlight
_Configure Connection_ step.

This replaces the `returnUrl` and massages the logic into displaying the
proper step for the form.

Fixes #2543