### PR TITLE
Deleting a connection which is used by an integration leads to inconsistent state (backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ hs_err_pid*
 .pmd
 .pmdruleset.xml
 .factorypath
+.sts4-cache/
 
 # System Files
 .DS_Store

--- a/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
@@ -41,6 +41,8 @@ public interface LeveledMessage extends WithMetadata {
         SYNDESIS006, // One or more required properties is not set
         SYNDESIS007, // Secrets update needed
         SYNDESIS008, // Validation Error
+        SYNDESIS009, // Connection has been deleted
+        SYNDESIS010, // Multiple extension installed
     }
 
     enum Level {

--- a/app/ui/src/app/core/providers/status-code-decoder-provider.service.ts
+++ b/app/ui/src/app/core/providers/status-code-decoder-provider.service.ts
@@ -1,28 +1,22 @@
 import { Injectable } from '@angular/core';
-import { StatusCodeDecoderService, MessageCode, LeveledMessage, StringMap } from '@syndesis/ui/platform';
+import { StatusCodeDecoderService, MessageCode, LeveledMessage, StringMap, I18NService } from '@syndesis/ui/platform';
+import { environment } from '../../../environments/environment';
+const { fallbackValue } = environment.i18n;
 
 @Injectable()
 export class StatusCodeDecoderProviderService extends StatusCodeDecoderService {
 
-  // TODO eventually this would be in a separate json file, also better messages
-  private static messages = {
-    'SYNDESIS000': 'An unknown error has occurred', // generic message
-    'SYNDESIS001': 'There are parameter updates. Click <strong>Edit</strong> to update parameter settings.',
-    'SYNDESIS002': 'One or more properties have been updated or removed', // One or more properties have been added or removed
-    'SYNDESIS003': 'The connector associated with this connection has been deleted', // Connector has been deleted
-    'SYNDESIS004': 'The associated extension has been deleted', // Extension has been deleted
-    'SYNDESIS005': 'The associated action has been deleted', // Action has been deleted
-    'SYNDESIS006': 'One or more required properties is not set', // One or more required properties is not set
-    'SYNDESIS007': 'Secrets for this connection need to be updated', // Secrets update needed
-    'SYNDESIS008': 'There has a validation error', // Validation Error
-  } as StringMap<string>;
+  constructor(public i18NService: I18NService) {
+    super(i18NService);
+  }
 
-  // TODO use 'context' for variable substitution in message string
-  getMessageString(message: LeveledMessage, context?: StringMap<any>) {
+  getMessageString(message: LeveledMessage, args?: any[]) {
     if (message.message) {
       return message.message;
     }
-    const answer = StatusCodeDecoderProviderService.messages[message.code];
-    return answer ? answer : 'An unknown error has occurred and no specific message corresponding to ' + message.code + ' has been set';
+    const answer = this.i18NService.localize('errors.' + message.code, args);
+    return !answer || answer === fallbackValue ?
+      'An unknown error has occurred and no specific message corresponding to ' + message.code + ' has been set'
+      : answer;
   }
 }

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -160,8 +160,14 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   preInitialize(position: number, page: number) {
     this.error = undefined;
     const step = this.currentFlowService.getStep(this.position);
-    if (!step) {
+    if (!step || !step.connection) {
       this.router.navigate(['connection-select', this.position], {
+        relativeTo: this.route.parent
+      });
+      return;
+    }
+    if (!step.action) {
+      this.router.navigate(['action-select', this.position], {
         relativeTo: this.route.parent
       });
       return;
@@ -176,7 +182,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
         this.configuredPropertiesForMetadataCall(step.action)
       )
       .toPromise()
-      .then( (descriptor: ActionDescriptor) => {
+      .then((descriptor: ActionDescriptor) => {
         this.currentFlowService.events.emit({
           kind: 'integration-set-descriptor',
           position: this.position,

--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -545,10 +545,10 @@ export class CurrentFlowService {
         const integration = this.getIntegrationClone();
         const tags = integration.tags || [];
         const connectorIds = this.getSubsequentConnections(0).map(
-          step => step.connection.connectorId
+          step => step.connection ? step.connection.connectorId : undefined
         );
         connectorIds.forEach(id => {
-          if (tags.indexOf(id) === -1) {
+          if (id && tags.indexOf(id) === -1) {
             tags.push(id);
           }
         });

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -3,15 +3,15 @@
         class="step-block inline-block text-center">
     <ng-container [ngSwitch]="step.stepKind">
       <div *ngSwitchCase="'endpoint'"
-            id="{{ step.connection.name | synSlugify }}"
+            id="{{ step.connection?.name | synSlugify }}"
             class="text-center connection" 
             (click)="onViewDetails(step)" 
-            title="{{ step.connection.name }}&nbsp;{{ step.action.name }}">
+            title="{{ step.connection?.name }}&nbsp;{{ step.action?.name }}">
         <div [class]="'step-line ' + getStepLineClass(index)"></div>
         <div class="icon">
           <img class="syn-icon-small" [src]="step.connection | synIconPath">
         </div>
-        <div class="syn-truncate__ellipsis">{{ step.connection.name | capitalize }}</div>
+        <div class="syn-truncate__ellipsis">{{ step.connection?.name | capitalize }}</div>
       </div>
       <div *ngSwitchDefault
             id="{{ (step.name || step.stepKind) | synSlugify }}"

--- a/app/ui/src/app/platform/types/status-code-decoder/status-code-decoder.service.ts
+++ b/app/ui/src/app/platform/types/status-code-decoder/status-code-decoder.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { LeveledMessage, StringMap } from '@syndesis/ui/platform';
+import { LeveledMessage, StringMap, I18NService } from '@syndesis/ui/platform';
 
 @Injectable()
 export abstract class StatusCodeDecoderService {
-  abstract getMessageString(message: LeveledMessage, context?: StringMap<any>);
+  constructor(public i18NService: I18NService) {}
+  abstract getMessageString(message: LeveledMessage, args?: any[]);
 }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -93,7 +93,18 @@
       "networkonline": "Your internet connection has been restored",
       "networkoffline": "Your internet connection has been interrupted",
       "httperror": "The server returned an error",
-      "httperrordefaultmsg": "Your request could not be completed. Please try again."
+      "httperrordefaultmsg": "Your request could not be completed. Please try again.",
+      "syndesis000": "An unknown error has occurred",
+      "syndesis001": "There are parameter updates. Click <strong>Edit</strong> to update parameter settings.",
+      "syndesis002": "One or more properties have been updated or removed",
+      "syndesis003": "The connector associated with this connection has been deleted",
+      "syndesis004": "The associated extension has been deleted",
+      "syndesis005": "The associated action has been deleted",
+      "syndesis006": "One or more required properties is not set",
+      "syndesis007": "Secrets for this connection need to be updated",
+      "syndesis008": "There has been a validation error",
+      "syndesis009": "A connection has been deleted from this integration",
+      "syndesis010": "Multiple extensions installed"
     },
     "shared": {
       "loading": "loading",


### PR DESCRIPTION
This PR is related to #2524 and:


- fixes the NPE thrown by syndesis-server when an integration with deleted connector is invoked
- introduces additional checks on integration level warn about inconsistent state of extensions or deleted connectors, @gashcrumb related codes are:

    ```java
        SYNDESIS009, // Connection has been deleted
        SYNDESIS010, // Multiple extension installed
    ```

The integration page now shows a warning on the impacted connection:

![image](https://user-images.githubusercontent.com/1868933/39577664-3f138b2a-4ee2-11e8-8633-0c7d9b0d5686.png)

Going to integration summary, the following is shown:

![image](https://user-images.githubusercontent.com/1868933/39577730-67351466-4ee2-11e8-8fcc-2cd18bb208f8.png)

There are some remaining issues I cannot fix on backend side

1. when an integration with deleted connections is edited, UI invokes the following endpoint

        /api/v1/connections/undefined/actions/${actionId}

    Here _undefined_ if obviously wrong and happens because the actualized connection does not have    the _connectorId_ set (as the connection does not exists any more).

2. New codes need to be integrated on UI side


