### PR TITLE
Issue #2706 - sql connector should not parse body when no parameters

### DIFF
--- a/app/connector/odata/create-entity/pom.xml
+++ b/app/connector/odata/create-entity/pom.xml
@@ -69,7 +69,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
-      <version>${spring-boot.version}</version>
     </dependency>
 
     <dependency>
@@ -89,7 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -101,7 +99,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
@@ -111,7 +108,6 @@
       <plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-package-maven-plugin</artifactId>
-        <version>${camel.version}</version>
         <executions>
           <execution>
             <id>prepare</id>
@@ -134,7 +130,6 @@
       <plugin>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-connector-maven-plugin</artifactId>
-        <version>${camel.version}</version>
         <executions>
           <execution>
             <id>boot</id>

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.sql.common;
 
 import java.io.IOException;
 import java.sql.Types;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,16 +74,30 @@ public final class JSONBeanUtil {
     }
 
     public static Map<String,SqlParameterValue> parseSqlParametersFromJSONBean(final String json, final Map<String, Integer> jdbcTypeMap) {
+        if (json == null || json.isEmpty()) {
+            return Collections.emptyMap(); // json is empty so no need to parse
+        }
+
         final Map<String, String> parsed;
         try {
             parsed = MAPPER.readerFor(STRING_STRING_MAP).readValue(json);
         } catch (final IOException e) {
             throw new IllegalArgumentException("Unable to parse given JSON", e);
         }
+
         final Map<String,SqlParameterValue> ret = new HashMap<>();
         for (String key : parsed.keySet()) {
             Object value = parsed.get(key);
-            Integer jdbcType = (jdbcType = jdbcTypeMap.get(key)) != null ? jdbcType : Types.VARCHAR;
+
+            Integer jdbcType = null;
+            if (jdbcTypeMap != null) {
+                jdbcType = jdbcTypeMap.get(key);
+            }
+
+            if (jdbcType == null) {
+                jdbcType = Types.VARCHAR;
+            }
+
             SqlParameterValue sqlParam = new SqlParameterValue(jdbcType, value);
             ret.put(key,sqlParam);
         }


### PR DESCRIPTION
* JSONBeanUtil
 * Checks the json parameter and returns if empty
 * Check the jdbcTypeMap and assigns VARCHAR if null

* JSONBeanUtilTest
 * Test to check what happens if parameters are null