### PR TITLE
fix(ui): send accept header with application/json for /version endpoint

### DIFF
--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -68,40 +68,45 @@ export class ApiHttpProviderService extends ApiHttpService {
   get<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = this.getHeaders(options);
     return this.httpClient
-      .get(url, options)
+      .get(url, { headers, ...options })
       .catch(error => this.handleError(error));
   }
 
   post<T>(endpoint: string | any[], body?: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = this.getHeaders(options);
     return this.httpClient
-      .post<T>(url, body, options)
+      .post<T>(url, body, { headers, ...options })
       .catch(error => this.handleError(error));
   }
 
   put<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = this.getHeaders(options);
     return this.httpClient
-      .put<T>(url, body, options)
+      .put<T>(url, body, { headers, ...options })
       .catch(error => this.handleError(error));
   }
 
   patch<T>(endpoint: string | any[], body: any, options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = this.getHeaders(options);
     return this.httpClient
-      .patch<T>(url, body, options)
+      .patch<T>(url, body, { headers, ...options })
       .catch(error => this.handleError(error));
   }
 
   delete<T>(endpoint: string | any[], options?: ApiRequestOptions | any): Observable<T> {
     const { endpointKey, endpointParams } = this.deconstructEndpointParams(endpoint);
     const url = this.getEndpointUrl(endpointKey, ...endpointParams);
+    const headers = this.getHeaders(options);
     return this.httpClient
-      .delete<T>(url, options)
+      .delete<T>(url, { headers, ...options })
       .catch(error => this.handleError(error));
   }
 
@@ -152,6 +157,14 @@ export class ApiHttpProviderService extends ApiHttpService {
       .map(requestEvent => requestEvent as HttpResponse<T>)
       .map(requestEvent => requestEvent.body)
       .catch(error => this.handleError(error.error));
+  }
+
+  private getHeaders(options: ApiRequestOptions | any) {
+    const headers = new HttpHeaders({
+      'Accept': 'application/json',
+      ...(options ? options.headers : undefined)
+    });
+    return headers;
   }
 
   private emitProgressEvent(httpProgressEvent?: HttpProgressEvent): void {

--- a/app/ui/src/app/api/providers/api-http-provider.service.ts
+++ b/app/ui/src/app/api/providers/api-http-provider.service.ts
@@ -161,7 +161,6 @@ export class ApiHttpProviderService extends ApiHttpService {
 
   private getHeaders(options: ApiRequestOptions | any) {
     const headers = new HttpHeaders({
-      'Accept': 'application/json',
       ...(options ? options.headers : undefined)
     });
     return headers;

--- a/app/ui/src/app/support/support.component.ts
+++ b/app/ui/src/app/support/support.component.ts
@@ -268,6 +268,8 @@ export class SupportComponent implements OnInit {
       this.updateItems();
     });
     this.store.loadAll();
-    this.version$ = this.apiHttpService.get('/version');
+    this.version$ = this.apiHttpService.get('/version', {
+      headers: 'Accept: application/json'
+    });
   }
 }


### PR DESCRIPTION
This removes setting the default `Accept` header to `application/json`,
thus the `Accept` header by default will be
`Accept: application/json, text/plain, */*`.

Also for `/api/v1/version` endpoint the `Accept` header is explicitly
set to `Accept: application/json`.

Fixes #2604