### PR TITLE
Add a dependency-management version for hibernate-validator.   syndes…

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1538,6 +1538,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${hibernate.validator.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jdbi</groupId>
         <artifactId>jdbi</artifactId>
         <version>${jdbi.version}</version>


### PR DESCRIPTION
…is-parent currently sets a hibernate.validator.version but does not respect it because there is no dependency-management entry.

(cherry picked from commit f26a8a285c053cae371805553aa80ab51d486ae1)