### PR TITLE
fix(server): gather integration logs for support

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1011,7 +1011,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-model</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.10</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
At a point we stopped using labels on integration pods, so we need to
use annotations to identify individual integrations. This changes this
behavior only for fetching logs of integration pods.

`kubernetes-model` needed to be updated to include fix for
fabric8io/kubernetes-model/issues/296[1]

Fixes #2386

[1] https://github.com/fabric8io/kubernetes-model/issues/296