### PR TITLE
fix(a11y-cleanup): improve router navigation experience

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -27,7 +27,10 @@
       <div class="navbar-header">
 
         <!-- Toggle Sidebar-->
-        <button type="button" class="navbar-toggle">
+        <button
+          aria-label="Toggle Main Naivgation"
+          type="button"
+          class="navbar-toggle">
           <span class="sr-only">{{ 'menu.navbartoggle' | synI18n }}</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -46,7 +49,7 @@
           <!-- Help Navbar -->
 
           <li dropdown class="dropdown help">
-            <button dropdownToggle 
+            <button dropdownToggle
                     class="btn btn-link dropdown-toggle nav-item-iconic"
                     id="helpDropdown"
                     aria-haspopup="true"
@@ -94,7 +97,7 @@
           <li dropdown
               class="dropdown user">
             <button dropdownToggle
-              class="btn btn-link dropdown-toggle nav-item-iconic" 
+              class="btn btn-link dropdown-toggle nav-item-iconic"
                 id="userDropdown"
                 aria-haspopup="true"
                 aria-controls="userDropdownMenu"

--- a/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.html
+++ b/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.html
@@ -71,17 +71,19 @@
       <div class="col-sm-6 col-md-3 metrics__cards-item metrics__cards-item--uptime">
         <div class="card-pf card-pf-accented card-pf-aggregate-status">
           <div class="card-pf-title">
-            <h3 class="metrics__uptime-header metrics__uptime-label">
+            <h2 class="metrics__uptime-header metrics__uptime-label">
               {{ 'dashboard.metrics.uptime.uptime' | synI18n }}
-            </h3>
-            <h3 class="metrics__uptime-header metrics__uptime-kickoff">
+            </h2>
+            <time
+              [attr.datetime]="dateTime"
+              class="metrics__uptime-header metrics__uptime-kickoff">
               {{ 'dashboard.metrics.uptime.since' | synI18n: uptimeStart }}
-            </h3>
+            </time>
           </div>
           <div class="card-pf-body">
-            <h4 class="metrics__uptime-legend">
+            <span class="metrics__uptime-legend">
               {{ integrationMetrics.start | synDurationDiff$ | async }}
-            </h4>
+            </span>
           </div>
         </div>
       </div>

--- a/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.scss
+++ b/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.scss
@@ -28,10 +28,19 @@
 
         .metrics__uptime-header {
           margin-top: 0;
+          font-size: 16px;
         }
 
         .metrics__uptime-kickoff {
           font-size: 11px;
+        }
+
+        .card-pf-body {
+          .metrics__uptime-legend {
+            font-size: 15px;
+            margin-bottom: 0;
+            line-height: 1.2;
+          }
         }
       }
     }

--- a/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.ts
+++ b/app/ui/src/app/dashboard/dashboard_metrics/dashboard-metrics.component.ts
@@ -33,6 +33,7 @@ export class DashboardMetricsComponent implements OnInit, OnDestroy {
   @Output() refresh = new EventEmitter();
 
   uptimeStart: string;
+  dateTime: string;
 
   private metricsRefreshInterval: any;
 
@@ -52,6 +53,10 @@ export class DashboardMetricsComponent implements OnInit, OnDestroy {
     this.uptimeStart = moment(this.integrationMetrics.start).format(
       'MMM Do HH:mm A'
     ); // eg January 12nd 8:53 pm
+
+    this.dateTime = moment(this.integrationMetrics.start).format(
+      'YYYY-MM-DD HH:mm'
+    ); // eg 2018-07-13 09:05
 
     let pollingInterval: number;
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -58,7 +58,11 @@
                   size="1">
           </div>
           <div class="integration-name-edit" *ngIf="!editingName">
-            <button class="btn btn-link  integration-name-edit-btn" type="button" (click)="startEditingName()">
+            <button
+              aria-label="Edit Integration Name"
+              class="btn btn-link integration-name-edit-btn"
+              type="button"
+              (click)="startEditingName()">
               <span class="fa fa-pencil"></span>
             </button>
           </div>
@@ -106,10 +110,12 @@
       </div>
     </div>
   </syndesis-loading>
-  <button class="btn btn-default toggle-collapsed"
+  <button
+    class="btn btn-default toggle-collapsed"
     (click)="toggleCollapsed()"
     [class.collapsed]="isCollapsed"
     [tooltip]="toggleButtonTooltip"
+    aria-label="Integration Visualization Pane Details Toggle"
     placement="right"></button>
   <ng-template #toggleButtonTooltip><div class="syn-nowrap">Expand info</div></ng-template>
 </div>

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
@@ -70,6 +70,7 @@
                 let-item="item">
     <div class="list-pf-actions">
       <button *ngIf="!item.expanded"
+              [attr.aria-label]="('register' | synI18n) + ' ' + item.client.name"
               class="btn btn-default"
               (click)="item.expanded = !item.expanded">
               <ng-container *ngIf="!isConfigured(item)">{{ 'register' | synI18n }}</ng-container>


### PR DESCRIPTION
This PR cleans up the lack of accessible names and inconsistent markup used in a couple places within the UI. Small but impactful changes we were hoping to get in before end of sprint.

Should help close https://github.com/syndesisio/syndesis/issues/3075

assign accessible name for main nav toggle
use same size heading as other dashboard cards
use more appropriate markup for showing time
associate register button with client app
accessible name for inline edit integration name control
accessible name for IVP details collapse/expand btn