### PR TITLE
API connector - Clicking Next button now takes you to the Review Actions page whe either file or URL is used

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
@@ -86,18 +86,26 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
       .first(request => !!request && !!request.actionsSummary)
       .subscribe( apiConnectorState => {
         // TODO error handling!
-        const reader = new FileReader();
-        reader.onload = () => {
-          this.apiDef = new ApiDefinition();
-          this.apiDef.createdBy = 'user1';
-          this.apiDef.createdOn = new Date();
-          this.apiDef.tags = [];
-          this.apiDef.description = '';
-          this.apiDef.id = 'api-1';
-          this.apiDef.spec = reader.result;
-          this.currentActiveStep = WizardSteps.ReviewApiConnector;
-        };
-        reader.readAsText(apiConnectorState.specificationFile);
+        this.apiDef = new ApiDefinition();
+        this.apiDef.createdBy = 'user1';
+        this.apiDef.createdOn = new Date();
+        this.apiDef.tags = [];
+        this.apiDef.description = '';
+        this.apiDef.id = 'api-1';
+        this.currentActiveStep = WizardSteps.ReviewApiConnector;
+
+        if ( apiConnectorState.specificationFile ) {
+          const reader = new FileReader();
+
+          reader.onload = () => {
+            this.apiDef.spec = reader.result;
+          };
+
+          reader.readAsText( apiConnectorState.specificationFile );
+        } else {
+          // TODO next line sets spec to the URL. this is not right as spec needs to be set to the URL JSON response
+          this.apiDef.spec = apiConnectorState.configuredProperties.specification;
+        }
       });
 
     // Once the request object is flagged as 'isComplete', we redirect the user to the main listing


### PR DESCRIPTION
- See #3096
- FileReader instance is now only used for when file is used
- When URL is used, there is still a problem when Review/Edit is clicked to try and get to the ApiCurioComponent. This is because the ApiDefinition.spec is not being set correctly. ApiDefinition.spec should be set by using a File or a JSON object which I'm not sure we have one at this point. This will be worked in a different issue per @kahboom.