### PR TITLE
Fixes error while building with tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1490,6 +1490,10 @@
             <groupId>*</groupId>
             <artifactId>*</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 


### PR DESCRIPTION
* spring-social-salesforce requires logback-classic as a compile scope
  dependency. The server-endpoint module reduces logback-classic to test
  scope only
 ** Results in build error:
    [ERROR] Found a problem with test-scoped dependency ...
    Scope compile was expected by artifact ...

~~* Since logback-classic is expected by spring-social-salesforce it is
  probably better to leave it included rather than have the library
  complaining at runtime.~~

* Excludes logback-classic from spring-social-salesforce as not required
  for logging.