### PR TITLE
Simplified IVP

### DIFF
--- a/app/ui/src/app/integration/edit-page/edit-page.component.html
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.html
@@ -3,7 +3,7 @@
     <div [class]="getPageRow()">
 
       <!-- Sidebar -->
-      <div [class]="getSidebarClass()">
+      <div class="wizard-sidebar">
         <syndesis-integration-flow-view></syndesis-integration-flow-view>
       </div>
 

--- a/app/ui/src/app/integration/edit-page/edit-page.component.scss
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.scss
@@ -36,7 +36,7 @@
   }
 
   .wizard-sidebar {
-    min-width: 300px;
+    width: 450px;
     padding-top: $gutter;
   }
 

--- a/app/ui/src/app/integration/edit-page/edit-page.component.scss
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.scss
@@ -30,13 +30,11 @@
     position: relative;
     background: #fafafa;
     border-right: 1px solid #d1d1d1;
-    overflow-x: hidden;
-    overflow-y: auto;
+    height: 100%;
     padding: 0 $gutter;
   }
 
   .wizard-sidebar {
-    width: 450px;
     padding-top: $gutter;
   }
 

--- a/app/ui/src/app/integration/edit-page/edit-page.component.scss
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.scss
@@ -24,18 +24,11 @@
     margin-right: 0;
   }
 
-  .wizard-sidebar,
-  .mapper-sidebar {
+  .wizard-sidebar {
     flex: 0 0 auto;
-    position: relative;
     background: #fafafa;
     border-right: 1px solid #d1d1d1;
     height: 100%;
-    padding: 0 $gutter;
-  }
-
-  .wizard-sidebar {
-    padding-top: $gutter;
   }
 
   .main-panel {

--- a/app/ui/src/app/integration/edit-page/edit-page.component.ts
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.ts
@@ -57,15 +57,6 @@ export class IntegrationEditPage implements OnInit, OnDestroy {
     }
   }
 
-  getSidebarClass() {
-    switch (this.flowPageService.getCurrentStepKind(this.route)) {
-      case 'mapper':
-        return 'mapper-sidebar';
-      default:
-        return 'wizard-sidebar';
-    }
-  }
-
   getPageContainer() {
     switch (this.flowPageService.getCurrentStepKind(this.route)) {
       case 'mapper':

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -21,15 +21,9 @@
   <!-- Icon -->
   <div class="icon-container">
     <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()"
-      [popover]="tooltipPopover"
-      #connectionImgPop="bs-popover"
       placement="right"
-      triggers=""
-      containerClass="flow-view-popover"
-      popoverTitle="Connection Properties"
-      outsideClick="true"
-      container="body"
-      title="{{ stepName }}">
+      [tooltip]="stepNameTooltip"
+      container="body">
       <i [ngClass]="getIconClass()"
           *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
       <img class="syn-icon-small"
@@ -45,6 +39,7 @@
         outsideClick="true"
         (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
         container="body"></span>
+        <ng-template #stepNameTooltip><div class="syn-nowrap">{{ stepName }}</div></ng-template>
     </div>
   </div>
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -18,46 +18,8 @@
     </div>
   </ng-template>
 
-  <ng-template #tooltipPopover>
-    <div class="info-popover container-fluid">
-      <dl class="row">
-        <dt class="col-xs-6 text-right">
-          Name
-        </dt>
-        <dd class="col-xs-6">
-          {{ step.connection?.name }}
-        </dd>
-      </dl>
-      <dl class="row">
-        <dt class="col-xs-6 text-right">
-          Action
-        </dt>
-        <dd class="col-xs-6">
-          {{ step.action?.name }}
-        </dd>
-      </dl>
-      <dl class="row" *ngIf="inputDataShapeText">
-        <dt class="col-xs-6 text-right">
-          Input Data Type
-        </dt>
-        <dd class="col-xs-6">
-          {{ inputDataShapeText }}
-        </dd>
-      </dl>
-      <dl class="row" *ngIf="outputDataShapeText">
-        <dt class="col-xs-6 text-right">
-          Output Data Type
-        </dt>
-        <dd class="col-xs-6">
-          {{ outputDataShapeText }}
-        </dd>
-      </dl>
-    </div>
-  </ng-template>
-
   <!-- Icon Progress Line -->
-  <div class="col-md-3 progress-line">
-    <span class="step-index">{{ stepIndex }}</span>
+  <div class="progress-line">
     <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()"
       [popover]="tooltipPopover"
       #connectionImgPop="bs-popover"
@@ -74,49 +36,40 @@
       <img class="syn-icon-small"
            *ngIf="step.stepKind === 'endpoint' && step.connection"
            [src]="step.connection | synIconPath">
+      <span class="pficon pficon-warning-triangle-o data-mismatch"
+        *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"
+        [popover]="addDatamapper"
+        #datamapperInfoPop="bs-popover"
+        triggers=""
+        containerClass="flow-view-popover"
+        placement="right"
+        outsideClick="true"
+        (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
+        container="body"></span>
     </div>
   </div>
 
   <!-- Step Item Wrapper -->
-  <div class="col-md-9 menu"
+  <div class="menu"
        *ngIf="currentStepKind !== 'mapper'"
        [ngSwitch]="step.stepKind">
 
     <!-- Connection Steps -->
     <div *ngSwitchCase="'endpoint'"
-         [ngClass]="getParentActiveClass() + ' step-container'">
+         [ngClass]="getParentActiveClass()"
+         class="step-container clearfix"> 
 
       <!-- Connection Title -->
       <div [ngClass]="getParentClass()"
-            (click)="goto('action-configure')">
-        <span class="pficon pficon-warning-triangle-o data-mismatch"
-          *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"
-          [popover]="addDatamapper"
-          #datamapperInfoPop="bs-popover"
-          triggers=""
-          containerClass="flow-view-popover"
-          placement="right"
-          outsideClick="true"
-          (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
-          container="body"></span>
+            (click)="goto('action-configure')"
+            class="col-xs-12">
 
         <div class="step-content">
           <div class="step-name" title="{{ stepName }}">
-            {{ stepName }}
+              {{ stepIndex + '. ' + stepName }}
           </div>
 
           <div class="step-icons">
-            <!-- Info icon -->
-            <i class="fa fa-lg fa-info-circle"
-              [popover]="tooltipPopover"
-              #connectionInfoPop="bs-popover"
-              placement="right"
-              (click)="toggleInfoPopover(); $event.stopPropagation();"
-              triggers=""
-              containerClass="flow-view-popover"
-              popoverTitle="Connection Properties"
-              outsideClick="true"
-              container="body"></i>
             <!-- Delete Icon -->
             <i *ngIf="showDelete()"
               class="fa fa-lg fa-trash"
@@ -161,13 +114,14 @@
 
     <!-- Default Steps -->
     <div *ngSwitchDefault
-         [ngClass]="getParentActiveClass() + ' step-container'">
+         [ngClass]="getParentActiveClass()"
+         class="clearfix step-container">
       <!-- Step Heading -->
-      <div [ngClass]="getParentClass()"
+      <div class="col-xs-12" [ngClass]="getParentClass()"
         (click)="goto('step-configure')">
         <div class="step-content">
           <div class="step-name" title="{{ stepName }}">
-            {{ stepName }}
+            {{ stepIndex + '. ' + stepName }}
           </div>
           <div class="step-icons">
             <!-- Delete Icon -->
@@ -199,6 +153,39 @@
           <span [ngClass]="getTextClass('step-configure')">Configuration</span>
         </li>
       </ul>
+    </div>
+
+    <div class="container-fluid step-details">
+      <dl class="row">
+        <dt class="col-xs-4">
+          Name:
+        </dt>
+        <dd class="col-xs-8">
+          {{ step.connection?.name }}
+        </dd>
+        <dt class="col-xs-4">
+          Action:
+        </dt>
+        <dd class="col-xs-8">
+          {{ step.action?.name }}
+        </dd>
+        <ng-container *ngIf="inputDataShapeText">
+          <dt class="col-xs-4">
+            Input Type:
+          </dt>
+          <dd class="col-xs-8">
+            {{ inputDataShapeText }}
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="outputDataShapeText">
+          <dt class="col-xs-4">
+            Output Type:
+          </dt>
+          <dd class="col-xs-8">
+            {{ outputDataShapeText }}
+          </dd>
+        </ng-container>
+      </dl>
     </div>
   </div>
 </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -24,8 +24,6 @@
       [popover]="tooltipPopover"
       #connectionImgPop="bs-popover"
       placement="right"
-      (mouseover)="showInfoPopoverCollapsed()"
-      (mouseout)="hideInfoPopoverCollapsed()"
       triggers=""
       containerClass="flow-view-popover"
       popoverTitle="Connection Properties"
@@ -160,31 +158,21 @@
         <dt class="col-xs-4">
           Name:
         </dt>
-        <dd class="col-xs-8">
-          {{ step.connection?.name }}
+        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ step.connection?.name }}">
+          {{ step.connection?.name || 'n/a' }}
         </dd>
         <dt class="col-xs-4">
           Action:
         </dt>
-        <dd class="col-xs-8">
-          {{ step.action?.name }}
+        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ step.action?.name }}">
+          {{ step.action?.name || 'n/a' }}
         </dd>
-        <ng-container *ngIf="inputDataShapeText">
-          <dt class="col-xs-4">
-            Input Type:
-          </dt>
-          <dd class="col-xs-8">
-            {{ inputDataShapeText }}
-          </dd>
-        </ng-container>
-        <ng-container *ngIf="outputDataShapeText">
-          <dt class="col-xs-4">
-            Output Type:
-          </dt>
-          <dd class="col-xs-8">
-            {{ outputDataShapeText }}
-          </dd>
-        </ng-container>
+        <dt class="col-xs-4">
+          Data Type:
+        </dt>
+        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ inputDataShapeText || outputDataShapeText }}">
+          {{ inputDataShapeText || outputDataShapeText || 'n/a' }}
+        </dd>
       </dl>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -18,8 +18,8 @@
     </div>
   </ng-template>
 
-  <!-- Icon Progress Line -->
-  <div class="progress-line">
+  <!-- Icon -->
+  <div class="icon-container">
     <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()"
       [popover]="tooltipPopover"
       #connectionImgPop="bs-popover"
@@ -28,12 +28,13 @@
       containerClass="flow-view-popover"
       popoverTitle="Connection Properties"
       outsideClick="true"
-      container="body">
+      container="body"
+      title="{{ stepName }}">
       <i [ngClass]="getIconClass()"
-         *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
+          *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
       <img class="syn-icon-small"
-           *ngIf="step.stepKind === 'endpoint' && step.connection"
-           [src]="step.connection | synIconPath">
+            *ngIf="step.stepKind === 'endpoint' && step.connection"
+            [src]="step.connection | synIconPath">
       <span class="pficon pficon-warning-triangle-o data-mismatch"
         *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"
         [popover]="addDatamapper"
@@ -49,7 +50,6 @@
 
   <!-- Step Item Wrapper -->
   <div class="menu"
-       *ngIf="currentStepKind !== 'mapper'"
        [ngSwitch]="step.stepKind">
 
     <!-- Connection Steps -->
@@ -153,24 +153,28 @@
       </ul>
     </div>
 
-    <div class="container-fluid step-details">
-      <dl class="row">
-        <dt class="col-xs-4">
+    <div class="step-details">
+      <dl>
+        <dt>
           Name:
         </dt>
-        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ step.connection?.name }}">
+        <dd class="syn-truncate__ellipsis" title="{{ step.connection?.name }}">
           {{ step.connection?.name || 'n/a' }}
         </dd>
-        <dt class="col-xs-4">
+      </dl>
+      <dl>
+        <dt>
           Action:
         </dt>
-        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ step.action?.name }}">
+        <dd class="syn-truncate__ellipsis" title="{{ step.action?.name }}">
           {{ step.action?.name || 'n/a' }}
         </dd>
-        <dt class="col-xs-4">
+      </dl>
+      <dl>
+        <dt>
           Data Type:
         </dt>
-        <dd class="col-xs-8 syn-truncate__ellipsis" title="{{ inputDataShapeText || outputDataShapeText }}">
+        <dd class="syn-truncate__ellipsis" title="{{ inputDataShapeText || outputDataShapeText }}">
           {{ inputDataShapeText || outputDataShapeText || 'n/a' }}
         </dd>
       </dl>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -69,7 +69,6 @@
     }
 
     .connection-icon {
-      //width: 24px;
       height: 24px;
       margin-top: 1px;
     }

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -45,83 +45,72 @@
   ////////////////////////////////////////////////////////////////////////////////
   // SIDEBAR: LEFT HAND (VERTICAL PROGRESS LINE & ICON)
   ////////////////////////////////////////////////////////////////////////////////
-  .progress-line {
-    padding: 0;
 
-    .fa {
-      color: $color-pf-black-300;
-      font-size: x-large;
-    }
+  .icon {
+    border-radius: 50%;
+    border: 3px solid $color-pf-black-300;
+    padding: 11px;
+    width: 100%;
+    height: 100%;
+    background-color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
 
-    .icon {
-      border-radius: 50%;
-      border: 3px solid $color-pf-black-300;
-      padding: 11px;
-      width: 55px;
-      height: 55px;
+    &.not-connection {
       background-color: #ffffff;
-      text-align: center;
-      position: relative;
+      border-width: 10px;
+      padding: 5px 0px;
+      border-radius: 100px;
+      height: 33px;
+      margin: 11px;
+      width: 32px;
+    }
 
-      &.not-connection {
-        background-color: #ffffff;
-        border-width: 10px;
-        padding: 5px 0px;
-        border-radius: 100px;
-        height: 33px;
-        margin: 11px;
-        width: 32px;
-      }
+    .connection-icon {
+      //width: 24px;
+      height: 24px;
+      margin-top: 1px;
+    }
 
-      .connection-icon {
-        //width: 24px;
-        height: 24px;
-        margin-top: 1px;
-      }
+    //----- Sidebar: Progress Line: Published State ----------------->>
+    &.active {
+      border-color: $color-pf-blue-400;
+    }
 
-      //----- Sidebar: Progress Line: Published State ----------------->>
-      &.active {
-        border-color: $color-pf-blue-400;
-      }
+    //----- Sidebar: Progress Line: Unpublished State ----------------->>
+    &.inactive {
+      border-color: #d0d0d0;
+    }
 
-      //----- Sidebar: Progress Line: Unpublished State ----------------->>
-      &.inactive {
-        border-color: #d0d0d0;
-      }
-
-      //----- Sidebar: Progress Line: Complete State ----------------->>
-      &.complete {
-        .fa {
-          color: $color-pf-black-900;
-        }
-      }
-
-      //----- Sidebar: Progress Line: Incomplete State ----------------->>
-      &.incomplete {
-        .fa {
-          color: #d1d1d1;
-          line-height: 1.15;
-        }
-      }
-
-      .data-mismatch {
-        position: absolute;
-        background: #ec7a08;
-        border-radius: 50%;
-        padding: 5px;
-        top: -6px;
-        right: -6px;
-        cursor: pointer;
-
-        &::before {
-          color: $color-pf-white;
-        }
+    //----- Sidebar: Progress Line: Complete State ----------------->>
+    &.complete {
+      .fa {
+        color: $color-pf-black-900;
       }
     }
 
-    // Vertical Line
-    .step-line {
-      height: 100%;
+    //----- Sidebar: Progress Line: Incomplete State ----------------->>
+    &.incomplete {
+      .fa {
+        color: #d1d1d1;
+        line-height: 1.15;
+      }
+    }
+
+    .data-mismatch {
+      position: absolute;
+      background: #ec7a08;
+      border-radius: 50%;
+      padding: 5px;
+      top: -6px;
+      right: -6px;
+      cursor: pointer;
+
+      &::before {
+        color: $color-pf-white;
+      }
     }
   }
 
@@ -250,26 +239,26 @@
   .step-details {
     position: absolute;
     top: calc(100% + 10px);
-    width: 100%;
+    left: $gutter;
+    right: 0;
+
+    dl {
+      display: flex;
+      margin: 0;
+
+      dt {
+        width: 40%;
+        padding-left: $gutter;
+      }
+
+      dd {
+        flex: 1 1 0;
+        padding-right: $gutter;
+      }
+    }
   }
 }
 
 ::ng-deep .flow-view-popover {
   max-width: inherit;
-}
-
-.info-popover {
-  min-width: 350px;
-
-  dl {
-    dt,
-    dd {
-      padding-left: 0;
-      word-break: break-word;
-    }
-
-    dt {
-      padding-right: 1em;
-    }
-  }
 }

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -18,7 +18,7 @@
   // SIDEBAR: COMMON, REGARDLESS OF STATE
   ////////////////////////////////////////////////////////////////////////////////
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 
   ul {
     list-style-type: none;
@@ -131,7 +131,12 @@
   .menu {
     position: relative;
     flex: 1 0 auto;
-    padding-left: $gutter;
+    padding-left: 15px;
+    padding-top: 15px;
+
+    ::ng-deep .collapsed & {
+      display: none;
+    }
 
     //----- Sidebar: Menu & Parent Step Container ----------------->>
     .step-container {
@@ -146,6 +151,10 @@
       &.active {
         .fa.fa-trash {
           color: #ffffff;
+        }
+
+        + .step-details {
+          display: none;
         }
       }
 
@@ -205,10 +214,6 @@
         margin-top: 5px;
         min-width: 160px;
         padding: 5px 0;
-        -webkit-margin-before: 0;
-        -webkit-margin-after: 1em;
-        -webkit-margin-start: 0;
-        -webkit-margin-end: 0;
 
         // Each Step
         li {
@@ -244,8 +249,8 @@
 
   .step-details {
     position: absolute;
-    top: 100%;
-    width: 100%;    
+    top: calc(100% + 10px);
+    width: 100%;
   }
 }
 
@@ -255,6 +260,7 @@
 
 .info-popover {
   min-width: 350px;
+
   dl {
     dt,
     dd {

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -17,7 +17,8 @@
   ////////////////////////////////////////////////////////////////////////////////
   // SIDEBAR: COMMON, REGARDLESS OF STATE
   ////////////////////////////////////////////////////////////////////////////////
-  flex-wrap: nowrap;
+  display: flex;
+  align-items: center;
 
   ul {
     list-style-type: none;
@@ -46,25 +47,10 @@
   ////////////////////////////////////////////////////////////////////////////////
   .progress-line {
     padding: 0;
-    height: 55px;
 
     .fa {
       color: $color-pf-black-300;
       font-size: x-large;
-    }
-
-    .step-index,
-    .icon {
-      position: absolute;
-    }
-
-    .step-index {
-      left: 0;
-      top: 50%;
-      transform: translate(-20px, -50%);
-      width: 35px;
-      background: #d6eefa;
-      padding-left: 7px;
     }
 
     .icon {
@@ -72,9 +58,10 @@
       border: 3px solid $color-pf-black-300;
       padding: 11px;
       width: 55px;
-      height: 100%;
+      height: 55px;
       background-color: #ffffff;
       text-align: center;
+      position: relative;
 
       &.not-connection {
         background-color: #ffffff;
@@ -116,6 +103,20 @@
           line-height: 1.15;
         }
       }
+
+      .data-mismatch {
+        position: absolute;
+        background: #ec7a08;
+        border-radius: 50%;
+        padding: 5px;
+        top: -6px;
+        right: -6px;
+        cursor: pointer;
+
+        &::before {
+          color: $color-pf-white;
+        }
+      }
     }
 
     // Vertical Line
@@ -129,9 +130,8 @@
   ////////////////////////////////////////////////////////////////////////////////
   .menu {
     position: relative;
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 9px;
+    flex: 1 0 auto;
+    padding-left: $gutter;
 
     //----- Sidebar: Menu & Parent Step Container ----------------->>
     .step-container {
@@ -153,24 +153,9 @@
       .parent-step {
         background-color: $color-pf-black-300;
         cursor: pointer;
-        padding: 8px 18px 8px 8px;
+        padding-top: 2px;
+        padding-bottom: 2px;
         position: relative;
-
-        .data-mismatch {
-          position: absolute;
-          left: 0;
-          top: 0;
-          bottom: 0;
-          background: #ec7a08;
-          display: flex;
-          align-items: center;
-          transform: translateX(-100%);
-          padding: 0 5px;
-
-          &::before {
-            color: #ffffff;
-          }
-        }
 
         .step-content {
           display: flex;
@@ -255,6 +240,12 @@
         }
       }
     }
+  }
+
+  .step-details {
+    position: absolute;
+    top: 100%;
+    width: 100%;    
   }
 }
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -41,7 +41,6 @@ export class FlowViewStepComponent implements OnChanges {
   // the current state/page of the current step
   @Input() currentState: string;
 
-  @ViewChild('connectionImgPop') connectionImgPop: PopoverDirective;
   @ViewChild('datamapperInfoPop') datamapperInfoPop: PopoverDirective;
 
   inputDataShapeText: string;

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -41,7 +41,6 @@ export class FlowViewStepComponent implements OnChanges {
   // the current state/page of the current step
   @Input() currentState: string;
 
-  @ViewChild('connectionInfoPop') connectionInfoPop: PopoverDirective;
   @ViewChild('connectionImgPop') connectionImgPop: PopoverDirective;
   @ViewChild('datamapperInfoPop') datamapperInfoPop: PopoverDirective;
 
@@ -60,32 +59,6 @@ export class FlowViewStepComponent implements OnChanges {
 
   get currentStepKind() {
     return this.flowPageService.getCurrentStepKind(this.route);
-  }
-
-  showInfoPopover() {
-    this.connectionInfoPop.show();
-  }
-
-  showInfoPopoverCollapsed() {
-    if (!this.step || this.step.stepKind !== ENDPOINT) {
-      return;
-    }
-    const currentStep = this.currentFlowService.getStep(this.currentPosition);
-    if (currentStep && currentStep.kind === DATA_MAPPER) {
-      this.connectionImgPop.show();
-    }
-  }
-
-  hideInfoPopoverCollapsed() {
-    this.connectionImgPop.hide();
-  }
-
-  hideInfoPopover() {
-    this.connectionInfoPop.hide();
-  }
-
-  toggleInfoPopover() {
-    this.connectionInfoPop.toggle();
   }
 
   toggleAddDatamapperInfo() {

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -1,31 +1,32 @@
-<div class="flow-view">
-  <!-- Insert step popover -->
-  <ng-template #popTemplate let-position='position'>
-    <div class="popover-body">
-      <div *ngIf="showAddStep();">
-        <a (click)="insertStepAfter(position)">Add a step</a>
-      </div>
-      <div *ngIf="showAddConnection();">
-        <a (click)="insertConnectionAfter(position)">Add a connection</a>
-      </div>
+<!-- Insert step popover -->
+<ng-template #popTemplate let-position='position' class="asdfasdf">
+  <div class="popover-body">
+    <div *ngIf="showAddStep();" class="syn-nowrap">
+      <a (click)="insertStepAfter(position)">Add a step</a>
     </div>
-  </ng-template>
+    <div *ngIf="showAddConnection();" class="syn-nowrap">
+      <a (click)="insertConnectionAfter(position)">Add a connection</a>
+    </div>
+  </div>
+</ng-template>
+
+<div class="flow-view">
   <!-- Insert step line -->
   <ng-template #insertStepTemplate let-position='position'>
     <div *ngIf="currentState === 'save-or-add-step'"
          class="step step-insert"
-         (click)="pop.toggle()"
-         (mouseover)="pop.show()"
-         (mouseleave)="pop.hide()">
-      <div class="step-line"></div>
-      <div class="col-md-2 square-icon"
-           [popover]="popTemplate"
-           [popoverContext]="{ position: position }"
-           placement="right"
-           #pop="bs-popover">
-        <i class="fa fa-plus-square"></i>
-      </div>
-      <div class="col-md-10">
+         (click)="pop.toggle()">
+      <div class="icon-container">
+        <div class="square-icon"
+            [popover]="popTemplate"
+            [popoverContext]="{ position: position }"
+            placement="{{ isCollapsed ? 'bottom' : 'right' }}"
+            container="body"
+            #pop="bs-popover"
+            containerClass="flow-view-add-popover"
+            (click)="pop.toggle()">
+          <i class="fa fa-plus-square"></i>
+        </div>
       </div>
     </div>
   </ng-template>
@@ -37,11 +38,10 @@
                   message="{{ 'integrations.edit.delete-step-modal' | synI18n }}">
   </syndesis-modal>
 
-  <syndesis-loading [loading]="!loaded()">
+  <syndesis-loading [loading]="!loaded()" class="syn-scrollable">
 
     <!-- Header -->
-    <div class="row name"
-         *ngIf="currentStepKind !== 'mapper'">
+    <div class="row name">
       <div class="col-md-12">
         <div class="vertical-align">
           <div class="integration-name">
@@ -68,13 +68,12 @@
       </div>
     </div>
 
-    <div class="flow-view-container"
-         [ngClass]="{ 'collapsed': isCollapsed || containerClass }"
+    <div class="flow-view-container syn-scrollable--body"
+         [ngClass]="{ 'collapsed': isCollapsed }"
          *ngIf="i && i.steps">
 
       <!-- First Step -->
       <div class="step start">
-        <div class="step-line"></div>
         <syndesis-integration-flow-view-step [step]="startConnection()"
                                               [position]="firstPosition()"
                                               [currentPosition]="currentPosition"
@@ -90,7 +89,6 @@
                    [ngForOf]="getMiddleSteps()"
                    let-position="index">
         <div class="step">
-          <div class="step-line"></div>
           <syndesis-integration-flow-view-step [step]="step"
                                                 [position]="position + 1"
                                                 [currentPosition]="currentPosition"
@@ -112,5 +110,6 @@
   </syndesis-loading>
   <button class="btn btn-default toggle-collapsed"
     (click)="toggleCollapsed()"
-    [class.collapsed]="isCollapsed"></button>
+    [class.collapsed]="isCollapsed"
+    title="Expand info"></button>
 </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -49,11 +49,13 @@
                   #nameInput
                   class="form-control integration-name-field"
                   placeholder="Enter integration name..."
+                  [title]="integrationName"
                   [(ngModel)]="integrationName"
                   [readonly]="!editingName"
                   (blur)="stopEditingName()"
                   (click)="!editingName && startEditingName()"
-                  (keyup)="$event.keyCode == 13 && stopEditingName()">
+                  (keyup)="$event.keyCode == 13 && stopEditingName()"
+                  size="1">
           </div>
           <div class="integration-name-edit">
             <button class="btn btn-link  integration-name-edit-btn" type="button">
@@ -66,7 +68,8 @@
       </div>
     </div>
 
-    <div [class]="containerClass"
+    <div class="flow-view-container"
+         [ngClass]="{ 'collapsed': isCollapsed || containerClass }"
          *ngIf="i && i.steps">
 
       <!-- First Step -->
@@ -105,8 +108,9 @@
                                               [currentPosition]="currentPosition"
                                               [currentState]="currentState"></syndesis-integration-flow-view-step>
       </div>
-
     </div>
   </syndesis-loading>
-
+  <button class="btn btn-default toggle-collapsed"
+    (click)="toggleCollapsed()"
+    [class.collapsed]="isCollapsed"></button>
 </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -111,5 +111,7 @@
   <button class="btn btn-default toggle-collapsed"
     (click)="toggleCollapsed()"
     [class.collapsed]="isCollapsed"
-    title="Expand info"></button>
+    [tooltip]="toggleButtonTooltip"
+    placement="right"></button>
+  <ng-template #toggleButtonTooltip><div class="syn-nowrap">Expand info</div></ng-template>
 </div>

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -20,7 +20,7 @@
         <div class="square-icon"
             [popover]="popTemplate"
             [popoverContext]="{ position: position }"
-            placement="{{ isCollapsed ? 'bottom' : 'right' }}"
+            placement="right"
             container="body"
             #pop="bs-popover"
             containerClass="flow-view-add-popover"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -12,6 +12,28 @@
 
 .flow-view {
   height: 100%;
+  position: relative;
+  padding-right: 30px;
+
+  .toggle-collapsed { 
+    position: absolute;
+    top: -$gutter;
+    right: -$gutter;
+    bottom: 0;
+    width: 30px;
+    border: solid #d1d1d1;
+    border-width: 0 0 0 1px;
+    font-size: 1.5em;
+    font-weight: 200;
+
+    &:before {
+      content: '\00ab';
+    }
+
+    &.collapsed:before {
+      content: '\00bb';
+    }
+  }
 
   syndesis-loading {
     display: flex;
@@ -24,13 +46,19 @@
     flex: 1 1 auto;
     padding-top: 15px;
     padding-bottom: 20px;
+    padding-left: 30px;
     margin-right: -20px;
     display: flex;
     flex-direction: column;
+    width: 400px;
+    position: relative;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     &.collapsed {
-      width: 130px;
+      width: auto;
       margin-right: 0;
+      padding-right: $gutter;
     }
 
     .start,
@@ -89,6 +117,7 @@
         font-style: normal;
 
         &[readonly] {
+          @include truncate(ellipsis);
           background: none;
           border-color: transparent;
           box-shadow: none;
@@ -110,7 +139,7 @@
     flex: 0 0 auto;
 
     &:not(:last-child) {
-      padding-bottom: 24px;
+      padding-bottom: 50px;
     }
 
     .step-line {
@@ -132,7 +161,7 @@
 
       ::ng-deep .popover {
         margin-top: -2px;
-        margin-left: 28px !important;
+        //margin-left: 28px !important;
         border-color: $color-pf-black-500;
 
         &.right > .arrow {

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -168,6 +168,7 @@
 
 ::ng-deep .flow-view-add-popover {
   border-color: $color-pf-black-500;
+  transform: translateX(10px);
 
   .popover-body {
     a {
@@ -186,9 +187,7 @@
 
   &.right > .arrow {
     border-right-color: $color-pf-black-500;
-  }
-
-  &.bottom > .arrow {
-    border-bottom-color: $color-pf-black-500;
+    margin: 0 !important;
+    transform: translateY(-50%);
   }
 }

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -25,7 +25,6 @@
     padding-top: 15px;
     padding-bottom: 20px;
     margin-right: -20px;
-    width: 320px;
     display: flex;
     flex-direction: column;
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -109,7 +109,8 @@
   .name {
     flex: 0 0 auto;
     border-bottom: 1px #d9d9d9 solid;
-    padding-bottom: 20px;
+    padding-right: $gutter;
+    padding-bottom: $gutter;
 
     .integration-name {
       flex: 1 0 0;

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -1,30 +1,21 @@
 @import 'syndesis-sass';
 
-.collapsed {
-  .step-insert {
-    display: none;
-  }
-}
-
-.popover-body > div {
-  padding: 5px;
-}
-
 .flow-view {
   height: 100%;
   position: relative;
-  padding-right: 30px;
+  padding: $gutter 30px 0 $gutter;
 
   .toggle-collapsed { 
     position: absolute;
-    top: -$gutter;
-    right: -$gutter;
+    top: 0;
+    right: 0;
     bottom: 0;
     width: 30px;
     border: solid #d1d1d1;
     border-width: 0 0 0 1px;
     font-size: 1.5em;
     font-weight: 200;
+    outline: 0;
 
     &:before {
       content: '\00ab';
@@ -35,30 +26,43 @@
     }
   }
 
-  syndesis-loading {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: visible;
-  }
-
   .flow-view-container {
     flex: 1 1 auto;
     padding-top: 15px;
     padding-bottom: 20px;
     padding-left: 30px;
-    margin-right: -20px;
     display: flex;
     flex-direction: column;
     width: 400px;
-    position: relative;
-    overflow-y: auto;
-    overflow-x: hidden;
 
     &.collapsed {
       width: auto;
-      margin-right: 0;
-      padding-right: $gutter;
+      padding-right: 50px;
+    }
+
+    ::ng-deep {
+      .icon-container {
+        padding-bottom: 50px;
+        width: 55px;
+        height: 105px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
+
+      .step:not(:last-child) .icon-container {
+        &::before {
+          content: '';
+          position: absolute;
+          width: 2px;
+          background-color: #d4d4d4;
+          top: 0;
+          bottom: 0;
+          left: 50%;
+          transform: translateX(-50%);
+        }
+      }
     }
 
     .start,
@@ -134,22 +138,7 @@
   // LEFT-HAND NAV BAR W/ STEPS
   ////////////////////////////////////////////////////////////////////////////////
   .step {
-    position: relative;
-    flex-wrap: nowrap;
     flex: 0 0 auto;
-
-    &:not(:last-child) {
-      padding-bottom: 50px;
-    }
-
-    .step-line {
-      position: absolute;
-      height: 100%;
-      top: 0;
-      left: 26px;
-      width: 2px;
-      background-color: #d4d4d4;
-    }
 
     &.finish {
       flex: 0 0 auto;
@@ -159,37 +148,47 @@
     &.step-insert {
       flex: 0 0 auto;
 
-      ::ng-deep .popover {
-        margin-top: -2px;
-        //margin-left: 28px !important;
-        border-color: $color-pf-black-500;
-
-        &.right > .arrow {
-          border-right-color: $color-pf-black-500;
-        }
-      }
-
       a {
         text-decoration: none;
       }
 
-      .popover-body {
-        a {
-          cursor: pointer;
-          padding: 10px;
-        }
-      }
-
       .square-icon {
-        padding-left: 0;
+        position: relative;
+        cursor: pointer;
 
         .fa.fa-plus-square {
           color: #158acc;
           background-color: white;
           font-size: x-large;
-          margin-left: 17px;
         }
       }
     }
+  }
+}
+
+::ng-deep .flow-view-add-popover {
+  border-color: $color-pf-black-500;
+
+  .popover-body {
+    a {
+      cursor: pointer;
+      display: inline-block;
+
+      &:not(:last-child) {
+        margin-bottom: 5px;
+      }
+    }
+
+    > div {
+      padding: 5px;
+    }
+  }
+
+  &.right > .arrow {
+    border-right-color: $color-pf-black-500;
+  }
+
+  &.bottom > .arrow {
+    border-bottom-color: $color-pf-black-500;
   }
 }

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
@@ -30,7 +30,7 @@ export class FlowViewComponent implements OnDestroy {
   urls: UrlSegment[];
   selectedKind: string | boolean = false;
   editingName = false;
-  isCollapsed: boolean;
+  isCollapsed = true;
 
   @ViewChildren(PopoverDirective) popovers: PopoverDirective[];
   @ViewChild('nameInput') nameInput: ElementRef;
@@ -62,6 +62,7 @@ export class FlowViewComponent implements OnDestroy {
     return this.flowPageService.getCurrentStepKind(this.route);
   }
 
+  /*
   get containerClass() {
     switch (this.flowPageService.getCurrentStepKind(this.route)) {
       case 'mapper':
@@ -70,6 +71,7 @@ export class FlowViewComponent implements OnDestroy {
         return false;
     }
   }
+  */
 
   toggleCollapsed() {
     this.isCollapsed = !this.isCollapsed;

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
@@ -30,6 +30,7 @@ export class FlowViewComponent implements OnDestroy {
   urls: UrlSegment[];
   selectedKind: string | boolean = false;
   editingName = false;
+  isCollapsed: boolean;
 
   @ViewChildren(PopoverDirective) popovers: PopoverDirective[];
   @ViewChild('nameInput') nameInput: ElementRef;
@@ -64,10 +65,14 @@ export class FlowViewComponent implements OnDestroy {
   get containerClass() {
     switch (this.flowPageService.getCurrentStepKind(this.route)) {
       case 'mapper':
-        return 'flow-view-container collapsed';
+        return true;
       default:
-        return 'flow-view-container';
+        return false;
     }
+  }
+
+  toggleCollapsed() {
+    this.isCollapsed = !this.isCollapsed;
   }
 
   showAddStep() {


### PR DESCRIPTION
fix https://github.com/syndesisio/syndesis/issues/2993

Outstanding issues I need code/design help with.

1. To get the "add step/connection" popover to display outside of the scrollable IVP (overflow hidden), I appended the popover to `body`. Then the `mouseover`/`mouseout` events on the "+" icon that would display/hide the popover no longer worked - as you hovered off the icon and into the popover, it would disappear. So I changed the popover to fire on click. I wonder if this is OK as is?
    * Another workaround this could be to display the popover below the "+" icon (`placement="bottom"`) when the IVP is collapsed, and to the right (`placement="right"`) when the IVP is expanded. Then the popover wouldn't overflow the IVP.
    * Or figure out how to keep the popover open when you hover over either the "+" icon or the popover itself.
1. ~~I don't know how to make tooltips work. @sjcox-rh wants a tooltip for the expand/collapse button that says "expand info", and a tooltip on the non-connection step icons that says "data mapper" or "log" or whatever that step is. For now, I just used the `title` attr instead. Maybe this is OK as is, too?~~ 
    * nevermind, figured it out