### PR TITLE
fix(connector): Salesforce output unmarshalling

### DIFF
--- a/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizerTest.java
+++ b/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizerTest.java
@@ -146,7 +146,7 @@ public class DataShapeCustomizerTest extends SalesforceTestSupport {
     public void shouldUnmarshallToSpecifiedOutputType() throws Exception {
         final ComponentProxyComponent component = setUpComponent("salesforce-create-sobject");
         final Exchange exchange = new DefaultExchange(context);
-        final Message out = exchange.getOut();
+        final Message out = exchange.getIn();
         out.setBody("{}");
 
         component.getAfterProducer().process(exchange);


### PR DESCRIPTION
The Salesforce connector was trying to unmarshall the outgoing exchange
message where it should have used the incoming message. This caused
the output of the Salesforce connector for create/create-or-update and
notifications (starting) actions to be `null` instead of the expected
type populated with data from the Salesforce response.

Fixes #2853