### PR TITLE
chore: Remove workarounds used for GA release

### DIFF
--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -213,8 +213,10 @@
       maven:
         repositories:
           01_maven_central: https://repo1.maven.org/maven2
-          02_redhat_ea_repository: https://maven.repository.redhat.com/earlyaccess/all
-          03_jboss_ea: https://repository.jboss.org/nexus/content/groups/ea
+{{#EarlyAccess}}          02_redhat_ea_repository: https://maven.repository.redhat.com/earlyaccess/all
+          03_jboss_ea: https://repository.jboss.org/nexus/content/groups/ea{{/EarlyAccess}}{{^EarlyAccess}}
+          02_redhat_ea_repository: https://maven.repository.redhat.com/ga/
+          03_jboss_ea: https://repository.jboss.org/{{/EarlyAccess}}
 {{/Productized}}      openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}

--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -37,7 +37,7 @@
     spec:
       containers:
       - name: upgrade
-        image: syndesis/syndesis-upgrade:${SYNDESIS_VERSION}
+        image: {{ Images.SyndesisImage}}/{{ Images.Syndesis.Upgrade }}:${SYNDESIS_VERSION}
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -37,7 +37,7 @@
     spec:
       containers:
       - name: upgrade
-        image: {{ Images.SyndesisImage}}/{{ Images.Syndesis.Upgrade }}:${SYNDESIS_VERSION}
+        image: {{ Images.SyndesisImagesPrefix }}/{{ Images.Syndesis.Upgrade }}:${SYNDESIS_VERSION}
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/install/generator/syndesis-template.go
+++ b/install/generator/syndesis-template.go
@@ -47,6 +47,7 @@ type syndesisImages struct {
 	Ui       string
 	Verifier string
 	S2i      string
+	Upgrade  string
 }
 
 type images struct {
@@ -70,6 +71,7 @@ type Context struct {
 	AllowLocalHost   bool
 	WithDockerImages bool
 	Productized      bool
+	EarlyAccess      bool
 	Oso              bool
 	Ocp              bool
 	Tag              string
@@ -95,6 +97,7 @@ var syndesisContext = Context{
 			Ui:       "syndesis-ui",
 			Verifier: "syndesis-meta",
 			S2i:      "syndesis-s2i",
+			Upgrade:  "syndesis-upgrade",
 		},
 	},
 	Tags: tags{
@@ -108,7 +111,7 @@ var syndesisContext = Context{
 var productContext = Context{
 	Images: images{
 		ImageStreamNamespace:  "fuse-ignite",
-		SyndesisImagesPrefix:  "syndesis",
+		SyndesisImagesPrefix:  "fuse7",
 		OAuthProxyImagePrefix: "openshift",
 		PrometheusImagePrefix: "prom",
 		Support: supportImages{
@@ -121,6 +124,7 @@ var productContext = Context{
 			Ui:       "fuse-ignite-ui",
 			Verifier: "fuse-ignite-meta",
 			S2i:      "fuse-ignite-s2i",
+			Upgrade:  "fuse-ignite-upgrade",
 		},
 	},
 	Tags: tags{
@@ -142,6 +146,7 @@ func init() {
 	flags.StringVar(&context.Tags.Syndesis, "syndesis-tag", "latest", "Syndesis Image tag to use")
 	flags.BoolVar(&context.Oso, "oso", false, "Generate product templates for SO")
 	flags.BoolVar(&context.Ocp, "ocp", false, "Generate product templates for OCP")
+	flags.BoolVar(&context.EarlyAccess, "early-access", false, "Point repositories to early-access repos")
 	flags.StringVar(&context.Registry, "registry", "docker.io", "Registry to use for imagestreams")
 	flags.BoolVar(&context.Debug, "debug", false, "Enable debug support")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
Fixes #2639

A new flag --early-access has been introduced for the generator so
that the EA Maven repos can be added for the productised builds.
Otherwise, and by default, the 'real' repos are used:

EA-Repos:

02_redhat_ea_repository: https://maven.repository.redhat.com/earlyaccess/all
03_jboss_ea: https://repository.jboss.org/nexus/content/groups/ea

GA Repos:

02_redhat_ea_repository: https://maven.repository.redhat.com/ga/
03_jboss_ea: https://repository.jboss.org/

Please only merge together with https://github.com/syndesisio/fuse-ignite-install/pull/28