### PR TITLE
Issue #2693: resuming after publish of integration violates same name

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-page.service.ts
+++ b/app/ui/src/app/integration/edit-page/flow-page.service.ts
@@ -81,6 +81,13 @@ export class FlowPageService {
       error: reason => {
         this.errorMessage = reason;
         this.saveInProgress = false;
+        //
+        // Error occurred while publishing
+        // so reset publish progress flag
+        //
+        if (this.publishInProgress) {
+          this.publishInProgress = false;
+        }
       }
     });
   }


### PR DESCRIPTION
* When the publish operation fails, the publish button is left disabled and
  the spinner is displayed. By setting publishInProgress to false in the
  event of an error will reset both of these and allow the name to be
  re-edited and the publish be re-attempted with the new name.