### PR TITLE
Allow to specify http headers for datamapper step in Webhooks

### DIFF
--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -29,6 +29,16 @@
   <packaging>jar</packaging>
 
   <dependencies>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
@@ -49,13 +59,20 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>connector-support-verifier</artifactId>
-      <version>${project.version}</version>
-      <optional>true</optional>
-      <scope>provided</scope>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration</groupId>
+      <artifactId>integration-component-proxy</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
@@ -69,10 +86,7 @@
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>io.syndesis.integration</groupId>
-      <artifactId>integration-component-proxy</artifactId>
-    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
+++ b/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
@@ -15,21 +15,91 @@
  */
 package io.syndesis.connector.webhook;
 
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
-import org.apache.camel.Exchange;
-
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
-public class WebhookConnectorCustomizer implements ComponentProxyCustomizer {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeAware;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.util.Json;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.RuntimeCamelException;
+
+public class WebhookConnectorCustomizer implements ComponentProxyCustomizer, CamelContextAware, DataShapeAware {
+    public static final String SCHEMA_ID = "io:syndesis:webhook";
+
+    private CamelContext camelContext;
+    private DataShape inputDataShape;
+    private DataShape outputDataShape;
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public DataShape getInputDataShape() {
+        return inputDataShape;
+    }
+
+    @Override
+    public void setInputDataShape(DataShape inputDataShape) {
+        this.inputDataShape = inputDataShape;
+    }
+
+    @Override
+    public DataShape getOutputDataShape() {
+        return outputDataShape;
+    }
+
+    @Override
+    public void setOutputDataShape(DataShape outputDataShape) {
+        this.outputDataShape = outputDataShape;
+    }
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        if (outputDataShape != null && outputDataShape.getKind() == DataShapeKinds.JSON_SCHEMA && outputDataShape.getSpecification() != null) {
+            try {
+                ObjectSchema schema = Json.reader().forType(ObjectSchema.class).readValue(outputDataShape.getSpecification());
+                if (SCHEMA_ID.equals(schema.getId())) {
+                    // check that the schema contains the right properties
+                    if (!(schema.getProperties().get("parameters") instanceof ObjectSchema)) {
+                        throw new IllegalArgumentException("JsonSchema does not define parameters property");
+                    }
+                    if (!(schema.getProperties().get("body") instanceof ObjectSchema)) {
+                        throw new IllegalArgumentException("JsonSchema does not define body property");
+                    }
+
+                    component.setBeforeConsumer(new WrapperProcessor(schema));
+                }
+            } catch (IOException e) {
+                throw new RuntimeCamelException(e);
+            }
+        }
+
         // Unconditionally we remove output in 7.1 release
         component.setAfterConsumer(this::removeOutput);
     }
 
-    public void removeOutput(final Exchange exchange) {
+    private void removeOutput(final Exchange exchange) {
         exchange.getOut().setBody("");
         exchange.getOut().removeHeaders("*");
 
@@ -37,6 +107,47 @@ public class WebhookConnectorCustomizer implements ComponentProxyCustomizer {
             // In case of exception, we leave the error code as is
             exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 204);
             exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_TEXT, "No Content");
+        }
+    }
+
+    private static class WrapperProcessor implements Processor {
+        private final ObjectSchema schema;
+
+        public WrapperProcessor(ObjectSchema schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            final Message message = exchange.getIn();
+            final Object body = message.getBody();
+            final Map<String, JsonSchema> properties = this.schema.getProperties();
+
+            ObjectNode rootNode = Json.copyObjectMapperConfiguration().createObjectNode();
+            ObjectNode parametersNode = rootNode.putObject("parameters");
+
+            if (body instanceof String) {
+                rootNode.putPOJO("body", Json.reader().forType(JsonNode.class).readValue((String)body));
+            } else if (body instanceof InputStream) {
+                rootNode.putPOJO("body", Json.reader().forType(JsonNode.class).readValue((InputStream)body));
+            } else {
+                rootNode.putPOJO("body", body);
+            }
+
+            if (properties.get("parameters") instanceof ObjectSchema) {
+                ObjectSchema parameters = (ObjectSchema)properties.get("parameters");
+
+                for (Map.Entry<String, JsonSchema> header : parameters.getProperties().entrySet()) {
+                    if (header.getValue() instanceof StringSchema) {
+                        parametersNode.put(
+                            header.getKey(),
+                            message.getHeader(header.getKey(), String.class)
+                        );
+                    }
+                }
+            }
+
+            message.setBody(Json.toString(rootNode));
         }
     }
 }


### PR DESCRIPTION
Fixes #2902 

This PR add initial support for webhooks headers averaging a specific json schema to define the headers that have to be included, the proposed schema template is:
 
```json
{
  "$schema": "http: //json-schema.org/schema#",
   "id": "io:syndesis:webhook",
   "type": "object",
   "properties": {
      "parameters": {
         "type": "object",
         "properties": {
         }
      },
      "body": {
         "type": "object",
         "properties": {
         }
      }
   }
}
```

The webhook connector wraps the payload only if:
- the data shape is of type `JSON Schema`
- the schema id is `io:syndesis:webhook`
