### PR TITLE
refactor(db): replace database maintenance CronJob with aggressive autovacuum configuration

### DIFF
--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -72,59 +72,18 @@
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
-    name: syndesis-db-maintenance-script
+    name: syndesis-db-conf
   data:
-    maintenance.sh: |
-      #!/bin/bash
-      cat << EOF| psql -h syndesis-db -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
-      VACUUM FULL ANALYSE jsondb;
-      REINDEX TABLE jsondb;
-      SELECT COUNT(*) FROM jsondb;
-      EOF
-
-- apiVersion: batch/v1beta1
-  kind: CronJob
-  metadata:
-    name: syndesis-db-maintenance
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-db-maintenance
-  spec:
-    schedule: "15 4 * * *"
-    jobTemplate:
-      spec:
-        template:
-          metadata:
-            labels:
-              syndesis.io/app: syndesis
-              syndesis.io/type: infrastructure
-              syndesis.io/component: syndesis-db-maintenance
-          spec:
-            containers:
-            - name: syndesis-db-maintenance
-              env:
-              - name: POSTGRESQL_USER
-                value: ${POSTGRESQL_USER}
-              - name: PGPASSWORD
-                value: ${POSTGRESQL_PASSWORD}
-              - name: POSTGRESQL_DATABASE
-                value: ${POSTGRESQL_DATABASE}
-              image: centos/postgresql-95-centos7
-              command:
-                - /bin/sh
-                - -c
-                - /data/maintenance.sh
-              volumeMounts:
-              - mountPath: /data
-                name: syndesis-db-maintenance-script
-            restartPolicy: Never
-            volumes:
-            - configMap:
-                defaultMode: 511
-                name: syndesis-db-maintenance-script
-              name: syndesis-db-maintenance-script
+    syndesis-postgresql.conf: |
+      log_autovacuum_min_duration = 0
+      autovacuum_max_workers = 6
+      autovacuum_naptime = 15s
+      autovacuum_vacuum_threshold = 25
+      autovacuum_vacuum_scale_factor = 0.1
+      autovacuum_analyze_threshold = 10
+      autovacuum_analyze_scale_factor = 0.05
+      autovacuum_vacuum_cost_delay = 10ms
+      autovacuum_vacuum_cost_limit = 1000
 
 - apiVersion: v1
   kind: Service
@@ -165,6 +124,7 @@
     resources:
       requests:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
+
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -242,6 +202,8 @@
             name: syndesis-db-data
           - mountPath: /var/lib/pgsql/sampledb
             name: syndesis-sampledb-config
+          - mountPath: /opt/app-root/src/postgresql-cfg/
+            name: syndesis-db-conf
         volumes:
         - name: syndesis-db-data
           persistentVolumeClaim:
@@ -250,6 +212,9 @@
             defaultMode: 511
             name: syndesis-sampledb-config
           name: syndesis-sampledb-config
+        - configMap:
+            name: syndesis-db-conf
+          name: syndesis-db-conf
     triggers:
     - imageChangeParams:
         automatic: true

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -521,59 +521,18 @@ objects:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
-    name: syndesis-db-maintenance-script
+    name: syndesis-db-conf
   data:
-    maintenance.sh: |
-      #!/bin/bash
-      cat << EOF| psql -h syndesis-db -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
-      VACUUM FULL ANALYSE jsondb;
-      REINDEX TABLE jsondb;
-      SELECT COUNT(*) FROM jsondb;
-      EOF
-
-- apiVersion: batch/v1beta1
-  kind: CronJob
-  metadata:
-    name: syndesis-db-maintenance
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-db-maintenance
-  spec:
-    schedule: "15 4 * * *"
-    jobTemplate:
-      spec:
-        template:
-          metadata:
-            labels:
-              syndesis.io/app: syndesis
-              syndesis.io/type: infrastructure
-              syndesis.io/component: syndesis-db-maintenance
-          spec:
-            containers:
-            - name: syndesis-db-maintenance
-              env:
-              - name: POSTGRESQL_USER
-                value: ${POSTGRESQL_USER}
-              - name: PGPASSWORD
-                value: ${POSTGRESQL_PASSWORD}
-              - name: POSTGRESQL_DATABASE
-                value: ${POSTGRESQL_DATABASE}
-              image: centos/postgresql-95-centos7
-              command:
-                - /bin/sh
-                - -c
-                - /data/maintenance.sh
-              volumeMounts:
-              - mountPath: /data
-                name: syndesis-db-maintenance-script
-            restartPolicy: Never
-            volumes:
-            - configMap:
-                defaultMode: 511
-                name: syndesis-db-maintenance-script
-              name: syndesis-db-maintenance-script
+    syndesis-postgresql.conf: |
+      log_autovacuum_min_duration = 0
+      autovacuum_max_workers = 6
+      autovacuum_naptime = 15s
+      autovacuum_vacuum_threshold = 25
+      autovacuum_vacuum_scale_factor = 0.1
+      autovacuum_analyze_threshold = 10
+      autovacuum_analyze_scale_factor = 0.05
+      autovacuum_vacuum_cost_delay = 10ms
+      autovacuum_vacuum_cost_limit = 1000
 
 - apiVersion: v1
   kind: Service
@@ -614,6 +573,7 @@ objects:
     resources:
       requests:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
+
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -691,6 +651,8 @@ objects:
             name: syndesis-db-data
           - mountPath: /var/lib/pgsql/sampledb
             name: syndesis-sampledb-config
+          - mountPath: /opt/app-root/src/postgresql-cfg/
+            name: syndesis-db-conf
         volumes:
         - name: syndesis-db-data
           persistentVolumeClaim:
@@ -699,6 +661,9 @@ objects:
             defaultMode: 511
             name: syndesis-sampledb-config
           name: syndesis-sampledb-config
+        - configMap:
+            name: syndesis-db-conf
+          name: syndesis-db-conf
     triggers:
     - imageChangeParams:
         automatic: true

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -521,59 +521,18 @@ objects:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
-    name: syndesis-db-maintenance-script
+    name: syndesis-db-conf
   data:
-    maintenance.sh: |
-      #!/bin/bash
-      cat << EOF| psql -h syndesis-db -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
-      VACUUM FULL ANALYSE jsondb;
-      REINDEX TABLE jsondb;
-      SELECT COUNT(*) FROM jsondb;
-      EOF
-
-- apiVersion: batch/v1beta1
-  kind: CronJob
-  metadata:
-    name: syndesis-db-maintenance
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-db-maintenance
-  spec:
-    schedule: "15 4 * * *"
-    jobTemplate:
-      spec:
-        template:
-          metadata:
-            labels:
-              syndesis.io/app: syndesis
-              syndesis.io/type: infrastructure
-              syndesis.io/component: syndesis-db-maintenance
-          spec:
-            containers:
-            - name: syndesis-db-maintenance
-              env:
-              - name: POSTGRESQL_USER
-                value: ${POSTGRESQL_USER}
-              - name: PGPASSWORD
-                value: ${POSTGRESQL_PASSWORD}
-              - name: POSTGRESQL_DATABASE
-                value: ${POSTGRESQL_DATABASE}
-              image: centos/postgresql-95-centos7
-              command:
-                - /bin/sh
-                - -c
-                - /data/maintenance.sh
-              volumeMounts:
-              - mountPath: /data
-                name: syndesis-db-maintenance-script
-            restartPolicy: Never
-            volumes:
-            - configMap:
-                defaultMode: 511
-                name: syndesis-db-maintenance-script
-              name: syndesis-db-maintenance-script
+    syndesis-postgresql.conf: |
+      log_autovacuum_min_duration = 0
+      autovacuum_max_workers = 6
+      autovacuum_naptime = 15s
+      autovacuum_vacuum_threshold = 25
+      autovacuum_vacuum_scale_factor = 0.1
+      autovacuum_analyze_threshold = 10
+      autovacuum_analyze_scale_factor = 0.05
+      autovacuum_vacuum_cost_delay = 10ms
+      autovacuum_vacuum_cost_limit = 1000
 
 - apiVersion: v1
   kind: Service
@@ -614,6 +573,7 @@ objects:
     resources:
       requests:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
+
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -691,6 +651,8 @@ objects:
             name: syndesis-db-data
           - mountPath: /var/lib/pgsql/sampledb
             name: syndesis-sampledb-config
+          - mountPath: /opt/app-root/src/postgresql-cfg/
+            name: syndesis-db-conf
         volumes:
         - name: syndesis-db-data
           persistentVolumeClaim:
@@ -699,6 +661,9 @@ objects:
             defaultMode: 511
             name: syndesis-sampledb-config
           name: syndesis-sampledb-config
+        - configMap:
+            name: syndesis-db-conf
+          name: syndesis-db-conf
     triggers:
     - imageChangeParams:
         automatic: true


### PR DESCRIPTION
It's difficult for us to use the CronJob as the container image used would need to be productized. Seems that as CronJob is a non-OpenShift resource referencing the same PostgreSQL image we use for the database pod -- referencing via lookup image stream from other namespace (in this case openshift) is currently not possible.

With this we loose `FULL ANALYSE` from `VACUUM` and `REINDEX TABLE` for `jsondb` table, the hope is that a more aggressive autovacuum configuration will be good enough.

See https://dba.stackexchange.com/questions/21068/aggressive-autovacuum-on-postgresql

Fixes #3252