### PR TITLE
Enables drag/drop UI for API connector upload to be similar as rest of app

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -1,4 +1,8 @@
-<article class="wizard syn-scrollable">
+<article class="wizard syn-scrollable"
+         onDragStart="return false;"
+         ondragenter="return false;"
+         ondragover="return false;"
+         ondrop="return false;">
   <section class="wizard__ui wizard__nav" *ngIf="!showApiEditor">
     <nav class="wizard-nav row toolbar-pf">
       <div class="col-sm-12">

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -64,7 +64,7 @@
                   </p>
                 </div>
               </div>
-              <p class="help-block"><em>Accepted file type: .json</em></p>
+              <p class="help-block"><em>{{ 'customizations.api-client-connectors.api-upload-helper-text' | synI18n }}</em></p>
             </div>
           </div>
         </div>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -1,11 +1,11 @@
 <div class="card-pf-heading">
   <h2 class="card-pf-title">
-    Upload OpenAPI Specification
+    {{ 'customizations.api-client-connectors.create-upload-spec-step-title' | synI18n }}
   </h2>
 </div>
 <div class="card-pf-body">
   <syndesis-validation-error *ngIf="swaggerFileUrlInput.errors?.requiredIfChecked && fetchUrlOption.checked">
-    You must enter a valid URL before submitting the form
+    {{ 'customizations.api-client-connectors.url-validation-error' | synI18n }}
   </syndesis-validation-error>
 
   <syndesis-validation-error *ngIf="validationError">
@@ -17,33 +17,60 @@
   </syndesis-validation-error>
 
   <p>
-    Upload the OpenAPI 2.0 file for your custom API client ocnnector. Custom APIs are RESTful APIs and can be hosted anywhere,
-    as long as a well-documented API specification is available and conforms to the OpenAPI standard.
+    {{ 'customizations.api-client-connectors.url-upload-instructions' | synI18n }}
   </p>
   <p>
-    <strong>Choose how you want to create your connector:</strong>
+    <strong>{{ 'customizations.api-client-connectors.api-upload-choose-method' | synI18n }}</strong>
   </p>
   <form class="form-horizontal syn-form--swagger-upload" (ngSubmit)="onSubmit(swaggerForm, uploadFileOption.checked)" #swaggerForm="ngForm" novalidate>
     <fieldset class="container-fluid">
       <div class="form-group row">
         <div class="col-xs-12 radio">
           <label>
-            <input type="radio" checked="checked" name="connectorSource" #uploadFileOption> Upload an OpenAPI file
+            <input type="radio" checked="checked" name="connectorSource" #uploadFileOption>
+            {{ 'customizations.api-client-connectors.api-file-upload' | synI18n }}
           </label>
         </div>
       </div>
       <div class="container-fluid">
         <div class="form-group row"
           [class.syn-visuallyhidden]="!uploadFileOption.checked">
-          <div class="col-xs-12">
-            <input type="file" (change)="onFile($event)">
+          <div class="syn-drop-zone"
+               ng2FileDrop
+               [uploader]="uploader"
+               [ngClass]="{'syn-drop-zone--hover': hasBaseDropZoneOver}"
+               (onFileDrop)="onFileDrop($event)"
+               (fileOver)="onFileOver($event)">
+            <p>{{ 'customizations.api-client-connectors.api-file-upload-dnd' | synI18n }}</p>
+            <div class="row syn-drop-zone__file-select">
+              <div>
+                <p>
+                  <input #fileSelect
+                         class="api-file-chooser"
+                         type="file"
+                         ng2FileSelect
+                         [uploader]="uploader">
+                </p>
+              </div>
+            </div>
+            <div>
+              <p class="row" *ngIf="fileToUpload">
+                <span class="pficon-ok"></span>
+                '{{ fileToUpload.name }}' will be uploaded
+              </p>
+              <p class="row" *ngIf="invalidFileMsg">
+                <span class="pficon-error-circle-o"></span>
+                {{ invalidFileMsg }}
+              </p>
+            </div>
           </div>
         </div>
       </div>
       <div class="form-group row">
         <div class="col-xs-12 radio">
           <label>
-            <input type="radio" name="connectorSource" #fetchUrlOption> Use a URL
+            <input type="radio" name="connectorSource" #fetchUrlOption>
+            {{ 'customizations.api-client-connectors.api-url-upload' | synI18n }}
           </label>
         </div>
       </div>
@@ -59,7 +86,7 @@
               [requiredIf]="fetchUrlOption.checked"
               #swaggerFileUrlInput="ngModel">
             <em class="text-muted">
-              * Note: we will download this for you but any updates to the online version will not be updated in our app.
+              {{ 'customizations.api-client-connectors.api-url-upload-note' | synI18n }}
             </em>
           </div>
         </div>
@@ -69,8 +96,8 @@
     <fieldset>
       <syndesis-button type="submit"
         [loading]="apiConnectorState.loading"
-        [disabled]="(!uploadFileOption.checked && !swaggerFileUrlInput.value) || (uploadFileOption.checked && !swaggerFileList)">
-        Next
+        [disabled]="(!uploadFileOption.checked && !swaggerFileUrlInput.value) || (uploadFileOption.checked && !fileToUpload)">
+        {{ 'next' | synI18n }}
       </syndesis-button>
     </fieldset>
   </form>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -35,33 +35,36 @@
       <div class="container-fluid">
         <div class="form-group row"
           [class.syn-visuallyhidden]="!uploadFileOption.checked">
-          <div class="syn-drop-zone"
-               ng2FileDrop
-               [uploader]="uploader"
-               [ngClass]="{'syn-drop-zone--hover': hasBaseDropZoneOver}"
-               (onFileDrop)="onFileDrop($event)"
-               (fileOver)="onFileOver($event)">
-            <p>{{ 'customizations.api-client-connectors.api-file-upload-dnd' | synI18n }}</p>
-            <div class="row syn-drop-zone__file-select">
-              <div>
-                <p>
-                  <input #fileSelect
-                         class="api-file-chooser"
-                         type="file"
-                         ng2FileSelect
-                         [uploader]="uploader">
-                </p>
+          <div class="col-xs-12">
+            <div class="syn-drop-zone"
+                ng2FileDrop
+                [uploader]="uploader"
+                [ngClass]="{'syn-drop-zone--hover': hasBaseDropZoneOver}"
+                (onFileDrop)="onFileDrop($event)"
+                (fileOver)="onFileOver($event)">
+              <p>{{ 'customizations.api-client-connectors.api-file-upload-dnd' | synI18n }}</p>
+              <div class="row syn-drop-zone__file-select">
+                <div class="col-md-5">
+                  <p>
+                    <input #fileSelect
+                      class="api-file-chooser"
+                      type="file"
+                      ng2FileSelect
+                      [uploader]="uploader">
+                  </p>
+                </div>
+                <div class="col-md-7">
+                  <p *ngIf="validFileMsg">
+                    <span class="pficon-ok"></span>
+                    {{ validFileMsg }}
+                  </p>
+                  <p *ngIf="invalidFileMsg">
+                    <span class="pficon-error-circle-o"></span>
+                    {{ invalidFileMsg }}
+                  </p>
+                </div>
               </div>
-            </div>
-            <div>
-              <p class="row" *ngIf="fileToUpload">
-                <span class="pficon-ok"></span>
-                '{{ fileToUpload.name }}' will be uploaded
-              </p>
-              <p class="row" *ngIf="invalidFileMsg">
-                <span class="pficon-error-circle-o"></span>
-                {{ invalidFileMsg }}
-              </p>
+              <p class="help-block"><em>Accepted file type: .json</em></p>
             </div>
           </div>
         </div>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.scss
@@ -7,3 +7,7 @@
     }
   }
 }
+
+.api-file-chooser {
+  width: 100%;
+}

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
@@ -27,6 +27,7 @@ export class ApiConnectorSwaggerUploadComponent implements OnInit {
   fileToUpload: File;
   hasBaseDropZoneOver: boolean;
   invalidFileMsg: string;
+  validFileMsg: string;
   swaggerFileUrl: string;
   uploader: FileUploader;
 
@@ -60,6 +61,10 @@ export class ApiConnectorSwaggerUploadComponent implements OnInit {
 
       // pop off file from queue to set file and clear queue
       this.fileToUpload = this.uploader.queue.pop()._file;
+
+      this.validFileMsg = this.i18NService.localize( 'customizations.api-client-connectors.api-upload-valid-file',
+                                                      [ this.fileToUpload.name ] );
+      this.fileSelect.nativeElement.value = '';
     };
 
     this.uploader.onWhenAddingFileFailed = (
@@ -68,7 +73,7 @@ export class ApiConnectorSwaggerUploadComponent implements OnInit {
       // occurs when not a *.json file
       this.invalidFileMsg = this.i18NService.localize( 'customizations.api-client-connectors.api-upload-invalid-file',
                                                        [ file.name ] );
-      this.fileToUpload = null;
+      this.validFileMsg = null;
       this.fileSelect.nativeElement.value = '';
       this.uploader.clearQueue();
     };

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -45,6 +45,7 @@
         "url-upload-instructions": "Upload the OpenAPI 2.0 file for your custom API client connector. Custom APIs are RESTful APIs and can be hosted anywhere, as long as a well-documented API specification is available and conforms to the OpenAPI standard.",
         "api-upload-valid-file": "Successfully uploaded '{{0}}'.",
         "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json' can be uploaded.",
+        "api-upload-helper-text": "Accepted file type: .json",
         "api-url-upload": "Use a URL",
         "api-url-upload-note": "* Note: After uploading this specification, Syndesis/Fuse Online does not automatically obtain any updates to it. You would have to upload an updated specification and create a new API client connector that incorporates the updates.",
         "url-validation-error": "You must enter a valid URL before submitting the form."

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -40,10 +40,11 @@
         "create-details-step-title": "Review/Edit Connector Details",
         "edit-tooltip": "{{project.name}} cannot make this specification available for review/edit. If you want to review or edit the API before {{project.name}} creates the connector, try manually downloading the specification and then upload that file.",
         "api-file-upload": "Upload an OpenAPI file",
-        "api-file-upload-dnd": "Drag and drop your OpenAPI file here or click the 'Choose File' button to use the file chooser.",
+        "api-file-upload-dnd": "Drag and drop your OpenAPI file here or",
         "api-upload-choose-method": "Choose how you want to create your connector:",
         "url-upload-instructions": "Upload the OpenAPI 2.0 file for your custom API client connector. Custom APIs are RESTful APIs and can be hosted anywhere, as long as a well-documented API specification is available and conforms to the OpenAPI standard.",
-        "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json' can be imported.",
+        "api-upload-valid-file": "Successfully uploaded '{{0}}'.",
+        "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json' can be uploaded.",
         "api-url-upload": "Use a URL",
         "api-url-upload-note": "* Note: After uploading this specification, Syndesis/Fuse Online does not automatically obtain any updates to it. You would have to upload an updated specification and create a new API client connector that incorporates the updates.",
         "url-validation-error": "You must enter a valid URL before submitting the form."

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -38,7 +38,15 @@
         "create-review-step-title": "Review Actions",
         "create-security-step-title": "Specify Security",
         "create-details-step-title": "Review/Edit Connector Details",
-        "edit-tooltip": "{{project.name}} cannot make this specification available for review/edit. If you want to review or edit the API before {{project.name}} creates the connector, try manually downloading the specification and then upload that file."
+        "edit-tooltip": "{{project.name}} cannot make this specification available for review/edit. If you want to review or edit the API before {{project.name}} creates the connector, try manually downloading the specification and then upload that file.",
+        "api-file-upload": "Upload an OpenAPI file",
+        "api-file-upload-dnd": "Drag and drop your OpenAPI file here or click the 'Choose File' button to use the file chooser.",
+        "api-upload-choose-method": "Choose how you want to create your connector:",
+        "url-upload-instructions": "Upload the OpenAPI 2.0 file for your custom API client connector. Custom APIs are RESTful APIs and can be hosted anywhere, as long as a well-documented API specification is available and conforms to the OpenAPI standard.",
+        "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json' can be imported.",
+        "api-url-upload": "Use a URL",
+        "api-url-upload-note": "* Note: After uploading this specification, Syndesis/Fuse Online does not automatically obtain any updates to it. You would have to upload an updated specification and create a new API client connector that incorporates the updates.",
+        "url-validation-error": "You must enter a valid URL before submitting the form."
       }
     },
     "integrations": {


### PR DESCRIPTION
- See issue #2850 
- ApiConnectorSwaggerUploadComponent is now using the same file upload component as in other places in app that allow DND
- Added code in api-connector-create.component.html that does not allow a file to be DND'd in the ApiCurio wizard unless in a drop zone.
- i18n'd files that were touched

@michael-coker please take a look at CSS change to see if what I did is OK
@TovaCohen please take a look at the i18n file for any changes you might want to make