### PR TITLE
fix(copy-component): fix copy to clipboard component to accepts tooltips

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -65,7 +65,7 @@
     "oai-ts-commands": "^0.2.28",
     "oai-ts-core": "^0.2.15",
     "patternfly": "3.51.2",
-    "patternfly-ng": "^4.0.0",
+    "patternfly-ng": "^4.5.0",
     "pluralize": "5.0.0",
     "rxjs": "^6.2.0",
     "snyk": "^1.88.1",

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -1,25 +1,18 @@
 import { Component, Input, ViewChild, OnChanges } from '@angular/core';
-import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
-import { Observable, Subscription } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
 import { PopoverDirective } from 'ngx-bootstrap/popover';
 
 import {
   Action,
-  Integration,
   Step,
   DataShape,
   DataShapeKinds
 } from '@syndesis/ui/platform';
-import { ModalService } from '@syndesis/ui/common';
-import { log, getCategory } from '@syndesis/ui/logging';
-import { StepStore, DATA_MAPPER, ENDPOINT } from '@syndesis/ui/store';
+import { StepStore } from '@syndesis/ui/store';
 import {
   CurrentFlowService,
-  FlowEvent,
   FlowPageService
 } from '@syndesis/ui/integration/edit-page';
-
-const category = getCategory('IntegrationsCreatePage');
 
 @Component({
   selector: 'syndesis-integration-flow-view-step',

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -29,15 +29,13 @@
     <div class="col-sm-8">
       <p>
         <pfng-block-copy
-          [buttonAriaLabel]="'Copy External URL'"
-          [expandToggleAriaLabel]="'Expand External URL'"
-          [buttonLabel]="'Copy'"
-          [label]="'External URL'"
-          [value]="integration.url"
-          (onCopy)="handleCopy($event, {
-            name: 'External URL',
-            msg: 'External URL Copied'
-          })">
+          [buttonAriaLabel]="'integrations.external-url.copy-instruction' | synI18n"
+          [expandToggleAriaLabel]="'integrations.external-url.expand-instruction' | synI18n"
+          [tooltipText]="'external-url' | synI18n"
+          [buttonLabel]="'copy' | synI18n"
+          [label]="'external-url' | synI18n"
+          [width]="'695px'"
+          [value]="integration.url">
         </pfng-block-copy>
       </p>
     </div>

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.scss
@@ -107,9 +107,5 @@
   .block-copy-container,
   [class^="col-"] {
     padding: 0;
-
-    .pfng-block-copy-inner-container {
-      background-color: #fff;
-    }
   }
 }

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.ts
@@ -1,6 +1,4 @@
 import { Integration, Step } from '@syndesis/ui/platform';
-import { NotificationService } from '@syndesis/ui/common';
-import { CopyEvent, NotificationType } from 'patternfly-ng';
 import {
   Component,
   Input,
@@ -24,8 +22,6 @@ export class IntegrationDescriptionComponent {
   @Output() viewDetails = new EventEmitter<Step>();
   @Output() attributeUpdated = new EventEmitter<{ [key: string]: string }>();
 
-  constructor(private notificationService: NotificationService) {}
-
   onViewDetails(step: Step): void {
     this.viewDetails.emit(step);
   }
@@ -42,17 +38,4 @@ export class IntegrationDescriptionComponent {
         : '';
   }
 
-  handleCopy($event: CopyEvent, result: any): void {
-    this.notify(result);
-  }
-
-  notify(result: any): void {
-    this.notificationService.message(
-      NotificationType.SUCCESS,
-      null,
-      result.msg,
-      false,
-      null,
-      null);
-  }
 }

--- a/app/ui/src/app/integration/integration_detail/integration-metrics.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration-metrics.component.ts
@@ -6,13 +6,10 @@ import {
   Output,
   EventEmitter
 } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { moment } from '@syndesis/ui/vendor';
 import { ConfigService } from '@syndesis/ui/config.service';
 import {
-  IntegrationState,
   Integration,
   IntegrationMetrics
 } from '@syndesis/ui/platform';

--- a/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.ts
+++ b/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { ListConfig, ActionConfig } from 'patternfly-ng';
+import { ListConfig } from 'patternfly-ng';
 
 import { Integration, IntegrationDeployment, IntegrationActionsService } from '@syndesis/ui/platform';
 

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-form.component.ts
@@ -1,13 +1,12 @@
-import { Component, OnInit, EventEmitter, Input, Output, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
-import { OAuthApp, OAuthApps } from '@syndesis/ui/settings';
+import { OAuthApp } from '@syndesis/ui/settings';
 import { FormFactoryService } from '@syndesis/ui/platform';
 import { OAuthAppStore } from '@syndesis/ui/store/oauthApp/oauth-app.store';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
-  DynamicFormService,
-  DynamicInputModel
+  DynamicFormService
 } from '@ng-dynamic-forms/core';
 import { Subscription } from 'rxjs';
 

--- a/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-app-modal.component.ts
@@ -4,7 +4,6 @@ import { NotificationType } from 'patternfly-ng';
 
 import { OAuthAppListItem } from '@syndesis/ui/settings/oauth-apps/oauth-apps.component';
 import { OAuthAppStore } from '@syndesis/ui/store/oauthApp/oauth-app.store';
-import { OAuthApp, OAuthApps } from '@syndesis/ui/settings';
 import { ModalService } from '@syndesis/ui/common/modal/modal.service';
 import { NotificationService } from '@syndesis/ui/common/ui-patternfly/notification-service';
 

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.html
@@ -7,12 +7,10 @@
   " (click)="handleLinks($event)"></p>
   <p>{{ 'settings.oauth-apps.registration-instruction' | synI18n }}
     <pfng-inline-copy
-      [buttonAriaLabel]="'Copy Callback URL'"
-      [value]="callbackURL"
-      (onCopy)="handleCopy($event, {
-        name: 'Callback URL',
-        msg: 'Callback URL Copied'
-      })"></pfng-inline-copy>
+      [buttonAriaLabel]="'settings.oauth-apps.copy-instruction' | synI18n"
+      [tooltipText]="'callback-url' | synI18n"
+      [width]="'335px'"
+      [value]="callbackURL"></pfng-inline-copy>
   </p>
 
   <!-- Modal -->

--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
@@ -9,12 +9,8 @@ import { ObjectPropertySortConfig } from '@syndesis/ui/common/object-property-so
 import {
   FilterConfig,
   SortConfig,
-  ToolbarConfig,
-  CopyEvent,
-  NotificationType
+  ToolbarConfig
 } from 'patternfly-ng';
-
-import { NotificationService } from '@syndesis/ui/common';
 
 export interface OAuthAppListItem {
   expanded: boolean;
@@ -78,8 +74,7 @@ export class OAuthAppsComponent implements OnInit {
 
   constructor(
     public store: OAuthAppStore,
-    public config: ConfigService,
-    private notificationService: NotificationService
+    public config: ConfigService
   ) {
     this.loading = store.loading;
     this.list = store.list;
@@ -157,17 +152,4 @@ export class OAuthAppsComponent implements OnInit {
       '/api/v1/credentials/callback';
   }
 
-  handleCopy($event: CopyEvent, result: any): void {
-    this.notify(result);
-  }
-
-  notify(result: any): void {
-    this.notificationService.message(
-      NotificationType.SUCCESS,
-      null,
-      result.msg,
-      false,
-      null,
-      null);
-  }
 }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -45,6 +45,10 @@
       "integration": "{{integration}}",
       "integrations": "{{integrations}}",
       "integration-summary": "{{integration}} Summary",
+      "external-url": {
+        "copy-instruction": "{{copy}} {{external-url}}",
+        "expand-instruction": "{{expand}} {{external-url}}"
+      },
       "edit-integration": "{{edit}} {{integrations.integration}}",
       "publish-thing": "{{integrations.publish}} {{0}}",
       "unpublish-thing": "{{integrations.unpublish}} {{0}}",
@@ -163,6 +167,7 @@
         "description": "To connect to an application that uses the OAuth protocol, obtain a client ID and a client secret from the application. See the {{0}} for help.",
         "documentation-link": "<a href=\"{{links.oauth-access}}\" rel=\"nofollow\">documentation</a>",
         "registration-instruction": "During registration, enter this callback URL:",
+        "copy-instruction": "{{copy}} {{callback-url}}",
         "list": {
           "item": {
             "description": "Access to this application is not configured.",
@@ -321,7 +326,11 @@
       "starting": "Starting",
       "integration-detail-state": "{{0}} ( {{1}} / {{2}} )",
       "log-link": "<a href=\"{{0}}\" target=\"_blank\">View Logs <i class=\"fa fa-external-link\"></i></a>",
-      "bar-width": "{{0}} Complete"
+      "bar-width": "{{0}} Complete",
+      "callback-url": "Callback URL",
+      "external-url": "External URL",
+      "copy": "Copy",
+      "expand": "Expand"
     }
   }
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -360,8 +360,8 @@
   resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-1.0.6.tgz#db25c630a2afb9191fe51ba61dd37baee9dd44c7"
 
 "@types/d3-quadtree@*":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz#1ce1e659eae4530df0cb127f297f1741a367a82e"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-1.0.6.tgz#45da9e603688ba90eedd3d40f6e504764e06e493"
 
 "@types/d3-queue@*":
   version "3.0.6"
@@ -384,8 +384,8 @@
     "@types/d3-time" "*"
 
 "@types/d3-selection@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-1.3.1.tgz#c6227f4e39d429cc429ce3882fd533facc7f014c"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-1.3.2.tgz#dd5661a560ba9ce3aba823c424b8d4a1bc7e833f"
 
 "@types/d3-shape@*":
   version "1.2.3"
@@ -6342,9 +6342,9 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-ng@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/patternfly-ng/-/patternfly-ng-4.2.2.tgz#c60359c9f4fcdc2b1e44a68d2cf73b032c508441"
+patternfly-ng@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/patternfly-ng/-/patternfly-ng-4.5.0.tgz#107cb927a45dd8273ba9c940d2097636f5d2c7aa"
   dependencies:
     lodash "^4.17.10"
     patternfly "^3.28.0"


### PR DESCRIPTION
This PR fixes an issue where previously we couldn't use the tooltips feature of copy to clipboard component because there was a namespace conflict over the "tooltip" input property. Now that we've addressed this, and other styling alignments for copy to clipboard, we'd like to pull in the latest and use that instead.

upgrade to latest pfng 4.5.0
use new input properties for copy to clipboard components
remove oncopy notification handlers
remove unused imports