### PR TITLE
fix(ui): mutation order in API Client connector wizard OAuth settings

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
@@ -10,7 +10,7 @@
   <form [formGroup]="authSetupForm" #form="ngForm" (ngSubmit)="onSubmit(form)" class="form-horizontal" novalidate>
     <fieldset class="container-fluid">
       <div class="row">
-        <div *ngFor="let authType of customConnectorRequest.properties.authenticationType.enum; let i = index" class="col-xs-12">
+        <div *ngFor="let authType of customConnectorRequest.properties.authenticationType.enum" class="col-xs-12">
           <div class="form-group">
             <div class="col-xs-12">
               <div class="radio">
@@ -19,7 +19,6 @@
                     name="authenticationType"
                     formControlName="authenticationType"
                     [value]="authType.value"
-                    [checked]="i == 0"
                     #authenticationType> {{ authType.label }}
                 </label>
               </div>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
@@ -30,9 +30,12 @@ export class ApiConnectorAuthComponent implements OnInit, OnDestroy {
       authorizationEndpoint,
       tokenEndpoint
     } = this.customConnectorRequest.properties;
+
+    const defaultAuthenticationType = (authenticationType && authenticationType.defaultValue)
+          || (authenticationType.enum.length > 0 && authenticationType.enum[0].value);
     this.authSetupForm = this.formBuilder.group({
       authenticationType: [
-        authenticationType ? authenticationType.defaultValue : ''
+        defaultAuthenticationType
       ],
       authorizationEndpoint: [
         authorizationEndpoint ? authorizationEndpoint.defaultValue : ''


### PR DESCRIPTION
This presets the default value for `authenticationType` so that it's `input[type=radio]` is `checked` before the dependent child is checked by Angular change management. So that `ExpressionChangedAfterItHasBeenCheckedError` is not raised on initial
render.

Fixes #3042