### PR TITLE
feat(server): add `specification` `configuredProperty` to the `../info` endpoint

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorSummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorSummary.java
@@ -18,11 +18,12 @@ package io.syndesis.common.model.connection;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Violation;
 import io.syndesis.common.model.WithConfigurationProperties;
+import io.syndesis.common.model.WithConfiguredProperties;
 import io.syndesis.common.model.WithName;
-import io.syndesis.common.model.WithProperties;
 import io.syndesis.common.model.action.ActionsSummary;
 import org.immutables.value.Value;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorSummary.Builder.class)
 @SuppressWarnings("immutables")
-public interface ConnectorSummary extends WithName, WithConfigurationProperties {
+public interface ConnectorSummary extends WithName, WithConfigurationProperties, WithConfiguredProperties {
 
     final class Builder extends ImmutableConnectorSummary.Builder {
         // make ImmutableConnectorSummary.Builder accessible
@@ -50,10 +51,11 @@ public interface ConnectorSummary extends WithName, WithConfigurationProperties 
                 )
                 .build();
 
-            return new Builder().createFrom((WithProperties) connector)//
+            return new Builder().createFrom((WithConfigurationProperties) connector)//
                 .name(connector.getName())//
                 .description(connector.getDescription())//
                 .icon(connector.getIcon())
+                .configuredProperties(Collections.emptyMap())//
                 .actionsSummary(actionsSummary);
         }
 

--- a/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/server/connector-generator/src/main/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -118,8 +118,13 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
                 .actionCountByTags(tagCounts)//
                 .build();
 
-            return new ConnectorSummary.Builder().createFrom(connector).actionsSummary(actionsSummary).errors(swaggerInfo.getErrors())
-                .warnings(swaggerInfo.getWarnings()).build();
+            return new ConnectorSummary.Builder()//
+                .createFrom(connector)//
+                .actionsSummary(actionsSummary)//
+                .errors(swaggerInfo.getErrors())//
+                .warnings(swaggerInfo.getWarnings())//
+                .putConfiguredProperty("specification", swaggerInfo.getResolvedSpecification())//
+                .build();
         } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") final Exception ex) {
             if (!swaggerInfo.getErrors().isEmpty()) {
                 // Just log and return the validation errors if any

--- a/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/connector-generator/src/test/java/io/syndesis/server/connector/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import static io.syndesis.server.connector.generator.swagger.TestHelper.reformatJson;
 import static io.syndesis.server.connector.generator.swagger.TestHelper.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,11 +212,13 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .name("Swagger Petstore")//
             .actionsSummary(actionsSummary)//
             .build();
-        assertThat(summary).isEqualToIgnoringGivenFields(expected, "icon", "description", "properties", "warnings");
+        assertThat(summary).isEqualToIgnoringGivenFields(expected, "icon", "description", "properties", "warnings", "configuredProperties");
         assertThat(summary.getIcon()).startsWith("data:image");
         assertThat(summary.getDescription()).startsWith("This is a sample server Petstore server");
         assertThat(summary.getProperties().keySet()).contains("host", "basePath", "authenticationType", "clientId", "clientSecret",
-            "accessToken", "authorizationEndpoint", "specification");
+            "accessToken", "authorizationEndpoint", "oauthScopes", "specification");
+        assertThat(summary.getConfiguredProperties().keySet()).containsOnly("specification");
+        assertThat(reformatJson(summary.getConfiguredProperties().get("specification"))).isEqualTo(reformatJson(specification));
     }
 
     @Test

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -840,6 +840,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
     </dependency>


### PR DESCRIPTION
This adds `configuredProperties` to the `ConnectorSummary` model with the `specification` populated when Custom API connector summary is generated on the `POST /api/v1/connectors/custom/info` endpoint.

cc @kahboom

Ref #3174