### PR TITLE
fix(connector): allow for schema/payloads with only parameters

### DIFF
--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -87,6 +87,36 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
+++ b/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
@@ -16,29 +16,28 @@
 package io.syndesis.connector.webhook;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
-import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeAware;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
 import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 
 public class WebhookConnectorCustomizer implements ComponentProxyCustomizer, CamelContextAware, DataShapeAware {
     public static final String SCHEMA_ID = "io:syndesis:webhook";
+
+    static final ObjectReader READER = Json.reader().forType(ObjectSchema.class);
 
     private CamelContext camelContext;
     private DataShape inputDataShape;
@@ -78,13 +77,15 @@ public class WebhookConnectorCustomizer implements ComponentProxyCustomizer, Cam
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         if (outputDataShape != null && outputDataShape.getKind() == DataShapeKinds.JSON_SCHEMA && outputDataShape.getSpecification() != null) {
             try {
-                ObjectSchema schema = Json.reader().forType(ObjectSchema.class).readValue(outputDataShape.getSpecification());
+                final ObjectSchema schema = READER.readValue(outputDataShape.getSpecification());
                 if (SCHEMA_ID.equals(schema.getId())) {
                     // check that the schema contains the right properties
                     if (!(schema.getProperties().get("parameters") instanceof ObjectSchema)) {
                         throw new IllegalArgumentException("JsonSchema does not define parameters property");
                     }
-                    if (!(schema.getProperties().get("body") instanceof ObjectSchema)) {
+
+                    final JsonSchema bodySchema = schema.getProperties().get("body");
+                    if (bodySchema != null && !(bodySchema instanceof ObjectSchema)) {
                         throw new IllegalArgumentException("JsonSchema does not define body property");
                     }
 
@@ -110,44 +111,4 @@ public class WebhookConnectorCustomizer implements ComponentProxyCustomizer, Cam
         }
     }
 
-    private static class WrapperProcessor implements Processor {
-        private final ObjectSchema schema;
-
-        public WrapperProcessor(ObjectSchema schema) {
-            this.schema = schema;
-        }
-
-        @Override
-        public void process(Exchange exchange) throws Exception {
-            final Message message = exchange.getIn();
-            final Object body = message.getBody();
-            final Map<String, JsonSchema> properties = this.schema.getProperties();
-
-            ObjectNode rootNode = Json.copyObjectMapperConfiguration().createObjectNode();
-            ObjectNode parametersNode = rootNode.putObject("parameters");
-
-            if (body instanceof String) {
-                rootNode.putPOJO("body", Json.reader().forType(JsonNode.class).readValue((String)body));
-            } else if (body instanceof InputStream) {
-                rootNode.putPOJO("body", Json.reader().forType(JsonNode.class).readValue((InputStream)body));
-            } else {
-                rootNode.putPOJO("body", body);
-            }
-
-            if (properties.get("parameters") instanceof ObjectSchema) {
-                ObjectSchema parameters = (ObjectSchema)properties.get("parameters");
-
-                for (Map.Entry<String, JsonSchema> header : parameters.getProperties().entrySet()) {
-                    if (header.getValue() instanceof StringSchema) {
-                        parametersNode.put(
-                            header.getKey(),
-                            message.getHeader(header.getKey(), String.class)
-                        );
-                    }
-                }
-            }
-
-            message.setBody(Json.toString(rootNode));
-        }
-    }
 }

--- a/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WrapperProcessor.java
+++ b/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WrapperProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.webhook;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import io.syndesis.common.util.Json;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.util.ObjectHelper;
+
+class WrapperProcessor implements Processor {
+    final Set<String> parameters;
+
+    static final ObjectReader READER = Json.reader().forType(JsonNode.class);
+
+    WrapperProcessor(ObjectSchema schema) {
+        final Map<String, JsonSchema> properties = schema.getProperties();
+
+        final JsonSchema parametersSchema = properties.get("parameters");
+        if (!(parametersSchema instanceof ObjectSchema)) {
+            parameters = Collections.emptySet();
+        } else {
+            parameters = ((ObjectSchema) parametersSchema).getProperties().keySet();
+        }
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        final Message message = exchange.getIn();
+        final Object body = message.getBody();
+
+        final ObjectNode rootNode = Json.copyObjectMapperConfiguration().createObjectNode();
+
+        if (!parameters.isEmpty()) {
+            final ObjectNode parametersNode = rootNode.putObject("parameters");
+
+            for (String parameter : parameters) {
+                parametersNode.put(parameter, message.getHeader(parameter, String.class));
+            }
+        }
+
+        if (body instanceof String) {
+            final String string = (String) body;
+            if (ObjectHelper.isNotEmpty(string)) {
+                rootNode.set("body", READER.readValue(string));
+            }
+        } else if (body instanceof InputStream) {
+            try (InputStream stream = (InputStream) body) {
+                if (stream.available() > 0) {
+                    rootNode.set("body", READER.readValue(stream));
+                }
+            }
+        } else if (body != null){
+            rootNode.putPOJO("body", body);
+        }
+
+        message.setBody(Json.toString(rootNode));
+    }
+}

--- a/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WebhookConnectorCustomizerTest.java
+++ b/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WebhookConnectorCustomizerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.webhook;
+
+import java.util.Collections;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookConnectorCustomizerTest {
+
+    static final String SIMPLE_SCHEMA = "{\n" + //
+        "  \"type\": \"object\",\n" + //
+        "  \"id\": \"io:syndesis:webhook\",\n" + //
+        "  \"properties\": {\n" + //
+        "    \"parameters\": {\n" + //
+        "      \"type\": \"object\",\n" + //
+        "      \"properties\": {\n" + //
+        "        \"source\": {\n" + //
+        "          \"type\": \"string\"\n" + //
+        "        },\n" + //
+        "        \"status\": {\n" + //
+        "          \"type\": \"string\"\n" + //
+        "        }\n" + //
+        "      }\n" + //
+        "    },\n" + //
+        "    \"body\": {\n" + //
+        "      \"type\": \"object\",\n" + //
+        "      \"properties\": {\n" + //
+        "        \"company\": {\n" + //
+        "          \"type\": \"string\"\n" + //
+        "        },\n" + //
+        "        \"email\": {\n" + //
+        "          \"type\": \"string\"\n" + //
+        "        },\n" + //
+        "        \"phone\": {\n" + //
+        "          \"type\": \"string\"\n" + //
+        "        }\n" + //
+        "      }\n" + //
+        "    }\n" + //
+        "  }\n" + //
+        "}";
+
+    final ComponentProxyComponent component = new ComponentProxyComponent("test", "test");
+
+    @Test
+    public void shouldAddWrapperProcessorIfSyndesisJsonSchemaGiven() {
+        final WebhookConnectorCustomizer customizer = new WebhookConnectorCustomizer();
+        customizer.setOutputDataShape(new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA).specification(SIMPLE_SCHEMA).build());
+
+        customizer.customize(component, Collections.emptyMap());
+
+        final Processor beforeConsumer = component.getBeforeConsumer();
+        assertThat(beforeConsumer).isInstanceOf(WrapperProcessor.class);
+        final WrapperProcessor wrapper = (WrapperProcessor) beforeConsumer;
+        assertThat(wrapper.parameters).containsOnly("source", "status");
+    }
+
+    @Test
+    public void shouldDestroyAllOutput() throws Exception {
+        final WebhookConnectorCustomizer customizer = new WebhookConnectorCustomizer();
+        customizer.customize(component, Collections.emptyMap());
+
+        final Processor afterConsumer = component.getAfterConsumer();
+        assertThat(afterConsumer).isNotNull();
+
+        final Exchange exchange = mock(Exchange.class);
+        final Message message = mock(Message.class);
+        when(exchange.getOut()).thenReturn(message);
+
+        afterConsumer.process(exchange);
+
+        verify(message).setBody("");
+        verify(message).removeHeaders("*");
+        verify(message).setHeader(Exchange.HTTP_RESPONSE_CODE, 204);
+        verify(message).setHeader(Exchange.HTTP_RESPONSE_TEXT, "No Content");
+    }
+
+}

--- a/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WrapperProcessorTest.java
+++ b/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WrapperProcessorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.webhook;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class WrapperProcessorTest {
+
+    private static final String PARAMS_AND_BODY = "{\"parameters\":{\"param1\":\"param_value1\",\"param2\":\"param_value2\"},\"body\":{\"body1\":\"body_value1\",\"body2\":\"body_value2\"}}";
+
+    private static final String ONLY_PARAMS = "{\"parameters\":{\"param1\":\"param_value1\",\"param2\":\"param_value2\"}}";
+
+    @Parameter(0)
+    public Object givenBody;
+
+    @Parameter(1)
+    public Object replacedBody;
+
+    final ObjectSchema schema = new ObjectSchema();
+
+    public WrapperProcessorTest() {
+        final ObjectSchema parameters = new ObjectSchema();
+        parameters.putProperty("param1", JsonSchema.minimalForFormat(JsonFormatTypes.STRING));
+        parameters.putProperty("param2", JsonSchema.minimalForFormat(JsonFormatTypes.STRING));
+        schema.putProperty("parameters", parameters);
+
+        final ObjectSchema body = new ObjectSchema();
+        body.putProperty("body1", JsonSchema.minimalForFormat(JsonFormatTypes.STRING));
+        body.putProperty("body2", JsonSchema.minimalForFormat(JsonFormatTypes.STRING));
+        schema.putProperty("body", body);
+    }
+
+    @Parameters
+    public static Collection<Object[]> cases() {
+        return Arrays.asList(//
+            new Object[] {null, ONLY_PARAMS}, //
+            new Object[] {"", ONLY_PARAMS}, //
+            new Object[] {"{\"body1\":\"body_value1\",\"body2\":\"body_value2\"}", PARAMS_AND_BODY}, //
+            new Object[] {new ByteArrayInputStream(new byte[0]), ONLY_PARAMS}//
+        );
+
+    }
+
+    @Test
+    public void testCases() throws Exception {
+        final WrapperProcessor processor = new WrapperProcessor(schema);
+
+        final Exchange exchange = mock(Exchange.class);
+        final Message message = mock(Message.class);
+        when(exchange.getIn()).thenReturn(message);
+        when(message.getBody()).thenReturn(givenBody);
+        when(message.getHeader("param1", String.class)).thenReturn("param_value1");
+        when(message.getHeader("param2", String.class)).thenReturn("param_value2");
+
+        processor.process(exchange);
+
+        verify(message).setBody(replacedBody);
+    }
+
+}


### PR DESCRIPTION
The webhook connector mandated that the JSON schema specifies the `body` and that the HTTP request contains a non-empty body. This does not hold true for HTTP GET requests.

This changes the JSON schema `body` property to optional and skips over empty body of HTTP requests.

Fixes #3389