### PR TITLE
fix(server): when discarding activity logs leave the newest entries

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/KeyGenerator.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/KeyGenerator.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 import static java.lang.System.currentTimeMillis;
 
@@ -36,13 +37,17 @@ import static java.lang.System.currentTimeMillis;
  */
 public final class KeyGenerator {
 
-    private static final AtomicLong LAST_TIMESTAMP = new AtomicLong(currentTimeMillis());
-    private static final byte RANDOMNESS_BYTE;
+    static final LongSupplier DEFAULT_CLOCK = () -> currentTimeMillis();
+
+    static LongSupplier clock = DEFAULT_CLOCK;
+
+    private static final AtomicLong LAST_TIMESTAMP = new AtomicLong(clock.getAsLong());
+    static byte randomnessByte;
     private static final AtomicLong RANDOMNESS_LONG;
 
     static {
         final Random random = ThreadLocalRandom.current();
-        RANDOMNESS_BYTE = (byte) random.nextInt();
+        randomnessByte = (byte) random.nextInt();
         RANDOMNESS_LONG = new AtomicLong(random.nextLong());
     }
 
@@ -53,11 +58,11 @@ public final class KeyGenerator {
      * Generates a new key.
      */
     public static String createKey() {
-        final long now = currentTimeMillis();
+        final long now = clock.getAsLong();
 
         final ByteBuffer buffer = ByteBuffer.wrap(new byte[8 + 1 + 8]);
         buffer.putLong(now);
-        buffer.put(RANDOMNESS_BYTE);
+        buffer.put(randomnessByte);
 
         buffer.putLong(getRandomPart(now));
 

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
@@ -157,7 +157,7 @@ public class ActivityTrackingController implements Closeable {
         return dbi.inTransaction((conn, status) -> {
             final String sql = "DELETE FROM jsondb "
                 + "WHERE path LIKE ? AND path NOT IN ("
-                +     "SELECT path FROM jsondb WHERE path LIKE ? ORDER BY path FETCH FIRST (?) ROWS ONLY"
+                +     "SELECT path FROM jsondb WHERE path LIKE ? ORDER BY path DESC FETCH FIRST (?) ROWS ONLY"
                 + ")";
 
                 return conn.update(sql, path, path, retention);


### PR DESCRIPTION
We were missing descending ordering of the `path` column. The `path` column contains the key generated when the activity is persisted, the key is chronologically ordered -- so newer keys are lexically greater than older keys. That means we should have ordered in descending order (`ORDER BY path DESC`) instead of the default, which is ascending.

Fixes #3396