### PR TITLE
chore: editing of scopes, token and authorization endpoints

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -1,19 +1,26 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.syndesis.server.endpoint.v1.handler.setup;
 
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.server.credential.Credentials;
 
-import org.springframework.boot.autoconfigure.social.SocialProperties;
-
 public final class OAuthApp {
-    private static final class OAuthProperties extends SocialProperties {
 
-        public OAuthProperties(final String clientId, final String clientSecret) {
-            setAppId(clientId);
-            setAppSecret(clientSecret);
-        }
-
-    }
+    private String authorizationUrl;
 
     private String clientId;
 
@@ -25,6 +32,10 @@ public final class OAuthApp {
 
     private String name;
 
+    private String scopes;
+
+    private String tokenUrl;
+
     public OAuthApp() {
     }
 
@@ -34,10 +45,13 @@ public final class OAuthApp {
         icon = connector.getIcon();
         clientId = connector.propertyTaggedWith(Credentials.CLIENT_ID_TAG).orElse(null);
         clientSecret = connector.propertyTaggedWith(Credentials.CLIENT_SECRET_TAG).orElse(null);
+        authorizationUrl = connector.propertyTaggedWith(Credentials.AUTHORIZATION_URL_TAG).orElse(null);
+        tokenUrl = connector.propertyTaggedWith(Credentials.ACCESS_TOKEN_URL_TAG).orElse(null);
+        scopes = connector.propertyTaggedWith(Credentials.SCOPE_TAG).orElse(null);
     }
 
-    public SocialProperties asSocialProperties() {
-        return new OAuthProperties(clientId, clientSecret);
+    public String getAuthorizationUrl() {
+        return authorizationUrl;
     }
 
     public String getClientId() {
@@ -60,6 +74,18 @@ public final class OAuthApp {
         return name;
     }
 
+    public String getScopes() {
+        return scopes;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public void setAuthorizationUrl(final String authorizationUrl) {
+        this.authorizationUrl = authorizationUrl;
+    }
+
     public void setClientId(final String clientId) {
         this.clientId = clientId;
     }
@@ -78,6 +104,14 @@ public final class OAuthApp {
 
     public void setName(final String name) {
         this.name = name;
+    }
+
+    public void setScopes(final String scopes) {
+        this.scopes = scopes;
+    }
+
+    public void setTokenUrl(final String tokenUrl) {
+        this.tokenUrl = tokenUrl;
     }
 
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -1,0 +1,83 @@
+package io.syndesis.server.endpoint.v1.handler.setup;
+
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.Credentials;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+
+public final class OAuthApp {
+    private static final class OAuthProperties extends SocialProperties {
+
+        public OAuthProperties(final String clientId, final String clientSecret) {
+            setAppId(clientId);
+            setAppSecret(clientSecret);
+        }
+
+    }
+
+    private String clientId;
+
+    private String clientSecret;
+
+    private String icon;
+
+    private String id;
+
+    private String name;
+
+    public OAuthApp() {
+    }
+
+    OAuthApp(final Connector connector) {
+        id = connector.getId().get();
+        name = connector.getName();
+        icon = connector.getIcon();
+        clientId = connector.propertyTaggedWith(Credentials.CLIENT_ID_TAG).orElse(null);
+        clientSecret = connector.propertyTaggedWith(Credentials.CLIENT_SECRET_TAG).orElse(null);
+    }
+
+    public SocialProperties asSocialProperties() {
+        return new OAuthProperties(clientId, clientSecret);
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setClientId(final String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setClientSecret(final String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public void setIcon(final String icon) {
+        this.icon = icon;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
@@ -15,33 +15,41 @@
  */
 package io.syndesis.server.endpoint.v1.handler.setup;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.ws.rs.core.UriInfo;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiParam;
-import io.syndesis.common.util.SuppressFBWarnings;
-import io.syndesis.server.credential.Credentials;
-import io.syndesis.server.dao.manager.DataManager;
+import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.Credentials;
+import io.syndesis.server.dao.manager.DataManager;
+import io.syndesis.server.endpoint.util.PaginationFilter;
+import io.syndesis.server.endpoint.util.ReflectiveFilterer;
+import io.syndesis.server.endpoint.util.ReflectiveSorter;
+import io.syndesis.server.endpoint.v1.operations.FilterOptionsFromQueryParams;
+import io.syndesis.server.endpoint.v1.operations.PaginationOptionsFromQueryParams;
+import io.syndesis.server.endpoint.v1.operations.SortOptionsFromQueryParams;
 
-import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,96 +62,76 @@ public class OAuthAppHandler {
 
     private final DataManager dataMgr;
 
-    public OAuthAppHandler(DataManager dataMgr) {
+    public OAuthAppHandler(final DataManager dataMgr) {
         this.dataMgr = dataMgr;
     }
 
-    // Since this a a view model DTO, and not a domain model lets define it here instead
-    // of placing it into the model module.
-    @SuppressFBWarnings(
-        value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
-        justification = "All fields are encode by jackson and sent to the UI")
-    public static final class OAuthApp extends SocialProperties {
-        public String id;
-        public String name;
-        public String icon;
-        public String clientId;
-        public String clientSecret;
-
-        @Override
-        @JsonIgnore
-        public String getAppId() {
-            return clientId;
-        }
-
-        @Override
-        @JsonIgnore
-        public String getAppSecret() {
-            return clientSecret;
-        }
-    }
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "")
-    public List<OAuthApp> get() {
-        ArrayList<OAuthApp> apps = new ArrayList<>();
-
-        List<Connector> items = dataMgr.fetchAll(Connector.class).getItems();
-        items.forEach(connector -> {
-            if (isOauthConnector(connector)) {
-                apps.add(createOAuthApp(connector));
-            }
-        });
-
-        return apps;
+    @DELETE
+    @Consumes("application/json")
+    @Path(value = "/{id}")
+    public void delete(@NotNull @PathParam("id") @ApiParam(required = true) final String id) {
+        // delete is to remove OAuth properties from the connector
+        update(id, new OAuthApp());
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path(value = "/{id}")
-    public OAuthApp get(@PathParam("id") @ApiParam(required = true) String id) {
+    public OAuthApp get(@NotNull @PathParam("id") @ApiParam(required = true) final String id) {
 
-        Connector connector = dataMgr.fetch(Connector.class, id);
-        if( connector == null ) {
+        final Connector connector = dataMgr.fetch(Connector.class, id);
+        if (connector == null || !isOauthConnector(connector)) {
             throw new EntityNotFoundException();
         }
-        if (isOauthConnector(connector)) {
-            return createOAuthApp(connector);
-        }
 
-        throw new EntityNotFoundException();
+        return createOAuthApp(connector);
     }
 
-    private static OAuthApp createOAuthApp(Connector connector) {
-        OAuthApp app = new OAuthApp();
-        app.id = connector.getId().get();
-        app.name = connector.getName();
-        app.icon = connector.getIcon();
-        app.clientId = connector.propertyTaggedWith(Credentials.CLIENT_ID_TAG).orElse(null);
-        app.clientSecret = connector.propertyTaggedWith(Credentials.CLIENT_SECRET_TAG).orElse(null);
-        return app;
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "sort", value = "Sort the result list according to the given field value", paramType = "query",
+            dataType = "string"),
+        @ApiImplicitParam(name = "direction",
+            value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " + "(ascending) or 'desc' (descending)",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(name = "page", value = "Page number to return", paramType = "query", dataType = "integer", defaultValue = "1"),
+        @ApiImplicitParam(name = "per_page", value = "Number of records per page", paramType = "query", dataType = "integer",
+            defaultValue = "20"),
+        @ApiImplicitParam(name = "query", value = "The search query to filter results on", paramType = "query", dataType = "string"),
+
+    })
+    public ListResult<OAuthApp> list(@Context final UriInfo uriInfo) {
+        final List<Connector> oauthConnectors = dataMgr.fetchAll(Connector.class, //
+            OAuthConnectorFilter.INSTANCE,
+            new ReflectiveFilterer<>(Connector.class, new FilterOptionsFromQueryParams(uriInfo).getFilters()),
+            new ReflectiveSorter<>(Connector.class, new SortOptionsFromQueryParams(uriInfo)),
+            new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo))).getItems();
+
+        final List<OAuthApp> apps = oauthConnectors.stream().map(OAuthAppHandler::createOAuthApp).collect(Collectors.toList());
+
+        return ListResult.of(apps);
     }
 
     @PUT
     @Path(value = "/{id}")
-    @Consumes("application/json")
-    public void update(@NotNull @PathParam("id") String id, @NotNull @Valid OAuthApp app) {
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void update(@NotNull @PathParam("id") final String id, @NotNull @Valid final OAuthApp app) {
         final Connector connector = dataMgr.fetch(Connector.class, id);
         if (connector == null) {
             throw new WebApplicationException(Response.Status.NOT_FOUND);
         }
 
         final Connector updated = new Connector.Builder().createFrom(connector)
-            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_ID_TAG, app.clientId)
-            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_SECRET_TAG, app.clientSecret)
-            .build();
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_ID_TAG, app.getClientId())
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_SECRET_TAG, app.getClientSecret()).build();
 
         dataMgr.update(updated);
 
-        final boolean shouldBeDerived = app.clientId != null && app.clientSecret != null;
+        final boolean shouldBeDerived = app.getClientId() != null && app.getClientSecret() != null;
 
-        dataMgr.fetchAllByPropertyValue(Connection.class, "connectorId", id).forEach(connection -> toggleDerived(connection, shouldBeDerived));
+        dataMgr.fetchAllByPropertyValue(Connection.class, "connectorId", id)
+            .forEach(connection -> toggleDerived(connection, shouldBeDerived));
     }
 
     private void toggleDerived(final Connection connection, final boolean newDerived) {
@@ -152,11 +140,14 @@ public class OAuthAppHandler {
         dataMgr.update(underived);
     }
 
-    private static boolean isOauthConnector(Connector connector) {
+    private static OAuthApp createOAuthApp(final Connector connector) {
+        return new OAuthApp(connector);
+    }
+
+    private static boolean isOauthConnector(final Connector connector) {
         return connector.getProperties().values().stream().anyMatch(x -> {
-                return x.getTags().contains(Credentials.CLIENT_ID_TAG);
-            }
-        );
+            return x.getTags().contains(Credentials.CLIENT_ID_TAG);
+        });
     }
 
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
@@ -124,7 +124,11 @@ public class OAuthAppHandler {
 
         final Connector updated = new Connector.Builder().createFrom(connector)
             .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_ID_TAG, app.getClientId())
-            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_SECRET_TAG, app.getClientSecret()).build();
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.CLIENT_SECRET_TAG, app.getClientSecret())
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.AUTHORIZATION_URL_TAG, app.getAuthorizationUrl())
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.ACCESS_TOKEN_URL_TAG, app.getTokenUrl())
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.SCOPE_TAG, app.getScopes())//
+            .build();
 
         dataMgr.update(updated);
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.setup;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.Credentials;
+
+final class OAuthConnectorFilter implements Function<ListResult<Connector>, ListResult<Connector>> {
+
+    public static final Function<ListResult<Connector>, ListResult<Connector>> INSTANCE = new OAuthConnectorFilter();
+
+    private OAuthConnectorFilter() {
+    }
+
+    @Override
+    public ListResult<Connector> apply(final ListResult<Connector> result) {
+        final List<Connector> oauthConnectors = result.getItems().stream()
+            .filter(c -> c.propertyEntryTaggedWith(Credentials.CLIENT_ID_TAG).isPresent()).collect(Collectors.toList());
+
+        return ListResult.of(oauthConnectors);
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
@@ -1,12 +1,11 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.setup;
+
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.Credentials;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuthConnectorFilterTest {
+
+    @Test
+    public void shouldFilterOutNonOAuthConnectors() {
+        final Connector connector1 = new Connector.Builder().build();
+        final Connector connector2 = new Connector.Builder()
+            .putProperty("clientId", new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_ID_TAG).build())
+            .putConfiguredProperty("clientId", "my-client-id").build();
+        final Connector connector3 = new Connector.Builder()
+            .putProperty("clientId", new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_ID_TAG).build()).build();
+
+        final ListResult<Connector> result = ListResult.of(connector1, connector2, connector3);
+
+        assertThat(OAuthConnectorFilter.INSTANCE.apply(result)).containsOnly(connector2, connector3);
+    }
+}

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
@@ -176,6 +176,10 @@ public abstract class BaseITCase {
         return http(HttpMethod.GET, url, null, responseClass, token, expectedStatus);
     }
 
+    protected <T> ResponseEntity<T> get(String url, ParameterizedTypeReference<T> responseClass) {
+        return http(HttpMethod.GET, url, null, responseClass, tokenRule.validToken(), new HttpHeaders(), HttpStatus.OK);
+    }
+
     protected <T> ResponseEntity<T> get(String url, ParameterizedTypeReference<T> responseClass, String token, HttpStatus expectedStatus) {
         return http(HttpMethod.GET, url, null, responseClass, token, new HttpHeaders(), expectedStatus);
     }
@@ -202,6 +206,10 @@ public abstract class BaseITCase {
 
     protected <T> ResponseEntity<T> post(String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus, HttpHeaders headers) {
         return http(HttpMethod.POST, url, body, responseClass, token, headers, expectedStatus);
+    }
+
+    protected <T> ResponseEntity<T> put(String url, Object body) {
+        return put(url, body, null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
     }
 
     protected <T> ResponseEntity<T> put(String url, Object body, Class<T> responseClass, String token, HttpStatus expectedStatus) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
@@ -15,13 +15,22 @@
  */
 package io.syndesis.server.runtime;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.awaitility.Awaitility.given;
-
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.CredentialFlowState;
+import io.syndesis.server.credential.CredentialProvider;
+import io.syndesis.server.credential.CredentialProviderLocator;
+import io.syndesis.server.credential.OAuth1CredentialFlowState;
+import io.syndesis.server.credential.OAuth1CredentialProvider;
+import io.syndesis.server.endpoint.v1.handler.setup.OAuthApp;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,86 +39,121 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.social.oauth1.OAuthToken;
 
-import io.syndesis.server.credential.CredentialFlowState;
-import io.syndesis.server.credential.CredentialProvider;
-import io.syndesis.server.credential.CredentialProviderLocator;
-import io.syndesis.server.credential.OAuth1CredentialFlowState;
-import io.syndesis.server.credential.OAuth1CredentialProvider;
-import io.syndesis.common.model.connection.Connection;
-import io.syndesis.server.endpoint.v1.handler.setup.OAuthAppHandler;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.awaitility.Awaitility.given;
 
 /**
  * /setup/* related endpoint tests.
  */
 public class SetupITCase extends BaseITCase {
 
+    @JsonDeserialize
+    public static class OAuthResult implements ListResult<OAuthApp> {
+
+        private List<OAuthApp> items = new ArrayList<>();
+
+        @Override
+        public List<OAuthApp> getItems() {
+            return items;
+        }
+
+        @Override
+        public int getTotalCount() {
+            return items.size();
+        }
+
+        public void setItems(final List<OAuthApp> items) {
+            this.items = items;
+        }
+    }
+
     @Autowired
     protected CredentialProviderLocator locator;
 
     @Test
     public void getOauthApps() {
-
-        ResponseEntity<OAuthAppHandler.OAuthApp[]> result = get("/api/v1/setup/oauth-apps",
-                OAuthAppHandler.OAuthApp[].class);
-        List<OAuthAppHandler.OAuthApp> apps = Arrays.asList(result.getBody());
+        final ResponseEntity<OAuthResult> result = get("/api/v1/setup/oauth-apps", OAuthResult.class);
+        final List<OAuthApp> apps = result.getBody().getItems();
         assertThat(apps.size()).isEqualTo(2);
 
-        OAuthAppHandler.OAuthApp twitter = apps.stream().filter(x -> "twitter".equals(x.id)).findFirst().get();
-        assertThat(twitter.id).isEqualTo("twitter");
-        assertThat(twitter.name).isEqualTo("Twitter");
-        assertThat(twitter.icon).startsWith("data:image/svg+xml;base64");
-        assertThat(twitter.clientId).isNull();
-        assertThat(twitter.clientSecret).isNull();
+        final OAuthApp twitter = apps.stream().filter(x -> "twitter".equals(x.getId())).findFirst().get();
+        assertThat(twitter.getId()).isEqualTo("twitter");
+        assertThat(twitter.getName()).isEqualTo("Twitter");
+        assertThat(twitter.getIcon()).startsWith("data:image/svg+xml;base64");
+        assertThat(twitter.getClientId()).isNull();
+        assertThat(twitter.getClientSecret()).isNull();
 
     }
 
     @Test
+    public void shouldDeleteOAuthSettings() {
+        final OAuthApp twitter = new OAuthApp();
+        twitter.setClientId("test-id");
+        twitter.setClientSecret("test-secret");
+
+        put("/api/v1/setup/oauth-apps/twitter", twitter);
+
+        given().ignoreExceptions().await().atMost(10, SECONDS).pollInterval(1, SECONDS).until(() -> {
+            return locator.providerWithId("twitter") != null;
+        });
+
+        delete("/api/v1/setup/oauth-apps/twitter");
+
+        given().ignoreExceptions().await().atMost(10, SECONDS).pollInterval(1, SECONDS).until(() -> {
+            try {
+                return locator.providerWithId("twitter") == null;
+            } catch (final IllegalArgumentException e) {
+                return e.getMessage().startsWith("No property tagged with `oauth-client-id` on connector");
+            }
+        });
+
+        final Connector connector = dataManager.fetch(Connector.class, "twitter");
+
+        assertThat(connector).isNotNull();
+    }
+
+    @Test
     public void updateOauthApp() {
-        // Validate initial state assumptions.
-        getOauthApps();
+        OAuthApp twitter = new OAuthApp();
+        twitter.setClientId("test-id");
+        twitter.setClientSecret("test-secret");
 
-        OAuthAppHandler.OAuthApp twitter = new OAuthAppHandler.OAuthApp();
-        twitter.clientId = "test-id";
-        twitter.clientSecret = "test-secret";
+        http(HttpMethod.PUT, "/api/v1/setup/oauth-apps/twitter", twitter, null, tokenRule.validToken(), HttpStatus.NO_CONTENT);
 
-        http(HttpMethod.PUT, "/api/v1/setup/oauth-apps/twitter", twitter, null, tokenRule.validToken(),
-                HttpStatus.NO_CONTENT);
-
-        ResponseEntity<OAuthAppHandler.OAuthApp[]> result = get("/api/v1/setup/oauth-apps",
-                OAuthAppHandler.OAuthApp[].class);
-        List<OAuthAppHandler.OAuthApp> apps = Arrays.asList(result.getBody());
+        final ResponseEntity<OAuthResult> result = get("/api/v1/setup/oauth-apps", OAuthResult.class);
+        final List<OAuthApp> apps = result.getBody().getItems();
         assertThat(apps.size()).isEqualTo(2);
 
-        twitter = apps.stream().filter(x -> "twitter".equals(x.id)).findFirst().get();
-        assertThat(twitter.id).isEqualTo("twitter");
-        assertThat(twitter.name).isEqualTo("Twitter");
-        assertThat(twitter.icon).startsWith("data:image/svg+xml;base64");
-        assertThat(twitter.clientId).isEqualTo("test-id");
-        assertThat(twitter.clientSecret).isEqualTo("test-secret");
+        twitter = apps.stream().filter(x -> "twitter".equals(x.getId())).findFirst().get();
+        assertThat(twitter.getId()).isEqualTo("twitter");
+        assertThat(twitter.getName()).isEqualTo("Twitter");
+        assertThat(twitter.getIcon()).startsWith("data:image/svg+xml;base64");
+        assertThat(twitter.getClientId()).isEqualTo("test-id");
+        assertThat(twitter.getClientSecret()).isEqualTo("test-secret");
 
         // Now that we have configured the app, we should be able to create the
         // connection factory.
-        // The connection factory is setup async so we might need to wait a little bit
-        // for it to register.
+        // The connection factory is setup async so we might need to wait a
+        // little bit for it to register.
         given().ignoreExceptions().await().atMost(10, SECONDS).pollInterval(1, SECONDS).until(() -> {
             final CredentialProvider twitterCredentialProvider = locator.providerWithId("twitter");
 
-            // preparing is something we could not do with a `null` ConnectionFactory
-            assertThat(twitterCredentialProvider).isNotNull().isInstanceOfSatisfying(OAuth1CredentialProvider.class,
-                    p -> {
-                        final Connection connection = new Connection.Builder().build();
-                        final CredentialFlowState flowState = new OAuth1CredentialFlowState.Builder()
-                                .accessToken(new OAuthToken("value", "secret")).connectorId("connectorId").build();
-                        final Connection appliedTo = p.applyTo(connection, flowState);
+            // preparing is something we could not do with a `null`
+            // ConnectionFactory
+            assertThat(twitterCredentialProvider).isNotNull().isInstanceOfSatisfying(OAuth1CredentialProvider.class, p -> {
+                final Connection connection = new Connection.Builder().build();
+                final CredentialFlowState flowState = new OAuth1CredentialFlowState.Builder().accessToken(new OAuthToken("value", "secret"))
+                    .connectorId("connectorId").build();
+                final Connection appliedTo = p.applyTo(connection, flowState);
 
-                        // test that the updated values are used
-                        assertThat(appliedTo.getConfiguredProperties())
-                            .contains(entry("consumerKey", "test-id"), entry("consumerSecret", "test-secret"));
-                    });
+                // test that the updated values are used
+                assertThat(appliedTo.getConfiguredProperties()).contains(entry("consumerKey", "test-id"),
+                    entry("consumerSecret", "test-secret"));
+            });
 
             return true;
         });
 
     }
-
 }

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
@@ -27,6 +27,21 @@ const OAUTH_APP_FORM_CONFIG = {
     displayName: 'Client Secret',
     type: 'password',
     labelHint: 'The OAuth client secret value for the target application'
+  },
+  authorizationUrl: {
+    displayName: 'Authorization URL',
+    type: 'string',
+    labelHint: 'URL to the authorization endpoint of the target application'
+  },
+  tokenUrl: {
+    displayName: 'Access Token URL',
+    type: 'string',
+    labelHint: 'URL to the access token endpoint of the target application'
+  },
+  scopes: {
+    displayName: 'OAuth scopes',
+    type: 'string',
+    labelHint: 'Comma separated list of OAuth scopes used when requesting authorization from the target application'
   }
 };
 

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
@@ -47,7 +47,14 @@ export class OAuthAppModalComponent {
 
   // Clear the store credentials for the selected oauth app
   removeCredentials() {
-    const app = { ...this.item.client, clientId: null, clientSecret: null };
+    const app = {
+      ...this.item.client,
+      clientId: null,
+      clientSecret: null,
+      authorizationUrl: null,
+      tokenUrl: null,
+      scopes: null
+    };
     return this.store
       .delete(app)
       .take(1)

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
@@ -49,7 +49,7 @@ export class OAuthAppModalComponent {
   removeCredentials() {
     const app = { ...this.item.client, clientId: null, clientSecret: null };
     return this.store
-      .update(app)
+      .delete(app)
       .take(1)
       .toPromise();
   }

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -244,6 +244,9 @@ export abstract class AbstractStore<
     const deleted = new Subject<T>();
     this.service.delete(entity).subscribe(
       e => {
+        if (e === null) {
+          e = entity;
+        }
         deleted.next(this.plain(e));
       },
       error => {


### PR DESCRIPTION
This allows editing of scopes, token and authorization endpoints.

Also adds a check to see if the resolved value from `service::delete` is
`null` and uses the given `entity` instead for the resolved value.

Fixes #2767, #2718