### PR TITLE
fix(server): don't destroy Connector's configuredProperties on second startup

### DIFF
--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataManager.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataManager.java
@@ -150,6 +150,14 @@ public class DataManager implements DataAccessObjectRegistry {
 
                         if (connector != null) {
                             LOGGER.info("Load connector: {} from resource: {}", connector.getId().orElse(""), resource.getURI());
+                            final String id = connector.getId().get();
+                            final Connector existing = fetch(Connector.class, id);
+                            if (existing != null) {
+                                // the only mutable part of the Connector
+                                final Map<String, String> configuredProperties = existing.getConfiguredProperties();
+
+                                connector = connector.builder().configuredProperties(configuredProperties).build();
+                            }
                             store(connector, Connector.class);
                         }
                     }

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/DataManagerTest.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/DataManagerTest.java
@@ -39,6 +39,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -190,4 +191,21 @@ public class DataManagerTest {
         fail("Should fail before getting here");
     }
 
+    @Test
+    public void shouldNotDestroyConfiguredPropertiesOnSecondStartup() {
+        final Connector concur = dataManager.fetch(Connector.class, "concur");
+        final Connector configuredConcur = concur.builder()
+            .putConfiguredProperty("clientId", "my-client-id")
+            .putConfiguredProperty("clientSecret", "my-client-secret")
+            .build();
+
+        dataManager.store(configuredConcur, Connector.class);
+
+        dataManager.resetDeploymentData();
+
+        final Connector afterInit = dataManager.fetch(Connector.class, "concur");
+        assertThat(afterInit.getConfiguredProperties()).contains(
+            entry("clientId", "my-client-id"),
+            entry("clientSecret", "my-client-secret"));
+    }
 }


### PR DESCRIPTION
On startup `io.syndesis.server.runtime.Migrations::run` is invoking `DataManager::resetDeploymentData`, we need to make sure that the `configuredProperties` of the Connector are not overwriten by the loaded Connector definition.

Fixes #3386