### PR TITLE
Hide the Review/edit button if the provided URL to the spec file is unfetchable

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -47,7 +47,7 @@
             [apiConnectorTemplateName]="'OpenAPI'"
             [apiConnectorData]="(apiConnectorState$ | async)?.createRequest"
             [showNextButton]="true"
-            [showEditButton]="enableEditor"
+            [enableEditButton]="enableEditor"
             (reviewComplete)="onReviewComplete($event)">
           </syndesis-api-connector-review>
           <syndesis-api-connector-auth *ngIf="currentActiveStep == 3"

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -47,6 +47,7 @@
             [apiConnectorTemplateName]="'OpenAPI'"
             [apiConnectorData]="(apiConnectorState$ | async)?.createRequest"
             [showNextButton]="true"
+            [showEditButton]="enableEditor"
             (reviewComplete)="onReviewComplete($event)">
           </syndesis-api-connector-review>
           <syndesis-api-connector-auth *ngIf="currentActiveStep == 3"

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
@@ -45,6 +45,7 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
   displayDefinitionEditor = false;
   editorHasChanges = false;
   validationResponse: CustomConnectorRequest;
+  enableEditor = true;
 
   @ViewChild('_apiEditor') _apiEditor: ApiEditorComponent;
   apiDef: ApiDefinition;
@@ -111,9 +112,16 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
 
           reader.readAsText( apiConnectorState.specificationFile );
         } else {
-          // TODO next line sets spec to the URL. this is not right as spec needs to be set to the URL JSON response
-          this.apiDef.spec = apiConnectorState.configuredProperties.specification;
-          // TODO set this.apiDef.name here
+          this.enableEditor = false;
+
+          const fetch$ = Observable
+            .from(fetch(apiConnectorState.configuredProperties.specification))
+            .flatMap(response => response.json());
+
+          fetch$.subscribe(spec => {
+            this.apiDef.spec = spec;
+            this.enableEditor = true;
+          });
         }
       });
 

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
@@ -49,7 +49,7 @@
     Next
   </button>
 
-  <button *ngIf="showNextButton"
+  <button *ngIf="showNextButton && showEditButton"
           (click)="reviewComplete.emit({event: event, displayEditor: true})"
           type="button"
           class="connector-form__submit btn btn-default apicurio pull-right">

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
@@ -49,13 +49,20 @@
     Next
   </button>
 
-  <button *ngIf="showNextButton && showEditButton"
+  <ng-template #editTooltip>
+    The platform has not been able to download the linked specification. Please try manually downloading it an providing the downloaded file to enable the review/edit feature.
+  </ng-template>
+  <button *ngIf="showNextButton"
           (click)="reviewComplete.emit({event: event, displayEditor: true})"
+          [disabled]="!enableEditButton"
           type="button"
           class="connector-form__submit btn btn-default apicurio pull-right">
-    Review/Edit
+    <span [tooltip]="editTooltip"
+          [tooltipEnable]="enableEditButton"
+          placement="top">
+      Review/Edit
+    </span>
   </button>
-
 </div>
 <ng-template #validationFallback>
   <h5 class="connector-fallback">No connector details are currently available.</h5>

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
@@ -13,7 +13,7 @@ export class ApiConnectorReviewComponent {
 
   @Input() apiConnectorTemplateName: string;
   @Input() showNextButton: boolean;
-  @Input() showEditButton: boolean;
+  @Input() enableEditButton: boolean;
   @Input()
   set apiConnectorData(value: ApiConnectorData) {
     this.validation = value;

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
@@ -13,6 +13,7 @@ export class ApiConnectorReviewComponent {
 
   @Input() apiConnectorTemplateName: string;
   @Input() showNextButton: boolean;
+  @Input() showEditButton: boolean;
   @Input()
   set apiConnectorData(value: ApiConnectorData) {
     this.validation = value;


### PR DESCRIPTION
Fixes #3174 

# Changes

## Fetchable url (same protocol and CORS enabled)

![from-fetchable-url](https://user-images.githubusercontent.com/966316/43638712-23efaf60-971a-11e8-86f3-c6dab669aff4.gif)

## Unfetchable url (different protocol and/or CORS disabled)

![from-non-fetchable-url-tooltip](https://user-images.githubusercontent.com/966316/43641499-3a78980a-9724-11e8-891f-97da0698d909.gif)

## Todo

~Maybe it would be better to disable the Review/edit button instead of hiding it, showing the reason why it has been disabled.~ Done this, the reason for the disabled state is shown in a tooltip when hovering the button.

But I think it would be even better if we could change the backend to return the spec after the validation.