### PR TITLE
chore: Update to AtlasMap 1.35.4

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,7 +37,7 @@
     <syndesis.version>${project.version}</syndesis.version>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>1.35.0</atlasmap.version>
+    <atlasmap.version>1.35.4</atlasmap.version>
     <camel-atlasmap.version>${atlasmap.version}</camel-atlasmap.version>
 
     <!-- Image names -->
@@ -1235,6 +1235,12 @@
         <groupId>io.syndesis</groupId>
         <artifactId>project-generator</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.atlasmap</groupId>
+        <artifactId>atlas-api</artifactId>
+        <version>${atlasmap.version}</version>
       </dependency>
 
       <dependency>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -278,6 +278,10 @@
     <!-- Atlasmap Data Mapper Services -->
     <dependency>
       <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.atlasmap</groupId>
       <artifactId>atlas-java-model</artifactId>
     </dependency>
     <dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/atlas/SyndesisAtlasService.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/atlas/SyndesisAtlasService.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.server.endpoint.v1.handler.atlas;
 
+import io.atlasmap.api.AtlasException;
 import io.atlasmap.service.AtlasService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -25,4 +26,9 @@ import javax.ws.rs.Path;
 @ConditionalOnProperty(name="atlas.enabled", havingValue = "true", matchIfMissing = true)
 @Path("/atlas")
 public class SyndesisAtlasService extends AtlasService {
+
+    public SyndesisAtlasService() throws AtlasException {
+        super();
+    }
+
 }

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
-    "@atlasmap/atlasmap-data-mapper": "1.35.0",
+    "@atlasmap/atlasmap-data-mapper": "1.35.4",
     "@ng-dynamic-forms/core": "^5.4.6",
     "@ngrx/effects": "^4.1.1",
     "@ngrx/store": "^4.1.1",

--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -385,6 +385,13 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
       baseUrl,
       this.configService
     );
+
+    try {
+      this.cfg.initCfg.disableMappingPreviewMode =
+        this.configService.getSettings('datamapper', 'disableMappingPreviewMode');
+    } catch (err) {
+      this.cfg.initCfg.disableMappingPreviewMode = true;
+    }
   }
 
   private fetchServiceUrl(

--- a/app/ui/src/config.json.example
+++ b/app/ui/src/config.json.example
@@ -17,6 +17,7 @@
     "baseJavaInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/json/",
+    "disableMappingPreviewMode": true,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSources": false,

--- a/app/ui/src/config.json.minishift
+++ b/app/ui/src/config.json.minishift
@@ -22,6 +22,7 @@
     "baseJavaInspectionServiceUrl": "/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "/api/v1/atlas/json/",
+    "disableMappingPreviewMode": true,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSingleSource": false,

--- a/app/ui/src/config.json.staging
+++ b/app/ui/src/config.json.staging
@@ -20,6 +20,7 @@
     "baseJavaInspectionServiceUrl": "/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "/api/v1/atlas/json/",
+    "disableMappingPreviewMode": true,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSingleSource": false,

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -159,9 +159,9 @@
   dependencies:
     tslib "^1.7.1"
 
-"@atlasmap/atlasmap-data-mapper@1.35.0":
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.35.0.tgz#757a97001d90c486b3800d73c968e67a6040707a"
+"@atlasmap/atlasmap-data-mapper@1.35.4":
+  version "1.35.4"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.35.4.tgz#160fb2bb93f41333a9f0a5545ecf4628c9258ba3"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This update contains:
* Gap control for separate/combine index (atlasmap/atlasmap#449)
* A prototype of data preview mode for single mapping (atlasmap/atlasmap#451)