### PR TITLE
fix(ui): error handling with OAuth connections

### DIFF
--- a/app/ui/src/app/connections/create-page/review/review.component.html
+++ b/app/ui/src/app/connections/create-page/review/review.component.html
@@ -7,7 +7,7 @@
         </h2>
       </div>
       <div class="card-pf-body">
-        <ng-container *ngIf='!hasCredentials'>
+        <ng-container *ngIf='!hasCredentialError'>
           <form id="reviewForm"
                 [formGroup]="reviewForm"
                 class="form-horizontal"
@@ -48,12 +48,8 @@
             </div>
           </form>
         </ng-container>
-        <ng-container *ngIf='hasCredentials'>
-          <div class="alert alert-warning alert-dismissable"
-               *ngIf="current.oauthError">
-            <button type="button"
-                    class="close"
-                    (click)="current.clearOAuthError()"></button>
+        <ng-container *ngIf='hasCredentialError'>
+          <div class="alert alert-warning alert-dismissable">
             <span class="pficon pficon-warning-triangle-o"></span>
             <p [innerHTML]='current.oauthStatus.message'></p>
           </div>

--- a/app/ui/src/app/connections/create-page/review/review.component.ts
+++ b/app/ui/src/app/connections/create-page/review/review.component.ts
@@ -55,8 +55,8 @@ export class ConnectionsReviewComponent
     return this.reviewForm.get('name');
   }
 
-  get hasCredentials() {
-    return this.current.hasCredentials();
+  get hasCredentialError() {
+    return this.current.oauthStatus && this.current.oauthStatus.status != 'SUCCESS';
   }
 
   createConnection(): void {


### PR DESCRIPTION
Displays error message only if the error is reported, not if the
connection supports OAuth.

Fixes #3329

(cherry picked from commit d9bbdb0c685089af1ea3206c668e1408b29d4499)