### PR TITLE
fix: remove namespace from Endpoints resource in minishift-restore.sh

### DIFF
--- a/app/ui/scripts/minishift-restore.sh
+++ b/app/ui/scripts/minishift-restore.sh
@@ -59,8 +59,7 @@ oc replace --force -f - <<EOF
       "syndesis.io/component": "syndesis-ui",
       "syndesis.io/type": "infrastructure"
     },
-    "name": "syndesis-ui",
-    "namespace": "syndesis"
+    "name": "syndesis-ui"
   },
   "subsets": [
     {


### PR DESCRIPTION
Fixes #3375