### PR TITLE
fix(connector): set Timer's output shape to none

### DIFF
--- a/app/connector/timer/src/main/resources/META-INF/syndesis/connector/timer.json
+++ b/app/connector/timer/src/main/resources/META-INF/syndesis/connector/timer.json
@@ -23,7 +23,7 @@
                     "kind": "none"
                 },
                 "outputDataShape": {
-                    "kind": "any"
+                    "kind": "none"
                 },
                 "configuredProperties": {
                     "timerName": "syndesis-timer"


### PR DESCRIPTION
Timer connector is used at the start of the integration (_pattern=From_)
at that point the only body possible as it is a new exchange is `null`,
so defining a shape of `null` body doesn't make sense and leads to
errors.

Fixes #3034