### PR TITLE
chore(build): use base-pom for documentation

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -123,6 +123,7 @@
     <module>s2i</module>
     <module>meta</module>
     <module>ui</module>
+    <module>../doc/tools</module>
   </modules>
 
   <profiles>

--- a/doc/tools/pom.xml
+++ b/doc/tools/pom.xml
@@ -20,10 +20,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.syndesis</groupId>
+    <artifactId>syndesis-parent</artifactId>
+    <version>1.4-SNAPSHOT</version>
+    <relativePath>../../app/pom.xml</relativePath>
+  </parent>
+
   <groupId>io.syndesis</groupId>
   <artifactId>syndesis-documentation-tools</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <name>Documentation</name>
 
   <modules>
     <module>syndesis-documentation-maven-plugin</module>

--- a/doc/tools/syndesis-documentation-maven-plugin/pom.xml
+++ b/doc/tools/syndesis-documentation-maven-plugin/pom.xml
@@ -22,13 +22,14 @@
   <parent>
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-documentation-tools</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>syndesis-documentation-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Syndesis :: Documentation :: Maven plugin</name>
+  <name>Documentation :: Maven plugin</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Switches the parent of `doc/tools` - documentation module to use
`syndesis-parent` and adds it as a module to the `syndesis-parent`.

This way the documentation tooling is using the same base-pom version
and Maven configuration as the rest of Syndesis Maven modules.

Fixes #297