### PR TITLE
user doc: Adds doc about using Apicurio to edit OpenAPI spec.

### DIFF
--- a/doc/integrating_applications/topics/about_api_connectors.adoc
+++ b/doc/integrating_applications/topics/about_api_connectors.adoc
@@ -3,7 +3,9 @@
 
 After you upload an OpenAPI specification to {prodname}, a connector to the REST API
 becomes available. You can select the connector to create
-a REST API client connection, and then add that connection to an integration.
+a REST API client connection. You can then create a new integration and 
+add the REST API client connection, or you can edit an existing integration 
+to add the REST API client connection. 
 
 {prodname} connectors support OAuth 2.0 and HTTP Basic
 Authorization. If access to the REST API requires Transport Layer Security (TLS)

--- a/doc/integrating_applications/topics/creating_api_connectors.adoc
+++ b/doc/integrating_applications/topics/creating_api_connectors.adoc
@@ -18,14 +18,27 @@ displays information about what needs to be corrected. Select a different
 OpenAPI file to upload or click *Cancel*,
 revise the OpenAPI file, and upload the updated file.
 +
-If the specification is valid and complete, {prodname} displays a summary of
-the actions that the connector will provide. This might include errors and
+If the specification is valid, {prodname} displays a summary of
+the actions that the connector provides. This might include errors and
 warnings about the action specifications.
 
-. To revise the OpenAPI file,
-click *Cancel*, revise the OpenAPI file, and upload the updated file.
+. If you are satisfied with the action summary, click *Next*.
 +
-If you are satisfied with the action summary, click *Next*.
+Or, to revise the OpenAPI specification, in the lower right, click *Review/Edit* 
+to open Apicurio Studio. Update the specification as needed. 
+In the upper right, click *Save* to incorporate your updates into the 
+new API client connector. Then click *Next* to continue creating the 
+API client connector. 
++
+For details about using Apicurio Studio, see https://www.apicur.io/. 
+Sometimes, if you provide a URL for the OpenAPI specification, {prodname} 
+can upload it but  cannot open it for editing. Typically, this is caused by 
+settings on the file’s host. To open the specification for editing, 
+{prodname} requires that the file host has:
++
+* An `https` URL. An `http` URL does not work. 
+* Enabled CORS. 
+
 . Indicate the API's security requirements by selecting one of the
 following:
 .. *No Security*
@@ -63,7 +76,9 @@ To override a value obtained from
 the OpenAPI file, edit the field value that you want to change.
 After {prodname} creates a connector,
 you cannot change it. To effect a change, you need to upload an updated
-OpenAPI specification so that {prodname} can create a new connector.
+OpenAPI specification so that {prodname} can create a new connector
+or you can upload the same specification and then edit it in Apicurio Studio. 
+You then continue the process for creating a new API client connector. 
 . When you are satisfied with the connector details, click *Create API Connector*.
 {prodname} displays the new connector with the other connectors. 
 

--- a/doc/integrating_applications/topics/guidelines_for_openapi_specifications.adoc
+++ b/doc/integrating_applications/topics/guidelines_for_openapi_specifications.adoc
@@ -13,11 +13,17 @@ defines the corresponding connection action as typeless. However, in an
 integration, you cannot add a data mapping step immediately before or
 immediately after an API connection that performs a typeless action.
 
-One remedy for this is to add more information to the OpenAPI specification
-before you upload it to {prodname}. Identify the OpenAPI resource operations that
+One remedy for this is to add more information to the OpenAPI specification.
+Identify the OpenAPI resource operations that
 will map to the actions you want the API connection to perform. In the
 OpenAPI specification, ensure that there is a JSON schema that specifies
 each operation's request and response types.
+
+After you upload the specification, {prodname} gives you an opportunity 
+to review and edit it in Apicurio Studio, which is a visual editor for 
+designing APIs based on the OpenAPI specification. You can add more detail, 
+save  your updates, and {prodname} creates an API client connector hat 
+incorporates your updates. 
 
 If the OpenAPI specification for the API declares support for
 `application/json` content type and also `application/xml` content type

--- a/doc/integrating_applications/topics/updating_api_connectors.adoc
+++ b/doc/integrating_applications/topics/updating_api_connectors.adoc
@@ -2,11 +2,15 @@
 = Updating API client connectors
 
 You cannot update an API client connector. If there is
-an update to the API's OpenAPI specification, then you must upload the updated
-OpenAPI specification and create a new API client connector.
+an update to the API's OpenAPI specification, 
+then you must do one of the following:
 
-To update integrations to use connections based on the updated OpenAPI
-specification:
+* Upload the updated OpenAPI specification and create a new API client connector.
+* Upload the out-of-date specification again, update it in Apicurio Studio, 
+and create a new API client connector. 
+
+To update integrations to use connections that are based on 
+the updated OpenAPI specification:
 
 . Create a new API client connector based on the updated OpenAPI specification.
 To easily distinguish between the old connector and the new connector, 


### PR DESCRIPTION
SME review done.
I am merging this so that I can bring it downstream and get the content into the 7.1 staging site for doc. We can still update it based on QE feedback. But need to move this along. 