### PR TITLE
chore: upgrade resteasy to 3.5.1.Final

### DIFF
--- a/app/common/pom.xml
+++ b/app/common/pom.xml
@@ -74,6 +74,7 @@
   <modules>
 	  <module>util</module>
     <module>model</module>
+    <module>resteasy-spring-boot-starter</module>
   </modules>
 
   <dependencyManagement>

--- a/app/common/resteasy-spring-boot-starter/pom.xml
+++ b/app/common/resteasy-spring-boot-starter/pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.syndesis.common</groupId>
+        <artifactId>common-parent</artifactId>
+        <version>1.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>common-resteasy-spring-boot-starter</artifactId>
+    <name>Common :: RESTEasy :: Spring Boot Starter</name>
+
+    <description>A Spring Boot starter for RESTEasy</description>
+    <url>https://github.com/paypal/resteasy-spring-boot</url>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Fabio Carvalho</name>
+            <email>facarvalho@paypal.com</email>
+            <organization>PayPal</organization>
+            <organizationUrl>http://www.paypal.com</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:git@github.com:paypal/resteasy-spring-boot.git</connection>
+        <developerConnection>scm:git:git@github.com:paypal/resteasy-spring-boot.git</developerConnection>
+        <url>git@github.com:paypal/resteasy-spring-boot.git</url>
+    </scm>
+
+    <properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <coverage.line>80</coverage.line>
+        <coverage.branch>80</coverage.branch>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-servlet-initializer</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-spring</artifactId>
+            <version>${resteasy.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jettison-provider</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng-common</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUnusedDeclaredDependencies>
+                        <ignoredUnusedDeclaredDependency>org.jboss.resteasy:resteasy-jackson2-provider</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.jboss.resteasy:resteasy-servlet-initializer</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-web</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/JaxrsApplicationScanner.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/JaxrsApplicationScanner.java
@@ -1,0 +1,65 @@
+package com.paypal.springboot.resteasy;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.ws.rs.core.Application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Helper class to scan the classpath under the specified packages
+ * searching for JAX-RS Application sub-classes
+ *
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+public class JaxrsApplicationScanner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsApplicationScanner.class);
+
+    public static Set<Class<? extends Application>> getApplications(List<String> packagesToBeScanned) {
+        return findJaxrsApplicationClasses(packagesToBeScanned);
+    }
+
+    /*
+     * Scan the classpath under the specified packages looking for JAX-RS Application sub-classes
+     */
+    @SuppressWarnings("unchecked")
+    private static Set<Class<? extends Application>> findJaxrsApplicationClasses(List<String> packagesToBeScanned) {
+        LOGGER.info("Scanning classpath to find JAX-RS Application classes");
+
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(Application.class));
+
+        Set<BeanDefinition> candidates = new HashSet<>();
+        Set<BeanDefinition> candidatesSubSet;
+
+        for (String packageToScan : packagesToBeScanned) {
+            candidatesSubSet = scanner.findCandidateComponents(packageToScan);
+            candidates.addAll(candidatesSubSet);
+        }
+
+        Set<Class<? extends Application>> classes = new HashSet<>();
+        ClassLoader classLoader = JaxrsApplicationScanner.class.getClassLoader();
+        Class<? extends Application> type;
+        for (BeanDefinition candidate : candidates) {
+            try {
+                type = (Class<? extends Application>) ClassUtils.forName(candidate.getBeanClassName(), classLoader);
+                classes.add(type);
+            } catch (ClassNotFoundException e) {
+                LOGGER.error("JAX-RS Application subclass could not be loaded", e);
+            }
+        }
+
+        // We don't want the JAX-RS Application class itself in there
+        classes.remove(Application.class);
+
+        return classes;
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/JaxrsApplicationScanner.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/JaxrsApplicationScanner.java
@@ -18,9 +18,11 @@ import org.springframework.util.ClassUtils;
  *
  * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
  */
-public class JaxrsApplicationScanner {
-
+public final class JaxrsApplicationScanner {
     private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsApplicationScanner.class);
+
+    private JaxrsApplicationScanner() {
+    }
 
     public static Set<Class<? extends Application>> getApplications(List<String> packagesToBeScanned) {
         return findJaxrsApplicationClasses(packagesToBeScanned);

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyApplicationBuilder.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyApplicationBuilder.java
@@ -1,0 +1,105 @@
+package com.paypal.springboot.resteasy;
+
+import java.util.Set;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletContainerInitializer;
+
+import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+
+/**
+ * This class is the Spring Boot equivalent of {@link ResteasyServletInitializer},
+ * which implements the Servlet API {@link ServletContainerInitializer} interface
+ * to find all JAX-RS Application, Provider and Path classes in the classpath.
+ * <p>
+ * As we all know, in Spring Boot we use an embedded servlet container. However,
+ * the Servlet spec does not support embedded containers, and many portions of it
+ * do not apply to embedded containers, and ServletContainerInitializer is one of them.
+ * <p>
+ * This class fills in this gap.
+ * <p>
+ * Notice that the JAX-RS Application classes are found in this RESTEasy starter by class
+ * ResteasyEmbeddedServletInitializer, and that is done by scanning the classpath.
+ * <p>
+ * The Path and Provider annotated classes are found by using Spring framework (instead of
+ * scanning the classpath), since it is assumed those classes are ALWAYS necessarily
+ * Spring beans (this starter is meant for Spring Boot applications that use RESTEasy
+ * as the JAX-RS implementation)
+ *
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+public class ResteasyApplicationBuilder {
+
+    public static final String BEAN_NAME = "JaxrsApplicationServletBuilder";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResteasyApplicationBuilder.class);
+
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.UseStringBufferForStringAppends"})
+    public ServletRegistrationBean build(String applicationClassName, String path, Set<Class<?>> resources, Set<Class<?>> providers) {
+        Servlet servlet = new HttpServlet30Dispatcher();
+
+        ServletRegistrationBean servletRegistrationBean = new ServletRegistrationBean(servlet);
+
+        servletRegistrationBean.setName(applicationClassName);
+        servletRegistrationBean.setLoadOnStartup(1);
+        servletRegistrationBean.setAsyncSupported(true);
+        servletRegistrationBean.addInitParameter("javax.ws.rs.Application", applicationClassName);
+
+        if (path != null) {
+            String mapping = path;
+            if (!mapping.startsWith("/")) {
+                mapping = "/" + mapping;
+            }
+            String prefix = mapping;
+            if (!"/".equals(prefix) && prefix.endsWith("/")) {
+                prefix = prefix.substring(0, prefix.length() - 1);
+            }
+            if (mapping.endsWith("/")) {
+                mapping += "*";
+            } else {
+                mapping += "/*";
+            }
+            // resteasy.servlet.mapping.prefix
+            servletRegistrationBean.addInitParameter("resteasy.servlet.mapping.prefix", prefix);
+            servletRegistrationBean.addUrlMappings(mapping);
+        }
+
+        if (!resources.isEmpty()) {
+            StringBuilder builder = new StringBuilder();
+            boolean first = true;
+            for (Class<?> resource : resources) {
+                if (first) {
+                    first = false;
+                } else {
+                    builder.append(',');
+                }
+
+                builder.append(resource.getName());
+            }
+            servletRegistrationBean.addInitParameter(ResteasyContextParameters.RESTEASY_SCANNED_RESOURCES, builder.toString());
+        }
+        if (!providers.isEmpty()) {
+            StringBuilder builder = new StringBuilder();
+            boolean first = true;
+            for (Class<?> provider : providers) {
+                if (first) {
+                    first = false;
+                } else {
+                    builder.append(',');
+                }
+                builder.append(provider.getName());
+            }
+            servletRegistrationBean.addInitParameter(ResteasyContextParameters.RESTEASY_SCANNED_PROVIDERS, builder.toString());
+        }
+
+        LOGGER.debug("ServletRegistrationBean has just bean created for JAX-RS class {}", applicationClassName);
+
+        return servletRegistrationBean;
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyApplicationBuilder.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyApplicationBuilder.java
@@ -39,7 +39,7 @@ public class ResteasyApplicationBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResteasyApplicationBuilder.class);
 
-    @SuppressWarnings({"PMD.NPathComplexity", "PMD.UseStringBufferForStringAppends"})
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.UseStringBufferForStringAppends", "PMD.SimplifyStartsWith"})
     public ServletRegistrationBean build(String applicationClassName, String path, Set<Class<?>> resources, Set<Class<?>> providers) {
         Servlet servlet = new HttpServlet30Dispatcher();
 

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyAutoConfiguration.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyAutoConfiguration.java
@@ -1,0 +1,118 @@
+package com.paypal.springboot.resteasy;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.jboss.resteasy.core.AsynchronousDispatcher;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.ResourceMethodRegistry;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+import org.jboss.resteasy.plugins.spring.SpringBeanProcessor;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This is the main class that configures this Resteasy Sring Boot starter
+ *
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+@Configuration
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+@EnableConfigurationProperties
+public class ResteasyAutoConfiguration {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResteasyAutoConfiguration.class);
+
+    @Bean
+    @Qualifier("ResteasyProviderFactory")
+    public static BeanFactoryPostProcessor springBeanProcessor() {
+        ResteasyProviderFactory resteasyProviderFactory = new ResteasyProviderFactory();
+        ResourceMethodRegistry resourceMethodRegistry = new ResourceMethodRegistry(resteasyProviderFactory);
+
+        SpringBeanProcessor springBeanProcessor = new SpringBeanProcessor();
+        springBeanProcessor.setProviderFactory(resteasyProviderFactory);
+        springBeanProcessor.setRegistry(resourceMethodRegistry);
+
+        LOGGER.debug("SpringBeanProcessor has been created");
+
+        return springBeanProcessor;
+    }
+
+    /**
+     * This is a modified version of {@link ResteasyBootstrap}
+     *
+     * @return a ServletContextListener object that configures and start a ResteasyDeployment
+     */
+    @Bean
+    public ServletContextListener resteasyBootstrapListener(@Qualifier("ResteasyProviderFactory") final BeanFactoryPostProcessor beanFactoryPostProcessor) {
+        ServletContextListener servletContextListener = new ServletContextListener() {
+
+            private SpringBeanProcessor springBeanProcessor = (SpringBeanProcessor) beanFactoryPostProcessor;
+
+            protected ResteasyDeployment deployment;
+
+            @Override
+            public void contextInitialized(ServletContextEvent sce) {
+                ServletContext servletContext = sce.getServletContext();
+
+                ListenerBootstrap config = new ListenerBootstrap(servletContext);
+
+                ResteasyProviderFactory resteasyProviderFactory = springBeanProcessor.getProviderFactory();
+                ResourceMethodRegistry resourceMethodRegistry = (ResourceMethodRegistry) springBeanProcessor.getRegistry();
+
+                deployment = config.createDeployment();
+
+                deployment.setProviderFactory(resteasyProviderFactory);
+                deployment.setRegistry(resourceMethodRegistry);
+
+                if (deployment.isAsyncJobServiceEnabled()) {
+                    AsynchronousDispatcher dispatcher = new AsynchronousDispatcher(resteasyProviderFactory, resourceMethodRegistry);
+                    deployment.setDispatcher(dispatcher);
+                } else {
+                    SynchronousDispatcher dispatcher = new SynchronousDispatcher(resteasyProviderFactory, resourceMethodRegistry);
+                    deployment.setDispatcher(dispatcher);
+                }
+
+                deployment.start();
+
+                servletContext.setAttribute(ResteasyProviderFactory.class.getName(), deployment.getProviderFactory());
+                servletContext.setAttribute(Dispatcher.class.getName(), deployment.getDispatcher());
+                servletContext.setAttribute(Registry.class.getName(), deployment.getRegistry());
+            }
+
+            @Override
+            public void contextDestroyed(ServletContextEvent sce) {
+                if (deployment != null) {
+                    deployment.stop();
+                }
+            }
+        };
+
+        LOGGER.debug("ServletContextListener has been created");
+
+        return servletContextListener;
+    }
+
+    @Bean(name = ResteasyApplicationBuilder.BEAN_NAME)
+    public ResteasyApplicationBuilder resteasyApplicationBuilder() {
+        return new ResteasyApplicationBuilder();
+    }
+
+    @Bean
+    public static ResteasyEmbeddedServletInitializer resteasyEmbeddedServletInitializer() {
+        return new ResteasyEmbeddedServletInitializer();
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializer.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializer.java
@@ -1,0 +1,330 @@
+package com.paypal.springboot.resteasy;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * This is a Spring version of {@link ResteasyServletInitializer}.
+ * It does not register the servlets though, that is done by {@link ResteasyApplicationBuilder}
+ * It only finds the JAX-RS Application classes (by scanning the classpath), and
+ * the JAX-RS Path and Provider annotated Spring beans, and then register the
+ * Spring bean definitions that represent each servlet registration.
+ *
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+public class ResteasyEmbeddedServletInitializer implements BeanFactoryPostProcessor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResteasyEmbeddedServletInitializer.class);
+
+    private static final String JAXRS_APP_CLASSES_DEFINITION_PROPERTY = "resteasy.jaxrs.app.registration";
+    private static final String JAXRS_APP_CLASSES_PROPERTY = "resteasy.jaxrs.app.classes";
+
+    // This is how JAXRS_APP_CLASSES_PROPERTY was named originally. It conflicted with "resteasy.jaxrs.app.registration"
+    // in case of YAML files, since registration was a child of app from an YAML perspective, which is not allowed.
+    // Because of that its name was changed (the ".classes" suffix was added).
+    // This legacy property has not been removed though, to keep backward compatibility, but it is marked as deprecated. It will be
+    // available only for .properties files, but not for YAML files. It should be finally removed in a future major release.
+    private static final String JAXRS_APP_CLASSES_PROPERTY_LEGACY = "resteasy.jaxrs.app";
+
+    private Set<Class<? extends Application>> applications = new HashSet<>();
+    private Set<Class<?>> allResources = new HashSet<>();
+    private Set<Class<?>> providers = new HashSet<>();
+
+    private enum JaxrsAppClassesRegistration {
+        BEANS, PROPERTY, SCANNING, AUTO
+    }
+
+    /*
+     * Find the JAX-RS application classes.
+     * This is done by one of these three options in this order:
+     *
+     * 1- By having them defined as Spring beans
+     * 2- By setting property {@code resteasy.jaxrs.app.classes} via Spring Boot application properties file.
+     *    This property should contain a comma separated list of JAX-RS sub-classes
+     * 3- Via classpath scanning (looking for javax.ws.rs.core.Application sub-classes)
+     *
+     * First try to find JAX-RS Application sub-classes defined as Spring beans. If that is existent,
+     * the search stops, and those are the only JAX-RS applications to be registered.
+     * If no JAX-RS application Spring beans are found, then see if Spring Boot property {@code resteasy.jaxrs.app.classes}
+     * has been set. If it has, the search stops, and those are the only JAX-RS applications to be registered.
+     * If not, then scan the classpath searching for JAX-RS applications.
+     *
+     * There is a way though to force one of the options above, which is by setting property
+     * {@code resteasy.jaxrs.app.registration} via Spring Boot application properties file. The possible valid
+     * values are {@code beans}, {@code property}, {@code scanning} or {@code auto}. If this property is not
+     * present, the default value is {@code auto}, which means every approach will be tried in the order and way
+     * explained earlier.
+     *
+     * @param beanFactory
+     */
+    private void findJaxrsApplications(ConfigurableListableBeanFactory beanFactory) {
+        LOGGER.info("Finding JAX-RS Application classes");
+
+        JaxrsAppClassesRegistration registration = getJaxrsAppClassesRegistration(beanFactory);
+
+        switch (registration) {
+            case AUTO:
+                findJaxrsApplicationBeans(beanFactory);
+                if(applications.isEmpty()) {
+                    findJaxrsApplicationProperty(beanFactory);
+                }
+                if(applications.isEmpty()) {
+                    findJaxrsApplicationScanning(beanFactory);
+                }
+                break;
+            case BEANS:
+                findJaxrsApplicationBeans(beanFactory);
+                break;
+            case PROPERTY:
+                findJaxrsApplicationProperty(beanFactory);
+                break;
+            case SCANNING:
+                // TODO
+                // Remove this warning after implementing
+                // https://github.com/paypal/resteasy-spring-boot/issues/69
+                LOGGER.warn("\n-------------\nStarting on version 3.0.0, the behavior of the `scanning` JAX-RS Application subclass registration method will change, being more restrictive.\nInstead of scanning the whole classpath, it will scan only packages registered to be scanned by Spring framework (regardless of the JAX-RS Application subclass being a Spring bean or not). The reason is to improve application startup performance.\nHaving said that, it is recommended that every application use any method, other than `scanning`. Or, if using `scanning`, make sure your JAX-RS Application subclass is under a package to be scanned by Spring framework. If not, starting on version 3.0.0,it won't be found.\n-------------");
+                findJaxrsApplicationScanning(beanFactory);
+                break;
+            default:
+                LOGGER.error("JAX-RS application registration method (%s) not known, no application will be registered", registration.name());
+                break;
+        }
+
+        for (Class<? extends Application> appClass : applications) {
+            LOGGER.info("JAX-RS Application class found: {}", appClass.getName());
+        }
+    }
+
+    @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
+    private JaxrsAppClassesRegistration getJaxrsAppClassesRegistration(ConfigurableListableBeanFactory beanFactory) {
+        ConfigurableEnvironment configurableEnvironment = beanFactory.getBean(ConfigurableEnvironment.class);
+        String jaxrsAppClassesRegistration = configurableEnvironment.getProperty(JAXRS_APP_CLASSES_DEFINITION_PROPERTY);
+        JaxrsAppClassesRegistration registration = JaxrsAppClassesRegistration.AUTO;
+
+        if (jaxrsAppClassesRegistration == null) {
+            LOGGER.info("Property {} has not been set, JAX-RS Application classes registration is being set to AUTO", JAXRS_APP_CLASSES_DEFINITION_PROPERTY);
+        } else {
+            LOGGER.info("Property {} has been set to {}", JAXRS_APP_CLASSES_DEFINITION_PROPERTY, jaxrsAppClassesRegistration);
+            try {
+                registration = JaxrsAppClassesRegistration.valueOf(jaxrsAppClassesRegistration.toUpperCase());
+            } catch(IllegalArgumentException ex) {
+                String errorMesage = String.format("Property %s has not been properly set, value %s is invalid. JAX-RS Application classes registration is being set to AUTO.", JAXRS_APP_CLASSES_DEFINITION_PROPERTY, jaxrsAppClassesRegistration);
+                LOGGER.error(errorMesage);
+                throw new IllegalArgumentException(errorMesage, ex);
+            }
+        }
+
+        return registration;
+    }
+
+    /*
+     * Find JAX-RS application classes by searching for their related
+     * Spring beans
+     *
+     * @param beanFactory
+     */
+    private void findJaxrsApplicationBeans(ConfigurableListableBeanFactory beanFactory) {
+        LOGGER.info("Searching for JAX-RS Application Spring beans");
+
+        Map<String, Application> applicationBeans = beanFactory.getBeansOfType(Application.class, true, false);
+        if (applicationBeans == null || applicationBeans.isEmpty()) {
+            LOGGER.info("No JAX-RS Application Spring beans found");
+            return;
+        }
+
+        for (Application application : applicationBeans.values()) {
+            applications.add(application.getClass());
+        }
+    }
+
+    /*
+     * Find JAX-RS application classes via property {@code resteasy.jaxrs.app.classes}
+     */
+    @SuppressWarnings("unchecked")
+    private void findJaxrsApplicationProperty(ConfigurableListableBeanFactory beanFactory) {
+        ConfigurableEnvironment configurableEnvironment = beanFactory.getBean(ConfigurableEnvironment.class);
+        String jaxrsAppsProperty = configurableEnvironment.getProperty(JAXRS_APP_CLASSES_PROPERTY);
+        if (jaxrsAppsProperty == null) {
+            jaxrsAppsProperty = configurableEnvironment.getProperty(JAXRS_APP_CLASSES_PROPERTY_LEGACY);
+            if(jaxrsAppsProperty == null) {
+                LOGGER.info("No JAX-RS Application set via property {}", JAXRS_APP_CLASSES_PROPERTY);
+                return;
+            }
+            LOGGER.warn("Property {} has been set. Notice that this property has been deprecated and will be removed soon. Please replace it by property {}", JAXRS_APP_CLASSES_PROPERTY_LEGACY, JAXRS_APP_CLASSES_PROPERTY);
+        } else {
+            LOGGER.info("Property {} has been set to {}", JAXRS_APP_CLASSES_PROPERTY, jaxrsAppsProperty);
+        }
+
+        String[] jaxrsClassNames = jaxrsAppsProperty.split(",", -1);
+
+        for(String jaxrsClassName : jaxrsClassNames) {
+            Class<? extends Application> jaxrsClass = null;
+            try {
+                jaxrsClass = (Class<? extends Application>) Class.forName(jaxrsClassName.trim());
+            } catch (ClassNotFoundException e) {
+                String exceptionMessage = String.format("JAX-RS Application class %s has not been found", jaxrsClassName.trim());
+                LOGGER.error(exceptionMessage, e);
+                throw new BeansException(exceptionMessage, e){};
+            }
+            applications.add(jaxrsClass);
+        }
+    }
+
+    /*
+     * Find JAX-RS application classes by scanning the classpath under
+     * packages already marked to be scanned by Spring framework
+     */
+    private void findJaxrsApplicationScanning(BeanFactory beanFactory) {
+        List<String> packagesToBeScanned = getSpringApplicationPackages(beanFactory);
+
+        Set<Class<? extends Application>> applications = JaxrsApplicationScanner.getApplications(packagesToBeScanned);
+        if(applications == null || applications.isEmpty()) {
+            return;
+        }
+        this.applications.addAll(applications);
+    }
+
+    /*
+     * Return the name of the packages to be scanned by Spring framework
+     */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
+    private List<String> getSpringApplicationPackages(BeanFactory beanFactory) {
+        // TODO
+        // See https://github.com/paypal/resteasy-spring-boot/issues/69
+
+        List<String> packages = new ArrayList<>();
+        packages.add("");
+        return packages;
+    }
+
+    /*
+     * Search for JAX-RS resource and provider Spring beans,
+     * which are the ones whose classes are annotated with
+     * {@link Path} or {@link Provider} respectively
+     *
+     * @param beanFactory
+     */
+    private void findJaxrsResourcesAndProviderClasses(ConfigurableListableBeanFactory beanFactory) {
+        LOGGER.debug("Finding JAX-RS resources and providers Spring bean classes");
+
+        String[] resourceBeans = beanFactory.getBeanNamesForAnnotation(Path.class);
+        String[] providerBeans = beanFactory.getBeanNamesForAnnotation(Provider.class);
+
+        if(resourceBeans != null) {
+            for(String resourceBean : resourceBeans) {
+                allResources.add(beanFactory.getType(resourceBean));
+            }
+        }
+
+        if(providerBeans != null) {
+            for(String providerBean : providerBeans) {
+                providers.add(beanFactory.getType(providerBean));
+            }
+        }
+
+        if(LOGGER.isDebugEnabled()) {
+            for (Object resourceClass : allResources.toArray()) {
+                LOGGER.debug("JAX-RS resource class found: {}", ((Class) resourceClass).getName());
+            }
+        }
+        if(LOGGER.isDebugEnabled()) {
+            for (Object providerClass: providers.toArray()) {
+                LOGGER.debug("JAX-RS provider class found: {}", ((Class) providerClass).getName());
+            }
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        LOGGER.debug("Post process bean factory has been called");
+
+        findJaxrsApplications(beanFactory);
+
+        // This is done by finding their related Spring beans
+        findJaxrsResourcesAndProviderClasses(beanFactory);
+
+        if (allResources.isEmpty()) {
+            LOGGER.warn("No JAX-RS resource Spring beans have been found");
+        }
+        if (applications.isEmpty()) {
+            LOGGER.info("No JAX-RS Application classes have been found. A default, one mapped to '/', will be registered.");
+            registerDefaultJaxrsApp(beanFactory);
+            return;
+        }
+
+        BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+
+        for (Class<? extends Application> applicationClass : applications) {
+            ApplicationPath path = AnnotationUtils.findAnnotation(applicationClass, ApplicationPath.class);
+            if (path == null) {
+                LOGGER.warn("JAX-RS Application class {} has no ApplicationPath annotation, so it will not be registered", applicationClass.getName());
+                continue;
+            }
+
+            LOGGER.debug("registering JAX-RS application class " + applicationClass.getName());
+
+            GenericBeanDefinition applicationServletBean = createApplicationServlet(applicationClass, path.value());
+            registry.registerBeanDefinition(applicationClass.getName(), applicationServletBean);
+        }
+
+    }
+
+    /**
+     * Register a default JAX-RS application, in case no other is present in the application.
+     * Read section 2.3.2 in JAX-RS 2.0 specification.
+     *
+     * @param beanFactory
+     */
+    private void registerDefaultJaxrsApp(ConfigurableListableBeanFactory beanFactory) {
+        BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+        GenericBeanDefinition applicationServletBean = createApplicationServlet(Application.class, "/");
+        registry.registerBeanDefinition(Application.class.getName(), applicationServletBean);
+    }
+
+    /**
+     * Creates a Servlet bean definition for the given JAX-RS application
+     *
+     * @param applicationClass
+     * @param path
+     * @return a Servlet bean definition for the given JAX-RS application
+     */
+    private GenericBeanDefinition createApplicationServlet(Class<? extends Application> applicationClass, String path) {
+        GenericBeanDefinition applicationServletBean = new GenericBeanDefinition();
+        applicationServletBean.setFactoryBeanName(ResteasyApplicationBuilder.BEAN_NAME);
+        applicationServletBean.setFactoryMethodName("build");
+
+        Set<Class<?>> resources = allResources;
+
+        ConstructorArgumentValues values = new ConstructorArgumentValues();
+        values.addIndexedArgumentValue(0, applicationClass.getName());
+        values.addIndexedArgumentValue(1, path);
+        values.addIndexedArgumentValue(2, resources);
+        values.addIndexedArgumentValue(3, providers);
+        applicationServletBean.setConstructorArgumentValues(values);
+
+        applicationServletBean.setAutowireCandidate(false);
+        applicationServletBean.setScope("singleton");
+
+        return applicationServletBean;
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializer.java
+++ b/app/common/resteasy-spring-boot-starter/src/main/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializer.java
@@ -45,9 +45,9 @@ public class ResteasyEmbeddedServletInitializer implements BeanFactoryPostProces
     // available only for .properties files, but not for YAML files. It should be finally removed in a future major release.
     private static final String JAXRS_APP_CLASSES_PROPERTY_LEGACY = "resteasy.jaxrs.app";
 
-    private Set<Class<? extends Application>> applications = new HashSet<>();
-    private Set<Class<?>> allResources = new HashSet<>();
-    private Set<Class<?>> providers = new HashSet<>();
+    private final Set<Class<? extends Application>> applications = new HashSet<>();
+    private final Set<Class<?>> allResources = new HashSet<>();
+    private final Set<Class<?>> providers = new HashSet<>();
 
     private enum JaxrsAppClassesRegistration {
         BEANS, PROPERTY, SCANNING, AUTO
@@ -280,7 +280,7 @@ public class ResteasyEmbeddedServletInitializer implements BeanFactoryPostProces
                 continue;
             }
 
-            LOGGER.debug("registering JAX-RS application class " + applicationClass.getName());
+            LOGGER.debug("registering JAX-RS application class {}", applicationClass.getName());
 
             GenericBeanDefinition applicationServletBean = createApplicationServlet(applicationClass, path.value());
             registry.registerBeanDefinition(applicationClass.getName(), applicationServletBean);

--- a/app/common/resteasy-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/app/common/resteasy-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+    com.paypal.springboot.resteasy.ResteasyAutoConfiguration

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/JaxrsAppRegistrationTest.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/JaxrsAppRegistrationTest.java
@@ -1,0 +1,255 @@
+package com.paypal.springboot.resteasy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
+
+import com.paypal.springboot.resteasy.sample.TestApplication1;
+import com.paypal.springboot.resteasy.sample.TestApplication2;
+import com.paypal.springboot.resteasy.sample.TestApplication3;
+import com.paypal.springboot.resteasy.sample.TestApplication4;
+import com.paypal.springboot.resteasy.sample.TestApplication5;
+import com.paypal.springboot.resteasy.sample.TestResource1;
+import com.paypal.springboot.resteasy.sample.TestResource2;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.api.mockito.mockpolicies.Slf4jMockPolicy;
+import org.powermock.core.classloader.annotations.MockPolicy;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Created by facarvalho on 7/19/16.
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+@PrepareForTest(AutoConfigurationPackages.class)
+@MockPolicy(Slf4jMockPolicy.class)
+public class JaxrsAppRegistrationTest extends PowerMockTestCase {
+
+    private static final String DEFINITION_PROPERTY = "resteasy.jaxrs.app.registration";
+    private static final String APP_CLASSES_PROPERTY = "resteasy.jaxrs.app.classes";
+    private static final String APP_CLASSES_PROPERTY_LEGACY = "resteasy.jaxrs.app";
+
+    private static Set<Class<?>> allPossibleAppClasses;
+
+    static {
+        Set<Class<?>> _allPossibleAppClasses = new HashSet<>();
+
+        _allPossibleAppClasses.add(TestApplication1.class);
+        _allPossibleAppClasses.add(TestApplication2.class);
+        _allPossibleAppClasses.add(TestApplication3.class);
+        _allPossibleAppClasses.add(TestApplication4.class);
+        _allPossibleAppClasses.add(TestApplication5.class);
+        _allPossibleAppClasses.add(Application.class);
+
+        allPossibleAppClasses = Collections.unmodifiableSet(_allPossibleAppClasses);
+    }
+
+    @BeforeMethod
+    public void beforeTest() {
+        PowerMockito.mockStatic(AutoConfigurationPackages.class);
+        List<String> packages = new ArrayList<String>();
+        packages.add("com.paypal.springboot.resteasy.sample");
+        PowerMockito.when(AutoConfigurationPackages.get(any(BeanFactory.class))).thenReturn(packages);
+    }
+
+    @Test
+    public void nullTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn(null);
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication1.class);
+        expectedRegisteredAppClasses.add(TestApplication2.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+        expectedRegisteredAppClasses.add(TestApplication5.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test
+    public void autoTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("auto");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication1.class);
+        expectedRegisteredAppClasses.add(TestApplication2.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+        expectedRegisteredAppClasses.add(TestApplication5.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test
+    public void beansTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("beans");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication1.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test
+    public void propertyTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("property");
+        when(configurableEnvironmentMock.getProperty(APP_CLASSES_PROPERTY)).thenReturn("com.paypal.springboot.resteasy.sample.TestApplication3, com.paypal.springboot.resteasy.sample.TestApplication4,com.paypal.springboot.resteasy.sample.TestApplication2");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication2.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test
+    public void legacyPropertyTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("property");
+        when(configurableEnvironmentMock.getProperty(APP_CLASSES_PROPERTY_LEGACY)).thenReturn("com.paypal.springboot.resteasy.sample.TestApplication3, com.paypal.springboot.resteasy.sample.TestApplication4,com.paypal.springboot.resteasy.sample.TestApplication2");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication2.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test
+    public void scanningTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("scanning");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(TestApplication1.class);
+        expectedRegisteredAppClasses.add(TestApplication2.class);
+        expectedRegisteredAppClasses.add(TestApplication4.class);
+        expectedRegisteredAppClasses.add(TestApplication5.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Property " + DEFINITION_PROPERTY +
+                    " has not been properly set, value blah is invalid. JAX-RS Application classes registration is being set to AUTO.")
+    public void invalidRegistrationTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("blah");
+
+        ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+        when(beanFactory.getBean(ConfigurableEnvironment.class)).thenReturn(configurableEnvironmentMock);
+
+        ResteasyEmbeddedServletInitializer resteasyEmbeddedServletInitializer = new ResteasyEmbeddedServletInitializer();
+        resteasyEmbeddedServletInitializer.postProcessBeanFactory(beanFactory);
+    }
+
+    @Test(expectedExceptions = BeansException.class)
+    public void classNotFoundTest() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("property");
+        when(configurableEnvironmentMock.getProperty(APP_CLASSES_PROPERTY)).thenReturn("com.paypal.springboot.resteasy.sample.TestApplication3, com.paypal.springboot.resteasy.sample.TestApplication4,com.paypal.springboot.resteasy.sample.TestApplication9");
+
+        ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+        when(beanFactory.getBean(ConfigurableEnvironment.class)).thenReturn(configurableEnvironmentMock);
+
+        ResteasyEmbeddedServletInitializer resteasyEmbeddedServletInitializer = new ResteasyEmbeddedServletInitializer();
+        resteasyEmbeddedServletInitializer.postProcessBeanFactory(beanFactory);
+    }
+
+    @Test
+    public void testPropertyNoApps() {
+        ConfigurableEnvironment configurableEnvironmentMock = mock(ConfigurableEnvironment.class);
+        when(configurableEnvironmentMock.getProperty(DEFINITION_PROPERTY)).thenReturn("property");
+
+        Set<Class<?>> expectedRegisteredAppClasses = new HashSet<>();
+        expectedRegisteredAppClasses.add(Application.class);
+
+        test(configurableEnvironmentMock, expectedRegisteredAppClasses);
+    }
+
+    private void test(ConfigurableEnvironment envMock, Set<Class<?>> expectedRegisteredAppClasses) {
+        ConfigurableListableBeanFactory beanFactory = prepareTest(envMock);
+        performTest(envMock, beanFactory, expectedRegisteredAppClasses);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConfigurableListableBeanFactory prepareTest(ConfigurableEnvironment envMock) {
+        ConfigurableListableBeanFactory beanFactory = mock(
+                ConfigurableListableBeanFactory.class,
+                withSettings().extraInterfaces(BeanDefinitionRegistry.class)
+        );
+
+        when(beanFactory.getBean(ConfigurableEnvironment.class)).thenReturn(envMock);
+        when(beanFactory.getBeanNamesForAnnotation(Path.class)).thenReturn(new String[]{"testResource1", "testResource2"});
+        when(beanFactory.getType("testResource1")).thenReturn((Class) TestResource1.class);
+        when(beanFactory.getType("testResource2")).thenReturn((Class) TestResource2.class);
+
+        String definition = envMock.getProperty(DEFINITION_PROPERTY);
+
+        if((definition != null && definition.equals("beans"))) {
+            // Although TestApplication1 and TestApplication4 are not really Spring beans, here we are simulating
+            // they are to see how the JAX-RS Application registration behaves
+            Map<String,Application> applicationsMap = new HashMap<String, Application>();
+            applicationsMap.put("testApplication1", new TestApplication1());
+            applicationsMap.put("testApplication4", new TestApplication4());
+            when(beanFactory.getBeansOfType(Application.class, true, false)).thenReturn(applicationsMap);
+        }
+
+        return beanFactory;
+    }
+
+    private void performTest(ConfigurableEnvironment envMock, ConfigurableListableBeanFactory beanFactory, Set<Class<?>> expectedRegisteredAppClasses) {
+        String definition = envMock.getProperty(DEFINITION_PROPERTY);
+        boolean findSpringBeans = (definition == null || definition.equals("auto") || definition.equals("beans"));
+        boolean getAppsProperty = (definition == null || definition.equals("auto") || definition.equals("property"));
+
+        ResteasyEmbeddedServletInitializer resteasyEmbeddedServletInitializer = new ResteasyEmbeddedServletInitializer();
+        resteasyEmbeddedServletInitializer.postProcessBeanFactory(beanFactory);
+
+        verify(beanFactory, VerificationModeFactory.times(getAppsProperty ? 2 : 1)).getBean(ConfigurableEnvironment.class);
+        verify(beanFactory, VerificationModeFactory.times(findSpringBeans ? 1 : 0)).getBeansOfType(Application.class, true, false);
+        verify(beanFactory, VerificationModeFactory.times(1)).getBeanNamesForAnnotation(Path.class);
+        verify(beanFactory, VerificationModeFactory.times(1)).getBeanNamesForAnnotation(Provider.class);
+        verify(beanFactory, VerificationModeFactory.times(2)).getType(anyString());
+
+        BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+
+        Set<Class<?>> expectedNotRegisteredAppClassess = new HashSet<>(allPossibleAppClasses);
+        for(Class<?> applicationClass : expectedRegisteredAppClasses) {
+            verify(registry, VerificationModeFactory.times(1)).registerBeanDefinition(eq(applicationClass.getName()), any(GenericBeanDefinition.class));
+            expectedNotRegisteredAppClassess.remove(applicationClass);
+        }
+        for(Class<?> applicationClass : expectedNotRegisteredAppClassess) {
+            verify(registry, VerificationModeFactory.times(0)).registerBeanDefinition(eq(applicationClass.getName()), any(GenericBeanDefinition.class));
+        }
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/JaxrsAppRegistrationTest.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/JaxrsAppRegistrationTest.java
@@ -57,16 +57,16 @@ public class JaxrsAppRegistrationTest extends PowerMockTestCase {
     private static Set<Class<?>> allPossibleAppClasses;
 
     static {
-        Set<Class<?>> _allPossibleAppClasses = new HashSet<>();
+        Set<Class<?>> tmpAllPossibleAppClasses = new HashSet<>();
 
-        _allPossibleAppClasses.add(TestApplication1.class);
-        _allPossibleAppClasses.add(TestApplication2.class);
-        _allPossibleAppClasses.add(TestApplication3.class);
-        _allPossibleAppClasses.add(TestApplication4.class);
-        _allPossibleAppClasses.add(TestApplication5.class);
-        _allPossibleAppClasses.add(Application.class);
+        tmpAllPossibleAppClasses.add(TestApplication1.class);
+        tmpAllPossibleAppClasses.add(TestApplication2.class);
+        tmpAllPossibleAppClasses.add(TestApplication3.class);
+        tmpAllPossibleAppClasses.add(TestApplication4.class);
+        tmpAllPossibleAppClasses.add(TestApplication5.class);
+        tmpAllPossibleAppClasses.add(Application.class);
 
-        allPossibleAppClasses = Collections.unmodifiableSet(_allPossibleAppClasses);
+        allPossibleAppClasses = Collections.unmodifiableSet(tmpAllPossibleAppClasses);
     }
 
     @BeforeMethod

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyAutoConfigurationTest.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyAutoConfigurationTest.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
  * Created by facarvalho on 11/24/15.
  * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
  */
+@SuppressWarnings("PMD.SignatureDeclareThrowsException")
 public class ResteasyAutoConfigurationTest {
 
     @Test

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyAutoConfigurationTest.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyAutoConfigurationTest.java
@@ -1,0 +1,76 @@
+package com.paypal.springboot.resteasy;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.ResourceMethodRegistry;
+import org.jboss.resteasy.plugins.spring.SpringBeanProcessor;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.mock.web.MockServletContext;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by facarvalho on 11/24/15.
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+public class ResteasyAutoConfigurationTest {
+
+    @Test
+    public void springBeanProcessor() {
+        BeanFactoryPostProcessor beanFactoryPostProcessor = ResteasyAutoConfiguration.springBeanProcessor();
+
+        Assert.assertNotNull(beanFactoryPostProcessor);
+        Assert.assertEquals(SpringBeanProcessor.class, beanFactoryPostProcessor.getClass());
+
+        SpringBeanProcessor springBeanProcessor = (SpringBeanProcessor) beanFactoryPostProcessor;
+        Registry springBeanProcessorRegistry = springBeanProcessor.getRegistry();
+        ResteasyProviderFactory providerFactory = springBeanProcessor.getProviderFactory();
+
+        Assert.assertNotNull(springBeanProcessorRegistry);
+        Assert.assertNotNull(providerFactory);
+        Assert.assertEquals(ResourceMethodRegistry.class, springBeanProcessorRegistry.getClass());
+    }
+
+    @Test
+    public void syncDispatcherServletContextListenerTest() throws Exception {
+        ServletContext servletContext = new MockServletContext();
+        testServletContextListener(servletContext);
+    }
+
+    @Test
+    public void asyncDispatcherServletContextListenerTest() throws Exception {
+        ServletContext servletContext = new MockServletContext();
+        servletContext.setInitParameter("resteasy.async.job.service.enabled", "true");
+        testServletContextListener(servletContext);
+    }
+
+    private void testServletContextListener(ServletContext servletContext) throws Exception {
+        ResteasyAutoConfiguration resteasyAutoConfiguration = new ResteasyAutoConfiguration();
+        BeanFactoryPostProcessor beanFactoryPostProcessor = ResteasyAutoConfiguration.springBeanProcessor();
+        ServletContextListener servletContextListener = resteasyAutoConfiguration.resteasyBootstrapListener(beanFactoryPostProcessor);
+        Assert.assertNotNull(servletContextListener);
+
+        ServletContextEvent sce = new ServletContextEvent(servletContext);
+        servletContextListener.contextInitialized(sce);
+
+        ResteasyProviderFactory servletContextProviderFactory = (ResteasyProviderFactory) servletContext.getAttribute(ResteasyProviderFactory.class.getName());
+        Dispatcher servletContextDispatcher = (Dispatcher) servletContext.getAttribute(Dispatcher.class.getName());
+        Registry servletContextRegistry = (Registry) servletContext.getAttribute(Registry.class.getName());
+
+        Assert.assertNotNull(servletContextProviderFactory);
+        Assert.assertNotNull(servletContextDispatcher);
+        Assert.assertNotNull(servletContextRegistry);
+
+        // Exercising fully cobertura branch coverage
+        servletContextListener.contextDestroyed(sce);
+        ServletContextListener servletContextListener2 = resteasyAutoConfiguration.resteasyBootstrapListener(beanFactoryPostProcessor);
+        servletContextListener2.contextDestroyed(sce);
+    }
+
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializerTest.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/ResteasyEmbeddedServletInitializerTest.java
@@ -1,0 +1,38 @@
+package com.paypal.springboot.resteasy;
+
+import java.util.Map;
+
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by facarvalho on 11/25/15.
+ * @author Fabio Carvalho (facarvalho@paypal.com or fabiocarvalho777@gmail.com)
+ */
+@ContextConfiguration("classpath:test-config.xml")
+public class ResteasyEmbeddedServletInitializerTest extends AbstractTestNGSpringContextTests {
+
+    @Test
+    public void postProcessBeanFactory() {
+        Map<String, ServletRegistrationBean> servletRegistrationBeans = applicationContext.getBeansOfType(ServletRegistrationBean.class);
+        Assert.assertNotNull(servletRegistrationBeans);
+
+        // Although there are 5 sample JAX-RS Application classes, one of them is not annotated with the ApplicationPath annotation!
+        Assert.assertEquals(servletRegistrationBeans.size(), 4);
+
+        for(String applicationClassName : servletRegistrationBeans.keySet()) {
+            testApplicaton(applicationClassName, servletRegistrationBeans.get(applicationClassName));
+        }
+    }
+
+    private void testApplicaton(String applicationClassName, ServletRegistrationBean servletRegistrationBean) {
+        Assert.assertEquals(applicationClassName, servletRegistrationBean.getServletName());
+        Assert.assertTrue(servletRegistrationBean.isAsyncSupported());
+        Assert.assertEquals(applicationClassName, servletRegistrationBean.getInitParameters().get("javax.ws.rs.Application"));
+        Assert.assertTrue(servletRegistrationBean.isAsyncSupported());
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/SampleApp.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/SampleApp.java
@@ -1,0 +1,14 @@
+package com.paypal.springboot.resteasy.sample;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sample app for test purposes
+ *
+ * Created by facarvalho on 5/17/17.
+ */
+@EnableAutoConfiguration
+@Component
+public class SampleApp {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication1.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication1.java
@@ -1,0 +1,13 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Sample test JAX-RS application.
+ *
+ * Created by facarvalho on 11/25/15.
+ */
+@ApplicationPath("/myapp1")
+public class TestApplication1 extends Application {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication2.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication2.java
@@ -1,0 +1,13 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Sample test JAX-RS application.
+ *
+ * Created by facarvalho on 11/25/15.
+ */
+@ApplicationPath("myapp2")
+public class TestApplication2 extends Application {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication3.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication3.java
@@ -1,0 +1,13 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.core.Application;
+
+/**
+ * This application, although extending Application class,
+ * is NOT annotated with ApplicationPath annotation, which
+ * should prevent its registration
+ *
+ * Created by facarvalho on 11/25/15.
+ */
+public class TestApplication3 extends Application {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication4.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication4.java
@@ -1,0 +1,13 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Sample test JAX-RS application.
+ *
+ * Created by facarvalho on 11/25/15.
+ */
+@ApplicationPath("/")
+public class TestApplication4 extends Application {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication5.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestApplication5.java
@@ -1,0 +1,13 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Sample test JAX-RS application.
+ *
+ * Created by facarvalho on 11/25/15.
+ */
+@ApplicationPath("myapp5/")
+public class TestApplication5 extends Application {
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestProvider1.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestProvider1.java
@@ -1,0 +1,20 @@
+package com.paypal.springboot.resteasy.sample;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by facarvalho on 6/9/16.
+ */
+@Component
+@Provider
+public class TestProvider1 implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception exception) {
+        return null;
+    }
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestResource1.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestResource1.java
@@ -1,0 +1,20 @@
+package com.paypal.springboot.resteasy.sample;
+
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by facarvalho on 6/9/16.
+ */
+@Path("resource1")
+@Component
+public class TestResource1 {
+
+    @GET
+    public void get() {
+        // Test get method
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestResource2.java
+++ b/app/common/resteasy-spring-boot-starter/src/test/java/com/paypal/springboot/resteasy/sample/TestResource2.java
@@ -1,0 +1,20 @@
+package com.paypal.springboot.resteasy.sample;
+
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by facarvalho on 6/9/16.
+ */
+@Path("resource2")
+@Component
+public class TestResource2 {
+
+    @GET
+    public void get() {
+        // Test get method
+    }
+
+}

--- a/app/common/resteasy-spring-boot-starter/src/test/resources/logback-test.xml
+++ b/app/common/resteasy-spring-boot-starter/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+        </encoder>
+        <file>target/resteasy-spring-boot-starter.log</file>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/app/common/resteasy-spring-boot-starter/src/test/resources/test-config.xml
+++ b/app/common/resteasy-spring-boot-starter/src/test/resources/test-config.xml
@@ -1,0 +1,14 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+	   http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context
+	   http://www.springframework.org/schema/context/spring-context.xsd
+	">
+
+    <context:component-scan base-package="com.paypal.springboot.resteasy"/>
+    <context:component-scan base-package="com.paypal.springboot.resteasy.sample"/>
+
+</beans>

--- a/app/connector/support/maven-plugin/pom.xml
+++ b/app/connector/support/maven-plugin/pom.xml
@@ -180,7 +180,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
   </dependencies>

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -99,7 +99,8 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -64,6 +64,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-resteasy-spring-boot-starter</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- ===================================================================================== -->
 
     <dependency>
@@ -81,13 +87,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.paypal.springboot</groupId>
-      <artifactId>resteasy-spring-boot-starter</artifactId>
-      <version>${resteasy-spring-boot-starter.version}</version>
       <scope>runtime</scope>
     </dependency>
 
@@ -189,7 +188,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -106,8 +106,7 @@
     <json-schema-validator.version>2.2.8</json-schema-validator.version>
     <junit.version>4.12</junit.version>
 
-    <resteasy.version>3.1.4.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>2.3.4-RELEASE</resteasy-spring-boot-starter.version>
+    <resteasy.version>3.5.1.Final</resteasy.version>
 
     <immutables.version>2.5.6</immutables.version>
 
@@ -580,6 +579,7 @@
               <exclude>**/.gitkeep</exclude>
               <exclude>**/*.webapp</exclude>
               <exclude>**/browserconfig.xml</exclude>
+              <exclude>common/resteasy-spring-boot-starter/**</exclude>
               <exclude>connector/**/META-INF/syndesis/connector/verifier/*</exclude>
               <exclude>connector/**/springboot/*Configuration.java</exclude><!-- auto generated without headers -->
               <exclude>connector/**/springboot/*Common.java </exclude><!-- auto generated without headers -->
@@ -747,6 +747,18 @@
         <groupId>io.syndesis.common</groupId>
         <artifactId>common-model</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.syndesis.common</groupId>
+        <artifactId>common-resteasy-spring-boot-starter</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- ::::::::::: rest :::::::::::: -->
@@ -1129,14 +1141,14 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.spec.javax.ws.rs</groupId>
-        <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-        <version>1.0.1.Beta1</version>
+        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        <version>1.0.0.Final</version>
       </dependency>
 
       <dependency>
@@ -1210,6 +1222,12 @@
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-java-model</artifactId>
         <version>${atlasmap.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1234,24 +1252,48 @@
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-json-module</artifactId>
         <version>${atlasmap.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-json-service</artifactId>
         <version>${atlasmap.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-xml-module</artifactId>
         <version>${atlasmap.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.atlasmap</groupId>
         <artifactId>atlas-xml-service</artifactId>
         <version>${atlasmap.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -150,7 +150,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/metrics/prometheus/pom.xml
+++ b/app/server/metrics/prometheus/pom.xml
@@ -173,6 +173,7 @@
             <!-- if declared complains about being unused -->
             <ignoredUsedUndeclaredDependency>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.code.findbugs:findbugs-annotations</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>commons-logging:commons-logging</ignoredUnusedDeclaredDependency>

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
@@ -44,8 +44,9 @@ public class HttpClient {
         final ResteasyJackson2Provider resteasyJacksonProvider = new ResteasyJackson2Provider();
         resteasyJacksonProvider.setMapper(MAPPER);
 
-        final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.newInstance();
+        final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
         providerFactory.register(resteasyJacksonProvider);
+
         final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);
 
         return ClientBuilder.newClient(configuration);

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -464,13 +464,6 @@
         <groupId>com.paypal.springboot</groupId>
         <artifactId>resteasy-spring-boot-starter</artifactId>
         <version>${resteasy-spring-boot-starter.version}</version>
-        <scope>runtime</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -584,6 +584,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-resteasy-spring-boot-starter</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.syndesis.server</groupId>
       <artifactId>server-dao</artifactId>
     </dependency>
@@ -813,11 +819,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.paypal.springboot</groupId>
-      <artifactId>resteasy-spring-boot-starter</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
@@ -829,7 +830,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -88,6 +88,17 @@
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
@@ -55,13 +55,17 @@ public class ExternalVerifierService implements Verifier {
         final ResteasyJackson2Provider resteasyJacksonProvider = new ResteasyJackson2Provider();
         resteasyJacksonProvider.setMapper(MAPPER);
 
-        final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.newInstance();
+        final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
         providerFactory.register(resteasyJacksonProvider);
+
         final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);
 
         Client client = ClientBuilder.newClient(configuration);
         WebTarget target = client.target(String.format("http://%s/api/v1/verifier/%s", config.getService(), connectorId));
-        return target.request(MediaType.APPLICATION_JSON).post(Entity.entity(options, MediaType.APPLICATION_JSON),
-                                                               new GenericType<List<Result>>(){});
+
+        return target.request(MediaType.APPLICATION_JSON).post(
+            Entity.entity(options, MediaType.APPLICATION_JSON),
+            new GenericType<List<Result>>(){}
+         );
     }
 }


### PR DESCRIPTION
Background:

- while developing servicenow connectror #1190 I've experienced some issues because the of mismatch of javax.ws.rs-api which was forced to be 2.0 in syndesis but cxf uses 2.1
- we leverage [resteasy-spring-boot-starter](https://github.com/paypal/resteasy-spring-boot/tree/master/resteasy-spring-boot-starter) from payal which is not more maintained and has been donated to [resteasy](https://github.com/resteasy/resteasy-spring-boot)
- resteasy-spring-boot-starter from paypal is locked at v2.0 specs
- resteasy-spring-boot-starter from resteasy moved to specs v2.1 but is based on spring boot 2.x

So I've copied the resteasy-spring-boot-starter from paypal to our repository as app/commons/resteasy-spring-boot-starter and I've upgraded it to spec 2.1. I've fixed all the issues reported by our tools and removed the old dependency across the project. 

This is of course an interim solution till we migrate to spring boot 2.x and the official resteasy starter.

@syndesisio/backend I did run a quick test and things seems to work but I need a review as I'm not a super expert about ws-rs.

 



