### PR TITLE
chore: use --force to ensure node-saas gets rebuilt as needed

### DIFF
--- a/app/ui/pom.xml
+++ b/app/ui/pom.xml
@@ -62,7 +62,7 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
-              <arguments>install --no-progress</arguments>
+              <arguments>install --no-progress --force</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This helps avoid any issues when doing local dev and running `syndesis build`, `--force` ensures that any native modules will get rebuilt using the same node version that the maven frontend plugin uses.