### PR TITLE
Revert "chore: Force Accept header to application/json since that's all we use"

### DIFF
--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -68,45 +68,40 @@ export class ApiHttpProviderService extends ApiHttpService {
   get<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
-    const headers = this.getHeaders(options);
     return this.httpClient
-      .get(url, { headers, ...options })
+      .get(url, options)
       .catch(error => this.handleError(error));
   }
 
   post<T>(endpoint: string | any[], body?: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
-    const headers = this.getHeaders(options);
     return this.httpClient
-      .post<T>(url, body, { headers, ...options })
+      .post<T>(url, body, options)
       .catch(error => this.handleError(error));
   }
 
   put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
-    const headers = this.getHeaders(options);
     return this.httpClient
-      .put<T>(url, body, { headers, ...options })
+      .put<T>(url, body, options)
       .catch(error => this.handleError(error));
   }
 
   patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
-    const headers = this.getHeaders(options);
     return this.httpClient
-      .patch<T>(url, body, { headers, ...options })
+      .patch<T>(url, body, options)
       .catch(error => this.handleError(error));
   }
 
   delete<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
-    const headers = this.getHeaders(options);
     return this.httpClient
-      .delete<T>(url, { headers, ...options })
+      .delete<T>(url, options)
       .catch(error => this.handleError(error));
   }
 
@@ -157,14 +152,6 @@ export class ApiHttpProviderService extends ApiHttpService {
       .map(requestEvent => requestEvent as HttpResponse<T>)
       .map(requestEvent => requestEvent.body)
       .catch(error => this.handleError(error.error));
-  }
-
-  private getHeaders(options: ApiRequestOptions | any) {
-    const headers = new HttpHeaders({
-      'Accept': 'application/json',
-      ...(options ? options.headers : undefined)
-    });
-    return headers;
   }
 
   private emitProgressEvent(httpProgressEvent?: HttpProgressEvent): void {


### PR DESCRIPTION
Reverts syndesisio/syndesis#2589

This commit, as is, breaks export functionality. It might be incomplete or lack something server side, but for the time being, I'm just reverting it.