### PR TITLE
chore: use both possible key references for config.json substitution

### DIFF
--- a/app/ui/src/app/core/providers/i18n-provider.service.ts
+++ b/app/ui/src/app/core/providers/i18n-provider.service.ts
@@ -54,6 +54,7 @@ export class I18NProviderService extends I18NService {
     // config.json overrides
     switch (dictionaryKey) {
       case 'shared.project.name':
+      case 'project.name':
         return this.configService.getSettings('branding', 'appName');
       default:
     }


### PR DESCRIPTION
fixes #3066