### PR TITLE
fix(build): use proper parent for documentation

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -123,7 +123,7 @@
     <module>s2i</module>
     <module>meta</module>
     <module>ui</module>
-    <module>../doc/tools</module>
+    <module>../doc</module>
   </modules>
 
   <profiles>

--- a/doc/connecting/topics/shared
+++ b/doc/connecting/topics/shared
@@ -1,1 +1,1 @@
-/home/tcohen/git/syndesis/doc/integrating_applications/topics/shared
+../../shared

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -23,11 +23,22 @@
 
     <name>Syndesis :: Docs</name>
 
+    <parent>
+      <groupId>io.syndesis</groupId>
+      <artifactId>syndesis-parent</artifactId>
+      <version>1.4-SNAPSHOT</version>
+      <relativePath>../app/pom.xml</relativePath>
+    </parent>
+
     <groupId>io.syndesis</groupId>
     <artifactId>syndesis-docs</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
 
     <packaging>pom</packaging>
+
+    <modules>
+	<module>tools</module>
+    </modules>
 
     <build>
         <plugins>
@@ -58,7 +69,7 @@
             <plugin>
                 <groupId>io.syndesis</groupId>
                 <artifactId>syndesis-documentation-maven-plugin</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
+		<version>${project.version}</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>

--- a/doc/tools/syndesis-documentation-maven-plugin/pom.xml
+++ b/doc/tools/syndesis-documentation-maven-plugin/pom.xml
@@ -85,15 +85,17 @@
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>
-      <version>${maven-resolver-api.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -103,13 +105,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,19 +124,16 @@
       <version>1.25.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-core</artifactId>
+      <version>1.25.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>

--- a/doc/tools/syndesis-documentation-maven-plugin/src/main/java/io/syndesis/maven/TooltipExtractorMojo.java
+++ b/doc/tools/syndesis-documentation-maven-plugin/src/main/java/io/syndesis/maven/TooltipExtractorMojo.java
@@ -16,7 +16,6 @@
 package io.syndesis.server.builder.maven;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -73,6 +72,7 @@ public class TooltipExtractorMojo extends AbstractMojo {
         private final ObjectMapper mapper = new ObjectMapper();
 
         private boolean isTooltip;
+	@SuppressWarnings("PMD.AvoidStringBufferField")
         private StringBuilder tooltip = new StringBuilder();
         private Map<String, Object> root = new HashMap<>();
 
@@ -106,7 +106,7 @@ public class TooltipExtractorMojo extends AbstractMojo {
                 }
             } else if (isTooltip) {
                 if (tooltip.length() > 0) {
-                    tooltip.append(" ");
+                    tooltip.append(' ');
                 }
 
                 tooltip.append(line.trim());


### PR DESCRIPTION
This changes the parent of the documentation POM to the Syndesis parent
and the parent of the documentation maven plugin to the documentation
parent in an effort to help the release build find the documentation
plugin and have all POMs inherit from Syndesis parent.

Also fixes dependency/codestyle issues in the Maven documentation plugin
and makes one of the links relative to the rest of the documentation.