### PR TITLE
Address problems identified in Issues 3411 and 3412

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -90,6 +90,7 @@
                         [disabled]="!editorHasChanges"
                         [tooltip]="'customizations.api-client-connectors.editor-save-button-tooltip' | synI18n"
                         placement="auto"
+                        container="body"
                         (click)="onDoneEditing()">
                   {{ 'shared.save' | synI18n }}
                 </button>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -49,6 +49,7 @@
                     <input #fileSelect
                       class="api-file-chooser"
                       type="file"
+                      accept="application/json"
                       ng2FileSelect
                       [uploader]="uploader">
                   </p>


### PR DESCRIPTION
- the Save button tooltip in the ApiCurio editor wizard page now displays much nicer
- the file chooser dialog in the upload API now only allows *.json files to be selected
- See #3411 and #3412 