### PR TITLE
chore(ui): logout endpoint

### DIFF
--- a/app/ui/angular.json
+++ b/app/ui/angular.json
@@ -40,7 +40,8 @@
               "src/mstile-150x150.png",
               "src/safari-pinned-tab.svg",
               "src/manifest.webapp",
-              "src/browserconfig.xml"
+              "src/browserconfig.xml",
+              "src/logout.html"
             ],
             "styles": [
               "node_modules/patternfly/dist/css/patternfly.css",

--- a/app/ui/docker/nginx-syndesis.conf
+++ b/app/ui/docker/nginx-syndesis.conf
@@ -1,11 +1,22 @@
 server {
     listen       8080;
     server_name  localhost;
-    gzip on;
+    gzip         on;
+    root         /usr/share/nginx/html;
+
+    location = /logout {
+        set $cookie "";
+        if ($http_syndesis_xsrf_token = "awesome") {
+            set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
+        }
+        add_header Set-Cookie $cookie;
+        default_type "text/html; charset=ISO-8859-1";
+        alias /usr/share/nginx/html/logout.html;
+    }
 
     location / {
-        root   /usr/share/nginx/html;
         index  index.html;
         try_files $uri $uri/ /index.html;
     }
+
 }

--- a/app/ui/src/app/core/providers/user-provider.service.ts
+++ b/app/ui/src/app/core/providers/user-provider.service.ts
@@ -2,20 +2,19 @@ import { Injectable, NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { UserService, ApiHttpService, User } from '@syndesis/ui/platform';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpXsrfTokenExtractor } from '@angular/common/http';
+
+import { environment } from '../../../environments/environment';
 
 @Injectable()
 export class UserProviderService extends UserService {
   private user$: Observable<User>;
 
-  /**
-   * UserService constructor
-   * @param {HttpClient} httpClient
-   */
   constructor(
     private httpClient: HttpClient,
     private apiHttpService: ApiHttpService,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private tokenExtractor: HttpXsrfTokenExtractor
   ) {
     super();
   }
@@ -28,11 +27,25 @@ export class UserProviderService extends UserService {
   }
 
   /**
-   * Triggers the logout flow and effectively returns the user to the login page
+   * Triggers the logout flow and renders the HTML response
    */
   logout(): void {
+    this.user$ = null;
     this.ngZone.runOutsideAngular(() => {
-      window.location.href = '/oauth/sign_out';
+      const headers = {};
+      const token = this.tokenExtractor.getToken() || environment.xsrf.defaultTokenValue;
+
+      headers[environment.xsrf.headerName] = token;
+      this.httpClient.get('/logout', {
+        headers: headers,
+        responseType: 'arraybuffer'
+      }).subscribe(buffy => {
+        const html = String.fromCharCode.apply(null, new Uint8Array(buffy));
+        window.history.pushState(null, null, '/logout');
+        window.document.open();
+        window.document.write(html);
+        window.document.close();
+      });
     });
   }
 }

--- a/app/ui/src/logout.html
+++ b/app/ui/src/logout.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en-us" class="layout-pf layout-pf-fixed">
+
+<head>
+  <meta charset="utf-8">
+  <title>You have been logged out</title>
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link id="touchIcon" rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link id="favicon32" rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link id="favicon16" rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#cc0000">
+  <meta name="theme-color" content="#ffffff">
+  <style>
+a:active,a:hover{outline:0;}
+h1{margin:.67em 0;}
+ @media print{
+*,:after,:before{background:0 0!important;color:#000!important;box-shadow:none!important;text-shadow:none!important;}
+a,a:visited{text-decoration:underline;}
+a[href]:after{content:" (" attr(href) ")";}
+p{orphans:3;widows:3;}
+}
+*,:after,:before{box-sizing:border-box;}
+body{margin:0;font-family:"Open Sans",Helvetica,Arial,sans-serif;font-size:12px;line-height:1.66666667;color:#363636;background-color:#fff;}
+a{background-color:transparent;color:#0088ce;text-decoration:none;}
+a:focus,a:hover{color:#00659c;text-decoration:underline;}
+a:focus{outline:-webkit-focus-ring-color auto 5px;outline-offset:-2px;}
+h1{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;}
+h1{margin-top:20px;margin-bottom:10px;}
+h1{font-size:24px;}
+p{margin:0 0 10px;}
+.container-fluid{margin-right:auto;margin-left:auto;padding-left:20px;padding-right:20px;}
+.row{margin-left:-20px;margin-right:-20px;}
+.col-lg-6,.col-md-6,.col-sm-8{position:relative;min-height:1px;padding-left:20px;padding-right:20px;}
+ @media (min-width:768px){
+.col-sm-8{float:left;}
+.col-sm-8{width:66.66666667%;}
+.col-sm-offset-2{margin-left:16.66666667%;}
+}
+ @media (min-width:992px){
+.col-md-6{float:left;}
+.col-md-6{width:50%;}
+.col-md-offset-3{margin-left:25%;}
+}
+ @media (min-width:1200px){
+.col-lg-6{float:left;}
+.col-lg-6{width:50%;}
+.col-lg-offset-4{margin-left:33.33333333%;}
+}
+.btn{display:inline-block;margin-bottom:0;font-weight:600;text-align:center;vertical-align:middle;touch-action:manipulation;cursor:pointer;background-image:none;border:1px solid transparent;white-space:nowrap;padding:2px 6px;font-size:12px;line-height:1.66666667;border-radius:1px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;}
+.btn:active:focus,.btn:focus{outline:-webkit-focus-ring-color auto 5px;outline-offset:-2px;}
+.btn:focus,.btn:hover{color:#4d5258;text-decoration:none;}
+.btn:active{outline:0;background-image:none;box-shadow:inset 0 3px 5px rgba(0,0,0,.125);}
+.btn-primary:focus{color:#fff;background-color:#00669b;border-color:#00121d;}
+.btn-primary:active,.btn-primary:hover{color:#fff;background-color:#00669b;border-color:#003d5f;}
+.btn-primary:active:focus,.btn-primary:active:hover{color:#fff;background-color:#004f77;border-color:#00121d;}
+.btn-primary:active{background-image:none;}
+.container-fluid:after,.container-fluid:before,.row:after,.row:before{content:" ";display:table;}
+.container-fluid:after,.row:after{clear:both;}
+.btn{box-shadow:0 2px 3px rgba(3,3,3,.1);}
+.btn:active{box-shadow:inset 0 2px 8px rgba(3,3,3,.2);}
+.btn-primary{background-color:#0088ce;background-image:linear-gradient(to bottom,#39a5dc 0,#0088ce 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff39a5dc', endColorstr='#ff0088ce', GradientType=0);border-color:#00659c;color:#fff;}
+.btn-primary:active,.btn-primary:focus,.btn-primary:hover{background-color:#0088ce;background-image:none;border-color:#00659c;color:#fff;}
+.btn-primary:active{background-image:none;}
+.btn-primary:active:focus,.btn-primary:active:hover{background-color:#0077b5;border-color:#004e78;}
+h1{font-weight:300;}
+.layout-pf body{min-height:100%;}
+.layout-pf.layout-pf-fixed body{padding-top:60px;}
+body{height:100%;}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:300;src:url(OpenSans-Light-webfont.357d675366cce0fbb6ca.eot);src:local("Open Sans Light"),local("OpenSans-Light"),url(OpenSans-Light-webfont.357d675366cce0fbb6ca.eot#iefix) format("embedded-opentype"),url(OpenSans-Light-webfont.ea284cc760cad1896d4c.woff2) format("woff2"),url(OpenSans-Light-webfont.3b3cbaef084e27f7fa05.woff) format("woff"),url(OpenSans-Light-webfont.1bf71be111189e76987a.ttf) format("truetype"),url(OpenSans-Light-webfont.41ef8e5d0ac536545113.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:400;src:url(OpenSans-Regular-webfont.98255d04bb0ce821171e.eot);src:local("Open Sans"),local("OpenSans"),url(OpenSans-Regular-webfont.98255d04bb0ce821171e.eot#iefix) format("embedded-opentype"),url(OpenSans-Regular-webfont.6fd1f924cd0bea5d5f74.woff2) format("woff2"),url(OpenSans-Regular-webfont.60bdb28dc8230486c5b0.woff) format("woff"),url(OpenSans-Regular-webfont.629a55a7e793da068dc5.ttf) format("truetype"),url(OpenSans-Regular-webfont.d9bee607e42329e3ae45.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:300;src:url(OpenSans-LightItalic-webfont.9a599f54797d2ae5a61a.eot);src:local("Open Sans Light Italic"),local("OpenSansLight-Italic"),url(OpenSans-LightItalic-webfont.9a599f54797d2ae5a61a.eot#iefix) format("embedded-opentype"),url(OpenSans-LightItalic-webfont.3ea4cffdf67ebf2ad373.woff2) format("woff2"),url(OpenSans-LightItalic-webfont.9c9017a313819aa54e95.woff) format("woff"),url(OpenSans-LightItalic-webfont.6943fb6fd4200f3d0734.ttf) format("truetype"),url(OpenSans-LightItalic-webfont.b348357e35677da79b5c.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:400;src:url(OpenSans-Italic-webfont.b07fc5b16bb5ecf336f3.eot);src:local("Open Sans Italic"),local("OpenSans-Italic"),url(OpenSans-Italic-webfont.b07fc5b16bb5ecf336f3.eot#iefix) format("embedded-opentype"),url(OpenSans-Italic-webfont.f01a4402103c9ef93506.woff2) format("woff2"),url(OpenSans-Italic-webfont.7aee35e0d937a1fa3456.woff) format("woff"),url(OpenSans-Italic-webfont.c7dcce084c445260a266.ttf) format("truetype"),url(OpenSans-Italic-webfont.3e2b2e91221492e315c4.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:600;src:url(OpenSans-Semibold-webfont.ce26ce4629f1e78f6665.eot);src:local("Open Sans Semibold"),local("OpenSans-Semibold-webfont"),url(OpenSans-Semibold-webfont.ce26ce4629f1e78f6665.eot#iefix) format("embedded-opentype"),url(OpenSans-Semibold-webfont.aa22ff6fd92ecdf402f0.woff2) format("woff2"),url(OpenSans-Semibold-webfont.2418db91905ed032bf3a.woff) format("woff"),url(OpenSans-Semibold-webfont.33f225b8f5f7d6b34a09.ttf) format("truetype"),url(OpenSans-Semibold-webfont.400ab808e8b3ba053d41.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:600;src:url(OpenSans-SemiboldItalic-webfont.ca4e3b468e0d24ae948b.eot);src:local("Open Sans Semibold Italic"),local("OpenSans-SemiboldItalic-webfont"),url(OpenSans-SemiboldItalic-webfont.ca4e3b468e0d24ae948b.eot#iefix) format("embedded-opentype"),url(OpenSans-SemiboldItalic-webfont.ca4d226c2c041ce9d9e9.woff2) format("woff2"),url(OpenSans-SemiboldItalic-webfont.cc62fb5c139ff4ec74ef.woff) format("woff"),url(OpenSans-SemiboldItalic-webfont.73f7301a9cd7a0862954.ttf) format("truetype"),url(OpenSans-SemiboldItalic-webfont.7350876ed9eaf44d9555.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:700;src:url(OpenSans-Bold-webfont.60449ee63020f7a26f19.eot);src:local("Open Sans Bold"),local("OpenSans-Bold"),url(OpenSans-Bold-webfont.60449ee63020f7a26f19.eot#iefix) format("embedded-opentype"),url(OpenSans-Bold-webfont.7a1d4327518eab8c5600.woff2) format("woff2"),url(OpenSans-Bold-webfont.0d8fa9d9810a6543e922.woff) format("woff"),url(OpenSans-Bold-webfont.50145685042b4df07a1f.ttf) format("truetype"),url(OpenSans-Bold-webfont.99c9f24dd717e50a36d0.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:700;src:url(OpenSans-BoldItalic-webfont.d09461e773d7a1945022.eot);src:local("Open Sans Bold Italic"),local("OpenSans-BoldItalic"),url(OpenSans-BoldItalic-webfont.d09461e773d7a1945022.eot#iefix) format("embedded-opentype"),url(OpenSans-BoldItalic-webfont.fba8b2a7052485cec44b.woff2) format("woff2"),url(OpenSans-BoldItalic-webfont.8642dbfe531a38f6ab83.woff) format("woff"),url(OpenSans-BoldItalic-webfont.78b08a68d05d5fabb0b8.ttf) format("truetype"),url(OpenSans-BoldItalic-webfont.04b273bca14cbdba6b0b.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:800;src:url(OpenSans-ExtraBoldItalic-webfont.957287ebc80dcf9381c2.eot);src:local("Open Sans Extrabold Italic"),local("OpenSans-ExtraboldItalic"),url(OpenSans-ExtraBoldItalic-webfont.957287ebc80dcf9381c2.eot#iefix) format("embedded-opentype"),url(OpenSans-ExtraBoldItalic-webfont.7789cb285e0fdd866795.woff2) format("woff2"),url(OpenSans-ExtraBoldItalic-webfont.51c4ab203f9003ce49cc.woff) format("woff"),url(OpenSans-ExtraBoldItalic-webfont.73d6bb0d4f596a91992e.ttf) format("truetype"),url(OpenSans-ExtraBoldItalic-webfont.6be75e80b3b60ec7e673.svg#OpenSans) format("svg");}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:800;src:url(OpenSans-ExtraBold-webfont.2291980bac6d45447c90.eot);src:local("Open Sans Extrabold"),local("OpenSans-Extrabold"),url(OpenSans-ExtraBold-webfont.2291980bac6d45447c90.eot#iefix) format("embedded-opentype"),url(OpenSans-ExtraBold-webfont.b91b03551cbc5aec3c29.woff2) format("woff2"),url(OpenSans-ExtraBold-webfont.b40092f742715ad203db.woff) format("woff"),url(OpenSans-ExtraBold-webfont.8bac22ed4fd7c8a30536.ttf) format("truetype"),url(OpenSans-ExtraBold-webfont.c13d9e6d9d5e10ed7891.svg#OpenSans) format("svg");}
+  </style>
+</head>
+
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-4">
+        <h1>You have been logged out</h1>
+        <p>To login again choose the login button below.</p>
+        <p><a class="btn btn-primary" href="/">Login</a></p>
+      </div><!-- col -->
+    </div><!-- row -->
+  </div><!-- container -->
+</body>
+
+</html>

--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -83,6 +83,8 @@
             - --cookie-secret=$(OAUTH_COOKIE_SECRET)
             - --pass-access-token
             - --skip-provider-button
+            - --skip-auth-regex=/logout
+            - --skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)
             - --skip-auth-regex=/api/v1/swagger.*
             - --skip-auth-regex=/api/v1/index.html
             - --skip-auth-regex=/api/v1/credentials/callback

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -887,6 +887,8 @@ objects:
             - --cookie-secret=$(OAUTH_COOKIE_SECRET)
             - --pass-access-token
             - --skip-provider-button
+            - --skip-auth-regex=/logout
+            - --skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)
             - --skip-auth-regex=/api/v1/swagger.*
             - --skip-auth-regex=/api/v1/index.html
             - --skip-auth-regex=/api/v1/credentials/callback

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -885,6 +885,8 @@ objects:
             - --cookie-secret=$(OAUTH_COOKIE_SECRET)
             - --pass-access-token
             - --skip-provider-button
+            - --skip-auth-regex=/logout
+            - --skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)
             - --skip-auth-regex=/api/v1/swagger.*
             - --skip-auth-regex=/api/v1/index.html
             - --skip-auth-regex=/api/v1/credentials/callback


### PR DESCRIPTION
This adds a `/logout` endpoint backed by nginx and static logout.html
file.

When `/logout` endpoint is requested with the `SYNDESIS_XSRF_TOKEN` set
to `awesome` the response will expire the `_oauth_proxy` cookie. In any
case it will serve the `logout.html`.

The UI when performing the logout will replace the `window.document`
with the response of the `/logout` endpoint and will set the URL to
`/logout`.

This design protects the denial of service if the `/logout` endpoint is
invoked cross origin and allows for the served page to be reloaded
making it deterministic and thus safer.

The `logout.html` embeds the used CSS and just displays a simple _You
have been logged out_ message offering to Login again by linking to `/`.

Fixes #2561