### PR TITLE
Fix typo in labels.adoc

### DIFF
--- a/doc/sdh/development/labels.adoc
+++ b/doc/sdh/development/labels.adoc
@@ -21,7 +21,7 @@ There must be only at most one label from the "Exclusive" groups.
 | Excl.
 
 | **cat/**
-| Misc categories which are can be added freely
+| Misc categories which can be added freely
 |
 
 | **prio/**


### PR DESCRIPTION
It's just a little thing I noticed reading the handbook.