### PR TITLE
feature(upgrade): Adapte templates and operator for referencing a registry

### DIFF
--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -20,9 +20,9 @@
       openshift.io/documentation-url: "https://syndesis.io"
       openshift.io/support-url: "https://access.redhat.com"
   parameters:
-  - name: SYNDESIS_VERSION
-    description: 'The version to upgrade to or "latest" for the newest version'
-    value: latest
+  - name: UPGRADE_REGISTRY
+    description: 'Registry from where to pick up the upgrade pod'
+    value: docker.io
     required: true
   message: |-
     Syndesis upgrade process started
@@ -30,12 +30,12 @@
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-${SYNDESIS_VERSION}
+      name: syndesis-upgrade-{{ Tags.Upgrade }}
     spec:
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade
-        image: {{ Images.SyndesisImagesPrefix }}/{{ Images.Syndesis.Upgrade }}:${SYNDESIS_VERSION}
+        image: ${UPGRADE_REGISTRY}/{{ Images.SyndesisImagesPrefix }}/{{ Images.Syndesis.Upgrade }}:{{ Tags.Upgrade }}
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/install/generator/syndesis-template.go
+++ b/install/generator/syndesis-template.go
@@ -64,6 +64,7 @@ type tags struct {
 	Postgresql string
 	OAuthProxy string
 	Prometheus string
+	Upgrade string
 }
 
 type Context struct {
@@ -144,6 +145,7 @@ func init() {
 	flags.BoolVar(&context.AllowLocalHost, "allow-localhost", false, "Allow localhost")
 	flags.BoolVar(&context.WithDockerImages, "with-docker-images", false, "With docker images")
 	flags.StringVar(&context.Tags.Syndesis, "syndesis-tag", "latest", "Syndesis Image tag to use")
+	flags.StringVar(&context.Tags.Upgrade, "upgrade-tag", "latest", "Syndesis Upgrade version")
 	flags.BoolVar(&context.Oso, "oso", false, "Generate product templates for SO")
 	flags.BoolVar(&context.Ocp, "ocp", false, "Generate product templates for OCP")
 	flags.BoolVar(&context.EarlyAccess, "early-access", false, "Point repositories to early-access repos")

--- a/install/operator/cmd/syndesis-operator/main.go
+++ b/install/operator/cmd/syndesis-operator/main.go
@@ -29,6 +29,8 @@ func main() {
 	printVersion()
 
 	configuration.TemplateLocation = flag.String("template", "/conf/syndesis-template.yml", "Path to template used for installation")
+	configuration.Registry = flag.String("registry", "docker.io", "Registry to use for loading images like the upgrade pod")
+
 	flag.Parse()
 	logrus.Infof("Using template %s", *configuration.TemplateLocation)
 

--- a/install/operator/pkg/syndesis/action/upgrade.go
+++ b/install/operator/pkg/syndesis/action/upgrade.go
@@ -173,7 +173,9 @@ func (a *Upgrade) getUpgradeResources(syndesis *v1alpha1.Syndesis) ([]runtime.Ob
 			OAuthClientSecret: "-",
 		},
 		SyndesisVersion: a.operatorVersion,
+		UpgradeRegistry: configuration.Registry,
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/install/operator/pkg/syndesis/configuration/configuration.go
+++ b/install/operator/pkg/syndesis/configuration/configuration.go
@@ -11,6 +11,9 @@ type SyndesisEnvVar string
 // Location from where the template should be loaded
 var TemplateLocation *string
 
+// Registry for looking up images
+var Registry *string
+
 const (
 	EnvRouteHostname 					SyndesisEnvVar = "ROUTE_HOSTNAME"
 	//EnvOpenshiftMaster 					SyndesisEnvVar = "OPENSHIFT_MASTER"
@@ -42,6 +45,7 @@ const (
 	EnvIntegrationStateCheckInterval SyndesisEnvVar = "INTEGRATION_STATE_CHECK_INTERVAL"
 
 	EnvSyndesisVersion 					SyndesisEnvVar = "SYNDESIS_VERSION"
+	EnvUpgradeRegistry                  SyndesisEnvVar = "UPGRADE_REGISTRY"
 )
 
 type SyndesisEnvVarConfig struct {

--- a/install/operator/pkg/syndesis/template/upgrade.go
+++ b/install/operator/pkg/syndesis/template/upgrade.go
@@ -11,12 +11,13 @@ import (
 )
 
 const (
-	SyndesisUpgrateTemplateName	= "syndesis-upgrade"
+	SyndesisUpgrateTemplateName = "syndesis-upgrade"
 )
 
 type UpgradeParams struct {
 	InstallParams
-	SyndesisVersion		string
+	SyndesisVersion string
+	UpgradeRegistry        *string
 }
 
 func GetUpgradeResources(syndesis *v1alpha1.Syndesis, params UpgradeParams) ([]runtime.RawExtension, error) {
@@ -37,10 +38,10 @@ func GetUpgradeResources(syndesis *v1alpha1.Syndesis, params UpgradeParams) ([]r
 	paramMap := configuration.GetEnvVars(syndesis)
 	paramMap[string(configuration.EnvOpenshiftOauthClientSecret)] = params.OAuthClientSecret
 	paramMap[string(configuration.EnvSyndesisVersion)] = params.SyndesisVersion
+	paramMap[string(configuration.EnvUpgradeRegistry)] = *params.UpgradeRegistry
 
 	return processor.Process(upgrateTempl, paramMap)
 }
-
 
 func findUpgradeTemplate(list []runtime.RawExtension) (*templatev1.Template, error) {
 	for _, object := range list {

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -1621,9 +1621,9 @@ objects:
       openshift.io/documentation-url: "https://syndesis.io"
       openshift.io/support-url: "https://access.redhat.com"
   parameters:
-  - name: SYNDESIS_VERSION
-    description: 'The version to upgrade to or "latest" for the newest version'
-    value: latest
+  - name: UPGRADE_REGISTRY
+    description: 'Registry from where to pick up the upgrade pod'
+    value: docker.io
     required: true
   message: |-
     Syndesis upgrade process started
@@ -1631,12 +1631,12 @@ objects:
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-${SYNDESIS_VERSION}
+      name: syndesis-upgrade-latest
     spec:
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade
-        image: syndesis/syndesis-upgrade:${SYNDESIS_VERSION}
+        image: ${UPGRADE_REGISTRY}/syndesis/syndesis-upgrade:latest
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1617,9 +1617,9 @@ objects:
       openshift.io/documentation-url: "https://syndesis.io"
       openshift.io/support-url: "https://access.redhat.com"
   parameters:
-  - name: SYNDESIS_VERSION
-    description: 'The version to upgrade to or "latest" for the newest version'
-    value: latest
+  - name: UPGRADE_REGISTRY
+    description: 'Registry from where to pick up the upgrade pod'
+    value: docker.io
     required: true
   message: |-
     Syndesis upgrade process started
@@ -1627,12 +1627,12 @@ objects:
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-${SYNDESIS_VERSION}
+      name: syndesis-upgrade-latest
     spec:
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade
-        image: syndesis/syndesis-upgrade:${SYNDESIS_VERSION}
+        image: ${UPGRADE_REGISTRY}/syndesis/syndesis-upgrade:latest
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:


### PR DESCRIPTION
Now the operator can be called with a `-registry <registry>` argument for using that registry when instantiation the upgrade pod

A productised Dockerfile should use this option to point the target registry.

Also, the template generator has an options `--upgrade-tag` to directly specify the upgrade tag.

Fixes #3440