### PR TITLE
chore: Update to AtlasMap 1.35.5 in Integration BOM

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <camel.version>2.21.0.fuse-000094</camel.version>
-    <atlasmap.version>1.35.0</atlasmap.version>
+    <atlasmap.version>1.35.5</atlasmap.version>
   </properties>
 
     <!-- Metadata need to publish to central -->


### PR DESCRIPTION
We need to update AtlasMap to 1.35.5 in Integration BOM as well,
otherwise our integrations run with older version.

cc @igarashitm