### PR TITLE
Fixes Issue 3108 Apicurio editor - Save button missing

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -1,24 +1,24 @@
 <article class="wizard syn-scrollable">
-  <section class="wizard__ui wizard__nav">
+  <section class="wizard__ui wizard__nav" *ngIf="!showApiEditor">
     <nav class="wizard-nav row toolbar-pf">
       <div class="col-sm-12">
         <div class="toolbar-pf-actions">
           <div class="wizard-nav__breadcrumbs inline-block">
             <ol class="breadcrumb no-bottom-margin">
               <li>
-                <a routerLink="/">Home</a>
+                <a routerLink="/">{{ 'menu.home' | synI18n }}</a>
               </li>
               <li>
-                <a routerLink="/customizations/api-connector">Customizations</a>
+                <a routerLink="/customizations/api-connector">{{ 'menu.customizations' | synI18n }}</a>
               </li>
               <li class="active">
-                <strong>API Client Connector</strong>
+                <strong>{{ 'customizations.api-client-connectors.api-client-connector' | synI18n }}</strong>
               </li>
             </ol>
           </div>
           <div class="wizard-nav__buttons toolbar-pf-action-right">
             <button class="wizard-nav__button btn btn-default" (click)="showCancelModal()">
-              Cancel
+              {{ 'shared.cancel' | synI18n }}
             </button>
           </div>
         </div>
@@ -28,10 +28,10 @@
   <div class="wizard__main syn-scrollable--body container-fluid">
     <section class="wizard__ui wizard__progress">
       <syndesis-wizard-progress-bar [steps]="[
-        'Upload OpenAPI Specification',
-        'Review Actions',
-        'Specify Security',
-        'Review/Edit Connector Details']" [selectedStep]="currentActiveStep">
+        'customizations.api-client-connectors.create-upload-spec-step-title' | synI18n,
+        'customizations.api-client-connectors.create-review-step-title' | synI18n,
+        'customizations.api-client-connectors.create-security-step-title' | synI18n,
+        'customizations.api-client-connectors.create-details-step-title' | synI18n]" [selectedStep]="currentActiveStep">
       </syndesis-wizard-progress-bar>
     </section>
 
@@ -58,25 +58,48 @@
             (update)="onCreateComplete($event)">
           </syndesis-api-connector-info>
         </div>
-      </div>
 
-      <div class="row row-cards-pf apicurio" *ngIf="currentActiveStep == 2 && displayDefinitionEditor === true">
-        <div class="card-pf">
-          <div class="card-pf-heading">
-            <h2 class="card-pf-title">
-              Edit Definition
-            </h2>
+        <div class="api-connector-editor syn-scrollable" *ngIf="showApiEditor">
+          <div class="toolbar-pf">
+            <div class="toolbar-pf-actions api-connector-editor__header">
+              <div class="api-connector-editor__title">
+                <button class="btn btn-link"
+                        [tooltip]="'customizations.api-client-connectors.editor-back-button-tooltip' | synI18n"
+                        placement="auto"
+                        (click)="showCancelApiEditorModal()">
+                  &lt; {{ 'shared.back' | synI18n }}
+                </button>
+                <h2>
+                  {{ editorTitle }}
+                </h2>
+              </div>
+              <div class="api-connector-editor__actions toolbar-pf-action-right">
+                <button class="btn btn-default"
+                        [tooltip]="'customizations.api-client-connectors.editor-back-button-tooltip' | synI18n"
+                        placement="auto"
+                        (click)="showCancelApiEditorModal()">
+                  {{ 'shared.cancel' | synI18n }}
+                </button>
+                <button class="btn btn-primary"
+                        *ngIf="currentActiveStep === 2 && displayDefinitionEditor === true"
+                        [disabled]="!editorHasChanges"
+                        [tooltip]="'customizations.api-client-connectors.editor-save-button-tooltip' | synI18n"
+                        placement="auto"
+                        (click)="onDoneEditing()">
+                  {{ 'shared.save' | synI18n }}
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="card-pf-body">
-            <api-editor #apiEditor
+          <div class="api-connector-editor__body syn-scrollable--body">
+            <api-editor #_apiEditor
                         [api]="apiDef"
                         [embedded]="true"
-                        (onCommandExecuted)="onUserChange($event)"
-                        (onSelectionChanged)="onUserSelection($event)"></api-editor>
+                        (onCommandExecuted)="onUserChange($event)">
+            </api-editor>
           </div>
         </div>
       </div>
-
     </section>
   </div>
 </article>
@@ -86,7 +109,18 @@
     (cancel)="onCancel($event)"
     primaryLabel="Yes"
     secondaryLabel="No">
-      <p class="lead">{{ 'customizations.api-client-connectors.cancel-connector-modal-lead' | synI18n }}</p>
-      <p>{{ 'customizations.api-client-connectors.cancel-connector-modal' | synI18n }}</p>
+    <p class="lead">{{ 'customizations.api-client-connectors.cancel-connector-modal-lead' | synI18n }}</p>
+    <p>{{ 'customizations.api-client-connectors.cancel-connector-modal' | synI18n }}</p>
+  </cancel-confirmation-modal>
+</ng-template>
+
+<ng-template #cancelEditorModalTemplate>
+  <cancel-confirmation-modal
+    (cancel)="onCancelApiEditor($event)"
+    primaryLabel="Yes"
+    secondaryLabel="No">
+    <p class="lead">{{ 'customizations.api-client-connectors.cancel-api-editor-modal-lead' | synI18n }}</p>
+    <p *ngIf="apiName">{{ 'customizations.api-client-connectors.cancel-api-editor-modal' | synI18n: apiName }}</p>
+    <p *ngIf="!apiName">{{ 'customizations.api-client-connectors.cancel-api-editor-unnamed-modal' | synI18n }}</p>
   </cancel-confirmation-modal>
 </ng-template>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.scss
@@ -1,6 +1,40 @@
 @import 'syndesis-sass';
 
 :host {
+  .api-connector-editor {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: $color-pf-white;
+
+    &__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-left: $gutter;
+      padding-right: $gutter;
+    }
+
+    &__title {
+      display: inline-flex;
+      align-items: center;
+
+      h2 {
+        border-left: 1px solid $color-pf-black-300;
+        font-size: 16px;
+        font-weight: normal;
+        margin: 0 0 0 1em;
+        padding-left: 1em;
+      }
+    }
+
+    &__body {
+      position: relative;
+    }
+  }
+
   .wizard {
     &__main {
       margin-left: -$gutter;

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -15,11 +15,24 @@
         "delete-extension-modal-lead": "Are you sure you want to delete the \"{{0}}\" extension?"
       },
       "api-client-connectors": {
+        "api-client-connector": "API Client Connector",
+        "api-client-connectors": "{{api-client-connector}}s",
         "delete-connector-modal": "Deleting a connector deletes all connections that were created from that connector but does not affect a running integration that uses one of those connections.",
         "delete-connector-modal-title": "Confirm Delete?",
         "delete-connector-modal-lead": "Are you sure you want to delete the \"{{0}}\" connector?",
+        "edit-api-definition": "Edit API Definition",
+        "edit-specific-api-definition": "Edit {{0}} API Definition",
+        "editor-back-button-tooltip": "Go back to Review/Edit API Definition step",
+        "editor-save-button-tooltip": "Save changes and return to Review/Edit API Definition step",
         "cancel-connector-modal": "You have not finished creating the API client connector. If you cancel now you will lose data you already entered. Do you still want to cancel?",
-        "cancel-connector-modal-lead": "Do you really want to cancel?"
+        "cancel-connector-modal-lead": "Do you really want to cancel?",
+        "cancel-api-editor-modal": "The OpenAPI specification of \"{{0}}\" has been changed. If you exit the editor now you will lose your changes. Do you still want to exit editing the API definition?",
+        "cancel-api-editor-unnamed-modal": "The OpenAPI specification has been changed. If you exit the editor now you will lose your changes. Do you still want to exit editing the API definition?",
+        "cancel-api-editor-modal-lead": "Are you sure you want to exit editing the API definition?",
+        "create-upload-spec-step-title": "Upload OpenAPI Specification",
+        "create-review-step-title": "Review Actions",
+        "create-security-step-title": "Specify Security",
+        "create-details-step-title": "Review/Edit Connector Details"
       }
     },
     "integrations": {
@@ -117,7 +130,7 @@
       "home": "{{home}}",
       "integrations": "{{integrations}}",
       "connections": "{{connections}}",
-      "customizations": "Customizations",
+      "customizations": "{{customizations}}",
       "settings": "Settings"
     },
     "links": {
@@ -246,6 +259,7 @@
       "connection-name": "{{Connection}} Name",
       "connections": "{{connection}}s",
       "configuration-required": "Configuration Required",
+      "customizations": "Customizations",
       "step": "Step",
       "steps": "{{step}}s",
       "connector": "Connector",


### PR DESCRIPTION
- See Issue #3108 
- UI implements UX Apicur.io Integration Version 2.1 Design
- i18n of the api-connector-create.component
- Cancel and Back display confirmation modal if changes have been made in the editor
- Save gets the modified API which is then used to create the connector