### PR TITLE
chore: Moved label 'syndesis.io/app' back to 'app' as it has a meaning for OpenShift

### DIFF
--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -13,7 +13,7 @@ metadata:
 # OAuthProxy Tag: {{Tags.OAuthProxy}}
 #
   labels:
-    syndesis.io/app: syndesis
+    app: syndesis
     syndesis.io/type: infrastructure
 parameters:
 # Parameters with no defaults (has to be be provided when template is applied):

--- a/install/generator/01-header.yml.mustache
+++ b/install/generator/01-header.yml.mustache
@@ -14,6 +14,7 @@ metadata:
 #
   labels:
     app: syndesis
+    syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
 parameters:
 # Parameters with no defaults (has to be be provided when template is applied):

--- a/install/generator/02-syndesis-image-streams.yml.mustache
+++ b/install/generator/02-syndesis-image-streams.yml.mustache
@@ -6,6 +6,7 @@
     name: {{ Images.Syndesis.Rest }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
   spec:
@@ -22,6 +23,7 @@
     name: {{ Images.Syndesis.Ui }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -38,6 +40,7 @@
     name: {{ Images.Syndesis.Verifier }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -54,6 +57,7 @@
     name: {{ Images.Support.OAuthProxy }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
   spec:
@@ -70,6 +74,7 @@
     name: {{ Images.Support.Prometheus }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -87,6 +92,7 @@
     name: {{ Images.Syndesis.S2i }}
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: s2i-java
   spec:

--- a/install/generator/02-syndesis-image-streams.yml.mustache
+++ b/install/generator/02-syndesis-image-streams.yml.mustache
@@ -5,7 +5,7 @@
   metadata:
     name: {{ Images.Syndesis.Rest }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
   spec:
@@ -21,7 +21,7 @@
   metadata:
     name: {{ Images.Syndesis.Ui }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -37,7 +37,7 @@
   metadata:
     name: {{ Images.Syndesis.Verifier }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -53,7 +53,7 @@
   metadata:
     name: {{ Images.Support.OAuthProxy }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
   spec:
@@ -69,7 +69,7 @@
   metadata:
     name: {{ Images.Support.Prometheus }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -86,7 +86,7 @@
   metadata:
     name: {{ Images.Syndesis.S2i }}
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: s2i-java
   spec:

--- a/install/generator/02-syndesis-secrets.yml.mustache
+++ b/install/generator/02-syndesis-secrets.yml.mustache
@@ -3,7 +3,7 @@
   metadata:
     name: syndesis-oauth-proxy-cookie-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
@@ -12,7 +12,7 @@
   metadata:
     name: syndesis-server-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
@@ -22,7 +22,7 @@
   metadata:
     name: syndesis-global-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     syndesis: "{{ Tags.Syndesis }}"

--- a/install/generator/02-syndesis-secrets.yml.mustache
+++ b/install/generator/02-syndesis-secrets.yml.mustache
@@ -4,6 +4,7 @@
     name: syndesis-oauth-proxy-cookie-secret
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
@@ -13,6 +14,7 @@
     name: syndesis-server-secret
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
@@ -23,6 +25,7 @@
     name: syndesis-global-config
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     syndesis: "{{ Tags.Syndesis }}"

--- a/install/generator/03-syndesis-ui.yml.mustache
+++ b/install/generator/03-syndesis-ui.yml.mustache
@@ -3,7 +3,7 @@
   metadata:
     name: syndesis-ui
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -12,20 +12,20 @@
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
     name: syndesis-ui
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
     strategy:
       rollingParams:
@@ -43,7 +43,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-ui
       spec:
@@ -98,7 +98,7 @@
   metadata:
     name: syndesis-ui-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   data:

--- a/install/generator/03-syndesis-ui.yml.mustache
+++ b/install/generator/03-syndesis-ui.yml.mustache
@@ -4,6 +4,7 @@
     name: syndesis-ui
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -13,12 +14,14 @@
       targetPort: 8080
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-ui
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
     name: syndesis-ui
@@ -26,6 +29,7 @@
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-ui
     strategy:
       rollingParams:
@@ -44,6 +48,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-ui
       spec:
@@ -99,6 +104,7 @@
     name: syndesis-ui-config
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   data:

--- a/install/generator/04-amq-example.yml.mustache
+++ b/install/generator/04-amq-example.yml.mustache
@@ -4,7 +4,7 @@
   metadata:
     name: jboss-amq-63
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: amq
   spec:
     tags:
@@ -36,20 +36,20 @@
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/example: broker-amq
     name: broker-amq
   spec:
     replicas: 0
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/example: broker-amq
     strategy:
       type: Recreate
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/example: broker-amq
         name: broker-amq
       spec:

--- a/install/generator/04-amq-example.yml.mustache
+++ b/install/generator/04-amq-example.yml.mustache
@@ -5,6 +5,7 @@
     name: jboss-amq-63
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: amq
   spec:
     tags:
@@ -37,12 +38,14 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/example: broker-amq
     name: broker-amq
   spec:
     replicas: 0
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/example: broker-amq
     strategy:
       type: Recreate
@@ -50,6 +53,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/example: broker-amq
         name: broker-amq
       spec:

--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -3,6 +3,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
     name: syndesis-sampledb-config
@@ -69,6 +70,7 @@
     name: syndesis-db
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
@@ -80,6 +82,7 @@
       targetPort: 5432
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-db
     sessionAffinity: None
     type: ClusterIP
@@ -91,6 +94,7 @@
     name: syndesis-db
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-db
   spec:
     accessModes:
@@ -104,12 +108,14 @@
     name: syndesis-db
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-db
     strategy:
       type: Recreate
@@ -122,6 +128,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/component: syndesis-db
       spec:
         containers:

--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -2,7 +2,7 @@
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
     name: syndesis-sampledb-config
@@ -68,7 +68,7 @@
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
@@ -79,7 +79,7 @@
       protocol: TCP
       targetPort: 5432
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     sessionAffinity: None
     type: ClusterIP
@@ -90,7 +90,7 @@
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
   spec:
     accessModes:
@@ -103,13 +103,13 @@
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     strategy:
       type: Recreate
@@ -121,7 +121,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/component: syndesis-db
       spec:
         containers:

--- a/install/generator/04-syndesis-meta.yml.mustache
+++ b/install/generator/04-syndesis-meta.yml.mustache
@@ -3,6 +3,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
@@ -13,6 +14,7 @@
       targetPort: 8080
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-meta
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -20,6 +22,7 @@
     name: syndesis-meta
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -33,6 +36,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
@@ -40,6 +44,7 @@
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-meta
     strategy:
       resources:
@@ -52,6 +57,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-meta
       spec:
@@ -136,6 +142,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta-config

--- a/install/generator/04-syndesis-meta.yml.mustache
+++ b/install/generator/04-syndesis-meta.yml.mustache
@@ -2,7 +2,7 @@
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
@@ -12,14 +12,14 @@
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: syndesis-meta
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -32,14 +32,14 @@
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
     strategy:
       resources:
@@ -51,7 +51,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-meta
       spec:
@@ -135,7 +135,7 @@
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta-config

--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -3,6 +3,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     annotations:
@@ -15,12 +16,14 @@
       targetPort: 8443
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-oauthproxy
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis
   spec:
@@ -38,6 +41,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     name: syndesis-oauthproxy
@@ -45,6 +49,7 @@
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-oauthproxy
     strategy:
       resources:
@@ -57,6 +62,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-oauthproxy
       spec:

--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -2,7 +2,7 @@
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     annotations:
@@ -14,13 +14,13 @@
       protocol: TCP
       targetPort: 8443
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis
   spec:
@@ -37,14 +37,14 @@
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     name: syndesis-oauthproxy
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
     strategy:
       resources:
@@ -56,7 +56,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-oauthproxy
       spec:

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -3,7 +3,7 @@
   metadata:
     name: syndesis-server
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
@@ -11,14 +11,14 @@
   metadata:
     name: syndesis-integration
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
@@ -28,20 +28,20 @@
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
     strategy:
       resources:
@@ -53,7 +53,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-server
       spec:
@@ -160,7 +160,7 @@
     annotations:
       io.syndesis/upgrade-mode: keep
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server-config

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -4,6 +4,7 @@
     name: syndesis-server
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
@@ -12,6 +13,7 @@
     name: syndesis-integration
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
@@ -19,6 +21,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
@@ -29,12 +32,14 @@
       targetPort: 8080
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
@@ -42,6 +47,7 @@
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-server
     strategy:
       resources:
@@ -54,6 +60,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-server
       spec:
@@ -161,6 +168,7 @@
       io.syndesis/upgrade-mode: keep
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server-config

--- a/install/generator/04-todo-example.yml.mustache
+++ b/install/generator/04-todo-example.yml.mustache
@@ -2,7 +2,7 @@
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -11,14 +11,14 @@
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
 
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -38,7 +38,7 @@
   kind: ImageStream
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     lookupPolicy:
@@ -52,7 +52,7 @@
   kind: BuildConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     postCommit: {}
@@ -82,12 +82,12 @@
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     strategy:
       resources:
@@ -102,7 +102,7 @@
           openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
         creationTimestamp: null
         labels:
-          syndesis.io/app: todo
+          app: todo
           syndesis.io/component: todo
       spec:
         containers:

--- a/install/generator/04-todo-example.yml.mustache
+++ b/install/generator/04-todo-example.yml.mustache
@@ -2,7 +2,8 @@
   kind: Service
   metadata:
     labels:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -11,14 +12,16 @@
       protocol: TCP
       targetPort: 8080
     selector:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
       syndesis.io/component: todo
 
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -38,7 +41,8 @@
   kind: ImageStream
   metadata:
     labels:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
     name: todo
   spec:
     lookupPolicy:
@@ -52,7 +56,8 @@
   kind: BuildConfig
   metadata:
     labels:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
     name: todo
   spec:
     postCommit: {}
@@ -82,12 +87,14 @@
   kind: DeploymentConfig
   metadata:
     labels:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
     name: todo
   spec:
     replicas: 1
     selector:
-      app: todo
+      app: syndesis
+      syndesis.io/app: todo
       syndesis.io/component: todo
     strategy:
       resources:
@@ -102,7 +109,8 @@
           openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
         creationTimestamp: null
         labels:
-          app: todo
+          app: syndesis
+          syndesis.io/app: todo
           syndesis.io/component: todo
       spec:
         containers:

--- a/install/generator/05-syndesis-security.yml.mustache
+++ b/install/generator/05-syndesis-security.yml.mustache
@@ -4,6 +4,7 @@
     name: syndesis:editors
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: edit
@@ -16,6 +17,7 @@
     name: syndesis:viewers
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: view

--- a/install/generator/05-syndesis-security.yml.mustache
+++ b/install/generator/05-syndesis-security.yml.mustache
@@ -3,7 +3,7 @@
   metadata:
     name: syndesis:editors
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: edit
@@ -15,7 +15,7 @@
   metadata:
     name: syndesis:viewers
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: view

--- a/install/generator/06-syndesis-prometheus.yml.mustache
+++ b/install/generator/06-syndesis-prometheus.yml.mustache
@@ -4,6 +4,7 @@
     name: syndesis-prometheus
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
 
@@ -12,6 +13,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
     name: syndesis-prometheus-config
@@ -100,6 +102,7 @@
     name: syndesis-prometheus
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -110,6 +113,7 @@
       targetPort: 9090
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-prometheus
   status:
     loadBalancer: {}
@@ -119,6 +123,7 @@
     name: syndesis-prometheus
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -133,12 +138,14 @@
     name: syndesis-prometheus
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
     replicas: 1
     selector:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/component: syndesis-prometheus
     strategy:
       type: Recreate
@@ -151,6 +158,7 @@
       metadata:
         labels:
           app: syndesis
+          syndesis.io/app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-prometheus
       spec:

--- a/install/generator/06-syndesis-prometheus.yml.mustache
+++ b/install/generator/06-syndesis-prometheus.yml.mustache
@@ -3,7 +3,7 @@
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
 
@@ -11,7 +11,7 @@
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
     name: syndesis-prometheus-config
@@ -99,7 +99,7 @@
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -109,7 +109,7 @@
       protocol: TCP
       targetPort: 9090
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
   status:
     loadBalancer: {}
@@ -118,7 +118,7 @@
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -132,13 +132,13 @@
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
     strategy:
       type: Recreate
@@ -150,7 +150,7 @@
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-prometheus
       spec:

--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -3,6 +3,7 @@
   metadata:
     labels:
       app: syndesis
+      syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis-upgrade
     annotations:

--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -2,7 +2,7 @@
   kind: Template
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis-upgrade
     annotations:

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -16,7 +16,7 @@ metadata:
 # OAuthProxy Tag: v1.1.0
 #
   labels:
-    syndesis.io/app: syndesis
+    app: syndesis
     syndesis.io/type: infrastructure
 parameters:
 # Parameters with no defaults (has to be be provided when template is applied):
@@ -157,7 +157,7 @@ objects:
   metadata:
     name: syndesis-server
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
   spec:
@@ -173,7 +173,7 @@ objects:
   metadata:
     name: syndesis-ui
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -189,7 +189,7 @@ objects:
   metadata:
     name: syndesis-meta
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -205,7 +205,7 @@ objects:
   metadata:
     name: oauth-proxy
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
   spec:
@@ -221,7 +221,7 @@ objects:
   metadata:
     name: prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -238,7 +238,7 @@ objects:
   metadata:
     name: syndesis-s2i
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: s2i-java
   spec:
@@ -255,7 +255,7 @@ objects:
   metadata:
     name: syndesis-oauth-proxy-cookie-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
@@ -264,7 +264,7 @@ objects:
   metadata:
     name: syndesis-server-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
@@ -274,7 +274,7 @@ objects:
   metadata:
     name: syndesis-global-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     syndesis: "latest"
@@ -307,7 +307,7 @@ objects:
   metadata:
     name: syndesis-ui
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -316,20 +316,20 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
     name: syndesis-ui
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
     strategy:
       rollingParams:
@@ -347,7 +347,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-ui
       spec:
@@ -398,7 +398,7 @@ objects:
   metadata:
     name: syndesis-ui-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   data:
@@ -435,7 +435,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
     name: syndesis-sampledb-config
@@ -501,7 +501,7 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
@@ -512,7 +512,7 @@ objects:
       protocol: TCP
       targetPort: 5432
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     sessionAffinity: None
     type: ClusterIP
@@ -523,7 +523,7 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
   spec:
     accessModes:
@@ -536,13 +536,13 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     strategy:
       type: Recreate
@@ -554,7 +554,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/component: syndesis-db
       spec:
         containers:
@@ -628,7 +628,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
@@ -638,14 +638,14 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: syndesis-meta
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -658,14 +658,14 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
     strategy:
       resources:
@@ -677,7 +677,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-meta
       spec:
@@ -756,7 +756,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta-config
@@ -778,7 +778,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     annotations:
@@ -790,13 +790,13 @@ objects:
       protocol: TCP
       targetPort: 8443
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis
   spec:
@@ -813,14 +813,14 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     name: syndesis-oauthproxy
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
     strategy:
       resources:
@@ -832,7 +832,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-oauthproxy
       spec:
@@ -914,7 +914,7 @@ objects:
   metadata:
     name: syndesis-server
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
@@ -922,14 +922,14 @@ objects:
   metadata:
     name: syndesis-integration
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
@@ -939,20 +939,20 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
     strategy:
       resources:
@@ -964,7 +964,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-server
       spec:
@@ -1066,7 +1066,7 @@ objects:
     annotations:
       io.syndesis/upgrade-mode: keep
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server-config
@@ -1121,7 +1121,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -1130,14 +1130,14 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
 
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -1157,7 +1157,7 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     lookupPolicy:
@@ -1171,7 +1171,7 @@ objects:
   kind: BuildConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     postCommit: {}
@@ -1201,12 +1201,12 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     strategy:
       resources:
@@ -1221,7 +1221,7 @@ objects:
           openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
         creationTimestamp: null
         labels:
-          syndesis.io/app: todo
+          app: todo
           syndesis.io/component: todo
       spec:
         containers:
@@ -1269,7 +1269,7 @@ objects:
   metadata:
     name: syndesis:editors
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: edit
@@ -1281,7 +1281,7 @@ objects:
   metadata:
     name: syndesis:viewers
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: view
@@ -1293,7 +1293,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
 
@@ -1301,7 +1301,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
     name: syndesis-prometheus-config
@@ -1389,7 +1389,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -1399,7 +1399,7 @@ objects:
       protocol: TCP
       targetPort: 9090
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
   status:
     loadBalancer: {}
@@ -1408,7 +1408,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -1422,13 +1422,13 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
     strategy:
       type: Recreate
@@ -1440,7 +1440,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-prometheus
       spec:
@@ -1496,7 +1496,7 @@ objects:
   kind: Template
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis-upgrade
     annotations:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -16,7 +16,7 @@ metadata:
 # OAuthProxy Tag: v1.1.0
 #
   labels:
-    syndesis.io/app: syndesis
+    app: syndesis
     syndesis.io/type: infrastructure
 parameters:
 # Parameters with no defaults (has to be be provided when template is applied):
@@ -157,7 +157,7 @@ objects:
   metadata:
     name: syndesis-server
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
   spec:
@@ -173,7 +173,7 @@ objects:
   metadata:
     name: syndesis-ui
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -189,7 +189,7 @@ objects:
   metadata:
     name: syndesis-meta
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -205,7 +205,7 @@ objects:
   metadata:
     name: oauth-proxy
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
   spec:
@@ -221,7 +221,7 @@ objects:
   metadata:
     name: prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -238,7 +238,7 @@ objects:
   metadata:
     name: syndesis-s2i
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: s2i-java
   spec:
@@ -255,7 +255,7 @@ objects:
   metadata:
     name: syndesis-oauth-proxy-cookie-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
@@ -264,7 +264,7 @@ objects:
   metadata:
     name: syndesis-server-secret
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     clientStateAuthenticationKey: ${CLIENT_STATE_AUTHENTICATION_KEY}
@@ -274,7 +274,7 @@ objects:
   metadata:
     name: syndesis-global-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   stringData:
     syndesis: "latest"
@@ -307,7 +307,7 @@ objects:
   metadata:
     name: syndesis-ui
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   spec:
@@ -316,20 +316,20 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
     name: syndesis-ui
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-ui
     strategy:
       rollingParams:
@@ -347,7 +347,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-ui
       spec:
@@ -398,7 +398,7 @@ objects:
   metadata:
     name: syndesis-ui-config
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-ui
   data:
@@ -435,7 +435,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
     name: syndesis-sampledb-config
@@ -501,7 +501,7 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
@@ -512,7 +512,7 @@ objects:
       protocol: TCP
       targetPort: 5432
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     sessionAffinity: None
     type: ClusterIP
@@ -523,7 +523,7 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
   spec:
     accessModes:
@@ -536,13 +536,13 @@ objects:
   metadata:
     name: syndesis-db
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-db
     strategy:
       type: Recreate
@@ -554,7 +554,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/component: syndesis-db
       spec:
         containers:
@@ -628,7 +628,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
@@ -638,14 +638,14 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: syndesis-meta
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
   spec:
@@ -658,14 +658,14 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-meta
     strategy:
       resources:
@@ -677,7 +677,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-meta
       spec:
@@ -754,7 +754,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-meta
     name: syndesis-meta-config
@@ -776,7 +776,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     annotations:
@@ -788,13 +788,13 @@ objects:
       protocol: TCP
       targetPort: 8443
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis
   spec:
@@ -811,14 +811,14 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-oauthproxy
     name: syndesis-oauthproxy
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-oauthproxy
     strategy:
       resources:
@@ -830,7 +830,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-oauthproxy
       spec:
@@ -912,7 +912,7 @@ objects:
   metadata:
     name: syndesis-server
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
@@ -920,14 +920,14 @@ objects:
   metadata:
     name: syndesis-integration
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
@@ -937,20 +937,20 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-server
     strategy:
       resources:
@@ -962,7 +962,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-server
       spec:
@@ -1062,7 +1062,7 @@ objects:
     annotations:
       io.syndesis/upgrade-mode: keep
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-server
     name: syndesis-server-config
@@ -1117,7 +1117,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -1126,14 +1126,14 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
 
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     name: todo
   spec:
@@ -1153,7 +1153,7 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     lookupPolicy:
@@ -1167,7 +1167,7 @@ objects:
   kind: BuildConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     postCommit: {}
@@ -1197,12 +1197,12 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      syndesis.io/app: todo
+      app: todo
     name: todo
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: todo
+      app: todo
       syndesis.io/component: todo
     strategy:
       resources:
@@ -1217,7 +1217,7 @@ objects:
           openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
         creationTimestamp: null
         labels:
-          syndesis.io/app: todo
+          app: todo
           syndesis.io/component: todo
       spec:
         containers:
@@ -1265,7 +1265,7 @@ objects:
   metadata:
     name: syndesis:editors
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: edit
@@ -1277,7 +1277,7 @@ objects:
   metadata:
     name: syndesis:viewers
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
   roleRef:
     name: view
@@ -1289,7 +1289,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
 
@@ -1297,7 +1297,7 @@ objects:
   kind: ConfigMap
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
     name: syndesis-prometheus-config
@@ -1385,7 +1385,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -1395,7 +1395,7 @@ objects:
       protocol: TCP
       targetPort: 9090
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
   status:
     loadBalancer: {}
@@ -1404,7 +1404,7 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
@@ -1418,13 +1418,13 @@ objects:
   metadata:
     name: syndesis-prometheus
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-prometheus
   spec:
     replicas: 1
     selector:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/component: syndesis-prometheus
     strategy:
       type: Recreate
@@ -1436,7 +1436,7 @@ objects:
     template:
       metadata:
         labels:
-          syndesis.io/app: syndesis
+          app: syndesis
           syndesis.io/type: infrastructure
           syndesis.io/component: syndesis-prometheus
       spec:
@@ -1492,7 +1492,7 @@ objects:
   kind: Template
   metadata:
     labels:
-      syndesis.io/app: syndesis
+      app: syndesis
       syndesis.io/type: infrastructure
     name: syndesis-upgrade
     annotations:


### PR DESCRIPTION
This change reverts the change introduced in https://github.com/syndesisio/syndesis/commit/7027e646ac75af9548b34c557b0ade3d63f81fa6 where other labels has been moved to a 'syndesis.io' prefix.

The change for 'app' was by accident.