### PR TITLE
fixes: #2095 missing log entries.

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
@@ -73,10 +73,11 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
         public boolean process(final Exchange exchange, final AsyncCallback callback) {
             final String trackerId = KeyGenerator.createKey();
             final long createdAt = System.nanoTime();
+            final Message in = exchange.getIn();
+            in.setHeader(IntegrationLoggingConstants.STEP_TRACKER_ID, trackerId);
 
             return super.process(exchange, doneSync -> {
                 final String activityId =  exchange.getProperty(IntegrationLoggingConstants.ACTIVITY_ID, String.class);
-                final Message in = exchange.getIn();
                 final String stepId = in.getHeader(IntegrationLoggingConstants.STEP_ID, String.class);
 
                 if (activityId != null) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/IntegrationLoggingListener.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/IntegrationLoggingListener.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.runtime.logging;
 
 import io.syndesis.common.util.KeyGenerator;
 import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 import org.apache.camel.spi.LogListener;
 import org.apache.camel.util.CamelLogger;
 import org.slf4j.Marker;
@@ -35,15 +36,20 @@ public class IntegrationLoggingListener implements LogListener {
         }
 
         final String activityId = exchange.getProperty(IntegrationLoggingConstants.ACTIVITY_ID, String.class);
-
         if (activityId != null) {
             final Marker marker = camelLogger.getMarker();
             final String step = marker != null ? marker.getName() : "null";
 
+            final Message in = exchange.getIn();
+            String stepTrackerId = in.getHeader(IntegrationLoggingConstants.STEP_TRACKER_ID, String.class);
+            if( stepTrackerId == null ) {
+                stepTrackerId = KeyGenerator.createKey();
+            }
+
             tracker.track(
                 "exchange", activityId,
                 "step", step,
-                "id", KeyGenerator.createKey(),
+                "id", stepTrackerId,
                 "message", message
             );
         }


### PR DESCRIPTION
I just discovered that one of my log parsing assumptions was wrong. I assumed that all log entries from the API server started with a fix length time prefix that looked like:

    2018-01-12T21:22:02.068338027Z { ..... }

Turns out that that time prefix is actually variable length.