### PR TITLE
fix: don't try to mount syndesis-db-data volume

### DIFF
--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -121,9 +121,6 @@
                 name: syndesis-db-maintenance-script
             restartPolicy: Never
             volumes:
-            - name: syndesis-db-data
-              persistentVolumeClaim:
-                claimName: syndesis-db
             - configMap:
                 defaultMode: 511
                 name: syndesis-db-maintenance-script

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -570,9 +570,6 @@ objects:
                 name: syndesis-db-maintenance-script
             restartPolicy: Never
             volumes:
-            - name: syndesis-db-data
-              persistentVolumeClaim:
-                claimName: syndesis-db
             - configMap:
                 defaultMode: 511
                 name: syndesis-db-maintenance-script
@@ -1215,6 +1212,11 @@ objects:
         health:
           sensitive: false
         jsondb:
+          enabled: true
+      monitoring:
+        kind: default
+      features:
+        monitoring:
           enabled: true
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -570,9 +570,6 @@ objects:
                 name: syndesis-db-maintenance-script
             restartPolicy: Never
             volumes:
-            - name: syndesis-db-data
-              persistentVolumeClaim:
-                claimName: syndesis-db
             - configMap:
                 defaultMode: 511
                 name: syndesis-db-maintenance-script
@@ -1211,6 +1208,11 @@ objects:
         health:
           sensitive: false
         jsondb:
+          enabled: true
+      monitoring:
+        kind: default
+      features:
+        monitoring:
           enabled: true
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1


### PR DESCRIPTION
Removes the mount of `syndesis-db-data` volume, it's not required and
prevents the creation of the pod as the `syndesis-db` maintains a lock
on `syndesis-db-data` volume.