### PR TITLE
fix: Found duplicate and different resources: git.properties

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -655,6 +655,7 @@
               <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
               <ignoredResourcePattern>draftv3/schema</ignoredResourcePattern>
               <ignoredResourcePattern>draftv4/schema</ignoredResourcePattern>
+              <ignoredResourcePattern>git.properties</ignoredResourcePattern>
             </ignoredResourcePatterns>
             <exceptions>
               <exception>


### PR DESCRIPTION
I was getting the following errors:

    [INFO] --- duplicate-finder-maven-plugin:1.2.1:check (default) @ connector-activemq ---
    [INFO] Checking compile classpath
    [INFO] Checking runtime classpath
    [INFO] Checking test classpath
    [WARNING] Found duplicate and different resources in [io.syndesis.connector:connector-support-util:1.4-SNAPSHOT, io.syndesis.connector:connector-support-verifier:1.4-SNAPSHOT]:
    [WARNING]   git.properties
    [WARNING] Found duplicate classes/resources in compile classpath.
    [WARNING] Found duplicate and different resources in [io.syndesis.connector:connector-support-test:1.4-SNAPSHOT, io.syndesis.connector:connector-support-util:1.4-SNAPSHOT, io.syndesis.connector:connector-support-verifier:1.4-SNAPSHOT]:
    [WARNING]   git.properties
    [WARNING] Found duplicate classes/resources in test classpath.