### PR TITLE
chore(build): maven-compiler configuration cleanup

### DIFF
--- a/app/common/model/src/test/java/io/syndesis/common/model/extension/ExtensionSerializationTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/extension/ExtensionSerializationTest.java
@@ -32,18 +32,14 @@ public class ExtensionSerializationTest {
         final ObjectWriter writer = Json.writer();
 
         try (InputStream source = getClass().getResourceAsStream("syndesis-extension-definition.json")) {
-            try {
-                reader.forType(Extension.class).readValue(
-                    writer.writeValueAsString(
-                        new Extension.Builder()
-                            .createFrom(reader.forType(Extension.class).readValue(source))
-                            .build()
-                    )
+           reader.forType(Extension.class).readValue(
+               writer.writeValueAsString(
+                   new Extension.Builder()
+                       .createFrom(reader.forType(Extension.class).readValue(source))
+                       .build()
+               )
 
-                );
-            } catch (IOException e) {
-                fail("Should not throw an exception");
-            }
+           );
         }
     }
 }

--- a/app/common/pom.xml
+++ b/app/common/pom.xml
@@ -508,49 +508,6 @@
         <defaultGoal>clean package</defaultGoal>
       </build>
     </profile>
-    <profile>
-      <id>non-m2e</id>
-      <activation>
-        <!-- active only when not running under M2E in Eclipse -->
-        <property>
-          <name>!m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <compilerArgs>
-                <arg>-Xlint:all</arg>
-                <arg>-Xlint:-deprecation</arg>
-                <arg>-Xlint:-processing</arg>
-                <arg>-Xlint:-serial</arg>
-                <arg>-Werror</arg>
-                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                <arg>-implicit:none</arg>
-              </compilerArgs>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.2</version>
-              </dependency>
-              <!-- override plexus-compiler-javac-errorprone's dependency on
-               Error Prone with the latest version -->
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.1.2</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>

--- a/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
+++ b/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
@@ -35,6 +35,7 @@ public class FtpVerifierExtension extends DefaultComponentVerifierExtension {
     // *********************************
     // Parameters validation
     //
+    @Override
     protected Result verifyParameters(Map<String, Object> parameters) {
         ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.PARAMETERS)
                 .error(ResultErrorHelper.requiresOption("host", parameters))

--- a/app/connector/http/src/test/java/io/syndesis/connector/http/HttpConnectorFactoriesTest.java
+++ b/app/connector/http/src/test/java/io/syndesis/connector/http/HttpConnectorFactoriesTest.java
@@ -92,14 +92,14 @@ public class HttpConnectorFactoriesTest {
     // Helpers
     // *************************
 
-    private static <K, V> Map<K, V> mapOf(K key, V value, Object... values) {
-        Map<K, V> map = new LinkedHashMap<>();
+    private static Map<String, Object> mapOf(String key, String value, String... values) {
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put(key, value);
 
         for(int i = 0; i < values.length; i += 2) {
             map.put(
-                (K) values[i],
-                (V) values[i + 1]
+                values[i],
+                values[i + 1]
             );
         }
 

--- a/app/connector/http/src/test/java/io/syndesis/connector/http/util/BasicValidationHandler.java
+++ b/app/connector/http/src/test/java/io/syndesis/connector/http/util/BasicValidationHandler.java
@@ -45,6 +45,7 @@ public class BasicValidationHandler implements HttpRequestHandler {
         this.responseContent = responseContent;
     }
 
+    @Override
     public void handle(final HttpRequest request, final HttpResponse response,
                        final HttpContext context) throws HttpException, IOException {
 

--- a/app/connector/odata/create-entity/pom.xml
+++ b/app/connector/odata/create-entity/pom.xml
@@ -99,16 +99,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>

--- a/app/connector/odata/delete-entity/pom.xml
+++ b/app/connector/odata/delete-entity/pom.xml
@@ -95,15 +95,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/app/connector/odata/model/pom.xml
+++ b/app/connector/odata/model/pom.xml
@@ -33,22 +33,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <build>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/app/connector/odata/replace-entity/pom.xml
+++ b/app/connector/odata/replace-entity/pom.xml
@@ -98,16 +98,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>

--- a/app/connector/odata/retrieve-entity/pom.xml
+++ b/app/connector/odata/retrieve-entity/pom.xml
@@ -100,16 +100,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>

--- a/app/connector/odata/update-entity/pom.xml
+++ b/app/connector/odata/update-entity/pom.xml
@@ -100,16 +100,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/XmlPayloadProcessor.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/XmlPayloadProcessor.java
@@ -73,7 +73,7 @@ final class XmlPayloadProcessor implements StreamFilter {
         default:
         }
 
-        return inRequest && inPayload || !inRequest;
+        return (inRequest && inPayload) || !inRequest;
     }
 
     private void processEndElement(final XMLStreamReader reader) {

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/OAuthRefreshTokenOnFailProcessorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/OAuthRefreshTokenOnFailProcessorTest.java
@@ -16,6 +16,7 @@
 package io.syndesis.connector.rest.swagger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.camel.Exchange;
@@ -208,6 +209,6 @@ public class OAuthRefreshTokenOnFailProcessorTest {
     }
 
     static HttpEntity entity(final String grantJson) {
-        return new ByteArrayEntity(grantJson.getBytes(), ContentType.APPLICATION_JSON);
+        return new ByteArrayEntity(grantJson.getBytes(StandardCharsets.US_ASCII), ContentType.APPLICATION_JSON);
     }
 }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/OAuthRefreshTokenProcessorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/OAuthRefreshTokenProcessorTest.java
@@ -16,6 +16,7 @@
 package io.syndesis.connector.rest.swagger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.apache.camel.Exchange;
@@ -134,7 +135,7 @@ public class OAuthRefreshTokenProcessorTest {
         final CloseableHttpClient client = mock(CloseableHttpClient.class);
         final CloseableHttpResponse response = mock(CloseableHttpResponse.class);
         when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
-        when(response.getEntity()).thenReturn(new ByteArrayEntity(grantJson.getBytes(), ContentType.APPLICATION_JSON));
+        when(response.getEntity()).thenReturn(new ByteArrayEntity(grantJson.getBytes(StandardCharsets.US_ASCII), ContentType.APPLICATION_JSON));
 
         when(client.execute(ArgumentMatchers.any(HttpUriRequest.class))).thenReturn(response);
 

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnectorFactory.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnectorFactory.java
@@ -31,11 +31,12 @@ public class SalesforceStreamingConnectorFactory implements ComponentProxyFactor
         return new SalesforceStreamingConnector(componentId, componentScheme);
     }
 
-    private class SalesforceStreamingConnector extends ComponentProxyComponent {
+    private static class SalesforceStreamingConnector extends ComponentProxyComponent {
         public SalesforceStreamingConnector(String componentId, String componentScheme) {
             super(componentId, componentScheme);
         }
 
+        @Override
         @SuppressWarnings("PMD.SignatureDeclareThrowsException")
         protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
             final String sObjectName = options.get(SalesforceEndpointConfig.SOBJECT_NAME);

--- a/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
+++ b/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
@@ -36,6 +36,7 @@ public class SftpVerifierExtension extends DefaultComponentVerifierExtension {
     // *********************************
     // Parameters validation
     //
+    @Override
     protected Result verifyParameters(Map<String, Object> parameters) {
         ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.PARAMETERS)
                 .error(ResultErrorHelper.requiresOption("username", parameters))

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
@@ -52,6 +52,11 @@ public class SqlConnectorVerifierExtension extends DefaultComponentVerifierExten
         if (builder.build().getErrors().isEmpty()) {
             try (Connection connection = SqlSupport.createConnection(parameters)) {
                 // just try to get the connection
+                if (!connection.isValid(0)) {
+                    builder.error(ResultErrorBuilder.withCodeAndDescription(
+                        VerificationError.StandardCode.GENERIC, "Unable to connect to database")
+                        .build());
+                }
             } catch (SQLException e) {
                 final Map<String, Object> redacted = new HashMap<>(parameters);
                 redacted.replace("password", "********");
@@ -90,7 +95,7 @@ public class SqlConnectorVerifierExtension extends DefaultComponentVerifierExten
     }
 
     private static void unsupportedDatabase(ResultBuilder builder) {
-        String supportedDatabases = Arrays.stream(DatabaseProduct.values()).map(Enum::name).collect(Collectors.joining(","));
+        String supportedDatabases = Arrays.stream(DatabaseProduct.values()).map(DatabaseProduct::name).collect(Collectors.joining(","));
         String msg = "Supported Databases are [" + supportedDatabases + "]";
 
         builder.error(

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
@@ -53,7 +53,7 @@ public class SqlParam {
 
 
     @Data
-    public class TypeValue<T> {
+    public static class TypeValue<T> {
 
         private Class<T> clazz;
         private T sampleValue;
@@ -84,19 +84,18 @@ public class SqlParam {
     @SuppressWarnings({"rawtypes", "PMD.CyclomaticComplexity"})
     static TypeValue<?> javaType(final JDBCType jdbcType) {
 
-        SqlParam sqlParam = new SqlParam();
         switch (jdbcType) {
         case ARRAY:
         case BINARY:
         case BLOB:
         case LONGVARBINARY:
         case VARBINARY:
-            return sqlParam.new TypeValue<>(List.class, SqlSampleValue.ARRAY_VALUE);
+            return new TypeValue<>(List.class, SqlSampleValue.ARRAY_VALUE);
         case BIT:
         case BOOLEAN:
-            return sqlParam.new TypeValue<>(Boolean.class, SqlSampleValue.BOOLEAN_VALUE);
+            return new TypeValue<>(Boolean.class, SqlSampleValue.BOOLEAN_VALUE);
         case CHAR:
-            return sqlParam.new TypeValue<>(Character.class, SqlSampleValue.CHAR_VALUE);
+            return new TypeValue<>(Character.class, SqlSampleValue.CHAR_VALUE);
         case CLOB:
         case DATALINK:
         case LONGNVARCHAR:
@@ -107,29 +106,29 @@ public class SqlParam {
         case ROWID:
         case SQLXML:
         case VARCHAR:
-            return sqlParam.new TypeValue<>(String.class, SqlSampleValue.STRING_VALUE);
+            return new TypeValue<>(String.class, SqlSampleValue.STRING_VALUE);
         case DATE:
-            return sqlParam.new TypeValue<>(Date.class, SqlSampleValue.DATE_VALUE);
+            return new TypeValue<>(Date.class, SqlSampleValue.DATE_VALUE);
         case TIME:
-            return sqlParam.new TypeValue<>(Time.class, SqlSampleValue.TIME_VALUE);
+            return new TypeValue<>(Time.class, SqlSampleValue.TIME_VALUE);
         case TIMESTAMP:
         case TIMESTAMP_WITH_TIMEZONE:
         case TIME_WITH_TIMEZONE:
-            return sqlParam.new TypeValue<>(Timestamp.class, SqlSampleValue.TIMESTAMP_VALUE);
+            return new TypeValue<>(Timestamp.class, SqlSampleValue.TIMESTAMP_VALUE);
         case DECIMAL:
         case NUMERIC:
-            return sqlParam.new TypeValue<>(BigDecimal.class, SqlSampleValue.DECIMAL_VALUE);
+            return new TypeValue<>(BigDecimal.class, SqlSampleValue.DECIMAL_VALUE);
         case FLOAT:
         case DOUBLE:
-            return sqlParam.new TypeValue<>(Double.class, SqlSampleValue.DOUBLE_VALUE);
+            return new TypeValue<>(Double.class, SqlSampleValue.DOUBLE_VALUE);
         case REAL:
-            return sqlParam.new TypeValue<>(Float.class, SqlSampleValue.FLOAT_VALUE);
+            return new TypeValue<>(Float.class, SqlSampleValue.FLOAT_VALUE);
         case BIGINT:
-            return sqlParam.new TypeValue<>(Long.class, SqlSampleValue.LONG_VALUE);
+            return new TypeValue<>(Long.class, SqlSampleValue.LONG_VALUE);
         case SMALLINT:
         case INTEGER:
         case TINYINT:
-            return sqlParam.new TypeValue<>(Integer.class, SqlSampleValue.INTEGER_VALUE);
+            return new TypeValue<>(Integer.class, SqlSampleValue.INTEGER_VALUE);
         case NULL:
             return null;
         case DISTINCT:
@@ -139,7 +138,7 @@ public class SqlParam {
         case REF_CURSOR:
         case STRUCT:
         default:
-            return sqlParam.new TypeValue<>(String.class, SqlSampleValue.STRING_VALUE);
+            return new TypeValue<>(String.class, SqlSampleValue.STRING_VALUE);
         }
     }
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -134,7 +134,7 @@ public class SqlStatementParser {
         }
         return null;
     }
-    
+
     private void parseInsert(DatabaseMetaData meta) throws SQLException {
         statementInfo.setStatementType(StatementType.INSERT);
         String tableNameInsert = statementInfo.addTable(sqlArrayUpperCase.get(2));
@@ -205,7 +205,7 @@ public class SqlStatementParser {
 
     List<String> splitSqlStatement(String sql) {
         List<String> sqlArray = new ArrayList<>();
-        String[] segments = sql.split("=|\\,|\\s|\\(|\\)");
+        String[] segments = sql.split("=|\\,|\\s|\\(|\\)", -1);
         for (String segment : segments) {
             if (!"".equals(segment)) {
                 sqlArray.add(segment);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
@@ -62,6 +62,7 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
         final String jsonBean;
 
         if (exchange.getIn().getBody(List.class) != null) {
+            @SuppressWarnings("unchecked")
             List<Map<String, Object>> maps = exchange.getIn().getBody(List.class);
             if (maps.isEmpty()) {
                 throw new IllegalStateException("Got an empty collection");
@@ -70,7 +71,9 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
             //Only grabbing the first record (map) in the list
             jsonBean = JSONBeanUtil.toJSONBean(maps.get(0));
         } else {
-            jsonBean = JSONBeanUtil.toJSONBean(exchange.getIn().getBody(Map.class));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = exchange.getIn().getBody(Map.class);
+            jsonBean = JSONBeanUtil.toJSONBean(body);
         }
 
         exchange.getIn().setBody(jsonBean);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartStoredConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartStoredConnectorCustomizer.java
@@ -29,6 +29,7 @@ public final class SqlStartStoredConnectorCustomizer implements ComponentProxyCu
     }
 
     private void doAfterProducer(Exchange exchange) {
+        @SuppressWarnings("unchecked")
         final Map<String, Object> body = exchange.getIn().getBody(Map.class);
         final String jsonBean = JSONBeanUtil.toJSONBean(body);
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
@@ -39,6 +39,7 @@ public final class SqlStoredConnectorCustomizer implements ComponentProxyCustomi
     }
 
     private void doAfterProducer(Exchange exchange) {
+        @SuppressWarnings("unchecked")
         final Map<String, Object> map = exchange.getIn().getBody(Map.class);
         final String jsonBean = JSONBeanUtil.toJSONBean(map);
 

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JSONBeanUtilTest {
 
-    class SimpleInputBean {
+    static class SimpleInputBean {
 
         int a;
         int b;
@@ -49,7 +49,7 @@ public class JSONBeanUtilTest {
         }
     }
 
-    class SimpleOutputBean {
+    static class SimpleOutputBean {
         int c;
 
         public int getC() {

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
@@ -37,7 +37,6 @@ public final class SqlConnectionRule extends ExternalResource {
             try (Statement stmt = connection.createStatement()) {
                 stmt.execute("DROP table NAME0");
                 stmt.execute("DROP table ADDRESS0");
-                stmt.close();
                 connection.close();
             } catch (final SQLException e) {
                 throw new AssertionError("Exception during database cleanup.", e);
@@ -62,14 +61,12 @@ public final class SqlConnectionRule extends ExternalResource {
             try (Statement stmt = connection.createStatement()) {
                 stmt.execute("DROP table NAME0");
                 stmt.execute("DROP table ADDRESS0");
-                stmt.close();
             } catch (final SQLException e) { // NOPMD
                 //ignore
             }
             try (Statement stmt = connection.createStatement()) {
                 stmt.executeUpdate("CREATE TABLE name0 (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))");
                 stmt.executeUpdate("CREATE TABLE ADDRESS0 (id INTEGER PRIMARY KEY, Address VARCHAR(255), " + "lastName VARCHAR(255))");
-                stmt.close();
             }
         } catch (final SQLException e) {
             throw new AssertionError("Exception during database startup.", e);

--- a/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
+++ b/app/connector/support/test/src/main/java/io/syndesis/connector/support/test/ConnectorTestSupport.java
@@ -134,7 +134,7 @@ public abstract class ConnectorTestSupport extends CamelTestSupport {
     //
     // ******************************
 
-    protected class ResourceManager implements IntegrationResourceManager {
+    protected static class ResourceManager implements IntegrationResourceManager {
         @Override
         public Optional<Connector> loadConnector(String id) {
             Connector connector = null;

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/VerifierResponse.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/VerifierResponse.java
@@ -58,6 +58,7 @@ public class VerifierResponse {
         return errors;
     }
 
+    @SuppressWarnings("JavaLangClash")
     public static class Error {
         String code;
         String description;

--- a/app/extension/annotation-processor/pom.xml
+++ b/app/extension/annotation-processor/pom.xml
@@ -83,11 +83,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
           <!-- Disable annotation processing for ourselves -->
           <proc>none</proc>
-          <verbose>false</verbose>
         </configuration>
       </plugin>
 

--- a/app/extension/api/src/main/java/io/syndesis/extension/api/Step.java
+++ b/app/extension/api/src/main/java/io/syndesis/extension/api/Step.java
@@ -24,5 +24,5 @@ import org.apache.camel.model.ProcessorDefinition;
 @FunctionalInterface
 public interface Step {
     @SuppressWarnings("rawtypes")
-    Optional<ProcessorDefinition> configure(CamelContext context, ProcessorDefinition definition, Map<String, Object> parameters);
+    Optional<ProcessorDefinition<?>> configure(CamelContext context, ProcessorDefinition<?> definition, Map<String, Object> parameters);
 }

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -378,38 +378,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>non-m2e</id>
-      <activation>
-        <!-- active only when not running under M2E in Eclipse -->
-        <property>
-          <name>!m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs combine.children="append">
-                <!-- no way to influence generated HelpMojo.java to contain
-                the required @Override, or to be marked as @Generated, next
-                errorprone version will add exclusions by path:
-                 -XepExcludedPaths:.*/generated-sources/.*
-                -->
-                <arg>-Xep:MissingOverride:OFF</arg>
-                <!-- no way to influence generated HelpMojo.java not to throw
-                from finally block, or to be marked as @Generated, next
-                errorprone version will add exclusions by path:
-                 -XepExcludedPaths:.*/generated-sources/.* -->
-                <arg>-Xep:Finally:OFF</arg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
@@ -161,10 +161,10 @@ public class GenerateMetadataMojo extends AbstractMojo {
         Path dir = Paths.get(directory, "generated-sources", "annotations");
         if (Files.exists(dir)) {
             getLog().info("Looking in for annotated classes in: " + dir);
-            try {
-                final ObjectMapper mapper = new ObjectMapper();
-                final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**.json");
-                final List<Path> paths = Files.find(dir, Integer.MAX_VALUE, (path, attr) -> matcher.matches(path)).sorted().collect(Collectors.toList());
+            final ObjectMapper mapper = new ObjectMapper();
+            final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**.json");
+            try (Stream<Path> matches = Files.find(dir, Integer.MAX_VALUE, (path, attr) -> matcher.matches(path)).sorted()) {
+                final List<Path> paths = matches.collect(Collectors.toList());
 
                 for (Path path: paths) {
                     try {

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageExtensionMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageExtensionMojo.java
@@ -173,7 +173,7 @@ public class RepackageExtensionMojo extends SupportMojo {
     }
 
     protected void addCustomBoms(Collection<MavenDependency> dependencies) {
-        String[] boms = blackListedBoms.split(",");
+        String[] boms = blackListedBoms.split(",", -1);
         try {
             for (String bom : boms) {
                 String trimmed = bom.trim();
@@ -197,7 +197,7 @@ public class RepackageExtensionMojo extends SupportMojo {
     }
 
     private String getVersionFromDependencyManagement(String artifact) {
-        String[] parts = artifact.split(":");
+        String[] parts = artifact.split(":", -1);
         String groupId = parts.length > 0 ? parts[0] : "";
         String artifactId = parts.length > 1 ? parts[1] : "";
         for (Dependency dep : project.getDependencyManagement().getDependencies()) {
@@ -224,7 +224,7 @@ public class RepackageExtensionMojo extends SupportMojo {
     }
 
     protected void addCustomGAVs(Collection<MavenDependency> dependencies) {
-        String[] gavs = blackListedGAVs.split(",");
+        String[] gavs = blackListedGAVs.split(",", -1);
 
         for (String gav : gavs) {
             dependencies.add(newMavenDependency(gav));

--- a/app/extension/pom.xml
+++ b/app/extension/pom.xml
@@ -100,39 +100,4 @@
     <module>maven-plugin</module>
   </modules>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Xlint:-deprecation</arg>
-            <arg>-Xlint:-processing</arg>
-            <arg>-Xlint:-serial</arg>
-            <arg>-Werror</arg>
-            <arg>-XepDisableWarningsInGeneratedCode</arg>
-            <arg>-implicit:none</arg>
-          </compilerArgs>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.2</version>
-          </dependency>
-          <!-- override plexus-compiler-javac-errorprone's dependency on
-           Error Prone with the latest version -->
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.1.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/app/integration/component-proxy/pom.xml
+++ b/app/integration/component-proxy/pom.xml
@@ -115,10 +115,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
@@ -419,7 +419,9 @@ public class ComponentProxyComponent extends DefaultComponent {
                         // A little nasty hack required as verifier uses Map<String, Object>
                         // to be compatible with all the methods in CamelContext whereas
                         // catalog deals with Map<String, String>
-                        options = Map.class.cast(buildEndpointOptions(null, map));
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> tmp = Map.class.cast(buildEndpointOptions(null, map));
+                        options = tmp;
                     } catch (Exception e) {
                         // If a failure is detected while reading the catalog, wrap it
                         // and stop the validation step.

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
@@ -83,6 +83,7 @@ public class ComponentProxyWithCustomComponentTest {
                 assertThat(component).isInstanceOf(SqlComponent.class);
                 assertThat(options).containsKey("dataSource");
                 assertThat(options).hasEntrySatisfying("dataSource", new Condition<Object>() {
+                    @Override
                     public boolean matches(Object value) {
                         return value instanceof DataSource;
                     }
@@ -121,6 +122,7 @@ public class ComponentProxyWithCustomComponentTest {
                 assertThat(component).isInstanceOf(SqlComponent.class);
                 assertThat(options).containsKey("dataSource");
                 assertThat(options).hasEntrySatisfying("dataSource", new Condition<Object>() {
+                    @Override
                     public boolean matches(Object value) {
                         return value instanceof DataSource;
                     }

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
@@ -53,7 +53,7 @@ public class ComponentProxyWithCustomEndpointTest {
                 assertThat(endpoint).isNotNull();
                 assertThat(endpoint).isInstanceOf(FtpEndpoint.class);
 
-                FtpEndpoint ftpEndpoint = FtpEndpoint.class.cast(endpoint);
+                FtpEndpoint<?> ftpEndpoint = FtpEndpoint.class.cast(endpoint);
                 boolean binary = Objects.equals("true", options.get("transfer-mode-binary"));
 
                 ftpEndpoint.getConfiguration().setBinary(binary);
@@ -86,7 +86,7 @@ public class ComponentProxyWithCustomEndpointTest {
             assertThat(names).contains("ftp-my-ftp-proxy");
             assertThat(context.getEndpointMap().keySet()).contains("ftp-my-ftp-proxy://localhost?username=my-user");
 
-            FtpEndpoint ftpEndpoint = context.getEndpoint("ftp-my-ftp-proxy://localhost?username=my-user", FtpEndpoint.class);
+            FtpEndpoint<?> ftpEndpoint = context.getEndpoint("ftp-my-ftp-proxy://localhost?username=my-user", FtpEndpoint.class);
             assertThat(ftpEndpoint).isNotNull();
             assertThat(ftpEndpoint.getConfiguration()).hasFieldOrPropertyWithValue("binary", binary);
             assertThat(ftpEndpoint.getConfiguration()).hasFieldOrPropertyWithValue("username", username);

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
@@ -125,7 +125,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
             return;
         }
 
-        ProcessorDefinition parent = configureRouteScheduler(integration);
+        ProcessorDefinition<?> parent = configureRouteScheduler(integration);
 
         for (int i = 0; i < steps.size(); i++) {
             final Step step = steps.get(i);
@@ -141,7 +141,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
                     throw new IllegalStateException("The handler for step kind " + step.getKind() + " is not a consumer");
                 }
 
-                Optional<ProcessorDefinition> definition = handler.handle(step, null, this, stepIndex);
+                Optional<ProcessorDefinition<?>> definition = handler.handle(step, null, this, stepIndex);
                 if (definition.isPresent()) {
                     parent = definition.get();
                     parent = configureRouteDefinition(parent, stepId);
@@ -188,7 +188,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         }
     }
 
-    private ProcessorDefinition configureRouteDefinition(ProcessorDefinition definition, String stepId) {
+    private ProcessorDefinition<?> configureRouteDefinition(ProcessorDefinition<?> definition, String stepId) {
         if (definition instanceof RouteDefinition) {
             final RouteDefinition rd = (RouteDefinition)definition;
             final List<RoutePolicy> rp = rd.getRoutePolicies();
@@ -206,7 +206,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         return definition;
     }
 
-    private ProcessorDefinition<PipelineDefinition> createPipeline(ProcessorDefinition parent, String stepId) {
+    private ProcessorDefinition<PipelineDefinition> createPipeline(ProcessorDefinition<?> parent, String stepId) {
         return parent.pipeline()
             .id(String.format("step:%s", stepId))
             .setHeader(IntegrationLoggingConstants.STEP_ID, constant(stepId));
@@ -216,7 +216,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
      * If the integration has a scheduler, start the route with a timer or quartz2
      * endpoint.
      */
-    private ProcessorDefinition configureRouteScheduler(Integration integration) throws URISyntaxException {
+    private ProcessorDefinition<?> configureRouteScheduler(Integration integration) throws URISyntaxException {
         if (integration.getScheduler().isPresent()) {
             Scheduler scheduler = integration.getScheduler().get();
 
@@ -262,7 +262,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         return Optional.empty();
     }
 
-    private Optional<ProcessorDefinition> configureConnectorSplit(Step step, ProcessorDefinition route, String index) {
+    private Optional<ProcessorDefinition<?>> configureConnectorSplit(Step step, ProcessorDefinition<?> route, String index) {
         if (step.getAction().filter(ConnectorAction.class::isInstance).isPresent()) {
             final ConnectorAction action = step.getAction().filter(ConnectorAction.class::isInstance).map(ConnectorAction.class::cast).get();
             final ConnectorDescriptor descriptor = action.getDescriptor();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationStepHandler.java
@@ -29,7 +29,7 @@ public interface IntegrationStepHandler {
     /**
      * Customize the given route according to the given step.
      */
-    Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex);
+    Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex);
 
     // Marker interface to mark handlers as valid start for a route
     interface Consumer {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
@@ -45,6 +45,7 @@ public class OutMessageCaptureProcessor implements Processor {
     }
 
     public static Map<String, Message> getCapturedMessageMap(Exchange exchange) {
+        @SuppressWarnings("unchecked")
         Map<String, Message> outMessagesMap = exchange.getProperty(CAPTURED_OUT_MESSAGES_MAP, Map.class);
         if( outMessagesMap == null ) {
             outMessagesMap = new HashMap<>();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AbstractFilterStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AbstractFilterStepHandler.java
@@ -30,7 +30,7 @@ import org.apache.camel.util.ObjectHelper;
 abstract class AbstractFilterStepHandler implements IntegrationStepHandler {
 
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex) {
         ObjectHelper.notNull(route, "route");
 
         final String expression = ObjectHelper.notNull(getFilterExpression(step), "expression");

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
@@ -71,7 +71,7 @@ public class ConnectorStepHandler implements IntegrationStepHandler, Integration
 
     @SuppressWarnings("PMD")
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, final String index) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, final String index) {
         // Model
         final Connection connection = step.getConnection().get();
         final Connector connector = connection.getConnector().get();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
@@ -32,7 +32,7 @@ public class DataMapperStepHandler implements IntegrationStepHandler{
     }
 
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex) {
         ObjectHelper.notNull(route, "route");
 
         return Optional.of(

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/EndpointStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/EndpointStepHandler.java
@@ -63,7 +63,7 @@ public class EndpointStepHandler implements IntegrationStepHandler, IntegrationS
 
     @SuppressWarnings({"unchecked", "PMD"})
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, final String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, final String stepIndex) {
         // Model
         final Connection connection = step.getConnection().get();
         final Connector connector = connection.getConnector().get();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
@@ -44,7 +44,7 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
 
     @SuppressWarnings("PMD")
     @Override
-    public Optional<ProcessorDefinition> handle(io.syndesis.common.model.integration.Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(io.syndesis.common.model.integration.Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex) {
         ObjectHelper.notNull(route, "route");
 
         // Model
@@ -116,7 +116,10 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
                     // the handler method.
                     ObjectHelper.trySetCamelContext(stepExtension, context);
 
-                    return stepExtension.configure(context, route, props);
+                    @SuppressWarnings({"rawtypes", "unchecked"})
+                    final Optional<ProcessorDefinition<?>> configured = (Optional) stepExtension.configure(context, route, props);
+
+                    return configured;
                 } catch (ClassNotFoundException e) {
                     throw new IllegalStateException(e);
                 }

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
@@ -33,7 +33,7 @@ public class LogStepHandler implements IntegrationStepHandler {
     }
 
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex) {
         if( step.getId().isPresent() ) {
             String stepId = step.getId().get();
             return Optional.of(route.log(LoggingLevel.INFO, (String) null, stepId, createMessage(step)));

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SimpleEndpointStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SimpleEndpointStepHandler.java
@@ -55,7 +55,7 @@ public class SimpleEndpointStepHandler implements IntegrationStepHandler, Integr
 
     @SuppressWarnings({"unchecked", "PMD"})
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, final String index) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, final String index) {
         // Model
         final ConnectorAction action = step.getActionAs(ConnectorAction.class).get();
         final ConnectorDescriptor descriptor = action.getDescriptor();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SplitStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SplitStepHandler.java
@@ -36,7 +36,7 @@ public class SplitStepHandler implements IntegrationStepHandler {
 
     @SuppressWarnings({"PMD.AvoidReassigningParameters", "PMD.AvoidDeeplyNestedIfStmts"})
     @Override
-    public Optional<ProcessorDefinition> handle(Step step, ProcessorDefinition route, IntegrationRouteBuilder builder, String stepIndex) {
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String stepIndex) {
         ObjectHelper.notNull(route, "route");
 
         String languageName = step.getConfiguredProperties().get("language");

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerTest.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.integration.component.proxy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -72,7 +73,7 @@ public class ComponentProxyCustomizerTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -84,7 +85,7 @@ public class ComponentProxyCustomizerTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerWithPlaceholdersTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerWithPlaceholdersTest.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.integration.component.proxy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -73,7 +74,7 @@ public class ComponentProxyCustomizerWithPlaceholdersTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -85,7 +86,7 @@ public class ComponentProxyCustomizerWithPlaceholdersTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyFactoryTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.integration.component.proxy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import io.syndesis.integration.runtime.IntegrationRuntimeAutoConfiguration;
@@ -71,7 +72,7 @@ public class ComponentProxyFactoryTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -83,7 +84,7 @@ public class ComponentProxyFactoryTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes());
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
@@ -358,7 +358,7 @@ public class ExtensionStepHandlerTest extends IntegrationTestSupport {
 
     public static class MyStepExtension implements Step {
         @Override
-        public Optional<ProcessorDefinition> configure(CamelContext context, ProcessorDefinition definition, Map<String, Object> map) {
+        public Optional<ProcessorDefinition<?>> configure(CamelContext context, ProcessorDefinition<?> definition, Map<String, Object> map) {
             map.forEach((k, v) -> definition.setHeader(k).constant(v));
 
             return Optional.empty();

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
@@ -150,7 +150,7 @@ public class LogsAndErrorsTest extends IntegrationTestSupport {
 
     public static class LogExtension implements Step {
         @Override
-        public Optional<ProcessorDefinition> configure(CamelContext context, ProcessorDefinition definition, Map<String, Object> parameters) {
+        public Optional<ProcessorDefinition<?>> configure(CamelContext context, ProcessorDefinition<?> definition, Map<String, Object> parameters) {
             return Optional.of(definition.log(LoggingLevel.INFO, definition.getId(), definition.getId(), "Got ${body}"));
         }
     }
@@ -159,8 +159,8 @@ public class LogsAndErrorsTest extends IntegrationTestSupport {
         private static int count;
 
         @Override
-        public Optional<ProcessorDefinition> configure(CamelContext context, ProcessorDefinition definition, Map<String, Object> parameters) {
-            ProcessorDefinition processor = definition.process(exchange -> {
+        public Optional<ProcessorDefinition<?>> configure(CamelContext context, ProcessorDefinition<?> definition, Map<String, Object> parameters) {
+            ProcessorDefinition<?> processor = definition.process(exchange -> {
                 count++;
                 if( count == 2 ) {
                     throw new IOException("Bean Error");

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -302,6 +302,13 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <!-- Needed by Guava at compile time -->
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- === Testing Dependencies ======================================================== -->
 
     <dependency>

--- a/app/meta/src/main/java/io/syndesis/connector/meta/JacksonContextResolver.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/JacksonContextResolver.java
@@ -38,6 +38,7 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
             .configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
     }
 
+    @Override
     public ObjectMapper getContext(Class<?> objectType) {
         return objectMapper;
     }

--- a/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
@@ -40,6 +40,7 @@ public class VerifierExceptionMapper implements ExceptionMapper<Throwable> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VerifierExceptionMapper.class);
 
+    @SuppressWarnings("JavaLangClash")
     public static class Error {
         public final String developerMsg;
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -491,6 +491,50 @@
       </build>
     </profile>
 
+	<profile>
+	  <id>non-m2e</id>
+	  <activation>
+	    <property>
+	      <name>!m2e.version</name>
+	    </property>
+	  </activation>
+	  <build>
+	    <plugins>
+	      <plugin>
+	        <artifactId>maven-compiler-plugin</artifactId>
+	        <configuration>
+	          <compilerId>javac-with-errorprone</compilerId>
+	          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+	          <compilerArgs>
+	            <arg>-Xlint:all</arg>
+	            <arg>-Xlint:-deprecation</arg>
+	            <arg>-Xlint:-processing</arg>
+	            <arg>-Xlint:-serial</arg>
+	            <arg>-Werror</arg>
+	            <arg>-XepDisableWarningsInGeneratedCode</arg>
+	            <arg>-XepExcludedPaths:.*/generated-sources/.*</arg>
+	            <arg>-implicit:none</arg>
+	          </compilerArgs>
+	        </configuration>
+	        <dependencies>
+	          <dependency>
+	            <groupId>org.codehaus.plexus</groupId>
+	            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+	            <version>2.8.4</version>
+	          </dependency>
+	          <!-- override plexus-compiler-javac-errorprone's dependency on
+	           Error Prone with the latest version -->
+	          <dependency>
+	            <groupId>com.google.errorprone</groupId>
+	            <artifactId>error_prone_core</artifactId>
+	            <version>2.3.1</version>
+	          </dependency>
+	        </dependencies>
+	      </plugin>
+	    </plugins>
+	  </build>
+	</profile>
+
   </profiles>
 
   <build>

--- a/app/server/builder/maven-plugin/pom.xml
+++ b/app/server/builder/maven-plugin/pom.xml
@@ -410,38 +410,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>non-m2e</id>
-      <activation>
-        <!-- active only when not running under M2E in Eclipse -->
-        <property>
-          <name>!m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs combine.children="append">
-                <!-- no way to influence generated HelpMojo.java to contain
-                the required @Override, or to be marked as @Generated, next
-                errorprone version will add exclusions by path:
-                -XepExcludedPaths:.*/generated-sources/.*
-                -->
-                <arg>-Xep:MissingOverride:OFF</arg>
-                <!-- no way to influence generated HelpMojo.java not to throw
-                from finally block, or to be marked as @Generated, next
-                errorprone version will add exclusions by path:
-                -XepExcludedPaths:.*/generated-sources/.* -->
-                <arg>-Xep:Finally:OFF</arg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
+++ b/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
@@ -164,7 +164,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         if (components == null) {
             return null;
         }
-        String[] part = components.split("\\s");
+        String[] part = components.split("\\s", -1);
         ObjectNode componentMeta = new ObjectNode(JsonNodeFactory.instance);
         for (String scheme : part) {
             // find the class name

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/util/Urls.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/util/Urls.java
@@ -73,7 +73,7 @@ public final class Urls {
     }
 
     static String basePath(final String path) {
-        final String[] parts = path.split("/");
+        final String[] parts = path.split("/", -1);
 
         return "/" + parts[1] + "/" + parts[2] + "/";
     }

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/Strings.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/Strings.java
@@ -56,7 +56,7 @@ public final class Strings {
 
     public static String splitPart(String delimiter, String value, int idx) {
         int i = idx-1;
-        String[] split = value.split(Pattern.quote(delimiter));
+        String[] split = value.split(Pattern.quote(delimiter), -1);
         if( i < split.length ) {
             return split[i];
         } else {

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
@@ -66,7 +66,7 @@ public class ActivityTrackingController implements Closeable {
     private final DBI dbi;
     private final KubernetesClient client;
     private final Map<String, PodLogMonitor> podHandlers = new HashMap<>();
-    private final JsonDB jsonDB;
+    private final JsonDB jsondb;
     private final KubernetesSupport kubernetesSupport;
     private ScheduledExecutorService scheduler;
 
@@ -79,8 +79,8 @@ public class ActivityTrackingController implements Closeable {
     private Duration startupDelay = Duration.ofSeconds(15);
 
     @Autowired
-    public ActivityTrackingController(JsonDB jsonDB, DBI dbi, KubernetesClient client) {
-        this.jsonDB = jsonDB;
+    public ActivityTrackingController(JsonDB jsondb, DBI dbi, KubernetesClient client) {
+        this.jsondb = jsondb;
         this.dbi = dbi;
         this.client = client;
         this.kubernetesSupport = new KubernetesSupport(client);
@@ -203,7 +203,7 @@ public class ActivityTrackingController implements Closeable {
             if (pods != null) {
                 pods.keySet().removeAll(podHandlers.keySet());
                 for (String o : pods.keySet()) {
-                    jsonDB.delete("/activity/pods/" + o);
+                    jsondb.delete("/activity/pods/" + o);
                     LOG.info("Pod state removed from db: {}", o);
                 }
             }
@@ -230,11 +230,11 @@ public class ActivityTrackingController implements Closeable {
     }
 
     public void deletePodLogState(String podName) throws IOException {
-        jsonDB.delete("/activity/pods/" + podName);
+        jsondb.delete("/activity/pods/" + podName);
     }
 
     public void setPodLogState(String podName, PodLogState state) throws IOException {
-        jsonDB.set("/activity/pods/" + podName, Json.writer().writeValueAsBytes(state));
+        jsondb.set("/activity/pods/" + podName, Json.writer().writeValueAsBytes(state));
     }
 
     public PodLogState getPodLogState(String podName) throws IOException {
@@ -246,7 +246,7 @@ public class ActivityTrackingController implements Closeable {
     }
 
     private <T> T dbGet(Class<T> type, String path, GetOptions options) throws IOException {
-        byte[] data = jsonDB.getAsByteArray(path, options);
+        byte[] data = jsondb.getAsByteArray(path, options);
         if (data == null) {
             return null;
         }
@@ -288,7 +288,7 @@ public class ActivityTrackingController implements Closeable {
                     }
 
                     // Write the batch..
-                    jsonDB.update("/activity", Json.writer().writeValueAsBytes(batch));
+                    jsondb.update("/activity", Json.writer().writeValueAsBytes(batch));
                     LOG.debug("Batch ingested {} log events", eventCounter);
 
                 } catch (IOException e) {

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpQuery.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpQuery.java
@@ -73,7 +73,7 @@ public interface HttpQuery {
 
     List<String> getByLabels();
 
-    @SuppressWarnings("PMD.NPathComplexity")
+    @SuppressWarnings({ "PMD.NPathComplexity", "OrphanedFormatString" })
     default UriBuilder getUriBuilder() {
         StringBuilder queryExpression = new StringBuilder();
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -49,10 +49,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     private static final String OPENSHIFT_PREFIX = "i-";
 
     // Labels used for generated objects
-    private static final Map<String, String> INTEGRATION_DEFAULT_LABELS = Collections.unmodifiableMap(new HashMap<String, String>() {{
-        put("syndesis.io/type", "integration");
-        put("syndesis.io/app", "syndesis");
-    }});
+    private static final Map<String, String> INTEGRATION_DEFAULT_LABELS = defaultLabels();
 
     private final NamespacedOpenShiftClient openShiftClient;
     private final OpenShiftConfigurationProperties config;
@@ -374,4 +371,13 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     protected static String openshiftName(String name) {
         return OPENSHIFT_PREFIX + Names.sanitize(name);
     }
+
+    private static Map<String, String> defaultLabels() {
+        final HashMap<String, String> labels = new HashMap<String, String>();
+        labels.put("syndesis.io/type", "integration");
+        labels.put("syndesis.io/app", "syndesis");
+
+        return Collections.unmodifiableMap(labels);
+    }
+
 }

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -788,49 +788,6 @@
       </build>
     </profile>
     <profile>
-      <id>non-m2e</id>
-      <activation>
-        <!-- active only when not running under M2E in Eclipse -->
-        <property>
-          <name>!m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <compilerArgs>
-                <arg>-Xlint:all</arg>
-                <arg>-Xlint:-deprecation</arg>
-                <arg>-Xlint:-processing</arg>
-                <arg>-Xlint:-serial</arg>
-                <arg>-Werror</arg>
-                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                <arg>-implicit:none</arg>
-              </compilerArgs>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.2</version>
-              </dependency>
-              <!-- override plexus-compiler-javac-errorprone's dependency on
-               Error Prone with the latest version -->
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.1.2</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>generate-licenses-xml</id>
       <build>
         <plugins>


### PR DESCRIPTION
**Please review if I made any mistakes in the refactoring, I'm labeling this as `pr/wip` to let everyone enough time to have a look.**

This pulls maven-compiler-plugin configuration to the parent POM. The
only exceptions are few modules that need to tweak the configuration.
Such as the annotation processing module, that needs to turn off
annotation processing.

This fixes a number of Error Prone issues and compiler warnings. In
particular these Error Prone issues were reported:

http://errorprone.info/bugpattern/ClassCanBeStatic
http://errorprone.info/bugpattern/DefaultCharset
http://errorprone.info/bugpattern/DoubleBraceInitialization
http://errorprone.info/bugpattern/InconsistentCapitalization
http://errorprone.info/bugpattern/JavaLangClash (ignored)
http://errorprone.info/bugpattern/MissingOverride
http://errorprone.info/bugpattern/OperatorPrecedence
http://errorprone.info/bugpattern/OrphanedFormatString
http://errorprone.info/bugpattern/StreamResourceLeak
http://errorprone.info/bugpattern/StringSplitter

And Java compiler warnings were mostly relating to parameterized/raw
type usage.

Fixes #2663 