### PR TITLE
fix: add initialDelaySeconds to readyness/liveness checks for prometheus

### DIFF
--- a/install/generator/06-syndesis-prometheus.yml.mustache
+++ b/install/generator/06-syndesis-prometheus.yml.mustache
@@ -177,11 +177,13 @@
           livenessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 60
           ports:
           - containerPort: 9090
           readinessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 30
           # DB QoS class is "Guaranteed" (requests == limits)
           # Note: On OSO there is no Guaranteed class, its always burstable
           resources:

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -1588,11 +1588,13 @@ objects:
           livenessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 60
           ports:
           - containerPort: 9090
           readinessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 30
           # DB QoS class is "Guaranteed" (requests == limits)
           # Note: On OSO there is no Guaranteed class, its always burstable
           resources:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1584,11 +1584,13 @@ objects:
           livenessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 60
           ports:
           - containerPort: 9090
           readinessProbe:
             httpGet:
               port: 9090
+            initialDelaySeconds: 30
           # DB QoS class is "Guaranteed" (requests == limits)
           # Note: On OSO there is no Guaranteed class, its always burstable
           resources:


### PR DESCRIPTION
Fixes #3178