### PR TITLE
fix: correct the values being passed to patch and fix how it's being called

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -341,12 +341,15 @@ public class IntegrationHandler extends BaseHandler
         for (IntegrationDeployment deployment: dataManager.fetchAll(IntegrationDeployment.class, new IdPrefixFilter<>(id+":"), ReverseFilter.getInstance())) {
             builder.addDeployment(IntegrationDeploymentOverview.of(deployment));
 
-            if (deployment.getCurrentState() == IntegrationDeploymentState.Published) {
+            final IntegrationDeploymentState currentState = deployment.getCurrentState();
+            if (currentState == IntegrationDeploymentState.Published) {
                 deployed = deployment;
-                builder.targetState(deployment.getTargetState());
-                builder.currentState(deployment.getCurrentState());
                 builder.deploymentVersion(deployment.getVersion());
             }
+
+            // this will effectively set the the integration target/current state to the target/current state of the last deployment
+            builder.targetState(deployment.getTargetState());
+            builder.currentState(currentState);
         }
 
         if (deployed != null) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -347,9 +347,16 @@ public class IntegrationHandler extends BaseHandler
                 builder.deploymentVersion(deployment.getVersion());
             }
 
-            // this will effectively set the the integration target/current state to the target/current state of the last deployment
-            builder.targetState(deployment.getTargetState());
-            builder.currentState(currentState);
+            if (currentState != IntegrationDeploymentState.Unpublished) {
+                // the bet is that any integration that the user wanted to publish
+                // will have it's status != Unpublished, the reason why we can't
+                // look at the last deployment is because users can choose to deploy
+                // previous deployments, so we bet that all the Unpublished
+                // integrations are not the ones that the user don't hold the
+                // current state
+                builder.targetState(deployment.getTargetState());
+                builder.currentState(currentState);
+            }
         }
 
         if (deployed != null) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -337,15 +337,20 @@ public class IntegrationHandler extends BaseHandler
         // Get the latest steps.
         builder.steps(integration.getSteps().stream().map(this::toCurrentSteps).collect(Collectors.toList()));
 
+        IntegrationDeployment deployed = null;
         for (IntegrationDeployment deployment: dataManager.fetchAll(IntegrationDeployment.class, new IdPrefixFilter<>(id+":"), ReverseFilter.getInstance())) {
             builder.addDeployment(IntegrationDeploymentOverview.of(deployment));
 
-            if (deployment.getVersion() == integration.getVersion()) {
-                builder.isDraft(deployment.getVersion() != integration.getVersion());
+            if (deployment.getCurrentState() == IntegrationDeploymentState.Published) {
+                deployed = deployment;
                 builder.targetState(deployment.getTargetState());
                 builder.currentState(deployment.getCurrentState());
                 builder.deploymentVersion(deployment.getVersion());
             }
+        }
+
+        if (deployed != null) {
+            builder.isDraft(!integration.equals(deployed.getSpec()));
         }
 
         return builder.build();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -360,10 +360,33 @@ public class IntegrationHandler extends BaseHandler
         }
 
         if (deployed != null) {
-            builder.isDraft(!integration.equals(deployed.getSpec()));
+            builder.isDraft(computeDraft(integration, deployed.getSpec()));
         }
 
         return builder.build();
+    }
+
+    private static boolean computeDraft(final Integration current, final Integration deployed) {
+        final List<Step> currentSteps = current.getSteps();
+        final List<Step> deployedSteps = deployed.getSteps();
+        if (currentSteps.size() != deployedSteps.size()) {
+            return true;
+        }
+
+        for (int i = 0; i < currentSteps.size(); i++) {
+            final Step currentStep = currentSteps.get(i);
+            final Step deployedStep = deployedSteps.get(i);
+
+            if (currentStep.getStepKind() != deployedStep.getStepKind()) {
+                return true;
+            }
+
+            if (!currentStep.getConfiguredProperties().equals(deployedStep.getConfiguredProperties())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private Optional<Connection> toCurrentConnection(Connection c) {

--- a/app/ui/src/app/integration/integration-actions-provider.service.ts
+++ b/app/ui/src/app/integration/integration-actions-provider.service.ts
@@ -222,10 +222,10 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
 
   replaceDraftAction(integration: Integration | IntegrationOverview, deployment: IntegrationDeployment | DeploymentOverview): Promise<any> {
       return this.integrationSupportService.getDeployment(integration.id, deployment.version.toString())
-        .map(_deployment => {
-          this.store.patch(<any>integration, {
+        .switchMap(_deployment => {
+          return this.store.patch(_deployment.integrationId, {
             steps: _deployment.spec.steps,
-            draft: true
+            isDraft: true
           });
         }).toPromise();
   }

--- a/app/ui/src/app/integration/integration-actions-provider.service.ts
+++ b/app/ui/src/app/integration/integration-actions-provider.service.ts
@@ -224,8 +224,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
       return this.integrationSupportService.getDeployment(integration.id, deployment.version.toString())
         .switchMap(_deployment => {
           return this.store.patch(_deployment.integrationId, {
-            steps: _deployment.spec.steps,
-            isDraft: true
+            steps: _deployment.spec.steps
           });
         }).toPromise();
   }


### PR DESCRIPTION
almost fixes #2540

The UI uses a PATCH request to update the `steps` attribute, however it also tries to update `isDraft` as well but that doesn't seem to be persisted.  So this halfway fixes the issue.