### PR TITLE
fix(basic-filter-form): update form bindings for default state

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.html
@@ -6,18 +6,18 @@
 
         <fieldset formGroupName="filterSettingsGroup" class="filterSettingsGroupContainer">
           <label for="basicFilterPredicateSelect">
-            {{ filterSettingsGroupObj.predicate.label }}
+            {{ form.get('filterSettingsGroup').value.predicateLabel }}
           </label>
           <select
             id="basicFilterPredicateSelect"
             formControlName="predicate"
             class="form-control predicate-select">
-            <option
-              [ngValue]="option.value"
-              *ngFor="let option of predicateOpsModel$ | async; let first = first;">
-              {{ option.label }}
-            </option>
-          </select>
+              <option
+                [ngValue]="option.value"
+                *ngFor="let option of predicateOpsModel$ | async;">
+                {{ option.label }}
+              </option>
+            </select>
         </fieldset>
       </div>
 

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -1,13 +1,12 @@
 import {
   Component,
-  Input,
   OnInit,
   OnDestroy,
   AfterViewInit,
   ChangeDetectorRef
 } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
@@ -15,21 +14,16 @@ import {
 } from '@ng-dynamic-forms/core';
 
 import {
-  Action,
   DataShape,
   FormFactoryService,
-  IntegrationSupportService,
   Step
 } from '@syndesis/ui/platform';
-import { log, getCategory } from '@syndesis/ui/logging';
 import { StepStore, DATA_MAPPER, BASIC_FILTER } from '@syndesis/ui/store';
 import {
   CurrentFlowService,
   FlowEvent,
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
-
-const category = getCategory('IntegrationsCreatePage');
 
 @Component({
   selector: 'syndesis-integration-step-configure',
@@ -52,7 +46,7 @@ export class IntegrationStepConfigureComponent
   dataShape: DataShape;
   loading = false;
   error: any;
-  valid = true;
+  valid = false;
   routeSubscription: Subscription;
   mappings: string;
 


### PR DESCRIPTION
This PR fixes issues with the basic filter form, where the value for the predicate field was not correctly reflected in the UI, and the done button was incorrectly available on initial display of the form, before users entered valid data.

Should fix https://github.com/syndesisio/syndesis/issues/3073

ensure predicate value is reflected in the ui
ensure done button is disabled until form is in a valid state