### PR TITLE
refactor(build): when installing with --local use provide the operator with local template

### DIFF
--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -104,6 +104,14 @@ deploy_syndesis_operator() {
     fi
 
     create_openshift_resource "install/operator/deploy/syndesis-operator.yml"
+    if [ $(hasflag --local) ]; then
+        # we need to include the `syndesis-template.yml` akka `syndesis.yml` in
+        # the operator image, this adds a ConfigMap that we mount into the
+        # operator container
+        oc delete configmap syndesis-template >/dev/null 2>&1
+        oc create configmap syndesis-template --from-file=template=$(appdir)/../install/syndesis.yml
+        oc patch deploymentconfig syndesis-operator -p '{"spec":{"template":{"spec":{"containers":[{"name":"syndesis-operator","command":["syndesis-operator","-template","/conf/syndesis-template.yml"],"volumeMounts":[{"mountPath":"/conf","name":"syndesis-template-config"}]}],"volumes":[{"configMap":{"name":"syndesis-template","items":[{"key":"template","path":"syndesis-template.yml"}]},"name":"syndesis-template-config"}]}}}}'
+    fi
 }
 
 # Create syndesis resource


### PR DESCRIPTION
Now when we build with `--local` operator uses the template it was built with and it is contained in the image of the operator.

This introduces a `syndesis-template` ConfigMap that contains the content of the local `syndesis.yml` OpenShift template. The `syndesis-operator` DeploymentConfig is patched to mount this template from the ConfigMap into the `/conf` directory and to use that template when creating Syndesis resources.