### PR TITLE
fix: fetch more things from the backend, add a config parameter

### DIFF
--- a/app/ui/src/app/store/action/action.service.ts
+++ b/app/ui/src/app/store/action/action.service.ts
@@ -2,10 +2,12 @@ import { Injectable } from '@angular/core';
 
 import { ApiHttpService, Action, Actions } from '@syndesis/ui/platform';
 import { RESTService } from '../entity';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 @Injectable()
 export class ActionService extends RESTService<Action, Actions> {
-  constructor(apiHttpService: ApiHttpService) {
-    super(apiHttpService, 'actions', 'action');
+  constructor(apiHttpService: ApiHttpService, configService: ConfigService) {
+    super(apiHttpService, 'actions', 'action', configService);
   }
+
 }

--- a/app/ui/src/app/store/connection/connection.service.ts
+++ b/app/ui/src/app/store/connection/connection.service.ts
@@ -4,11 +4,12 @@ import { ValidationErrors } from '@angular/forms';
 import { ApiHttpService, Connection, Connections } from '@syndesis/ui/platform';
 import { TypeFactory } from '@syndesis/ui/model';
 import { RESTService } from '../entity';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 @Injectable()
 export class ConnectionService extends RESTService<Connection, Connections> {
-  constructor(apiHttpService: ApiHttpService) {
-    super(apiHttpService, 'connections', 'connection');
+  constructor(apiHttpService: ApiHttpService, configService: ConfigService) {
+    super(apiHttpService, 'connections', 'connection', configService);
   }
 
   validateName(name: string): Promise<ValidationErrors | null> {

--- a/app/ui/src/app/store/connector/connector.service.ts
+++ b/app/ui/src/app/store/connector/connector.service.ts
@@ -3,6 +3,7 @@ import { Subscription, Observable } from 'rxjs';
 
 import { ApiHttpService, Connector, Connectors } from '@syndesis/ui/platform';
 import { RESTService } from '../entity';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 interface AcquisitionResponseState {
   persist: string;
@@ -17,8 +18,8 @@ interface AcquisitionResponse {
 
 @Injectable()
 export class ConnectorService extends RESTService<Connector, Connectors> {
-  constructor(apiHttpService: ApiHttpService) {
-    super(apiHttpService, 'connectors', 'connector');
+  constructor(apiHttpService: ApiHttpService, configService: ConfigService) {
+    super(apiHttpService, 'connectors', 'connector', configService);
   }
 
   validate(id: string, data: Map<string, string>) {

--- a/app/ui/src/app/store/entity/rest.service.ts
+++ b/app/ui/src/app/store/entity/rest.service.ts
@@ -2,13 +2,18 @@ import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 import { BaseEntity, ApiHttpService } from '@syndesis/ui/platform';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 export abstract class RESTService<T extends BaseEntity, L extends Array<T>> {
+  perPage: number;
   protected constructor(
     public apiHttpService: ApiHttpService,
     public endpoint: string,
-    public kind: string
-  ) {}
+    public kind: string,
+    configService: ConfigService
+  ) {
+    this.perPage = configService.getSettings().perPage || 50;
+  }
 
   get(id: string): Observable<T> {
     return this.apiHttpService
@@ -18,13 +23,12 @@ export abstract class RESTService<T extends BaseEntity, L extends Array<T>> {
 
   list(): Observable<L> {
     return this.apiHttpService
-      .setEndpointUrl(this.getEndpointSegment())
+      .setEndpointUrl(this.getEndpointSegment() + '?per_page=' + this.perPage)
       .get()
       .pipe(
-        map(
-          (response: any) =>
-            Array.isArray(response) ? response : response.items || ([] as L)
-        )
+        map((response: any) => {
+            return Array.isArray(response) ? response : response.items || ([] as L);
+        })
       );
   }
 

--- a/app/ui/src/app/store/extension/extension.service.ts
+++ b/app/ui/src/app/store/extension/extension.service.ts
@@ -9,11 +9,12 @@ import {
   Extensions,
   Integrations
 } from '@syndesis/ui/platform';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 @Injectable()
 export class ExtensionService extends RESTService<Extension, Extensions> {
-  constructor(public apiHttpService: ApiHttpService) {
-    super(apiHttpService, 'extensions', 'extension');
+  constructor(apiHttpService: ApiHttpService, configService: ConfigService) {
+    super(apiHttpService, 'extensions', 'extension', configService);
   }
 
   public getUploadUrl(id?: string) {

--- a/app/ui/src/app/store/integration/integration.service.ts
+++ b/app/ui/src/app/store/integration/integration.service.ts
@@ -10,12 +10,14 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { map, mergeMap, switchMap, catchError } from 'rxjs/operators';
 import { RESTService } from '../entity';
 import { log, getCategory } from '../../logging';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 @Injectable()
 export class IntegrationService extends RESTService<Integration, Integrations> {
   constructor(apiHttpService: ApiHttpService,
+              configService: ConfigService,
               protected integrationSupportService: IntegrationSupportService) {
-    super(apiHttpService, 'integrations', 'integration');
+    super(apiHttpService, 'integrations', 'integration', configService);
   }
 
   get(id: string): Observable<Integration> {

--- a/app/ui/src/app/store/oauthApp/oauth-app.service.ts
+++ b/app/ui/src/app/store/oauthApp/oauth-app.service.ts
@@ -3,10 +3,11 @@ import { Injectable } from '@angular/core';
 import { ApiHttpService } from '@syndesis/ui/platform';
 import { OAuthApp, OAuthApps } from '@syndesis/ui/settings';
 import { RESTService } from '../entity';
+import { ConfigService } from '@syndesis/ui/config.service';
 
 @Injectable()
 export class OAuthAppService extends RESTService<OAuthApp, OAuthApps> {
-  constructor(apiHttpService: ApiHttpService) {
-    super(apiHttpService, 'setup/oauth-apps', 'oauth-app');
+  constructor(apiHttpService: ApiHttpService, configService: ConfigService) {
+    super(apiHttpService, 'setup/oauth-apps', 'oauth-app', configService);
   }
 }


### PR DESCRIPTION
fixes #2925

This just bumps up the item limit to 50 by default on the UI side, this can be controlled in `config.json` by adding a `perPage` attribute to the root object with a numeric value.

@rhuss FYI

Should probably create an epic for proper pagination as a future enhancement for all pages, what's there now I don't think will be suitable long term.