### PR TITLE
Running yarn with Openshift using oc cluster up

### DIFF
--- a/app/ui/scripts/minishift-restore.sh
+++ b/app/ui/scripts/minishift-restore.sh
@@ -2,31 +2,85 @@
 
 set -euo pipefail
 
-# Backup the existing service
+SYNUI_REV=$(oc get deploymentconfig syndesis-ui --template={{.status.latestVersion}})
+echo "syndesis-ui current at revision ${SYNUI_REV}"
+
+POD_PREFIX="syndesis-ui-${SYNUI_REV}"
+SYNPOD=$(oc get pods | grep ${POD_PREFIX} | awk {'print $1'})
+echo "Currently running syndesis-ui pod: ${SYNPOD}"
+
+SYNIP=$(oc get pod ${SYNPOD} --template={{.status.podIP}})
+
+#
+# Restore the existing service
+#
 oc replace --force -f - <<EOF
-  {
-    "apiVersion": "v1",
-    "kind": "Service",
-    "metadata": {
-      "name": "syndesis-ui",
-      "labels": {
-        "app": "syndesis",
-        "component": "syndesis-ui"
-      }
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "syndesis-ui",
+    "labels": {
+      "app": "syndesis",
+      "syndesis.io/app": "syndesis",
+      "syndesis.io/type": "infrastructure",
+      "syndesis.io/component": "syndesis-ui"
+    }
+  },
+  "spec": {
+     "ports": [
+       {
+         "port": 80,
+         "protocol": "TCP",
+         "targetPort": 8080
+       }
+     ],
+     "selector": {
+       "app": "syndesis",
+       "syndesis.io/app": "syndesis",
+       "syndesis.io/component": "syndesis-ui"
+     }
+  }
+}
+EOF
+
+#
+# Restore the original endpoint
+# (Cannot do in same replace as service - generates error!)
+#
+oc replace --force -f - <<EOF
+{
+  "apiVersion": "v1",
+  "kind": "Endpoints",
+  "metadata": {
+    "labels": {
+      "app": "syndesis",
+      "syndesis.io/app": "syndesis",
+      "syndesis.io/component": "syndesis-ui",
+      "syndesis.io/type": "infrastructure"
     },
-    "spec": {
-      "ports": [
+    "name": "syndesis-ui",
+    "namespace": "syndesis"
+  },
+  "subsets": [
+    {
+      "addresses": [
         {
-          "port": 80,
-          "protocol": "TCP",
-          "targetPort": 8080
+          "ip": "${SYNIP}",
+		  "targetRef": {
+            "kind": "Pod",
+            "name": "${SYNPOD}",
+            "namespace": "syndesis"
+          }
         }
       ],
-      "selector": {
-        "app": "syndesis",
-        "component": "syndesis-ui"
-      }
+      "ports": [
+        {
+          "port": 8080,
+          "protocol": "TCP"
+        }
+      ]
     }
-  }
-
+  ]
+}
 EOF

--- a/app/ui/scripts/minishift-setup.sh
+++ b/app/ui/scripts/minishift-setup.sh
@@ -15,9 +15,10 @@ echo "Local IP is: ${LOCAL_IP}"
 mv -f src/config.json src/config.json.bak || true
 cp src/config.json.minishift src/config.json
 
+OS_HOST=$(oc status | head -n 1 | sed s/.*https/https/)
 
 sed -i.bu "s#syndesis.192.168.64.2.nip.io#$(oc get route syndesis  --template={{.spec.host}})#" src/config.json
-sed -i.bu "s#https://192.168.64.2:8443#$(minishift console --url)#" src/config.json
+sed -i.bu "s#https://192\.168\.64\.2:8443#${OS_HOST}#" src/config.json
 sed -i.bu "s/Syndesis/Syndesis - DEVELOPMENT/" src/config.json
 rm src/config.json.bu
 


### PR DESCRIPTION
* Can use the same scripts and configuration as running yarn with
  minishift. Couple of small modifications to the pertinent scripts.

* minishift-setup.sh
 * Provides an openshift-implementation independent mechanism to return the
   openshift console url

* minishift-restore.sh
 * Fixes the restoration of the syndesis-ui service and endpoint including
   extra labels and ensuring both are added back separately.
 * Effectively reverses/undoes the effect of minishift-setup.sh