### PR TITLE
fix: update 'contact us' link and update link on support page to use dictionary

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -67,7 +67,7 @@
                 <a routerLink="/support" role="link">{{ 'support' | synI18n }}</a>
               </li>
               <li>
-                <a href="mailto:{{ 'email' | synI18n }}"
+                <a [attr.href]="'links.contactus' | synI18n"
                 rel="nofollow"
                 role="link"
                 target="_blank">{{ 'contactus' | synI18n }}</a>

--- a/app/ui/src/app/support/support.component.html
+++ b/app/ui/src/app/support/support.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-12">
     <h1>Support</h1>
-      <p>To obtain support, download diagnostic information through this page and open a request on the <a href="https://access.redhat.com/support/cases/#/case/new">Red Hat Customer portal</a>. 
+      <p>To obtain support, download diagnostic information through this page and open a request on the <a [attr.href]="'links.contactus' | synI18n">Red Hat Customer portal</a>. 
         If the downloaded zip file is less than 1 GB, attach it to the case. For a larger zip file, tell the support team that the zip file is larger than 1 GB and ask for <a href="https://access.redhat.com/solutions/2112">instructions</a>.</p>
     <h2>Version</h2>
     <syndesis-loading [loading]="!(version$ | async)">

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -43,6 +43,7 @@
       "settings": "Settings"
     },
     "links": {
+      "contactus": "//access.redhat.com/support/cases/#/case/new",
       "userguide": "//access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-single/integrating_applications_with_ignite",
       "tutorial": "//access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-single/ignite_sample_integration_tutorials/",
       "oauth-access": "//access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-single/integrating_applications_with_ignite/#obtaining-authorization-to-access-applications"


### PR DESCRIPTION
fixes #2653
