### PR TITLE
Enforce the minimum version of oc

### DIFF
--- a/tools/bin/commands/tests/test-oc-version.sh
+++ b/tools/bin/commands/tests/test-oc-version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source ../util/openshift_funcs
+
+check_error() {
+    local msg="$*"
+    if [ "${msg//ERROR/}" != "${msg}" ]; then
+        echo $msg
+        exit 1
+    fi
+}
+
+
+#
+# Test standard approach
+#
+setup_oc
+
+#
+# Test other possibilities
+#
+echo "=== Expected to be OK ==="
+compare_oc_version '3.9.0' '3.9.0'
+compare_oc_version '3.9.1' '3.9.0'
+compare_oc_version '3.10.0' '3.9.0'
+compare_oc_version '3.10.1' '3.9.0'
+compare_oc_version '4.1.0' '3.9.0'
+compare_oc_version '4.4.5' '3.4.9'
+compare_oc_version '4.4.5' '4.4.4'
+
+
+echo "=== Expected to ERROR ==="
+echo "(will exit after testing each one)"
+#compare_oc_version '3.1.0' '3.9.0'
+#compare_oc_version '3.8.9' '3.9.0'
+#compare_oc_version '2.9.0' '3.9.0'
+#compare_oc_version '4.4.4' '4.4.5'
+compare_oc_version '3.9.0' '3.9.0.1'

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -1,5 +1,80 @@
 #!/bin/bash
 
+OC_MIN_VERSION=3.9.0
+
+compare_version_part() {
+    local test=$1
+    local min=$2
+
+    test=`expr $test`
+    min=`expr $min`
+
+    if [ $test -eq $min ]; then
+        echo 0;
+    elif [ $test -gt $min ]; then
+        echo 1;
+    else
+        # $test -lt $min
+        echo -1
+    fi
+}
+
+compare_oc_version() {
+    local test=$1
+    local min=$2
+
+    echo -n "Testing oc version '$test' against required minimum '$min' ... "
+
+    testparts=( ${test//./ } )
+    minparts=( ${min//./ } )
+
+    local i=0
+    while [ $i -lt ${#minparts[@]} ]
+    do
+        local testpart=${testparts[$i]}
+        local minpart=${minparts[$i]}
+
+        if [ -z "$testpart" ]; then
+            # test version does not extend as far as minimum
+            # in parts so append a 0
+            testpart=0
+        fi
+
+        ret=$(compare_version_part $testpart $minpart)
+        if [ $ret == -1 ]; then
+            #
+            # version part is less than minimum while all preceding
+            # parts were equal so version does not meet minimum
+            #
+            echo "ERROR: oc version ($test) should be at least $min"
+            return
+        elif [ $ret == 1 ]; then
+            #
+            # version part is greater than minimum so no need to test
+            # any further parts as version is greater than minimum
+            #
+            echo "OK"
+            return
+        fi
+
+        #
+        # Only if the version part is equal will the loop continue
+        # with further parts.
+        #
+        i=`expr $i + 1`
+    done
+
+    echo "OK"
+}
+
+check_oc_version()
+{
+    local minimum=${OC_MIN_VERSION}
+    local test=$(oc version | grep oc | tr -d oc\ v | cut -f1 -d "+")
+
+    echo $(compare_oc_version $test $minimum)
+}
+
 setup_oc() {
 
     # Check path first if it already exists
@@ -7,6 +82,8 @@ setup_oc() {
     which oc &>/dev/null
     if [ $? -eq 0 ]; then
       set -e
+      err=$(check_oc_version)
+      check_error $err
       return
     fi
 
@@ -15,6 +92,8 @@ setup_oc() {
     if [ $? -eq 0 ]; then
       set -e
       eval $(minishift oc-env)
+      err=$(check_oc_version)
+      check_error $err
       return
     fi
 


### PR DESCRIPTION
* Since 3.9.0 version of oc is required, check the version during the setup
  of oc stage of running syndesis commands.