### PR TITLE
Fix for Issue 3459 apicurio - warnings are not updated when changed via gui and saved

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
@@ -170,6 +170,7 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
     // save current state of editor
     const value = this._apiEditor.getValue();
     this.apiDef.spec = value[ 'spec' ]; // used in onCreateComplete
+    this.editorHasChanges = false;
 
     // go back to review step
     this.displayDefinitionEditor = false;
@@ -179,7 +180,10 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
 
     const request = {
       ...this.validationResponse,
-      specificationFile: file
+      specificationFile: file,
+      actionsSummary: {},
+      errors: [],
+      warnings: []
     } as CustomConnectorRequest;
 
     this.apiConnectorStore.dispatch(


### PR DESCRIPTION
- See #3459 
- the problem was that the `CustomConnectorRequest` instance is being reused and all the validation properties were not being cleared before re-validation.
- now clearing out these properties before requesting validation: actionsSummary, errors, and warnings.
- fixed an issue where the `Save` button would be enabled even though there was no change made in the editor. This would happen when the API was changed previously using the editor.