### PR TITLE
feature(build): Add support for building the operator on the Minishift docker daemon.

### DIFF
--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -65,6 +65,12 @@ do_operator() {
         echo "Building on Minishift"
         local minishift_build_dir="/opt/syndesis"
         local operator_source_dir="$top_dir/install/operator"
+
+        if [ $(hasflag --clean-cache) ]; then
+            echo "Cleaning cache on Minishift"
+            minishift ssh "sudo su -c 'rm -rf $minishift_build_dir'"
+        fi
+
         ensure_rcp_on_minishift
         rsync_source_to_minishift $operator_source_dir $minishift_build_dir
         build_operator_from_dir $minishift_build_dir 1000
@@ -97,7 +103,7 @@ is_minishift_docker_daemon() {
 
 ensure_rcp_on_minishift() {
     if ! $(minishift ssh type rsync >/dev/null 2>&1); then
-        echo "Installing rscyn on Minishift"
+        echo "Installing rsync on Minishift"
         minishift ssh sudo "su -c 'yum install -y rsync'"
     fi
 }
@@ -108,6 +114,7 @@ rsync_source_to_minishift() {
 
     echo "Rsync local sources to Minishift VM to $minishift_build_dir"
     # Ensure that target directory exist
+    mkdir_on_minishift $minishift_build_dir $minishift_build_dir/dep-cache $minishift_build_dir/vendor
     minishift ssh "sudo su -c '[ -d $minishift_build_dir ] || (mkdir $minishift_build_dir && chown docker $minishift_build_dir)'"
 
     rsync -az \
@@ -115,6 +122,11 @@ rsync_source_to_minishift() {
           --progress \
           ${operator_source_dir}/ \
           docker@$(minishift ip):${minishift_build_dir}
+}
+
+mkdir_on_minishift() {
+    local dir=${1}
+    minishift ssh "sudo su -c '[ -d $dir ] || (mkdir $dir && chown docker $dir)'"
 }
 
 rsync_binary_from_minishift() {

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -115,7 +115,6 @@ rsync_source_to_minishift() {
     echo "Rsync local sources to Minishift VM to $minishift_build_dir"
     # Ensure that target directory exist
     mkdir_on_minishift $minishift_build_dir $minishift_build_dir/dep-cache $minishift_build_dir/vendor
-    minishift ssh "sudo su -c '[ -d $minishift_build_dir ] || (mkdir $minishift_build_dir && chown docker $minishift_build_dir)'"
 
     rsync -az \
           -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i~/.minishift/machines/minishift/id_rsa"\
@@ -125,8 +124,10 @@ rsync_source_to_minishift() {
 }
 
 mkdir_on_minishift() {
-    local dir=${1}
-    minishift ssh "sudo su -c '[ -d $dir ] || (mkdir $dir && chown docker $dir)'"
+    local dirs="$@"
+    for dir in $dirs; do
+        minishift ssh "sudo su -c '[ -d $dir ] || (mkdir -p $dir && chown -R docker $dir)'"
+    done
 }
 
 rsync_binary_from_minishift() {

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -50,25 +50,84 @@ build::run() {
 
     # Build operator if required
     if $(should_build "operator" "$modules"); then
-        operator $top_dir
+        do_operator $top_dir
     fi
 
 }
 
-operator() {
+do_operator() {
     local top_dir=$1
     echo "=============================================================================="
     echo "Building syndesis-operator"
     echo "=============================================================================="
 
-    if [ "$(hasflag -e --ensure)" ]; then
-        dep_ensure "$top_dir" "$(hasflag -l --local)"
+    if [ ! $(hasflag -l --local) ] && $(is_minishift_docker_daemon); then
+        echo "Building on Minishift"
+        local minishift_build_dir="/opt/syndesis"
+        local operator_source_dir="$top_dir/install/operator"
+        ensure_rcp_on_minishift
+        rsync_source_to_minishift $operator_source_dir $minishift_build_dir
+        build_operator_from_dir $minishift_build_dir 1000
+        rsync_binary_from_minishift $minishift_build_dir/syndesis-operator $operator_source_dir
+    else
+        build_operator_from_dir $top_dir/install/operator
     fi
-    build_operator "$top_dir" "$(hasflag -l --local)" "$(hasflag -i --image --images)"
+}
+
+build_operator_from_dir() {
+    local top_dir=${1}
+    local as_user=${2:-}
+    if [ "$(hasflag -e --ensure)" ]; then
+        dep_ensure "$top_dir" "$(hasflag -l --local)" "$as_user"
+    fi
+    build_operator "$top_dir" "$(hasflag -l --local)" "$(hasflag -i --image --images)" "$as_user"
 
     if [ "$(hasflag -i --image --images --docker)" ]; then
         create_operator_image "$top_dir" "$(hasflag --docker)"
     fi
+}
+
+is_minishift_docker_daemon() {
+    if [ -n "${DOCKER_CERT_PATH:-}" ] && [ "${DOCKER_CERT_PATH//minishift/}" != "$DOCKER_CERT_PATH" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+ensure_rcp_on_minishift() {
+    if ! $(minishift ssh type rsync >/dev/null 2>&1); then
+        echo "Installing rscyn on Minishift"
+        minishift ssh sudo "su -c 'yum install -y rsync'"
+    fi
+}
+
+rsync_source_to_minishift() {
+    local operator_source_dir=${1}
+    local minishift_build_dir=${2}
+
+    echo "Rsync local sources to Minishift VM to $minishift_build_dir"
+    # Ensure that target directory exist
+    minishift ssh "sudo su -c '[ -d $minishift_build_dir ] || (mkdir $minishift_build_dir && chown docker $minishift_build_dir)'"
+
+    rsync -az \
+          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i~/.minishift/machines/minishift/id_rsa"\
+          --progress \
+          ${operator_source_dir}/ \
+          docker@$(minishift ip):${minishift_build_dir}
+}
+
+rsync_binary_from_minishift() {
+    local operator_bin=${1}
+    local local_target_dir=${2}
+
+    echo "Rsync compiled $operator_bin back to $local_target_dir"
+
+    rsync -az \
+          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i~/.minishift/machines/minishift/id_rsa"\
+          --progress \
+          docker@$(minishift ip):${operator_bin} \
+          $local_target_dir
 }
 
 maven_args() {

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -75,15 +75,15 @@ do_operator() {
 }
 
 build_operator_from_dir() {
-    local top_dir=${1}
+    local operator_dir=${1}
     local as_user=${2:-}
     if [ "$(hasflag -e --ensure)" ]; then
-        dep_ensure "$top_dir" "$(hasflag -l --local)" "$as_user"
+        dep_ensure "$operator_dir" "$(hasflag -l --local)" "$as_user"
     fi
-    build_operator "$top_dir" "$(hasflag -l --local)" "$(hasflag -i --image --images)" "$as_user"
+    build_operator "$operator_dir" "$(hasflag -l --local)" "$(hasflag -i --image --images)" "$as_user"
 
     if [ "$(hasflag -i --image --images --docker)" ]; then
-        create_operator_image "$top_dir" "$(hasflag --docker)"
+        create_operator_image "$operator_dir" "$(hasflag --docker)"
     fi
 }
 

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -7,8 +7,9 @@ GO_BUILDER_IMAGE="syndesis/godev:1.10"
 OPERATOR_IMAGE="syndesis/syndesis-operator"
 
 dep_ensure() {
-    local top_dir=${1}
+    local operator_dir=${1}
     local do_local=${2:-}
+    local as_user=${3:-}
 
     if [ "$do_local" ]; then
         local dir=$(gopath_dir)
@@ -20,9 +21,14 @@ dep_ensure() {
     else
         echo "Running 'dep ensure' with $GO_BUILDER_IMAGE"
         [ -d "dep-cache" ] || mkdir dep-cache
+        local extra_opts=""
+        if [ -n "$as_user" ]; then
+            extra_opts="$extra_opts -u $as_user"
+        fi
         docker run -w /gopath/src/github.com/syndesisio/syndesis/install/operator \
-                   -v $top_dir/install/operator/dep-cache:/gopath/pkg/dep:z \
-                   -v $top_dir:/gopath/src/github.com/syndesisio/syndesis:z \
+                   $extra_opts \
+                   -v $operator_dir/dep-cache:/gopath/pkg/dep:z \
+                   -v $operator_dir:/gopath/src/github.com/syndesisio/syndesis/install/operator:z \
                    $GO_BUILDER_IMAGE \
                    dep ensure -vendor-only -v
     fi
@@ -41,9 +47,10 @@ gopath_dir() {
 }
 
 build_operator() {
-    local top_dir="${1}"
+    local operator_dir="${1}"
     local do_local="${2:-}"
     local do_linux="${3:-}"
+    local as_user="${4:-}"
 
     if [ "${do_local}" ]; then
         echo "Running local build"
@@ -60,13 +67,16 @@ build_operator() {
         popd >/dev/null
     else
         echo "Creating syndesis-operator with $GO_BUILDER_IMAGE"
-        pushd "$top_dir/install/operator" >/dev/null
+        local extra_opts=""
+        if [ -n "$as_user" ]; then
+            extra_opts="$extra_opts -u $as_user -e XDG_CACHE_HOME=.cache"
+        fi
         docker run -w /gopath/src/github.com/syndesisio/syndesis/install/operator \
-                   -v $top_dir:/gopath/src/github.com/syndesisio/syndesis:z \
+                   $extra_opts \
+                   -v $operator_dir:/gopath/src/github.com/syndesisio/syndesis/install/operator:z \
                    -e CGO_ENABLED=0 \
                    $GO_BUILDER_IMAGE \
                    go build ./cmd/syndesis-operator
-        popd >/dev/null
     fi
 }
 

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -81,11 +81,11 @@ build_operator() {
 }
 
 create_operator_image() {
-    local top_dir=${1}
+    local operator_dir=${1}
     local do_docker=${2:-}
     local tag=${3:-latest}
 
-    local build_dir=$(prepare_docker_context "$top_dir")
+    local build_dir=$(prepare_docker_context "$operator_dir")
     pushd $build_dir > /dev/null
     trap "rm -rf $build_dir" EXIT
 
@@ -117,12 +117,11 @@ create_operator_image() {
 }
 
 prepare_docker_context() {
-    local top_dir="${1}"
+    local operator_dir="${1}"
     local dir=$(mktemp -d)
-    local operator_dir="$top_dir/install/operator"
 
     cp $operator_dir/Dockerfile $operator_dir/syndesis-operator ${dir}/
-    cp $top_dir/install/syndesis.yml ${dir}/syndesis-template.yml
+    cp $operator_dir/../syndesis.yml ${dir}/syndesis-template.yml
 
     echo $dir
 }


### PR DESCRIPTION
This is performed via rsync the source to minishift, run the docker build there, and rsyncing back the generated binary.

Fixes #3260.