### PR TITLE
refactor(operator): load syndesis-template.yml from /conf

### DIFF
--- a/install/operator/Dockerfile
+++ b/install/operator/Dockerfile
@@ -4,9 +4,9 @@ RUN adduser -r syndesis-operator
 USER syndesis-operator
 
 # Use that template for creating the operator
-ADD syndesis-template.yml /syndesis-template.yml
+ADD syndesis-template.yml /conf/syndesis-template.yml
 
 # Add the operator
 ADD syndesis-operator /usr/local/bin/syndesis-operator
 
-ENTRYPOINT [ "/usr/local/bin/syndesis-operator", "-template", "/syndesis-template.yml" ]
+ENTRYPOINT [ "/usr/local/bin/syndesis-operator", "-template", "/conf/syndesis-template.yml" ]

--- a/install/operator/cmd/syndesis-operator/main.go
+++ b/install/operator/cmd/syndesis-operator/main.go
@@ -28,7 +28,7 @@ func printVersion() {
 func main() {
 	printVersion()
 
-	configuration.TemplateLocation = flag.String("template", "./syndesis-template.yml", "Path to template used for installation")
+	configuration.TemplateLocation = flag.String("template", "/conf/syndesis-template.yml", "Path to template used for installation")
 	flag.Parse()
 	logrus.Infof("Using template %s", *configuration.TemplateLocation)
 


### PR DESCRIPTION
If we try to mount `syndesis-template.yml` via volume it needs not reside in `/`, so this changes the path to `/conf`.