### PR TITLE
Api connector inline edit 

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
@@ -23,72 +23,168 @@
               class="syn-form-filebrowser__preview"
               [src]="{ icon: iconFile } | synIconPath">
           </span>
-          <input class="syn-form-filebrowser__input" type="file" name="connectorIcon" (change)="onChange($event)">
+          <input class="syn-form-filebrowser__input" type="file" name="connectorIcon" (change)="saveValue($event)">
         </div>
       </div>
 
       <div class="form-group">
         <label class="required-pf col-sm-3 control-label" for="name">Connector Name</label>
-        <div class="col-sm-9">
-          <input class="form-control" type="text" id="name"
-            formControlName="name"
-            (keyup.enter)="onChange($event)"
-            (change)="onEditChange()"
-            #nameInput
-            [ngClass]="{'hidden': !createMode && editControlKey !== 'name'}">
-          <span class="syn-form-row__input--editor" *ngIf="!createMode && editControlKey !== 'name'" (click)="onEditEnable($event, 'name')">
+        <div class="col-sm-9"
+          [ngClass]="{'form-control-pf-editable': !createMode, 'form-control-pf-edit': editControlKey == 'name'}">
+          <button class="form-control-pf-value"
+            (click)="onEditEnable($event, 'name', nameInput)"
+            *ngIf="!createMode">
             {{ nameInput.value }}
-            <i class="fa fa-pencil"></i>
-          </span>
+            <i class="glyphicon glyphicon-pencil"></i>
+          </button>
+          <div class="form-control-pf-textbox">
+            <input class="form-control form-control-pf-editor" type="text" id="name"
+              formControlName="name"
+              #nameInput
+              required
+              (blur)="!createMode && !valueSaved && onBlur(nameInput)"
+              (keyup)="!createMode && onKeyup($event)"
+              [ngClass]="{'hidden': !createMode && editControlKey !== 'name'}">
+            <button type="button"
+              class="form-control-pf-empty"
+              aria-label="Clear Value"
+              (click)="clearValue($event,nameInput)"
+              *ngIf="!createMode">
+              <span class="fa fa-times-circle fa-lg"></span>
+            </button>
+          </div>
+          <button type="button"
+            class="btn btn-primary form-control-pf-save"
+            [disabled]="!enableSave"
+            aria-label="Save"
+            (mousedown)="saveValue($event)"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-ok"></i>
+          </button>
+          <button type="button"
+            class="btn btn-default form-control-pf-cancel"
+            aria-label="Cancel"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-remove"></i>
+          </button>
         </div>
       </div>
 
       <div class="form-group">
         <label class="col-sm-3 control-label" for="description">Description</label>
-        <div class="col-sm-9">
-          <textarea class="form-control" type="text" id="description" rows="4"
+        <div class="col-sm-9"
+          [ngClass]="{'form-control-pf-editable': !createMode, 'form-control-pf-edit form-control-pf-full-width': editControlKey == 'description'}">
+          <button class="form-control-pf-value"
+            (click)="onEditEnable($event, 'description', descriptionInput)"
+            *ngIf="!createMode">
+            <span [innerHTML]="descriptionInput.value | synParseMarkdownLinks"></span>
+            <i class="glyphicon glyphicon-pencil"></i>
+          </button>
+          <textarea class="form-control form-control-pf-editor" type="text" id="description" rows="4"
             formControlName="description"
-            (keyup.enter)="onChange($event)"
-            (change)="onEditChange()"
             #descriptionInput
+            (blur)="!createMode && !valueSaved && onBlur(descriptionInput)"
+            (keyup)="!createMode && onKeyup($event)"
             [ngClass]="{'hidden': !createMode && editControlKey !== 'description'}">
           </textarea>
-          <span class="syn-form-row__input--editor" *ngIf="!createMode && editControlKey !== 'description'" (click)="onEditEnable($event, 'description')">
-            <span [innerHtml]="descriptionInput.value | synParseMarkdownLinks"></span>
-            <i class="fa fa-pencil"></i>
-          </span>
+          <div class="action-buttons" *ngIf="!createMode">
+            <button type="button"
+              class="btn btn-primary form-control-pf-save"
+              [disabled]="!enableSave"
+              aria-label="Save"
+              (mousedown)="saveValue($event)">
+              <i class="glyphicon glyphicon-ok"></i>
+            </button>
+            <button type="button"
+              class="btn btn-default form-control-pf-cancel"
+              aria-label="Cancel">
+                <i class="glyphicon glyphicon-remove"></i>
+            </button>
+          </div>
         </div>
       </div>
 
       <div class="form-group">
         <label class="col-sm-3 control-label" for="host">Host</label>
-        <div class="col-sm-9">
-          <input class="form-control" type="text" id="host"
-            formControlName="host"
-            (keyup.enter)="onChange($event)"
-            (change)="onEditChange()"
-            #hostInput
-            [ngClass]="{'hidden': !createMode && editControlKey !== 'host'}">
-          <span class="syn-form-row__input--editor" *ngIf="!createMode && editControlKey !== 'host'" (click)="onEditEnable($event, 'host')">
+        <div class="col-sm-9"
+        [ngClass]="{'form-control-pf-editable': !createMode, 'form-control-pf-edit': editControlKey == 'host'}">
+          <button class="form-control-pf-value"
+            (click)="onEditEnable($event, 'host', hostInput)"
+            *ngIf="!createMode">
             {{ hostInput.value }}
-            <i class="fa fa-pencil"></i>
-          </span>
+            <i class="glyphicon glyphicon-pencil"></i>
+          </button>
+          <div class="form-control-pf-textbox">
+            <input class="form-control form-control-pf-editor" type="text" id="host"
+              formControlName="host"
+              #hostInput
+              (blur)="!createMode && !valueSaved && onBlur(hostInput)"
+              (keyup)="!createMode && onKeyup($event)"
+              [ngClass]="{'hidden': !createMode && editControlKey !== 'host'}">
+            <button type="button"
+              class="form-control-pf-empty"
+              aria-label="Clear Value"
+              (click)="clearValue($event,hostInput)"
+              *ngIf="!createMode">
+              <span class="fa fa-times-circle fa-lg"></span>
+            </button>
+          </div>
+          <button type="button"
+            class="btn btn-primary form-control-pf-save"
+            [disabled]="!enableSave"
+            aria-label="Save"
+            (mousedown)="saveValue($event)"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-ok"></i>
+          </button>
+          <button type="button"
+            class="btn btn-default form-control-pf-cancel"
+            aria-label="Cancel"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-remove"></i>
+          </button>
         </div>
       </div>
 
       <div class="form-group">
-        <label class="col-sm-3 control-label" for="basePath">Base URL</label>
-        <div class="col-sm-9">
-          <input class="form-control" type="text" id="basePath"
-            formControlName="basePath"
-            (keyup.enter)="onChange($event)"
-            (change)="onEditChange()"
-            #basePathInput
-            [ngClass]="{'hidden': !createMode && editControlKey !== 'basePath'}">
-          <span class="syn-form-row__input--editor" *ngIf="!createMode && editControlKey !== 'basePath'" (click)="onEditEnable($event, 'basePath')">
+        <label class="col-sm-3 control-label" for="host">Base URL</label>
+        <div class="col-sm-9"
+        [ngClass]="{'form-control-pf-editable': !createMode, 'form-control-pf-edit': editControlKey == 'basePath'}">
+          <button class="form-control-pf-value"
+            (click)="onEditEnable($event, 'basePath', basePathInput)"
+            *ngIf="!createMode">
             {{ basePathInput.value }}
-            <i class="fa fa-pencil"></i>
-          </span>
+            <i class="glyphicon glyphicon-pencil"></i>
+          </button>
+          <div class="form-control-pf-textbox">
+            <input class="form-control form-control-pf-editor" type="text" id="basePath"
+              formControlName="basePath"
+              #basePathInput
+              (blur)="!createMode && !valueSaved && onBlur(basePathInput)"
+              (keyup)="!createMode && onKeyup($event)"
+              [ngClass]="{'hidden': !createMode && editControlKey !== 'basePath'}">
+            <button type="button"
+              class="form-control-pf-empty"
+              aria-label="Clear Value"
+              (click)="clearValue($event,basePathInput)"
+              *ngIf="!createMode">
+              <span class="fa fa-times-circle fa-lg"></span>
+            </button>
+          </div>
+          <button type="button"
+            class="btn btn-primary form-control-pf-save"
+            [disabled]="!enableSave"
+            aria-label="Save"
+            (mousedown)="saveValue($event)"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-ok"></i>
+          </button>
+          <button type="button"
+            class="btn btn-default form-control-pf-cancel"
+            aria-label="Cancel"
+            *ngIf="!createMode">
+              <i class="glyphicon glyphicon-remove"></i>
+          </button>
         </div>
       </div>
     </fieldset>

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
@@ -1,27 +1,5 @@
 @import 'syndesis-sass';
 
-.syn-form--edit-mode {
-  .syn-form-row {
-    &__input--editor {
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 5px;
-
-      &:hover {
-        color: $color-pf-blue-500;
-      }
-
-      .fa-pencil {
-        border: none;
-        background: none;
-        color: $color-pf-blue-500;
-        margin-left: $forms-grid-gutter;
-        cursor: hand;
-      }
-    }
-  }
-}
-
 .syn-form-filebrowser {
   &__default-file {
     overflow: hidden;
@@ -52,10 +30,6 @@
           padding-top: 0;
         }
       }
-    }
-
-    .control-label {
-      display: block !important; // Override the flex setting in overrides.scss
     }
   }
 }

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
@@ -17,6 +17,9 @@ export class ApiConnectorInfoComponent implements OnInit {
   apiConnectorDataForm: FormGroup;
   editControlKey: string;
   iconFile: File;
+  originalValue: string;
+  enableSave: boolean;
+  valueSaved = false;
   private isDirty: boolean;
 
   constructor(
@@ -56,7 +59,7 @@ export class ApiConnectorInfoComponent implements OnInit {
     }
   }
 
-  onChange(event): void {
+  saveValue(event): void {
     if (event.target && event.target.files) {
       const fileList = event.target.files as FileList;
       if (fileList.length > 0) {
@@ -67,6 +70,7 @@ export class ApiConnectorInfoComponent implements OnInit {
     // If component is not in "Create" mode (eg. detail page), updating
     // any input field will automatically fire up the submit handler
     if (!this.createMode) {
+      this.valueSaved = true;
       this.onSubmit();
     }
   }
@@ -91,16 +95,36 @@ export class ApiConnectorInfoComponent implements OnInit {
     this.editControlKey = null;
   }
 
-  onEditEnable(event: Event, key: string): void {
+  onBlur(el) {
+    el.value = this.originalValue;
+  }
+
+  onEditEnable(event: Event, key: string, el): void {
     event.preventDefault();
     event.stopPropagation();
+    this.originalValue = el.value;
     this.editControlKey = key;
     this.isDirty = false;
+    this.valueSaved = false;
+    this.enableSave = false;
     setTimeout(() => this.renderer.selectRootElement(`#${key}`).focus(), 0);
   }
 
-  onEditChange(): void {
-    this.isDirty = true;
+  onKeyup(event) {
+    if (event.srcElement.value == this.originalValue || (event.srcElement.required && event.srcElement.value == '')) {
+      this.enableSave = false;
+    } else {
+      this.enableSave = true;
+    }
+  }
+
+  clearValue(event, el) {
+    event.stopPropagation();
+    el.value = '';
+    el.focus();
+    if (el.required) {
+      this.enableSave = false;
+    }
   }
 
   @HostListener('document:click', ['$event'])


### PR DESCRIPTION
Part of https://github.com/syndesisio/syndesis/issues/2452

This is also a branch of the patternfly upgrade branch which has yet to be merged - https://github.com/syndesisio/syndesis/pull/2847

The 3 files that changed for this are:

* `/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss`
* `/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html`
* `/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts`

You can see the new inline edit pattern in patternfly here: 
* https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/inline-edit-for-form.html

I took my best stab at updating the JS to support the new actions. I imagine this needs to be refactored 🙂

Also some things I couldn't figure out but probably aren't showstoppers.

* enable submitting the edit when you hit the "enter" key in `input` edits
* keep the inline edit active when you click on the disabled grey checkmark button
* for some reason when you hit "enter" in either the "host" or "base url" input fields, the focus changes to the "name" input field
* move the spinner from the top/right of the card into each individual field as it updates.