### PR TITLE
feat(copy-clipboard): introduce copy clipboard for callback/external url

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -25,9 +25,23 @@
     </ng-container>
     <span *ngIf="!last" class="step-sep fa fa-angle-right"></span>
   </div>
-  <p *ngIf="integration.url">
-    External URL: <strong>{{ integration.url }}</strong>
-  </p>
+  <div *ngIf="integration.url" class="block-copy-container container-fluid">
+    <div class="col-sm-8">
+      <p>
+        <pfng-block-copy
+          [buttonAriaLabel]="'Copy External URL'"
+          [expandToggleAriaLabel]="'Expand External URL'"
+          [buttonLabel]="'Copy'"
+          [label]="'External URL'"
+          [value]="integration.url"
+          (onCopy)="handleCopy($event, {
+            name: 'External URL',
+            msg: 'External URL Copied'
+          })">
+        </pfng-block-copy>
+      </p>
+    </div>
+  </div>
   <p>
     <syndesis-editable-textarea [value]="integration.description"
                                 placeholder="No description set..."

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.scss
@@ -103,4 +103,13 @@
       border-top: none;
     }
   }
+
+  .block-copy-container,
+  [class^="col-"] {
+    padding: 0;
+
+    .pfng-block-copy-inner-container {
+      background-color: #fff;
+    }
+  }
 }

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.ts
@@ -1,9 +1,18 @@
 import { Integration, Step } from '@syndesis/ui/platform';
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { NotificationService } from '@syndesis/ui/common';
+import { CopyEvent, NotificationType } from 'patternfly-ng';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ViewEncapsulation
+} from '@angular/core';
 
 import { StepStore } from '@syndesis/ui/store';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   selector: 'syndesis-integration-description',
   templateUrl: './integration-description.component.html',
   styleUrls: ['./integration-description.component.scss']
@@ -14,6 +23,8 @@ export class IntegrationDescriptionComponent {
 
   @Output() viewDetails = new EventEmitter<Step>();
   @Output() attributeUpdated = new EventEmitter<{ [key: string]: string }>();
+
+  constructor(private notificationService: NotificationService) {}
 
   onViewDetails(step: Step): void {
     this.viewDetails.emit(step);
@@ -29,5 +40,19 @@ export class IntegrationDescriptionComponent {
       : index === 0
         ? 'start'
         : '';
+  }
+
+  handleCopy($event: CopyEvent, result: any): void {
+    this.notify(result);
+  }
+
+  notify(result: any): void {
+    this.notificationService.message(
+      NotificationType.SUCCESS,
+      null,
+      result.msg,
+      false,
+      null,
+      null);
   }
 }

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
@@ -5,7 +5,15 @@
       'settings.oauth-apps.documentation-link' | synI18n
     )
   " (click)="handleLinks($event)"></p>
-  <p>{{ 'settings.oauth-apps.registration-instruction' | synI18n: callbackURL }}</p>
+  <p>{{ 'settings.oauth-apps.registration-instruction' | synI18n }}
+    <pfng-inline-copy
+      [buttonAriaLabel]="'Copy Callback URL'"
+      [value]="callbackURL"
+      (onCopy)="handleCopy($event, {
+        name: 'Callback URL',
+        msg: 'Callback URL Copied'
+      })"></pfng-inline-copy>
+  </p>
 
   <!-- Modal -->
   <syndesis-oauth-app-modal #modal></syndesis-oauth-app-modal>

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
@@ -1,14 +1,20 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
 import { OAuthAppStore } from '../../store/oauthApp/oauth-app.store';
 import { OAuthApp, OAuthApps } from '@syndesis/ui/settings';
 import { Observable } from 'rxjs';
 import { ConfigService } from '../../config.service';
-import { UserService } from '@syndesis/ui/platform';
 
 import { ObjectPropertyFilterConfig } from '../../common/object-property-filter.pipe';
 import { ObjectPropertySortConfig } from '../../common/object-property-sort.pipe';
-import { FilterConfig, SortConfig, ToolbarConfig } from 'patternfly-ng';
+import {
+  FilterConfig,
+  SortConfig,
+  ToolbarConfig,
+  CopyEvent,
+  NotificationType
+} from 'patternfly-ng';
+
+import { NotificationService } from '@syndesis/ui/common';
 
 export interface OAuthAppListItem {
   expanded: boolean;
@@ -73,7 +79,7 @@ export class OAuthAppsComponent implements OnInit {
   constructor(
     public store: OAuthAppStore,
     public config: ConfigService,
-    private router: Router
+    private notificationService: NotificationService
   ) {
     this.loading = store.loading;
     this.list = store.list;
@@ -141,5 +147,19 @@ export class OAuthAppsComponent implements OnInit {
       '//' +
       window.location.hostname +
       '/api/v1/credentials/callback';
+  }
+
+  handleCopy($event: CopyEvent, result: any): void {
+    this.notify(result);
+  }
+
+  notify(result: any): void {
+    this.notificationService.message(
+      NotificationType.SUCCESS,
+      null,
+      result.msg,
+      false,
+      null,
+      null);
   }
 }

--- a/app/ui/src/app/vendor/vendor.module.ts
+++ b/app/ui/src/app/vendor/vendor.module.ts
@@ -14,6 +14,8 @@ import {
 
 import {
   ActionModule,
+  BlockCopyModule,
+  InlineCopyModule,
   ToastNotificationModule,
   ToastNotificationListModule,
   InlineNotificationModule,
@@ -33,6 +35,8 @@ const imports = [
   TypeaheadModule.forRoot(),
   BsDropdownModule.forRoot(),
   ActionModule,
+  BlockCopyModule,
+  InlineCopyModule,
   ToastNotificationModule,
   ToastNotificationListModule,
   InlineNotificationModule,
@@ -51,6 +55,8 @@ const _exports = [
   TypeaheadModule,
   BsDropdownModule,
   ActionModule,
+  BlockCopyModule,
+  InlineCopyModule,
   ToastNotificationModule,
   ToastNotificationListModule,
   InlineNotificationModule,

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -132,7 +132,7 @@
         "heading": "OAuth Application Management",
         "description": "To connect to an application that uses the OAuth protocol, obtain a client ID and a client secret from the application. See the {{0}} for help.",
         "documentation-link": "<a href=\"{{links.oauth-access}}\" rel=\"nofollow\">documentation</a>",
-        "registration-instruction": "During registration, enter this callback URL: {{0}}",
+        "registration-instruction": "During registration, enter this callback URL:",
         "list": {
           "item": {
             "description": "Client ID and client secret not configured.",


### PR DESCRIPTION
This PR introduces a copy to clipboard functionality for two places within our UI. One for the external url in the integration details view, and another in the oauth settings management view.

One issue that was found during implementation was related to tooltips. Basically, when a tooltip is applied to one of the copy components, the attribute is duplicated onto the parent container which leaves us with twice tooltips, and doesn't look good. As a stop gap, I've added toast notifications to ensure the users receive adequate feedback regarding their actions.

This above mentioned issue has been captured in https://github.com/syndesisio/syndesis/issues/3022

replace static text for external/callback URL's with interactive copy component
utilize notification service for informing users of successful copy action
rework dictionary entry to account for new copy widget
bandaid copy component styling