### PR TITLE
Fix #3168: adjust priority and remove chatId from telegram consumer

### DIFF
--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>camel-telegram</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.syndesis.integration</groupId>
       <artifactId>integration-component-proxy</artifactId>
     </dependency>

--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -14,8 +14,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<project 
-  xmlns="http://maven.apache.org/POM/4.0.0" 
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
@@ -53,7 +53,10 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-telegram</artifactId>
-      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration</groupId>
+      <artifactId>integration-component-proxy</artifactId>
     </dependency>
 
     <!-- test -->

--- a/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
+++ b/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
@@ -35,12 +35,11 @@ public class TelegramSendMessageCustomizer implements ComponentProxyCustomizer {
 
     private void beforeProducer(Exchange exchange) {
         OutgoingTextMessage message = exchange.getIn().getBody(OutgoingTextMessage.class);
-        if (message != null) {
-            // Chat ID priority (in Syndesis) should be: chatId field in the message, chatId at action level, TelegramChatId header
-            if (this.configuredChatId.isPresent() && message.getChatId() == null) {
-                // Overriding Camel default priority giving action configuration higher priority than header
-                message.setChatId(this.configuredChatId.get());
-            }
+
+        // Chat ID priority (in Syndesis) should be: chatId field in the message, chatId at action level, TelegramChatId header
+        if (message != null && message.getChatId() == null && this.configuredChatId.isPresent()) {
+            // Overriding Camel default priority giving action configuration higher priority than header
+            message.setChatId(this.configuredChatId.get());
         }
     }
 }

--- a/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
+++ b/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.telegram;
+
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.telegram.model.OutgoingTextMessage;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class TelegramSendMessageCustomizer implements ComponentProxyCustomizer {
+
+    private Optional<String> configuredChatId;
+
+    @Override
+    public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        this.configuredChatId = Optional.ofNullable(options.get("chatId")).map(String.class::cast);
+        component.setBeforeProducer(this::beforeProducer);
+    }
+
+    private void beforeProducer(Exchange exchange) {
+        OutgoingTextMessage message = exchange.getIn().getBody(OutgoingTextMessage.class);
+        if (message != null) {
+            // Chat ID priority (in Syndesis) should be: chatId field in the message, chatId at action level, TelegramChatId header
+            if (this.configuredChatId.isPresent() && message.getChatId() == null) {
+                // Overriding Camel default priority giving action configuration higher priority than header
+                message.setChatId(this.configuredChatId.get());
+            }
+        }
+    }
+}

--- a/app/connector/telegram/src/main/resources/META-INF/syndesis/connector/telegram.json
+++ b/app/connector/telegram/src/main/resources/META-INF/syndesis/connector/telegram.json
@@ -44,27 +44,7 @@
         "configuredProperties": {
           "type": "bots"
         },
-        "propertyDefinitionSteps": [
-          {
-            "description": "Chat id",
-            "name": "chatId",
-            "properties": {
-              "chatId": {
-                "componentProperty": false,
-                "deprecated": false,
-                "description": "The telegram's Chat Id.",
-                "displayName": "Chat Id",
-                "javaType": "String",
-                "kind": "parameter",
-                "required": false,
-                "secret": false,
-                "type": "string",
-                "tags": [],
-                "enum": []
-              }
-            }
-          }
-        ]
+        "propertyDefinitionSteps": []
       }
     },
     {
@@ -82,6 +62,9 @@
         "outputDataShape": {
           "kind": "none"
         },
+        "connectorCustomizers": [
+          "io.syndesis.connector.telegram.TelegramSendMessageCustomizer"
+        ],
         "configuredProperties": {
           "type": "bots"
         },


### PR DESCRIPTION
Fix #3168.

I've removed the `chatId` property in the receive action because that was a producer-only option and it's not supported consumer side (also by Telegram API).

On the producer side, I've set the following priorities:
- Chat ID in the outgoing message field has highest priority
- Chat ID set in the action configuration comes next
- If nothing else is set, the TelegramChatId header is used (when the integration starts from telegram, replies are sent to the same chat)
