### PR TITLE
Deleting API connector should delete it's connections

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
@@ -48,6 +48,7 @@ import io.syndesis.server.inspector.Inspectors;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSummary;
 import io.syndesis.common.model.filter.FilterOptions;
@@ -101,6 +102,14 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     @Path("/custom")
     public CustomConnectorHandler customConnectorHandler() {
         return new CustomConnectorHandler(getDataManager(), applicationContext, iconDao);
+    }
+
+    @Override
+    public void delete(final String id) {
+        Deleter.super.delete(id);
+
+        getDataManager().fetchIdsByPropertyValue(Connection.class, "connectorId", id)
+            .forEach(connectionId -> getDataManager().delete(Connection.class, connectionId));
     }
 
     @Override

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/ConnectorsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/ConnectorsITCase.java
@@ -17,6 +17,7 @@ package io.syndesis.server.runtime;
 
 import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.connection.Connection;
 import io.syndesis.server.verifier.AlwaysOkVerifier;
 import io.syndesis.server.verifier.Verifier;
 
@@ -222,6 +223,19 @@ public class ConnectorsITCase extends BaseITCase {
         assertThat(result).isNotNull();
         assertThat(result.getStatus()).isEqualTo(Verifier.Result.Status.OK);
         assertThat(result.getErrors()).isEmpty();
+    }
+
+    @Test
+    public void shouldDeleteConnectors() {
+        dataManager.create(new Connector.Builder().id("test-connector").build());
+        dataManager.create(new Connection.Builder().id("test-connection").connectorId("test-connector").build());
+
+        final ResponseEntity<Void> response = delete("/api/v1/connectors/test-connector");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        assertThat(dataManager.fetch(Connector.class, "test-connector")).isNull();
+        assertThat(dataManager.fetch(Connection.class, "test-connection")).isNull();
     }
 
     private HttpHeaders multipartHeaders() {

--- a/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
@@ -54,8 +54,9 @@
 
 <ng-template #confirmDeleteModalTemplate>
   <delete-confirmation-modal (delete)="onDeleteConfirm($event)">
+    <h3>Removing connector removes all of it's connections</h3>
     <p>
-      Deleting this connector does not affect running integrations.
+      This will remove all connections for this connector. Deleting this connector does not affect running integrations.
     </p>
     <p>Are you sure you want to delete the "{{ deletableApiConnectorName }}" connector?</p>
   </delete-confirmation-modal>

--- a/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-list/api-connector-list.component.html
@@ -54,9 +54,7 @@
 
 <ng-template #confirmDeleteModalTemplate>
   <delete-confirmation-modal (delete)="onDeleteConfirm($event)">
-    <h3>You can no longer edit a connection that was created from this connector.</h3>
     <p>
-      You can still add connections created from this connector to integrations.
       Deleting this connector does not affect running integrations.
     </p>
     <p>Are you sure you want to delete the "{{ deletableApiConnectorName }}" connector?</p>


### PR DESCRIPTION
When a Connector is deleted it makes little sense in having Connections
of that Connector remaining. This removes all Connections of a Connector
when it's deleted.

Fixes #2586