### PR TITLE
feat: mark Connectors provided as tech preview

### DIFF
--- a/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
+++ b/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
@@ -9,9 +9,9 @@
            "id": "@project.groupId@:@project.artifactId@:@project.version@"
       }
   ],
-  "tags": [
-  	"tech-preview"
-  ],
+  "metadata": {
+  	"tech-preview": true
+  },
     "actions": [
         {
             "name": "IRC PRIVMSG",

--- a/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
+++ b/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
@@ -9,6 +9,9 @@
            "id": "@project.groupId@:@project.artifactId@:@project.version@"
       }
   ],
+  "tags": [
+  	"tech-preview"
+  ],
     "actions": [
         {
             "name": "IRC PRIVMSG",

--- a/app/ui/src/app/common/card-tech-preview.component.scss
+++ b/app/ui/src/app/common/card-tech-preview.component.scss
@@ -1,0 +1,26 @@
+@import 'syndesis-sass';
+
+.syn-card-info {
+  text-align: right;
+
+  &:after {
+    /* taken verbatim from patternfly/_icons.scss */
+    content: $pficon-var-info;
+    display: inline-block;
+    font-family: "#{$icon-font-name-pf}";
+    font-style: normal;
+    font-variant: normal;
+    font-weight: normal;
+    line-height: 1;
+    speak: none;
+    text-transform: none;
+    /* Better Font Rendering =========== */
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    padding-left: $padding-base-horizontal;
+  }
+}
+
+syndesis-card-tech-preview[is-tech-preview=true] + .card-pf-body {
+  height: 219px !important;
+}

--- a/app/ui/src/app/common/card-tech-preview.component.ts
+++ b/app/ui/src/app/common/card-tech-preview.component.ts
@@ -14,43 +14,27 @@ import { ConnectorStore } from '@syndesis/ui/store';
   styleUrls: ['./card-tech-preview.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class CardTechPreviewComponent implements OnInit, OnDestroy {
+export class CardTechPreviewComponent implements OnInit {
   @Input() item: Connection | Connector;
   @HostBinding('attr.is-tech-preview')
   isTechPreview: boolean;
-  private connectorsSubscription: Subscription;
-
-  constructor(
-    private connectorStore: ConnectorStore
-  ) {}
 
   ngOnInit(): void {
-    const [connector, connectorId] = CardTechPreviewComponent.determineConnector(this.item);
+    const connector = CardTechPreviewComponent.determineConnector(this.item);
 
     if (connector) {
       this.isTechPreview = CardTechPreviewComponent.taggedAsTechPreview(connector);
-    } else if (connectorId) {
-      this.connectorsSubscription = this.connectorStore.load(connectorId).subscribe(
-        loaded => {
-          this.isTechPreview = CardTechPreviewComponent.taggedAsTechPreview(loaded);
-        });
     }
   }
 
-  ngOnDestroy() {
-    if (this.connectorsSubscription) {
-      this.connectorsSubscription.unsubscribe();
-    }
-  }
-
-  private static determineConnector(connectionOrConnector: Connection | Connector): [Connector, string] {
+  private static determineConnector(connectionOrConnector: Connection | Connector) {
     if ((<Connection>connectionOrConnector).connector) {
       const connection = <Connection>connectionOrConnector;
-      return [connection.connector, connection.connectorId];
+      return connection.connector;
     }
 
     const connector = <Connector>connectionOrConnector;
-    return [connector, connector.id];
+    return connector;
   }
 
   private static taggedAsTechPreview(connector: Connector) {

--- a/app/ui/src/app/common/card-tech-preview.component.ts
+++ b/app/ui/src/app/common/card-tech-preview.component.ts
@@ -38,6 +38,6 @@ export class CardTechPreviewComponent implements OnInit {
   }
 
   private static taggedAsTechPreview(connector: Connector) {
-    return connector.tags && connector.tags.indexOf('tech-preview') >= 0;
+    return connector.metadata && connector.metadata['tech-preview'] === 'true';
   }
 }

--- a/app/ui/src/app/common/card-tech-preview.component.ts
+++ b/app/ui/src/app/common/card-tech-preview.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, OnInit, OnDestroy, HostBinding, ViewEncapsulation } from '@angular/core';
+import { Connection, Connector } from '@syndesis/ui/platform';
+import { Subscription } from 'rxjs';
+import { ConnectorStore } from '@syndesis/ui/store';
+
+@Component({
+  selector: 'syndesis-card-tech-preview',
+  template: `
+    <div *ngIf="isTechPreview"
+          class="card-pf-heading syn-card-info"
+          data-toggle="tooltip"
+          [title]="'connections.tech-preview-tooltip' | synI18n">{{ 'connections.tech-preview' | synI18n }}</div>
+  `,
+  styleUrls: ['./card-tech-preview.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class CardTechPreviewComponent implements OnInit, OnDestroy {
+  @Input() item: Connection | Connector;
+  @HostBinding('attr.is-tech-preview')
+  isTechPreview: boolean;
+  private connectorsSubscription: Subscription;
+
+  constructor(
+    private connectorStore: ConnectorStore
+  ) {}
+
+  ngOnInit(): void {
+    const [connector, connectorId] = CardTechPreviewComponent.determineConnector(this.item);
+
+    if (connector) {
+      this.isTechPreview = CardTechPreviewComponent.taggedAsTechPreview(connector);
+    } else if (connectorId) {
+      this.connectorsSubscription = this.connectorStore.load(connectorId).subscribe(
+        loaded => {
+          this.isTechPreview = CardTechPreviewComponent.taggedAsTechPreview(loaded);
+        });
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.connectorsSubscription) {
+      this.connectorsSubscription.unsubscribe();
+    }
+  }
+
+  private static determineConnector(connectionOrConnector: Connection | Connector): [Connector, string] {
+    if ((<Connection>connectionOrConnector).connector) {
+      const connection = <Connection>connectionOrConnector;
+      return [connection.connector, connection.connectorId];
+    }
+
+    const connector = <Connector>connectionOrConnector;
+    return [connector, connector.id];
+  }
+
+  private static taggedAsTechPreview(connector: Connector) {
+    return connector.tags && connector.tags.indexOf('tech-preview') >= 0;
+  }
+}

--- a/app/ui/src/app/common/common.module.ts
+++ b/app/ui/src/app/common/common.module.ts
@@ -26,6 +26,7 @@ import { IconPathPipe } from '@syndesis/ui/common/icon-path.pipe';
 import { ParseMarkdownLinksPipe } from '@syndesis/ui/common/parse-markdown-links.pipe';
 import { ButtonComponent } from '@syndesis/ui/common/button.component';
 import { InlineAlertComponent } from '@syndesis/ui/common/inline-alert';
+import { CardTechPreviewComponent } from '@syndesis/ui/common/card-tech-preview.component';
 
 // TODO: Move these services out to a CoreModule
 import { NotificationService } from '@syndesis/ui/common/ui-patternfly';
@@ -64,7 +65,8 @@ import { EmptyStateCardComponent } from '@syndesis/ui/common/empty-state-card/em
     InlineAlertComponent,
     ...SYNDESYS_EDITABLE_DIRECTIVES,
     ...SYNDESYS_VALIDATION_DIRECTIVES,
-    EmptyStateCardComponent
+    EmptyStateCardComponent,
+    CardTechPreviewComponent
   ],
   exports: [
     I18NPipe,
@@ -89,7 +91,8 @@ import { EmptyStateCardComponent } from '@syndesis/ui/common/empty-state-card/em
     InlineAlertComponent,
     ...SYNDESYS_EDITABLE_DIRECTIVES,
     ...SYNDESYS_VALIDATION_DIRECTIVES,
-    EmptyStateCardComponent
+    EmptyStateCardComponent,
+    CardTechPreviewComponent
   ]
 })
 export class SyndesisCommonModule {

--- a/app/ui/src/app/connections/list/list.component.html
+++ b/app/ui/src/app/connections/list/list.component.html
@@ -36,8 +36,8 @@
 
           <div class="card-pf card-pf-view card-pf-view-select card-pf-view-single-select"
               [class.active]="connection.id === selectedId">
+            <syndesis-card-tech-preview [item]="connection"></syndesis-card-tech-preview>
             <div class="card-pf-body">
-
               <div class="card-pf-heading-kebab">
                 <div *ngIf="showKebab">
                   <div dropdown
@@ -106,7 +106,7 @@
         </div>
       </ng-container>
       <ng-container *ngIf="showNewConnection && connections.length > 0">
-        <syndesis-empty-state-card class="col-lg-3 col-md-4 col-sm-6" 
+        <syndesis-empty-state-card class="col-lg-3 col-md-4 col-sm-6"
           (click)="onSelect(undefined, $event)">
           <div class="empty-state-card__body">
             <button class="btn btn-default">Create Connection</button>

--- a/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
+++ b/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.html
@@ -35,6 +35,7 @@
           <div class="card-pf card-pf-view card-pf-view-select card-pf-view-single-select"
                *ngIf="i<8"
                (click)="onSelect(connection)">
+            <syndesis-card-tech-preview [item]="connection"></syndesis-card-tech-preview>
             <div class="card-pf-body">
 
               <!-- Card Icon -->

--- a/app/ui/src/app/platform/types/connection/connection.models.ts
+++ b/app/ui/src/app/platform/types/connection/connection.models.ts
@@ -40,6 +40,7 @@ export interface Connector extends BaseEntity {
   description: string;
   connectorGroup: BaseEntity;
   tags: Array<string>;
+  metadata?: StringMap<any>;
 }
 
 export interface Organization extends BaseEntity {

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -81,7 +81,9 @@
       "delete-connection-modal": "Are you sure you want to delete the \"{{0}}\" connection?",
       "delete-connection-modal-title": "Confirm Delete?",
       "cancel-create-modal": "You have not finished creating the connection. If you cancel now you will lose data you already entered. Do you still want to cancel?",
-      "cancel-create-modal-lead": "Do you really want to cancel?"
+      "cancel-create-modal-lead": "Do you really want to cancel?",
+      "tech-preview": "Technology preview",
+      "tech-preview-tooltip": "We're happy to provide you with this early access preview feature, we encourage to provide feedback but limit our support to best effort."
     },
     "dashboard": {
       "heading": "Dashboard",


### PR DESCRIPTION
Adds a new tag `tech-preview` that can be added to connectors that are provided for early access technology preview.

First such Connector is the IRC Connector.

Visually when Connection is displayed the top of the Connection card will contain `Technology preview` text, which is also displayed during connection creation.

Fixes #3201