### PR TITLE
feat: add MAX_INTEGRATIONS_PER_USER parameter to syndesis-server configs

### DIFF
--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -129,6 +129,11 @@ parameters:
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
   required: true
+- description: Maximum number of integrations single user can create
+  displayName: Maximum number of integrations
+  name: MAX_INTEGRATIONS_PER_USER
+  value: "1"
+  required: true
 - description: Key used to perform authentication of client side stored state.
   displayName: Client side state authentication key
   from: '[a-zA-Z0-9]{32}'

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -91,6 +91,8 @@
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
+          - name: MAX_INTEGRATIONS_PER_USER
+            value: ${MAX_INTEGRATIONS_PER_USER}
 {{#Debug}}
           - name: JAVA_DEBUG
             value: "true"
@@ -218,3 +220,6 @@
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
+      controllers:
+        maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
+        maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -132,6 +132,11 @@ parameters:
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
   required: true
+- description: Maximum number of integrations single user can create
+  displayName: Maximum number of integrations
+  name: MAX_INTEGRATIONS_PER_USER
+  value: "1"
+  required: true
 - description: Key used to perform authentication of client side stored state.
   displayName: Client side state authentication key
   from: '[a-zA-Z0-9]{32}'
@@ -997,6 +1002,8 @@ objects:
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
+          - name: MAX_INTEGRATIONS_PER_USER
+            value: ${MAX_INTEGRATIONS_PER_USER}
           - name: JAVA_DEBUG
             value: "true"
           image: ' '
@@ -1107,6 +1114,9 @@ objects:
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
+      controllers:
+        maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
+        maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -132,6 +132,11 @@ parameters:
   name: SERVER_MEMORY_LIMIT
   value: 800Mi
   required: true
+- description: Maximum number of integrations single user can create
+  displayName: Maximum number of integrations
+  name: MAX_INTEGRATIONS_PER_USER
+  value: "1"
+  required: true
 - description: Key used to perform authentication of client side stored state.
   displayName: Client side state authentication key
   from: '[a-zA-Z0-9]{32}'
@@ -995,6 +1000,8 @@ objects:
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
+          - name: MAX_INTEGRATIONS_PER_USER
+            value: ${MAX_INTEGRATIONS_PER_USER}
           image: ' '
 
           imagePullPolicy: IfNotPresent
@@ -1103,6 +1110,9 @@ objects:
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
+      controllers:
+        maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
+        maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
wdyt? If it's not against some of the conventions, I think this would be an easier way to specify the maximum number of integrations. 
I just didn't like that much the server config-map update, as described in [the documentation.](https://access.qa.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-single/integrating_applications_with_ignite/#installing-on-ocp)