### PR TITLE
fix(basic-filter-form): add back autocomplete for property name field

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.html
@@ -32,7 +32,11 @@
                 class="form-control"
                 formControlName="path"
                 type="text"
+                [attr.list]="'path-list-' + i"
                 placeholder="Property name">
+              <datalist [attr.id]="'path-list-' + i">
+                <option *ngFor="let path of paths">{{ path }}</option>
+              </datalist>
               <span class="help-block">The data you want to evaluate</span>
               <span *ngIf="!ruleSet.controls.path.pristine && ruleSet.controls.path.errors?.required" class="help-block error">Object property name is required</span>
               <span *ngIf="ruleSet.controls.path.errors?.maxlength" class="help-block error">Maximum Characters Exceeded</span>


### PR DESCRIPTION
This PR restores autocomplete functionality that was lost as part of recent upgrade work.

Should help https://github.com/syndesisio/syndesis/issues/3087

utilize list attribute and datalist element to fulfill autocomplete functions