### PR TITLE
fix(ui): explicitly forbid caching / and /logout

### DIFF
--- a/app/ui/docker/nginx-syndesis.conf
+++ b/app/ui/docker/nginx-syndesis.conf
@@ -4,11 +4,20 @@ server {
     gzip         on;
     root         /usr/share/nginx/html;
 
+    location = / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
     location = /logout {
         set $cookie "";
         if ($http_syndesis_xsrf_token = "awesome") {
             set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
         }
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
         add_header Set-Cookie $cookie;
         default_type "text/html; charset=ISO-8859-1";
         alias /usr/share/nginx/html/logout.html;


### PR DESCRIPTION
This adds HTTP headers to prevent the browser from using cached versions of `/` and `/logout` endpoints and thus bypassing the login or the logout.

Fixes #3016