### PR TITLE
Meta pod doesn't start because: Cannot determine embedded database driver class for database type NONE

### DIFF
--- a/app/meta/src/main/resources/application.yml
+++ b/app/meta/src/main/resources/application.yml
@@ -34,7 +34,9 @@ endpoints:
 # Disable ActiveMQ auto-configuration of an embedded Broker
 spring:
   autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration
+    exclude:
+      - org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
 io:
   syndesis:


### PR DESCRIPTION
Fixes #2967