### PR TITLE
fix(release): Filter out non-three digit version when calculating snapshot name

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -171,7 +171,7 @@ calc_timestamp_version() {
         echo "ERROR: Cannot extract version from app/pom.xml"
         exit 1
     fi
-    local patch_level=$(git tag | grep ^$pom_version | grep -v '-' | sed -e s/${pom_version}.// | sort -n -r | head -1)
+    local patch_level=$(git tag | grep ^$pom_version | grep -v '-' | grep '[0-9]*\.[0-9]*\.' | sed -e s/${pom_version}.// | sort -n -r | head -1)
     echo "${pom_version}.$((patch_level+1))-$(date '+%Y%m%d')"
 }
 


### PR DESCRIPTION
Fixes #3162