### PR TITLE
Integration edit guard

### DIFF
--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -104,8 +104,8 @@
           </div>
         </syndesis-loading>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -104,6 +104,9 @@
           </div>
         </syndesis-loading>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router, RouterStateSnapshot } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
@@ -19,6 +19,8 @@ import {
   CurrentFlowService,
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
+
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 @Component({
   selector: 'syndesis-integration-action-configure',
@@ -52,7 +54,8 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
     public formFactory: FormFactoryService,
     public formService: DynamicFormService,
     public integrationSupport: IntegrationSupportService,
-    private userService: UserService
+    private userService: UserService,
+    public modalService: ModalService
   ) {
     // nothing to do
   }
@@ -303,6 +306,25 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
       }
     }
     return props;
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/connections/create/connection-basics') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -309,7 +309,6 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('action-configure') ||
       nextState.url.includes('describe-data') ||

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -311,18 +311,10 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/connections/create/connection-basics') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('action-configure') ||
+      nextState.url.includes('describe-data') ||
+      nextState.url.includes('save-or-add-step') ||
+      nextState.url.includes('action-select') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -48,6 +48,9 @@
             (onSelected)="onSelected($event)"></syndesis-list-actions>
         </div>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -48,8 +48,8 @@
             (onSelected)="onSelected($event)"></syndesis-list-actions>
         </div>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
@@ -1,7 +1,8 @@
 import { filter, switchMap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable, EMPTY, Subject, BehaviorSubject, Subscription } from 'rxjs';
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 import {
   Actions,
@@ -41,7 +42,8 @@ export class IntegrationSelectActionComponent implements OnInit, OnDestroy {
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
-    public router: Router
+    public router: Router,
+    public modalService: ModalService
   ) {
     this.flowSubscription = currentFlowService.events.subscribe(
       (event: FlowEvent) => {
@@ -160,6 +162,24 @@ export class IntegrationSelectActionComponent implements OnInit, OnDestroy {
       this.position = +params.get('position');
       this.loadActions();
     });
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnDestroy() {

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
@@ -167,17 +167,7 @@ export class IntegrationSelectActionComponent implements OnInit, OnDestroy {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('action-configure') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
@@ -165,7 +165,6 @@ export class IntegrationSelectActionComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('action-configure') ||
       this.modalService.show().then(modal => modal.result)

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -61,6 +61,9 @@
                                   [showKebab]="false"
                                   [showNewConnection]="true"></syndesis-connections-list>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.html
@@ -61,8 +61,8 @@
                                   [showKebab]="false"
                                   [showNewConnection]="true"></syndesis-connections-list>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
@@ -123,7 +123,6 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('action-select') ||
       nextState.url.includes('action-configure') ||

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
@@ -1,6 +1,6 @@
 import { map, first } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable, Subscription, BehaviorSubject } from 'rxjs';
 
 import { log, getCategory } from '@syndesis/ui/logging';
@@ -11,6 +11,8 @@ import {
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
 import { ConnectionStore } from '@syndesis/ui/store';
+
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 const category = getCategory('Integrations');
 
@@ -37,6 +39,7 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
     public router: Router,
+    public modalService: ModalService,
     private userService: UserService
   ) {
     this.flowSubscription = this.currentFlowService.events.subscribe(
@@ -117,6 +120,24 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
       default:
         break;
     }
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
@@ -127,6 +127,7 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
     return (
       nextState.url.includes('action-select') ||
       nextState.url.includes('action-configure') ||
+      nextState.url.includes('connection-basics') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
@@ -125,17 +125,8 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('action-select') ||
+      nextState.url.includes('action-configure') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
@@ -61,6 +61,9 @@
           </div>
         </ng-container>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.html
@@ -61,8 +61,8 @@
           </div>
         </ng-container>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
     </div>
   </div>

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription, BehaviorSubject, Observable } from 'rxjs';
 import { CurrentFlowService, FlowPageService, FlowEvent } from '@syndesis/ui/integration/edit-page';
-import { ActivatedRoute, Router, ParamMap } from '@angular/router';
+import { ActivatedRoute, Router, ParamMap, RouterStateSnapshot } from '@angular/router';
 import {
   Step,
   FormFactoryService,
@@ -13,6 +13,7 @@ import {
   DynamicFormControlModel
 } from '@ng-dynamic-forms/core';
 import { FormGroup } from '@angular/forms';
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 enum DataShapeDirection {
   INPUT = 'input',
@@ -106,7 +107,8 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
     public route: ActivatedRoute,
     public router: Router,
     public formFactoryService: FormFactoryService,
-    public dynamicFormService: DynamicFormService
+    public dynamicFormService: DynamicFormService,
+    public modalService: ModalService
   ) {
     // nothing to do
   }
@@ -238,6 +240,24 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
       this.userDefined = false;
       this.continue();
     }
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -243,7 +243,6 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('save-or-add-step') ||
       nextState.url.includes('describe-data') ||

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -245,17 +245,8 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('save-or-add-step') ||
+      nextState.url.includes('describe-data') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -23,7 +23,7 @@
             </div>
             <div class="toolbar-pf-action-right">
               <button class="btn btn-default"
-                      (click)="cancel()">Cancel
+                      (click)="showCancelModal()">Cancel
               </button> &nbsp;
               <button class="btn btn-default"
                       (click)="save()"
@@ -103,5 +103,13 @@
     <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
       message="{{ 'connections.leave-page-message' | synI18n }}">
     </syndesis-modal>
+    <ng-template #cancelModalTemplate>
+        <cancel-confirmation-modal (cancel)="onCancel($event)"
+                                    primaryLabel="{{ 'yes' | synI18n }}"
+                                    secondaryLabel="{{ 'no' | synI18n }}">
+          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
+          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+        </cancel-confirmation-modal>
+      </ng-template>
   </div>
 </div>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -100,5 +100,8 @@
         </div>
       </div>
     </div>
+    <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+      message="{{ 'connections.leave-page-message' | synI18n }}">
+    </syndesis-modal>
   </div>
 </div>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -100,8 +100,8 @@
         </div>
       </div>
     </div>
-    <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-      message="{{ 'connections.leave-page-message' | synI18n }}">
+    <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+      message="{{ 'integrations.leave-page-modal' | synI18n }}">
     </syndesis-modal>
     <ng-template #cancelModalTemplate>
         <cancel-confirmation-modal (cancel)="onCancel($event)"

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -108,7 +108,7 @@
                                     primaryLabel="{{ 'yes' | synI18n }}"
                                     secondaryLabel="{{ 'no' | synI18n }}">
           <p class="lead">{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
-          <p>{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
+          <p>{{ 'integrations.edit.cancel-modal' | synI18n }}</p>
         </cancel-confirmation-modal>
       </ng-template>
   </div>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.html
@@ -107,8 +107,8 @@
         <cancel-confirmation-modal (cancel)="onCancel($event)"
                                     primaryLabel="{{ 'yes' | synI18n }}"
                                     secondaryLabel="{{ 'no' | synI18n }}">
-          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
-          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+          <p class="lead">{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
+          <p>{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
         </cancel-confirmation-modal>
       </ng-template>
   </div>

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
@@ -103,17 +103,7 @@ export class IntegrationBasicsComponent implements OnInit {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('integrations') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, TemplateRef } from '@angular/core';
+import { Component, OnInit, ViewChild, TemplateRef, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import {
   CurrentFlowService,

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
@@ -118,7 +118,6 @@ export class IntegrationBasicsComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('integrations') ||
       this.modalService.show().then(modal => modal.result)

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, TemplateRef } from '@angular/core';
 import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import {
   CurrentFlowService,
@@ -14,7 +14,12 @@ import { ModalService } from '@syndesis/ui/common/modal/modal.service';
     './integration-basics.component.scss'
   ]
 })
-export class IntegrationBasicsComponent implements OnInit {
+export class IntegrationBasicsComponent implements OnInit, OnDestroy {
+
+  @ViewChild('cancelModalTemplate') cancelModalTemplate: TemplateRef<any>;
+
+  private cancelModalId = 'create-cancellation-modal';
+
   constructor(
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
@@ -33,6 +38,18 @@ export class IntegrationBasicsComponent implements OnInit {
 
   get publishInProgress() {
     return this.flowPageService.publishInProgress;
+  }
+
+  showCancelModal() {
+    this.modalService.show(this.cancelModalId).then(modal => {
+      if (modal.result) {
+        this.cancel();
+      }
+    });
+  }
+
+  onCancel(doCancel: boolean): void {
+    this.modalService.hide(this.cancelModalId, doCancel);
   }
 
   cancel() {
@@ -110,5 +127,13 @@ export class IntegrationBasicsComponent implements OnInit {
 
   ngOnInit() {
     this.flowPageService.initialize();
+    this.modalService.registerModal(
+      this.cancelModalId,
+      this.cancelModalTemplate
+    );
+  }
+
+  ngOnDestroy() {
+    this.modalService.unregisterModal(this.cancelModalId);
   }
 }

--- a/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
+++ b/app/ui/src/app/integration/edit-page/integration-basics/integration-basics.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import {
   CurrentFlowService,
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 @Component({
   selector: 'syndesis-integration-integration-basics',
@@ -18,7 +19,8 @@ export class IntegrationBasicsComponent implements OnInit {
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
-    public router: Router
+    public router: Router,
+    public modalService: ModalService
   ) {}
 
   get errorMessage() {
@@ -96,6 +98,24 @@ export class IntegrationBasicsComponent implements OnInit {
       property: 'tags',
       value: _tags
     });
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -28,14 +28,15 @@
                   (click)="cancel()">Cancel
               </button> &nbsp;
                 <button class="btn btn-default"
+                  [routerLink]="['/integrations/save']"
                   (click)="save()"
                   [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress">
                   <span *ngIf="flowPageService.saveInProgress"
                     class="spinner spinner-sm spinner-inline"></span>
                   Save as Draft
                 </button>
-                <button type="button"
-                  class="btn btn-primary"
+                <button class="btn btn-primary"
+                  [routerLink]="['/integrations/publish']"
                   (click)="publish()"
                   [disabled]="!flowPageService.canContinue() || flowPageService.saveInProgress || flowPageService.publishInProgress">
                   <span *ngIf="flowPageService.publishInProgress"
@@ -94,6 +95,9 @@
           </div>
         </div>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -25,7 +25,7 @@
               </div>
               <div class="toolbar-pf-action-right">
                 <button class="btn btn-default"
-                  (click)="cancel()">Cancel
+                (click)="showCancelModal()">Cancel
               </button> &nbsp;
                 <button class="btn btn-default"
                   [routerLink]="['/integrations/save']"
@@ -98,6 +98,14 @@
       <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
         message="{{ 'connections.leave-page-message' | synI18n }}">
       </syndesis-modal>
+      <ng-template #cancelModalTemplate>
+        <cancel-confirmation-modal (cancel)="onCancel($event)"
+                                    primaryLabel="{{ 'yes' | synI18n }}"
+                                    secondaryLabel="{{ 'no' | synI18n }}">
+          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
+          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+        </cancel-confirmation-modal>
+      </ng-template>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -102,8 +102,8 @@
         <cancel-confirmation-modal (cancel)="onCancel($event)"
                                     primaryLabel="{{ 'yes' | synI18n }}"
                                     secondaryLabel="{{ 'no' | synI18n }}">
-          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
-          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+          <p class="lead">{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
+          <p>{{ 'integrations.edit.cancel-modal' | synI18n }}</p>
         </cancel-confirmation-modal>
       </ng-template>
     </div>

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.html
@@ -95,8 +95,8 @@
           </div>
         </div>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
       <ng-template #cancelModalTemplate>
         <cancel-confirmation-modal (cancel)="onCancel($event)"

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -162,7 +162,6 @@ export class IntegrationSaveOrAddStepComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('action-configure') ||
       nextState.url.includes('step-configure') ||

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -1,5 +1,9 @@
 import { map } from 'rxjs/operators';
-import { Component, OnInit } from '@angular/core';
+import { Component,
+  OnInit,
+  OnDestroy,
+  ViewChild,
+  TemplateRef } from '@angular/core';
 import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
 import {
@@ -22,8 +26,12 @@ const category = getCategory('IntegrationsCreatePage');
     './save-or-add-step.component.scss'
   ]
 })
-export class IntegrationSaveOrAddStepComponent implements OnInit {
+export class IntegrationSaveOrAddStepComponent implements OnInit, OnDestroy {
   integration: Integration;
+
+  @ViewChild('cancelModalTemplate') cancelModalTemplate: TemplateRef<any>;
+
+  private cancelModalId = 'create-cancellation-modal';
 
   constructor(
     public currentFlowService: CurrentFlowService,
@@ -156,19 +164,26 @@ export class IntegrationSaveOrAddStepComponent implements OnInit {
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('action-configure') ||
+      nextState.url.includes('step-configure') ||
+      nextState.url.includes('step-select') ||
+      nextState.url.includes('connection-select') ||
+      nextState.url.includes('integration-basics') ||
+      nextState.url.includes('integrations/save') ||
       this.modalService.show().then(modal => modal.result)
     );
+  }
+
+  showCancelModal() {
+    this.modalService.show(this.cancelModalId).then(modal => {
+      if (modal.result) {
+        this.cancel();
+      }
+    });
+  }
+
+  onCancel(doCancel: boolean): void {
+    this.modalService.hide(this.cancelModalId, doCancel);
   }
 
   ngOnInit() {
@@ -179,5 +194,13 @@ export class IntegrationSaveOrAddStepComponent implements OnInit {
     if (validate) {
       this.validateFlow();
     }
+    this.modalService.registerModal(
+      this.cancelModalId,
+      this.cancelModalTemplate
+    );
+  }
+
+  ngOnDestroy() {
+    this.modalService.unregisterModal(this.cancelModalId);
   }
 }

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -170,6 +170,7 @@ export class IntegrationSaveOrAddStepComponent implements OnInit, OnDestroy {
       nextState.url.includes('connection-select') ||
       nextState.url.includes('integration-basics') ||
       nextState.url.includes('integrations/save') ||
+      nextState.url.includes('integrations/publish') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -1,6 +1,6 @@
 import { map } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
 import {
   FlowEvent,
@@ -10,6 +10,7 @@ import {
 import { IntegrationStore } from '@syndesis/ui/store';
 import { log, getCategory } from '@syndesis/ui/logging';
 import { Integration } from '@syndesis/ui/platform';
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 const category = getCategory('IntegrationsCreatePage');
 
@@ -28,7 +29,8 @@ export class IntegrationSaveOrAddStepComponent implements OnInit {
     public currentFlowService: CurrentFlowService,
     public flowPageService: FlowPageService,
     public route: ActivatedRoute,
-    public router: Router
+    public router: Router,
+    public modalService: ModalService
   ) {}
 
   get errorMessage() {
@@ -149,6 +151,24 @@ export class IntegrationSaveOrAddStepComponent implements OnInit {
       );
       return;
     }
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -117,8 +117,8 @@
           </div>
         </div>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
     </syndesis-loading>
   </div>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -117,6 +117,9 @@
           </div>
         </div>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
     </syndesis-loading>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -194,17 +194,7 @@ export class IntegrationStepConfigureComponent
   canDeactivate(nextState: RouterStateSnapshot) {
     console.log('NEXT STEP: ' + nextState.url);
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('save-or-add-step') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -192,7 +192,6 @@ export class IntegrationStepConfigureComponent
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     return (
       nextState.url.includes('save-or-add-step') ||
       this.modalService.show().then(modal => modal.result)

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -6,7 +6,7 @@ import {
   ChangeDetectorRef
 } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
@@ -24,6 +24,8 @@ import {
   FlowEvent,
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
+
+import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 
 @Component({
   selector: 'syndesis-integration-step-configure',
@@ -58,7 +60,8 @@ export class IntegrationStepConfigureComponent
     public router: Router,
     public formFactory: FormFactoryService,
     public formService: DynamicFormService,
-    public stepStore: StepStore
+    public stepStore: StepStore,
+    public modalService: ModalService
   ) {
     this.flowSubscription = this.currentFlowService.events.subscribe(
       (event: FlowEvent) => {
@@ -186,6 +189,24 @@ export class IntegrationStepConfigureComponent
       default:
         break;
     }
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    console.log('NEXT STEP: ' + nextState.url);
+    return (
+      nextState.url.includes('/edit/action-configure') ||
+      nextState.url.includes('/edit/step-configure') ||
+      nextState.url.includes('/edit/step-select') ||
+      nextState.url.includes('/integrations/create/connection-select') ||
+      nextState.url.includes('/integrations/create/describe-data') ||
+      nextState.url.includes('/integrations/create/save-or-add-step') ||
+      nextState.url.includes('/integrations/create/integration-basics') ||
+      nextState.url.includes('/integrations/create/action-select') ||
+      nextState.url.includes('/integrations/create/action-configure') ||
+      nextState.url.includes('/integrations/create/step-select') ||
+      nextState.url.includes('/integrations/create/step-configure') ||
+      this.modalService.show().then(modal => modal.result)
+    );
   }
 
   ngOnInit() {

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -61,6 +61,17 @@
           </div>
         </syndesis-loading>
       </div>
+      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
+        message="{{ 'connections.leave-page-message' | synI18n }}">
+      </syndesis-modal>
+      <ng-template #cancelModalTemplate>
+        <cancel-confirmation-modal (cancel)="onCancel($event)"
+                                    primaryLabel="{{ 'yes' | synI18n }}"
+                                    secondaryLabel="{{ 'no' | synI18n }}">
+          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
+          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+        </cancel-confirmation-modal>
+      </ng-template>
     </div>
   </div>
 </syndesis-loading>

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -61,15 +61,15 @@
           </div>
         </syndesis-loading>
       </div>
-      <syndesis-modal title="{{ 'connections.leave-page-title' | synI18n }}"
-        message="{{ 'connections.leave-page-message' | synI18n }}">
+      <syndesis-modal title="{{ 'integrations.leave-page-modal-title' | synI18n }}"
+        message="{{ 'integrations.leave-page-modal' | synI18n }}">
       </syndesis-modal>
       <ng-template #cancelModalTemplate>
         <cancel-confirmation-modal (cancel)="onCancel($event)"
                                     primaryLabel="{{ 'yes' | synI18n }}"
                                     secondaryLabel="{{ 'no' | synI18n }}">
-          <p class="lead">{{ 'connections.cancel-create-modal-lead' | synI18n }}</p>
-          <p>{{ 'connections.cancel-create-modal' | synI18n }}</p>
+          <p class="lead">{{ 'integrations.edit.cancel-modal-lead' | synI18n }}</p>
+          <p>{{ 'integrations.edit.cancel-modal' | synI18n }}</p>
         </cancel-confirmation-modal>
       </ng-template>
     </div>

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.ts
@@ -161,7 +161,6 @@ export class IntegrationStepSelectComponent implements OnInit, OnDestroy {
   }
 
   canDeactivate(nextState: RouterStateSnapshot) {
-    console.log('NEXT STEP: ' + nextState.url);
     if (nextState.url == '/integrations') {
       return this.modalService.show(this.cancelModalId).then(modal => modal.result);
     }

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.ts
@@ -166,17 +166,8 @@ export class IntegrationStepSelectComponent implements OnInit, OnDestroy {
       return this.modalService.show(this.cancelModalId).then(modal => modal.result);
     }
     return (
-      nextState.url.includes('/edit/action-configure') ||
-      nextState.url.includes('/edit/step-configure') ||
-      nextState.url.includes('/edit/step-select') ||
-      nextState.url.includes('/integrations/create/connection-select') ||
-      nextState.url.includes('/integrations/create/describe-data') ||
-      nextState.url.includes('/integrations/create/save-or-add-step') ||
-      nextState.url.includes('/integrations/create/integration-basics') ||
-      nextState.url.includes('/integrations/create/action-select') ||
-      nextState.url.includes('/integrations/create/action-configure') ||
-      nextState.url.includes('/integrations/create/step-select') ||
-      nextState.url.includes('/integrations/create/step-configure') ||
+      nextState.url.includes('step-configure') ||
+      nextState.url.includes('save-or-add-step') ||
       this.modalService.show().then(modal => modal.result)
     );
   }

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -87,7 +87,7 @@ const editIntegrationChildRoutes = [
     component: IntegrationDescribeDataComponent,
     canDeactivate: [CanDeactivateGuard]
   },
-  { 
+  {
     path: 'step-select/:position',
     component: IntegrationStepSelectComponent,
     canDeactivate: [CanDeactivateGuard]

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -19,6 +19,8 @@ import {
 } from '@syndesis/ui/integration/integration_detail';
 import { IntegrationLogsComponent } from '@syndesis/ui/integration/integration_logs';
 
+import { CanDeactivateGuard } from '@syndesis/ui/platform';
+
 import {
   IntegrationEditPage,
   IntegrationBasicsComponent,
@@ -47,40 +49,53 @@ const integrationListModuleFwd = forwardRef(() => IntegrationListModule);
 const editIntegrationChildRoutes = [
   {
     path: 'save-or-add-step',
-    component: IntegrationSaveOrAddStepComponent
+    component: IntegrationSaveOrAddStepComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'integration-basics',
-    component: IntegrationBasicsComponent
+    component: IntegrationBasicsComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'connection-select/:position',
-    component: IntegrationSelectConnectionComponent
+    component: IntegrationSelectConnectionComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'action-select/:position',
-    component: IntegrationSelectActionComponent
+    component: IntegrationSelectActionComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'action-configure/:position/:page',
-    component: IntegrationConfigureActionComponent
+    component: IntegrationConfigureActionComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'action-configure/:position',
-    component: IntegrationConfigureActionComponent
+    component: IntegrationConfigureActionComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'describe-data/:position',
-    redirectTo: 'describe-data/:position/input'
+    redirectTo: 'describe-data/:position/input',
+    canDeactivate: [CanDeactivateGuard]
   },
   {
     path: 'describe-data/:position/:direction',
-    component: IntegrationDescribeDataComponent
+    component: IntegrationDescribeDataComponent,
+    canDeactivate: [CanDeactivateGuard]
   },
-  { path: 'step-select/:position', component: IntegrationStepSelectComponent },
+  { 
+    path: 'step-select/:position',
+    component: IntegrationStepSelectComponent,
+    canDeactivate: [CanDeactivateGuard]
+  },
   {
     path: 'step-configure/:position',
-    component: IntegrationStepConfigureComponent
+    component: IntegrationStepConfigureComponent,
+    canDeactivate: [CanDeactivateGuard]
   }
 ];
 

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -58,7 +58,9 @@
           "description": "Enter any information about this data type that might be helpful to you."
         },
         "delete-step-modal": "Are you sure you want to delete this step from the integration?",
-        "delete-step-modal-title": "Confirm Delete?"
+        "delete-step-modal-title": "Confirm Delete?",
+        "cancel-modal": "You have not saved your updates to the integration. If you cancel now you will lose data you entered. Do you still want to cancel?",
+        "cancel-modal-lead": "Do you really want to cancel?"
       }
     },
     "connections": {

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -36,6 +36,8 @@
       "published": "Running",
       "unpublished": "Stopped",
       "pending": "Pending",
+      "leave-page-modal-title": "Leave page?",
+      "leave-page-modal": "Are you sure you want to leave this page and lose any unsaved work?",
       "import-export": {
         "header": "Import {{integration}}",
         "choose-files": "Choose one or more zip files that contain exported integrations that you want to import.",


### PR DESCRIPTION
fix https://github.com/syndesisio/syndesis/issues/3060

Some things I couldn't figure out

* Clicking "save as draft" from save-or-add-step when editing an integration takes you back to integration details.
* Clicking "cancel" from save-or-add-step when editing gives 2 modals.
* I'm not sure what routes to test for from the integration-basics step. It takes me back to /integrations/[unique string for the integration]. If I use that value, that would disable the route guard from that link in the breadcrumbs.
* If you trigger the route guard from the "connection-select" step, the wrong modal comes up.
* Tova would like different wording for the "cancel" modal for the integration create and edit paths.