### PR TITLE
[NOMERGE] RFC - Switch to Angular's own i18n tools

### DIFF
--- a/app/ui/angular.json
+++ b/app/ui/angular.json
@@ -61,6 +61,12 @@
             ]
           },
           "configurations": {
+            "it": {
+              "aot": true,
+              "i18nFile": "src/locale/messages.it.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "it"
+            },
             "production": {
               "optimization": true,
               "outputHashing": "all",
@@ -76,7 +82,10 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.prod.ts"
                 }
-              ]
+              ],
+              "i18nFile": "src/locale/messages.en.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "en"
             }
           }
         },
@@ -86,6 +95,9 @@
             "browserTarget": "syndesis-ui:build"
           },
           "configurations": {
+            "it": {
+              "browserTarget": "syndesis-ui:build:it"
+            },
             "production": {
               "browserTarget": "syndesis-ui:build:production"
             }

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -14,6 +14,7 @@
     "start": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js",
     "start:prod": "yarn ng serve --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js --aot --prod",
     "start:minishift": "./scripts/minishift-setup.sh && yarn ng serve --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}'); ./scripts/minishift-restore.sh",
+    "start:minishift:it": "./scripts/minishift-setup.sh && yarn ng serve --configuration=it --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}'); ./scripts/minishift-restore.sh",
     "start:minishift-aot": "./scripts/minishift-setup.sh && yarn ng serve --aot --host 0.0.0.0 --disable-host-check --public-host $(oc get routes syndesis --template '{{.spec.host}}'); ./scripts/minishift-restore.sh",
     "restore:minishift": "./scripts/minishift-restore.sh",
     "build:ci": "yarn ng build --aot --prod --progress=false",

--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -30,7 +30,7 @@
           aria-label="Toggle Main Naivgation"
           type="button"
           class="navbar-toggle">
-          <span class="sr-only">{{ 'menu.navbartoggle' | synI18n }}</span>
+          <span class="sr-only" i18n="The sidebar toggle button, also known as hamburger icon@@menu.navbartoggle">Toggle navigation</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -56,33 +56,41 @@
                     aria-controls="helpDropdownMenu"
                     role="link"
                     aria-expanded="true">
-              <span title="Help" class="pficon pficon-help"></span>
+              <span i18n-title="Topbar - Help dropdown|Dropdown title@@header.helpmenu.title" title="Help" class="pficon pficon-help"></span>
             </button>
             <ul class="dropdown-menu" id="helpDropdownMenu" aria-labelledby="helpDropdown">
               <li>
-                <a [attr.href]="'links.tutorial' | synI18n"
-                    rel="nofollow"
-                    role="link"
-                    target="_blank">{{ 'header.helpmenu.sampletutorials' | synI18n }}</a>
+                <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/fuse_online_sample_integration_tutorials/"
+                   rel="nofollow"
+                   role="link"
+                   target="_blank"
+                   i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.sampletutorials"
+                >Sample Integration Tutorials</a>
               </li>
               <li>
-                <a [attr.href]="'links.userguide' | synI18n:' '"
-                    rel="nofollow"
-                    role="link"
-                    target="_blank">{{ 'header.helpmenu.userguide' | synI18n }}</a>
+                <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/integrating_applications_with_fuse_online"
+                   rel="nofollow"
+                   role="link"
+                   target="_blank"
+                   i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.userguide"
+                >User Guide</a>
               <li>
-                <a [attr.href]="'links.connectorsguide' | synI18n:' '"
-                    rel="nofollow"
-                    role="link"
-                    target="_blank">{{ 'header.helpmenu.connectorsguide' | synI18n }}</a>
+                <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/connecting_fuse_online_to_applications_and_services/"
+                   rel="nofollow"
+                   role="link"
+                   target="_blank"
+                   i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.connectorsguide"
+                >Connectors Guide</a>
               <li>
-                <a routerLink="/support" role="link">{{ 'support' | synI18n }}</a>
+                <a routerLink="/support" role="link" i18n>Support</a>
               </li>
               <li>
-                <a [attr.href]="'links.contactus' | synI18n"
-                rel="nofollow"
-                role="link"
-                target="_blank">{{ 'contactus' | synI18n }}</a>
+                <a href="//access.redhat.com/support/cases/#/case/new"
+                   target="_blank"
+                   rel="nofollow"
+                   role="link"
+                   i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.contactus"
+                >Contact Us</a>
               </li>
             </ul>
           </li>
@@ -116,7 +124,7 @@
             </button>
             <ul *dropdownMenu class="dropdown-menu" id="userDropdownMenu" aria-labelledby="userDropdown">
               <li>
-                <a (click)="logout()" role="link">{{ 'header.usermenu.logout' | synI18n }}</a>
+                <a (click)="logout()" role="link" i18n="@@logout">Logout</a>
               </li>
               <!--
               <li>
@@ -143,50 +151,50 @@
     <ul class="list-group" role="list">
       <li class="list-group-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
         <a routerLink="/" role="link">
-          <span class="fa fa-tachometer" data-toggle="tooltip" title="Dashboard"></span>
-          <span class="list-group-item-value">{{ 'menu.home' | synI18n }}</span>
+          <span class="fa fa-tachometer" data-toggle="tooltip" i18n-title="Sidebar|Navigation item@@sidebar.home" title="Home"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.home">Home</span>
         </a>
       </li>
       <li class="list-group-item" routerLinkActive="active">
         <a routerLink="integrations" role="link">
-          <span class="pficon pficon-topology" data-toggle="tooltip" title="Integrations"></span>
-          <span class="list-group-item-value">{{ 'menu.integrations' | synI18n }}</span>
+          <span class="pficon pficon-topology" data-toggle="tooltip" i18n-title="Sidebar|Navigation item@@sidebar.integrations" title="Integrations"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.integrations">Integrations</span>
         </a>
       </li>
       <li class="list-group-item" routerLinkActive="active">
         <a routerLink="connections" role="link">
-          <span class="pficon pficon-network" data-toggle="tooltip" title="Connections"></span>
-          <span class="list-group-item-value">{{ 'menu.connections' | synI18n }}</span>
+          <span class="pficon pficon-network" data-toggle="tooltip" i18n-title="Sidebar|Navigation item@@sidebar.connections" title="Connections"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.connections">Connections</span>
         </a>
       </li>
       <li class="list-group-item" routerLinkActive="active">
         <a routerLink="customizations" role="link">
-          <span class="pficon pficon-network" data-toggle="tooltip" title="Customizations"></span>
-          <span class="list-group-item-value">{{ 'menu.customizations' | synI18n }}</span>
+          <span class="pficon pficon-network" data-toggle="tooltip" i18n-title="Sidebar|Navigation item@@sidebar.customizations" title="Customizations"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.customizations">Customizations</span>
         </a>
       </li>
       <li class="list-group-item" routerLinkActive="active">
         <a routerLink="settings" role="link">
-          <span class="fa fa-lock" data-toggle="tooltip" title="Settings"></span>
-          <span class="list-group-item-value">{{ 'menu.settings' | synI18n }}</span>
+          <span class="fa fa-lock" data-toggle="tooltip" i18n-title="Sidebar|Navigation item@@sidebar.settings" title="Settings"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.settings">Settings</span>
         </a>
       </li>
       <li class="list-group-item secondary-nav-item-pf mobile-nav-item-pf visible-xs-block">
         <a role="link">
           <span class="pficon pficon-user"
                 data-toggle="tooltip"
-                title="User"></span>
-          <span class="list-group-item-value">{{ 'user' | synI18n }}</span>
+                i18n-title="Sidebar|Navigation item@@sidebar.user" title="User"></span>
+          <span class="list-group-item-value" i18n="Sidebar|Navigation item@@sidebar.user">User</span>
         </a>
         <div class="nav-pf-secondary-nav">
           <div class="nav-item-pf-header">
             <a role="button" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
-            <span>{{ 'user' | synI18n }}</span>
+            <span>{{ ( user$ | async)?.username }}</span>
           </div>
           <ul class="list-group">
             <li class="list-group-item">
               <a (click)="logout()" role="link">
-                <span class="list-group-item-value">{{ 'header.usermenu.logout' | synI18n }}</span>
+                <span class="list-group-item-value" i18n="@@logout">Logout</span>
               </a>
             </li>
           </ul>
@@ -196,38 +204,48 @@
         <a role="link">
           <span class="pficon pficon-help"
                 data-toggle="tooltip"
-                title="User"></span>
-          <span class="list-group-item-value">{{ 'help' | synI18n }}</span>
+                i18n-title="Topbar - Help dropdown|Dropdown title@@header.helpmenu.title"
+                title="Help"></span>
+          <span class="list-group-item-value" i18n="Topbar - Help dropdown|Dropdown title@@header.helpmenu.title">Help</span>
         </a>
         <div class="nav-pf-secondary-nav">
           <div class="nav-item-pf-header">
             <a role="button" class="secondary-collapse-toggle-pf" data-toggle="collapse-secondary-nav"></a>
-            <span>{{ 'help' | synI18n }}</span>
+            <span i18n="Topbar - Help dropdown|Dropdown title@@header.helpmenu.title">Help</span>
           </div>
           <ul class="list-group">
             <li class="list-group-item">
-              <a [attr.href]="'links.tutorial' | synI18n"
-                rel="nofollow"
-                role="link"
-                target="_blank"
-                class="list-group-item-value">{{ 'header.helpmenu.sampletutorials' | synI18n }}</a>
+              <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/fuse_online_sample_integration_tutorials/"
+                 rel="nofollow"
+                 role="link"
+                 target="_blank"
+                 i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.sampletutorials"
+              >Sample Integration Tutorials</a>
             </li>
             <li class="list-group-item">
-              <a [attr.href]="'links.userguide' | synI18n:' '"
-                rel="nofollow"
-                role="link"
-                target="_blank"
-                class="list-group-item-value">{{ 'header.helpmenu.userguide' | synI18n }}</a>
+              <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/integrating_applications_with_fuse_online"
+                 rel="nofollow"
+                 role="link"
+                 target="_blank"
+                 i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.userguide"
+              >User Guide</a>
+            <li class="list-group-item">
+              <a href="//access.redhat.com/documentation/{{locale}}/red_hat_fuse/{{appVersion}}/html-single/connecting_fuse_online_to_applications_and_services/"
+                 rel="nofollow"
+                 role="link"
+                 target="_blank"
+                 i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.connectorsguide"
+              >Connectors Guide</a>
+            <li class="list-group-item">
+              <a routerLink="/support" role="link" i18n>Support</a>
             </li>
             <li class="list-group-item">
-              <a routerLink="/support" role="link"  class="list-group-item-value">{{ 'support' | synI18n }}</a>
-            </li>
-            <li class="list-group-item">
-              <a href="mailto:{{ 'email' | synI18n }}"
-                rel="nofollow"
-                role="link"
-                target="_blank"
-                class="list-group-item-value">{{ 'contactus' | synI18n }}</a>
+              <a href="//access.redhat.com/support/cases/#/case/new"
+                 target="_blank"
+                 rel="nofollow"
+                 role="link"
+                 i18n="Topbar - Help dropdown|Title of the Customer Portal link@@header.helpmenu.contactus"
+              >Contact Us</a>
             </li>
           </ul>
         </div>
@@ -240,7 +258,7 @@
 
   <syndesis-modal id="importDb" title="Import Selection" [body]="importDbModal">
     <ng-template #importDbModal let-modal="modal">
-        {{ 'import-db-txt' | synI18n }}
+      <ng-container i18n="Import selection modal@@import-db-txt">Select the data file to import:</ng-container>
       <input type="file" id="file-import" (change)="importDB($event, modal)">
     </ng-template>
   </syndesis-modal>

--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -69,8 +69,6 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   productBuild = false;
 
-  locale = LOCALE_ID;
-
   notifications: Observable<Notification[]>;
 
   /**
@@ -89,6 +87,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     private modalService: ModalService,
     private title: Title,
     private meta: Meta,
+    @Inject(LOCALE_ID) private locale: string,
     @Inject(DOCUMENT) private document: any
   ) {}
 

--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnInit, Inject } from '@angular/core';
+import { AfterViewInit, Component, OnInit, Inject, LOCALE_ID } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Meta, Title } from '@angular/platform-browser';
 import { saveAs } from 'file-saver';
@@ -56,12 +56,20 @@ export class AppComponent implements OnInit, AfterViewInit {
   appName = 'Syndesis';
 
   /**
+   * @type {string}
+   * Version of the application. Used to generate links to external resources.
+   */
+  appVersion = '0.0';
+
+  /**
    * @type {boolean}
    * Flag used to determine whether or not the user is a first time user.
    */
   firstTime = false;
 
   productBuild = false;
+
+  locale = LOCALE_ID;
 
   notifications: Observable<Notification[]>;
 
@@ -88,6 +96,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.store.dispatch(new PlatformActions.AppBootstrap());
 
     this.appName = this.config.getSettings('branding', 'appName', 'Syndesis');
+    this.appVersion = this.config.getSettings('branding', 'appVersion', '99.99');
     this.title.setTitle(this.appName);
     this.meta.updateTag({ content: this.appName }, 'id="appName"');
     this.meta.updateTag({ content: this.appName }, 'id="appTitle"');

--- a/app/ui/src/locale/messages.en.xlf
+++ b/app/ui/src/locale/messages.en.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="menu.navbartoggle" datatype="html">
         <source>Toggle navigation</source>
-        <target>Toggle navigation</source>
+        <target>Toggle navigation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">33</context>
@@ -13,7 +13,7 @@
       </trans-unit>
       <trans-unit id="header.helpmenu.title" datatype="html">
         <source>Help</source>
-        <target>Help</source>
+        <target>Help</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">59</context>
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="header.helpmenu.sampletutorials" datatype="html">
         <source>Sample Integration Tutorials</source>
-        <target>Sample Integration Tutorials</source>
+        <target>Sample Integration Tutorials</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">68</context>
@@ -49,7 +49,7 @@
       </trans-unit>
       <trans-unit id="header.helpmenu.userguide" datatype="html">
         <source>User Guide</source>
-        <target>User Guide</source>
+        <target>User Guide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">76</context>
@@ -63,7 +63,7 @@
       </trans-unit>
       <trans-unit id="header.helpmenu.connectorsguide" datatype="html">
         <source>Connectors Guide</source>
-        <target>Connectors Guide</source>
+        <target>Connectors Guide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">83</context>
@@ -77,7 +77,7 @@
       </trans-unit>
       <trans-unit id="b5629d298ff1a69b8db19a4ba2995c76b52da604" datatype="html">
         <source>Support</source>
-        <target>Support</source>
+        <target>Support</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">85</context>
@@ -89,7 +89,7 @@
       </trans-unit>
       <trans-unit id="header.helpmenu.contactus" datatype="html">
         <source>Contact Us</source>
-        <target>Contact Us</source>
+        <target>Contact Us</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">93</context>
@@ -103,7 +103,7 @@
       </trans-unit>
       <trans-unit id="logout" datatype="html">
         <source>Logout</source>
-        <target>Logout</source>
+        <target>Logout</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">127</context>
@@ -115,7 +115,7 @@
       </trans-unit>
       <trans-unit id="sidebar.home" datatype="html">
         <source>Home</source>
-        <target>Home</source>
+        <target>Home</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">154</context>
@@ -129,7 +129,7 @@
       </trans-unit>
       <trans-unit id="sidebar.integrations" datatype="html">
         <source>Integrations</source>
-        <target>Integrations</source>
+        <target>Integrations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">160</context>
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="sidebar.connections" datatype="html">
         <source>Connections</source>
-        <target>Connections</source>
+        <target>Connections</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">166</context>
@@ -157,7 +157,7 @@
       </trans-unit>
       <trans-unit id="sidebar.customizations" datatype="html">
         <source>Customizations</source>
-        <target>Customizations</source>
+        <target>Customizations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">172</context>
@@ -171,7 +171,7 @@
       </trans-unit>
       <trans-unit id="sidebar.settings" datatype="html">
         <source>Settings</source>
-        <target>Settings</source>
+        <target>Settings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">178</context>
@@ -185,7 +185,7 @@
       </trans-unit>
       <trans-unit id="sidebar.user" datatype="html">
         <source>User</source>
-        <target>User</source>
+        <target>User</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/app.component.ts</context>
           <context context-type="linenumber">186</context>

--- a/app/ui/src/locale/messages.en.xlf
+++ b/app/ui/src/locale/messages.en.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="menu.navbartoggle" datatype="html">
+        <source>Toggle navigation</source>
+        <target>Toggle navigation</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">The sidebar toggle button, also known as hamburger icon</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.title" datatype="html">
+        <source>Help</source>
+        <target>Help</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">208</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">214</context>
+        </context-group>
+        <note priority="1" from="description">Dropdown title</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.sampletutorials" datatype="html">
+        <source>Sample Integration Tutorials</source>
+        <target>Sample Integration Tutorials</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">223</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.userguide" datatype="html">
+        <source>User Guide</source>
+        <target>User Guide</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">231</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.connectorsguide" datatype="html">
+        <source>Connectors Guide</source>
+        <target>Connectors Guide</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">238</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="b5629d298ff1a69b8db19a4ba2995c76b52da604" datatype="html">
+        <source>Support</source>
+        <target>Support</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.contactus" datatype="html">
+        <source>Contact Us</source>
+        <target>Contact Us</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">248</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="logout" datatype="html">
+        <source>Logout</source>
+        <target>Logout</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sidebar.home" datatype="html">
+        <source>Home</source>
+        <target>Home</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.integrations" datatype="html">
+        <source>Integrations</source>
+        <target>Integrations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">160</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">161</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.connections" datatype="html">
+        <source>Connections</source>
+        <target>Connections</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.customizations" datatype="html">
+        <source>Customizations</source>
+        <target>Customizations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">172</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.settings" datatype="html">
+        <source>Settings</source>
+        <target>Settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.user" datatype="html">
+        <source>User</source>
+        <target>User</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">186</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">187</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="import-db-txt" datatype="html">
+        <source>Select the data file to import:</source>
+        <target>Select the data file to import:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">261</context>
+        </context-group>
+        <note priority="1" from="description">Import selection modal</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/app/ui/src/locale/messages.it.xlf
+++ b/app/ui/src/locale/messages.it.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file target-language="it" original="ng2.template" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit datatype="html" id="menu.navbartoggle">
+                <source>Toggle navigation</source>
+                <target>Mostra/nascondi la barra di navigazione</target>
+                <note from="description" priority="1">The sidebar toggle button, also known as hamburger icon</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">33</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="header.helpmenu.title">
+                <source>Help</source>
+                <target>Aiuto</target>
+                <note from="description" priority="1">Dropdown title</note>
+                <note from="meaning" priority="1">Topbar - Help dropdown</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">59</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">208</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">209</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">214</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="header.helpmenu.sampletutorials">
+                <source>Sample Integration Tutorials</source>
+                <target>Tutorial per una integrazione di esempio</target>
+                <note from="description" priority="1">Title of the Customer Portal link</note>
+                <note from="meaning" priority="1">Topbar - Help dropdown</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">68</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">223</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="header.helpmenu.userguide">
+                <source>User Guide</source>
+                <target>Guida utente</target>
+                <note from="description" priority="1">Title of the Customer Portal link</note>
+                <note from="meaning" priority="1">Topbar - Help dropdown</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">76</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">231</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="header.helpmenu.connectorsguide">
+                <source>Connectors Guide</source>
+                <target>Guida ai Connettori</target>
+                <note from="description" priority="1">Title of the Customer Portal link</note>
+                <note from="meaning" priority="1">Topbar - Help dropdown</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">83</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">238</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit id="b5629d298ff1a69b8db19a4ba2995c76b52da604" datatype="html">
+                <source>Support</source>
+                <target>Supporto</target>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">85</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">240</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="header.helpmenu.contactus">
+                <source>Contact Us</source>
+                <target>Contattaci</target>
+                <note from="description" priority="1">Title of the Customer Portal link</note>
+                <note from="meaning" priority="1">Topbar - Help dropdown</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">93</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">248</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit id="logout" datatype="html">
+                <source>Logout</source>
+                <target>Logout</target>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">127</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">197</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.home">
+                <source>Home</source>
+                <target>Home</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">154</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">155</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.integrations">
+                <source>Integrations</source>
+                <target>Integrazioni</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">160</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">161</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.connections">
+                <source>Connections</source>
+                <target>Connessioni</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">166</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">167</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.customizations">
+                <source>Customizations</source>
+                <target>Personalizzazioni</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">172</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">173</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.settings">
+                <source>Settings</source>
+                <target>Configurazioni</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">178</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">179</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="sidebar.user">
+                <source>User</source>
+                <target>Utente</target>
+                <note from="description" priority="1">Navigation item</note>
+                <note from="meaning" priority="1">Sidebar</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">186</context>
+                </context-group>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">187</context>
+                </context-group>
+            </trans-unit>
+            <trans-unit datatype="html" id="import-db-txt">
+                <source>Select the data file to import:</source>
+                <target>Seleziona il file da importare:</target>
+                <note from="description" priority="1">Import selection modal</note>
+                <context-group purpose="location">
+                    <context context-type="sourcefile">app/app.component.ts</context>
+                    <context context-type="linenumber">261</context>
+                </context-group>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/app/ui/src/main.ts
+++ b/app/ui/src/main.ts
@@ -1,3 +1,4 @@
+import { LOCALE_ID } from '@angular/core';
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { environment } from 'environments/environment';
@@ -9,6 +10,7 @@ if (environment.production) {
 
 /* tslint:disable:no-console */
 platformBrowserDynamic().bootstrapModule(AppModule, {
-  preserveWhitespaces: true
+  preserveWhitespaces: true,
+  providers: [{provide: LOCALE_ID, useValue: 'en-US' }]
 })
 .catch(err => console.log(err));

--- a/app/ui/src/messages.xlf
+++ b/app/ui/src/messages.xlf
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="menu.navbartoggle" datatype="html">
+        <source>Toggle navigation</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">The sidebar toggle button, also known as hamburger icon</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.title" datatype="html">
+        <source>Help</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">208</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">214</context>
+        </context-group>
+        <note priority="1" from="description">Dropdown title</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.sampletutorials" datatype="html">
+        <source>Sample Integration Tutorials</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">223</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.userguide" datatype="html">
+        <source>User Guide</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">231</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.connectorsguide" datatype="html">
+        <source>Connectors Guide</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">238</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="b5629d298ff1a69b8db19a4ba2995c76b52da604" datatype="html">
+        <source>Support</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">85</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="header.helpmenu.contactus" datatype="html">
+        <source>Contact Us</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">248</context>
+        </context-group>
+        <note priority="1" from="description">Title of the Customer Portal link</note>
+        <note priority="1" from="meaning">Topbar - Help dropdown</note>
+      </trans-unit>
+      <trans-unit id="logout" datatype="html">
+        <source>Logout</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sidebar.home" datatype="html">
+        <source>Home</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.integrations" datatype="html">
+        <source>Integrations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">160</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">161</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.connections" datatype="html">
+        <source>Connections</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">166</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">167</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.customizations" datatype="html">
+        <source>Customizations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">172</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.settings" datatype="html">
+        <source>Settings</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">178</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">179</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="sidebar.user" datatype="html">
+        <source>User</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">186</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">187</context>
+        </context-group>
+        <note priority="1" from="description">Navigation item</note>
+        <note priority="1" from="meaning">Sidebar</note>
+      </trans-unit>
+      <trans-unit id="import-db-txt" datatype="html">
+        <source>Select the data file to import:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/app.component.ts</context>
+          <context context-type="linenumber">261</context>
+        </context-group>
+        <note priority="1" from="description">Import selection modal</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
From issue #3200:
> take a stance on i18N solution to normalize our code base or officially deprecate the approach

I decided to try porting the current in-house backed i18n solution to [Angular's default one](https://angular.io/guide/i18n) and share a list of pros and cons of this solution as I understand it.

Feel free to update the list with your feedback! There is some amount of labor involved in switching i18n module, so before proceeding further I'd like to know if we all agree to do it or not.

### Pros
* the whole toolchain is provided by Angular, so we can drop the in-house backed i18n module and reduce the LOC count (and the surface area for bugs)
* translations are handled through XLIFF (XML Localization Interchange File Format) files, which is an open standard. [This is how it looks like for this POC](https://github.com/riccardo-forina/syndesis/blob/i18n/app/ui/src/locale/messages.en.xlf). It supports all the things an i18n module should support, like pluralization.
I'd like to hear @TovaCohen about this since she is the stakeholder for translations right now.
* I think the HTML code looks cleaner this way, and it's surely easier for the developers since it reduces the amount of steps to 1 (which is, mark the text to be translated with the `i18n` attribute), versus the actual process where you have 1 + N steps (1 is to write the `syni18n` pipe in the HTML, N is the number of dictionaries to update - one per supported language).
* the toolchain can be configured to mark as warnings the missing translations while developing, and stop the build with errors when building for production, thus ensuring that no "broken" app is served to the end users.
* Angular handles also date/numbers/currency localization, which is a good thing. Especially for dates, it removes the current ambiguity with date formatting, for which we sometimes use Angular's pipes and sometimes use moment.js format. By sticking to Angular, we make it simpler to drop moment.js completely. Relevant issue #2500. 

### Cons

* the app must be built for every single language we want to support, and (continued to the next point).
* the server must be instructed to understand which language should be delivered to the user. This can be done by looking at the [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) header for example, but should also allow the user to manually change it if desired.
* this solution doesn't automatically make the move to a new framework (eg. React) trivial. But being the XLIFF a standard, there are tools to migrate it to other formats if needed.
* strings defined in TS files can't be translated [yet](https://github.com/angular/angular/issues/11405).

# Screenshot

<img width="1111" alt="syndesis-it" src="https://user-images.githubusercontent.com/966316/44098327-301e7da6-9fe0-11e8-8d5e-9792be4bbe66.png">

Here is a sample of the app running against the Italian messages that I translated to test the app serving.