### PR TITLE
fix(ui): display error handling to OAuth /connections/create/review page

### DIFF
--- a/app/ui/src/app/connections/create-page/review/review.component.html
+++ b/app/ui/src/app/connections/create-page/review/review.component.html
@@ -7,45 +7,57 @@
         </h2>
       </div>
       <div class="card-pf-body">
-        <form id="reviewForm"
-              [formGroup]="reviewForm"
-              class="form-horizontal"
-              novalidate>
-          <p class="fields-status-pf" [innerHTML]="'required-fields' | synI18n"></p>
-          <div class="form-group"
-               [ngClass]="{'has-error': name.invalid && name.touched}">
-            <label for="nameInput" class="col-sm-3 control-label required-pf">{{ 'connections.connection-name' | synI18n }}</label>
-            <!-- data-id is used in automated tests -->
-            <div class="col-sm-9">
-              <input data-id="nameInput"
-                     id="nameInput"
-                     class="form-control"
-                     formControlName="name"
-                     (blur)="validateNameNotTaken()"
-                     required>
-              <div *ngIf="name.invalid && name.touched">
-                <span class="help-block"
-                      *ngIf="name.errors.required">
-                  {{ 'connections.name-is-required' | synI18n }}
-                </span>
-                <span class="help-block"
-                      *ngIf="name.errors.UniqueProperty">
-                  {{ 'connections.name-is-taken' | synI18n }}
-                </span>
+        <ng-container *ngIf='!hasCredentials'>
+          <form id="reviewForm"
+                [formGroup]="reviewForm"
+                class="form-horizontal"
+                novalidate>
+            <p class="fields-status-pf" [innerHTML]="'required-fields' | synI18n"></p>
+            <div class="form-group"
+                 [ngClass]="{'has-error': name.invalid && name.touched}">
+              <label for="nameInput" class="col-sm-3 control-label required-pf">{{ 'connections.connection-name' | synI18n }}</label>
+              <!-- data-id is used in automated tests -->
+              <div class="col-sm-9">
+                <input data-id="nameInput"
+                       id="nameInput"
+                       class="form-control"
+                       formControlName="name"
+                       (blur)="validateNameNotTaken()"
+                       required>
+                <div *ngIf="name.invalid && name.touched">
+                  <span class="help-block"
+                        *ngIf="name.errors.required">
+                    {{ 'connections.name-is-required' | synI18n }}
+                  </span>
+                  <span class="help-block"
+                        *ngIf="name.errors.UniqueProperty">
+                    {{ 'connections.name-is-taken' | synI18n }}
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="form-group">
-            <label for="descriptionInput" class="col-sm-3 control-label">{{ 'description' | synI18n }}</label>
-            <div class="col-sm-9">
-              <textarea data-id="descriptionInput"
-                        id="descriptionInput"
-                        class="form-control"
-                        formControlName="description"
-                        rows="2"></textarea>
+            <div class="form-group">
+              <label for="descriptionInput" class="col-sm-3 control-label">{{ 'description' | synI18n }}</label>
+              <div class="col-sm-9">
+                <textarea data-id="descriptionInput"
+                          id="descriptionInput"
+                          class="form-control"
+                          formControlName="description"
+                          rows="2"></textarea>
+              </div>
             </div>
+          </form>
+        </ng-container>
+        <ng-container *ngIf='hasCredentials'>
+          <div class="alert alert-warning alert-dismissable"
+               *ngIf="current.oauthError">
+            <button type="button"
+                    class="close"
+                    (click)="current.clearOAuthError()"></button>
+            <span class="pficon pficon-warning-triangle-o"></span>
+            <p [innerHTML]='current.oauthStatus.message'></p>
           </div>
-        </form>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/app/ui/src/app/connections/create-page/review/review.component.ts
+++ b/app/ui/src/app/connections/create-page/review/review.component.ts
@@ -55,6 +55,10 @@ export class ConnectionsReviewComponent
     return this.reviewForm.get('name');
   }
 
+  get hasCredentials() {
+    return this.current.hasCredentials();
+  }
+
   createConnection(): void {
     if (this.reviewForm.invalid) {
       this.touchFormFields();


### PR DESCRIPTION
With this OAuth error received via callback will be displayed in the UI.

This basically copies the error display logic from `../configure-fields` page. Not sure why we never added it to this page, the redirectUrl is set to return at this point at the end of the OAuth flow, so we should display any OAuth errors here as well.

Fixes #3294