### PR TITLE
UI work for fetching the detailed status

### DIFF
--- a/app/ui/src/app/core/providers/integration-support-provider.service.ts
+++ b/app/ui/src/app/core/providers/integration-support-provider.service.ts
@@ -16,7 +16,8 @@ import {
   ApiHttpService,
   integrationEndpoints,
   UNPUBLISHED,
-  PUBLISHED
+  PUBLISHED,
+  IntegrationStatusDetail
 } from '@syndesis/ui/platform';
 import { EventsService } from '@syndesis/ui/store';
 
@@ -162,6 +163,18 @@ export class IntegrationSupportProviderService extends IntegrationSupportService
     return this.apiHttpService
       .setEndpointUrl(integrationEndpoints.supportData)
       .post<Blob>(data, { responseType: 'blob' });
+  }
+
+  fetchDetailedStatus(id: string): Observable<IntegrationStatusDetail> {
+    return this.apiHttpService
+      .setEndpointUrl(integrationEndpoints.integrationStatusDetail, { id })
+      .get<IntegrationStatusDetail>();
+  }
+
+  fetchDetailedStatuses(): Observable<IntegrationStatusDetail[]> {
+    return this.apiHttpService
+      .setEndpointUrl(integrationEndpoints.integrationStatusDetails)
+      .get<IntegrationStatusDetail[]>();
   }
 
   private getOverview(id: string): Observable<any> {

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -33,9 +33,9 @@
           <syndesis-editable-text [value]="integration.name" [validationFn]="validateName" (onSave)="nameUpdated(integration.id, $event)"></syndesis-editable-text>
         </h1>
         <div>
-          <ng-container [ngSwitch]="integration.currentState">	 
-            <ng-container *ngSwitchCase="'Pending'">	  
-              <div class="spinner spinner-sm spinner-inline"></div> {{ (integration.targetState == 'Published' ? 'integrations.publishing' : 'integrations.unpublishing') | synI18n }}
+          <ng-container [ngSwitch]="integration.currentState">
+            <ng-container *ngSwitchCase="'Pending'">
+              <syndesis-integration-status-detail [integration]="integration"></syndesis-integration-status-detail>
             </ng-container>
             <ng-container *ngSwitchCase="'Published'">
               <span class="pficon pficon-ok"></span> {{ 'published-integration' | synI18n }} version {{ integration.deploymentVersion }}
@@ -50,7 +50,7 @@
         </div>
       </div>
 
-      <div *ngIf="integration.board?.messages && integration.board?.messages.length" class="integration-detail__row">        
+      <div *ngIf="integration.board?.messages && integration.board?.messages.length" class="integration-detail__row">
         <div *ngFor="let message of integration.board.messages">
           <syndesis-inline-alert [message]="message"></syndesis-inline-alert>
         </div>

--- a/app/ui/src/app/integration/list/index.ts
+++ b/app/ui/src/app/integration/list/index.ts
@@ -1,3 +1,4 @@
+export * from './status-detail.component';
 export * from './status.component';
 export * from './list.component';
 export * from './list.module';

--- a/app/ui/src/app/integration/list/list.module.ts
+++ b/app/ui/src/app/integration/list/list.module.ts
@@ -4,6 +4,7 @@ import { VendorModule } from '@syndesis/ui/vendor';
 import { SyndesisCommonModule } from '@syndesis/ui/common';
 import { IntegrationSupportModule } from '../integration-support.module';
 import { IntegrationStatusComponent } from './status.component';
+import { IntegrationStatusDetailComponent } from './status-detail.component';
 import { IntegrationActionMenuComponent } from './action-menu.component';
 import { IntegrationListComponent } from './list.component';
 
@@ -20,12 +21,14 @@ const integrationSupportModuleFwd = forwardRef(() => IntegrationSupportModule);
   declarations: [
     IntegrationActionMenuComponent,
     IntegrationStatusComponent,
+    IntegrationStatusDetailComponent,
     IntegrationListComponent
   ],
   exports: [
     IntegrationActionMenuComponent,
     IntegrationListComponent,
-    IntegrationStatusComponent
+    IntegrationStatusComponent,
+    IntegrationStatusDetailComponent
   ]
 })
 export class IntegrationListModule {}

--- a/app/ui/src/app/integration/list/status-detail.component.ts
+++ b/app/ui/src/app/integration/list/status-detail.component.ts
@@ -1,0 +1,81 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+import { Integration, IntegrationStatusDetail, I18NService, StringMap } from '@syndesis/ui/platform';
+import { ConfigService } from '@syndesis/ui/config.service';
+
+@Component({
+  selector: 'syndesis-integration-status-detail',
+  template: `
+    <ng-container *ngIf="statusDetail">
+      <div>
+        <i [innerHtml]="statusDetailText"></i>&nbsp;
+        <span *ngIf="logUrl" [innerHtml]="'log-link' | synI18n: logUrl"></span>
+      </div>
+      <div class="progress progress-xs">
+        <div class="progress-bar"
+              role="progressbar"
+              [ngStyle]="barWidth">
+              <span class="sr-only">{{ 'bar-width' | synI18n: barWidth.width }}</span>
+              </div>
+      </div>
+    </ng-container>
+    <!-- this is a fallback -->
+    <ng-container *ngIf="!statusDetail">
+      <div class="spinner spinner-sm spinner-inline"></div>
+      <ng-container [ngSwitch]="integration.targetState">
+        <ng-container *ngSwitchCase="'Published'">
+          {{ 'integrations.publishing' | synI18n }}
+        </ng-container>
+        <ng-container *ngSwitchCase="'Unpublished'">
+          {{ 'integrations.unpublishing' | synI18n }}
+        </ng-container>
+        <ng-container *ngSwitchDefault>
+          {{ 'integrations.pending' | synI18n }}
+        </ng-container>
+      </ng-container>
+    </ng-container>
+  `,
+  styles: [
+    `
+      progress: {
+        padding: 0;
+      }
+    `
+  ]
+})
+export class IntegrationStatusDetailComponent implements OnInit {
+  @Input() integration: Integration;
+  statusDetail: IntegrationStatusDetail;
+  statusDetailText: string;
+  logUrl: string;
+  barWidth: StringMap<String> = {
+    width: '0%'
+  };
+
+  constructor(private i18NService: I18NService,
+              private configService: ConfigService) {}
+
+  ngOnInit() {
+    if (this.integration && this.integration.statusDetail) {
+      const statusDetail = this.statusDetail = this.integration.statusDetail;
+      const total = statusDetail.detailedState.totalSteps;
+      const current = statusDetail.detailedState.currentStep;
+      this.statusDetailText =
+        this.i18NService.localize('integration-detail-state',
+                                  [this.i18NService.localize(statusDetail.detailedState.value),
+                                  current,
+                                  total]);
+      this.barWidth.width = ((current / total) * 100) + '%';
+      if (statusDetail.logsUrl) {
+        const base = this.configService.getSettings('consoleUrl');
+        if (base) {
+          const logUrl = statusDetail.logsUrl
+            .replace('https://openshift.default.svc/api/v1/namespaces', `${base}/project`)
+            .replace('/pods/', '/browse/pods/')
+            .replace('/logs', '?tab=logs');
+          this.logUrl = logUrl;
+        }
+      }
+    }
+  }
+}

--- a/app/ui/src/app/integration/list/status.component.ts
+++ b/app/ui/src/app/integration/list/status.component.ts
@@ -8,18 +8,7 @@ import { IntegrationOverview } from '@syndesis/ui/platform';
     <div class="syndesis-integration-status">
       <!-- In Progress -->
       <div class="status pending" *ngIf="integration.currentState === 'Pending'">
-        <div class="spinner spinner-sm spinner-inline"></div>
-        <ng-container [ngSwitch]="integration.targetState">
-          <ng-container *ngSwitchCase="'Published'">
-            {{ 'integrations.publishing' | synI18n }}
-          </ng-container>
-          <ng-container *ngSwitchCase="'Unpublished'">
-            {{ 'integrations.unpublishing' | synI18n }}
-          </ng-container>
-          <ng-container *ngSwitchDefault>
-            {{ 'integrations.pending' | synI18n }}
-          </ng-container>
-        </ng-container>
+        <syndesis-integration-status-detail [integration]="integration"></syndesis-integration-status-detail>
       </div>
       <!-- Status -->
       <div *ngIf="integration.currentState !== 'Pending'"

--- a/app/ui/src/app/platform/types/integration/integration-support.service.ts
+++ b/app/ui/src/app/platform/types/integration/integration-support.service.ts
@@ -11,7 +11,8 @@ import {
   IntegrationOverview,
   IntegrationOverviews,
   IntegrationStatus,
-  ApiHttpService
+  ApiHttpService,
+  IntegrationStatusDetail
 } from '@syndesis/ui/platform';
 
 @Injectable()
@@ -100,4 +101,8 @@ export abstract class IntegrationSupportService {
   ): Observable<Activity[]>;
 
   abstract downloadSupportData(data: any[]): Observable<Blob>;
+
+  abstract fetchDetailedStatus(id: string): Observable<IntegrationStatusDetail>;
+
+  abstract fetchDetailedStatuses(): Observable<IntegrationStatusDetail[]>;
 }

--- a/app/ui/src/app/platform/types/integration/integration.api.ts
+++ b/app/ui/src/app/platform/types/integration/integration.api.ts
@@ -3,6 +3,8 @@ import { Endpoints } from '@syndesis/ui/platform';
 export const integrationEndpoints: Endpoints = {
   integrations: '/integrations',
   integration: '/integrations/{id}',
+  integrationStatusDetail: '/monitoring/integrations/{id}',
+  integrationStatusDetails: '/monitoring/integrations',
   integrationMetrics: '/metrics/integrations',
   integrationMetricsById: '/metrics/integrations/{id}',
   // TODO does this belong here really

--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -63,6 +63,7 @@ export interface Integration extends IntegrationOverview {
   updatedAt: number;
   createdAt: number;
   url: string;
+  statusDetail?: IntegrationStatusDetail;
 }
 
 export type Integrations = Array<Integration>;
@@ -98,6 +99,22 @@ export interface DeploymentOverview extends BaseEntity {
   targetState: IntegrationStatus;
   createdAt: number;
   integrationVersion: number;
+}
+
+export type DetailedStatus = 'ASSEMBLING' | 'BUILDING' | 'DEPLOYING' | 'STARTING';
+
+export interface DetailedState {
+  value: DetailedStatus;
+  currentStep: number;
+  totalSteps: number;
+}
+
+export interface IntegrationStatusDetail {
+  detailedState: DetailedState;
+  logsUrl: string;
+  id: string;
+  integrationId: string;
+  deploymentVersion: number;
 }
 
 // this is for the basic filter operation

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -8,7 +8,7 @@ import {
   Subject
 } from 'rxjs';
 
-import { share, mergeMap, filter } from 'rxjs/operators';
+import { share, mergeMap, filter, debounceTime } from 'rxjs/operators';
 import { plural } from 'pluralize';
 
 import { BaseEntity } from '@syndesis/ui/platform';
@@ -71,7 +71,9 @@ export abstract class AbstractStore<
     // but also update it if we get notified the a change occurred.
     return observableMerge(
       this._list,
-      this.changeEvents.pipe(mergeMap(event => {
+      this.changeEvents.pipe(
+      debounceTime(500),
+        mergeMap(event => {
         // We could probably get fancy one day an only fetch the entry that matches event.id
         // simulate no data
         if (EMPTY_STATE) {

--- a/app/ui/src/app/store/integration/integration.service.ts
+++ b/app/ui/src/app/store/integration/integration.service.ts
@@ -1,16 +1,68 @@
 import { Injectable } from '@angular/core';
-
-import {
-  ApiHttpService,
+import { ApiHttpService,
   Integration,
   Integrations,
-  IntegrationState
-} from '@syndesis/ui/platform';
+  IntegrationSupportService,
+  PENDING,
+  IntegrationStatusDetail } from '@syndesis/ui/platform';
+import { forkJoin, Observable, of } from 'rxjs';
+import { map, mergeMap, switchMap, catchError } from 'rxjs/operators';
 import { RESTService } from '../entity';
+import { log, getCategory } from '../../logging';
 
 @Injectable()
 export class IntegrationService extends RESTService<Integration, Integrations> {
-  constructor(apiHttpService: ApiHttpService) {
+  constructor(apiHttpService: ApiHttpService,
+              protected integrationSupportService: IntegrationSupportService) {
     super(apiHttpService, 'integrations', 'integration');
   }
+
+  get(id: string): Observable<Integration> {
+    return super.get(id).pipe(
+      switchMap(integration => this.checkIfPending(integration))
+    );
+  }
+
+  list(): Observable<Integrations> {
+    return forkJoin<Integrations, IntegrationStatusDetail[]>([
+      super.list(),
+      this.integrationSupportService.fetchDetailedStatuses().pipe(
+        catchError( error => {
+          // can always fall back to showing the coarse status
+          log.warn('error fetching detailed status: ', error);
+          return [];
+        })
+      )
+    ]).pipe(
+      map( results => {
+        const integrations = <Integrations> results[0];
+        const statuses = <IntegrationStatusDetail[]> results [1];
+        statuses.forEach( status => {
+          const integration = integrations.find(i => i.id === status.integrationId);
+          if (integration) {
+            integration.statusDetail = status;
+          }
+        });
+        return integrations;
+      })
+    );
+  }
+
+  private checkIfPending(integration): Observable<Integration> {
+    if (integration.currentState === PENDING) {
+      return this.fetchDetailedStatus(integration);
+    } else {
+      return of(integration);
+    }
+  }
+
+  private fetchDetailedStatus(integration): Observable<Integration> {
+    return this.integrationSupportService.fetchDetailedStatus(integration.id).pipe(
+      map(detailedStatus => {
+        integration.statusDetail = detailedStatus;
+        return integration;
+      })
+    );
+  }
+
 }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -272,7 +272,14 @@
       "unpublish-integration-modal-primary-text": "Stop",
       "delete-integration-modal": "Are you sure you want to delete the \"{{0}}\" integration?",
       "delete-integration-modal-title": "Confirm Delete?",
-      "delete-modal-primary-text": "Delete"
+      "delete-modal-primary-text": "Delete",
+      "assembling": "Assembling",
+      "building": "Building",
+      "deploying": "Deploying",
+      "starting": "Starting",
+      "integration-detail-state": "{{0}} ( {{1}} / {{2}} )",
+      "log-link": "<a href=\"{{0}}\" target=\"_blank\">View Logs <i class=\"fa fa-external-link\"></i></a>",
+      "bar-width": "{{0}} Complete"
     }
   }
 }


### PR DESCRIPTION
fixes #2620

I've added a fallback in the detailed status component so that if the detailed status returns null like it is for me currently it'll just show the old spinner + stopping/starting text.  But when it does return the expected response:

![capture](https://user-images.githubusercontent.com/351660/42467542-339d343a-8380-11e8-9ec3-8a85cf427e03.PNG)


