### PR TITLE
Unecessary requests to `/api/v1/integrations`

### DIFF
--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/IntegrationController.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/IntegrationController.java
@@ -204,12 +204,14 @@ public class IntegrationController {
                     // handler.execute might block for while so refresh our copy of the integration
                     // data before we update the current status
                     IntegrationDeployment current = dataManager.fetch(IntegrationDeployment.class, integrationDeploymentId);
-                    dataManager.update(current.builder()
+                    final IntegrationDeployment updated = current.builder()
                         .statusMessage(Optional.ofNullable(update.getStatusMessage()))
                         .currentState(update.getState())
                         .stepsDone(update.getStepsPerformed())
-                        .updatedAt(System.currentTimeMillis())
-                        .build());
+                        .build();
+                    if (!(updated.equals(current))) {
+                        dataManager.update(updated.builder().updatedAt(System.currentTimeMillis()).build());
+                    }
                 });
             } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception e) {
                 LOG.error("Error while processing integration status for integration {}", integrationDeploymentId, e);

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
@@ -76,8 +76,7 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
 
             if (board != null) {
                 builder = new IntegrationBulletinBoard.Builder()
-                    .createFrom(board)
-                    .updatedAt(System.currentTimeMillis());
+                    .createFrom(board);
             } else {
                 builder = new IntegrationBulletinBoard.Builder()
                     .id(KeyGenerator.createKey())
@@ -248,7 +247,10 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
             builder.putMetadata("integration-version", Integer.toString(integration.getVersion()));
             builder.messages(messages);
 
-            boards.add(builder.build());
+            final IntegrationBulletinBoard updated = builder.build();
+            if (!updated.equals(board)) {
+                boards.add(builder.updatedAt(System.currentTimeMillis()).build());
+            }
         }
 
         return boards;


### PR DESCRIPTION
Copy paste from the commits:

**fix(server): don't perform updates without changes**

When we compare periodically state of objects in controllers we run for integration deployments, integrations, connections and connectors we should not generate updates of the JsonDB or emit changes via WebSockets if the state did not change.

This checks if the previous state is equal to the current state and only performs the database update end emits the WebSocket event if the change has occurred. Thusly it increases our performance by reducing the number of refreshes in the UI and decreasing the database load for updates and fetches initiated by the emitted change to the UI.

**fix(ui): consider refreshing the store only for events of the stores kind**

Events that are not related to the store should not be handled by the store.

With this we check for the `kind` of the store and if it matches the `kind` of the event then it will be processed by the store, i.e. reload the data from the server.

This decreases the load on the server by not requesting data for unrelated update events.

Fixes #3071