### PR TITLE
update editable textarea component to the new patternfly ui

### DIFF
--- a/app/ui/src/app/common/editable/editable-textarea.component.ts
+++ b/app/ui/src/app/common/editable/editable-textarea.component.ts
@@ -24,8 +24,8 @@ import { EditableComponent } from './editable.component';
         autocomplete="off"
         aria-label="description"
         (keyup)="valueChanged($event)"></textarea>
+      <span class="help-block pull-left" *ngIf="errorMessage">{{ errorMessage }}</span>
       <div class="action-buttons">
-        <span class="help-block pull-left" *ngIf="errorMessage">{{ errorMessage }}</span>
         <button
           type="button"
           class="btn btn-primary form-control-pf-save"

--- a/app/ui/src/app/common/editable/editable-textarea.component.ts
+++ b/app/ui/src/app/common/editable/editable-textarea.component.ts
@@ -4,26 +4,45 @@ import { EditableComponent } from './editable.component';
 @Component({
   selector: 'syndesis-editable-textarea',
   template: `
-    <ng-template [ngIf]="!editing">
-      <em class="text-muted" *ngIf="!value">
-        {{ placeholder }}
-      </em>
-      <ng-container *ngIf="value">
-        {{ value }}
-      </ng-container>
-      <button type="button" class="btn btn-link" (click)="editing = true">
-        <i class="fa fa-pencil" aria-hidden="true" title="Click to edit"></i>
+    <div class="form-control-pf-editable form-control-pf-full-width"
+      [ngClass]="{'form-control-pf-edit': editing, 'has-error': errorMessage}">
+      <button
+        (click)="startEditing(textareaInput)"
+        type="button"
+        class="form-control-pf-value">
+        <em class="text-muted" *ngIf="!value">
+          {{ placeholder }}
+        </em>
+        <ng-container *ngIf="value">
+          {{ value }}
+        </ng-container>
+        <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
       </button>
-    </ng-template>
-
-    <ng-template [ngIf]="editing">
-      <div class="form-group" [ngClass]="{'has-error': errorMessage}">
-        <textarea #textareaInput class="form-control" [ngModel]="value"></textarea>
-        <span class="help-block" *ngIf="errorMessage">{{ errorMessage }}</span>
+      <textarea #textareaInput
+        [ngModel]="value"
+        class="form-control form-control-pf-editor"
+        autocomplete="off"
+        aria-label="description"
+        (keyup)="valueChanged($event)"></textarea>
+      <div class="action-buttons">
+        <span class="help-block pull-left" *ngIf="errorMessage">{{ errorMessage }}</span>
+        <button
+          type="button"
+          class="btn btn-primary form-control-pf-save"
+          aria-label="Save"
+          [disabled]="!enableSave"
+          (mousedown)="submit(textareaInput.value.trim())">
+          <i class="glyphicon glyphicon-ok"></i>
+        </button>
+        <button
+          type="button"
+          class="btn btn-default form-control-pf-cancel"
+          aria-label="Cancel"
+          (click)="cancel()">
+          <i class="glyphicon glyphicon-remove"></i>
+        </button>
       </div>
-      <button type="button" class="btn btn-primary" (click)="submit(textareaInput.value.trim())">Save</button>
-      <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
-    </ng-template>
+    </div>
   `
 })
 export class EditableTextareaComponent extends EditableComponent {}

--- a/app/ui/src/app/common/editable/editable-textarea.component.ts
+++ b/app/ui/src/app/common/editable/editable-textarea.component.ts
@@ -18,11 +18,12 @@ import { EditableComponent } from './editable.component';
         </ng-container>
         <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
       </button>
-      <textarea #textareaInput
+      <textarea #textareaInput="ngModel"
         [ngModel]="value"
         class="form-control form-control-pf-editor"
         autocomplete="off"
         aria-label="description"
+        (blur)="cancel(textareaInput)"
         (keyup)="valueChanged($event)"></textarea>
       <span class="help-block pull-left" *ngIf="errorMessage">{{ errorMessage }}</span>
       <div class="action-buttons">
@@ -38,7 +39,7 @@ import { EditableComponent } from './editable.component';
           type="button"
           class="btn btn-default form-control-pf-cancel"
           aria-label="Cancel"
-          (click)="cancel()">
+          (click)="cancel(textareaInput)">
           <i class="glyphicon glyphicon-remove"></i>
         </button>
       </div>

--- a/app/ui/src/app/common/editable/editable.component.ts
+++ b/app/ui/src/app/common/editable/editable.component.ts
@@ -7,6 +7,8 @@ export abstract class EditableComponent {
   @Output() onSave = new EventEmitter<any>();
   editing: boolean;
   errorMessage: string;
+  originalValue: string;
+  enableSave: boolean;
 
   async submit(value) {
     this.errorMessage = await this.validate(value);
@@ -29,5 +31,19 @@ export abstract class EditableComponent {
   cancel() {
     this.errorMessage = null;
     this.editing = false;
+  }
+
+  startEditing(el) {
+    this.enableSave = false;
+    this.editing = true;
+    this.originalValue = el.value;
+  }
+
+  valueChanged(e) {
+    if (this.originalValue == e.srcElement.value) {
+      this.enableSave = false;
+    } else {
+      this.enableSave = true;
+    }
   }
 }

--- a/app/ui/src/app/common/editable/editable.component.ts
+++ b/app/ui/src/app/common/editable/editable.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgModel } from '@angular/forms';
 
 export abstract class EditableComponent {
   @Input() value;
@@ -28,19 +29,33 @@ export abstract class EditableComponent {
     this.editing = false;
   }
 
-  cancel() {
+  cancel(el) {
     this.errorMessage = null;
     this.editing = false;
+    if (!el) {
+      // currently for the input/tag controls el won't be set since the template doesn't pass it in as an argument
+      return;
+    }
+    // 'el' here is an instance of NgModel ideally
+    if (el.reset) {
+      el.reset(this.originalValue);
+    }
   }
 
   startEditing(el) {
+    // Access the underlying control, for the textarea template currently an NgModel instance is being passed in
+    const _el = el.control || el;
     this.enableSave = false;
     this.editing = true;
     this.originalValue = el.value;
+    if (_el.focus) {
+      setTimeout(() => _el.focus(), 500);
+    }
   }
 
   valueChanged(e) {
-    if (this.originalValue == e.srcElement.value) {
+    // ideally we should get ahold of the NgModel instance, no need to access the DOM element
+    if (this.originalValue === e.srcElement.value) {
       this.enableSave = false;
     } else {
       this.enableSave = true;


### PR DESCRIPTION
part of https://github.com/syndesisio/syndesis/issues/2452

2 things I couldn't figure out...

* I can't seem to get the `blur` or `focusout` events to fire on the `textarea`, so that when you click outside of it, it runs `cancel()`
* If you have a value in the `textarea`, then edit the `textarea` and remove all of the contents and hit `cancel`, that works and the original value is shown. However, if you then go back in and edit the `textarea` again, the textarea is empty while you're editing it.