### PR TITLE
fix(server): Notifies of stale integration after connection update

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
@@ -104,4 +104,30 @@ public interface Action extends WithResourceId, WithKind, WithName, WithTags, Wi
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
             : Collections.emptyMap();
     }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another an {@link Action} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    boolean equivalent(Action another);
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/action/ConnectorAction.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/ConnectorAction.java
@@ -17,7 +17,8 @@ package io.syndesis.common.model.action;
 
 import java.util.Collections;
 import java.util.List;
-
+import java.util.Objects;
+import java.util.Optional;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Dependency;
 import io.syndesis.common.model.WithDependencies;
@@ -52,5 +53,64 @@ public interface ConnectorAction extends Action, WithId<ConnectorAction>, WithDe
     }
 
     class Builder extends ImmutableConnectorAction.Builder {
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link ConnectorAction} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    @Override
+    default boolean equivalent(Action another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        if (! (another instanceof ConnectorAction)) {
+            return false;
+        }
+
+        ConnectorAction connectorAction = (ConnectorAction) another;
+
+        ConnectorDescriptor myDescriptor = getDescriptor();
+        ConnectorDescriptor anotherDescriptor = connectorAction.getDescriptor();
+        if (myDescriptor == null) {
+            if (anotherDescriptor != null) {
+                return false;
+            }
+        } else if (! myDescriptor.equivalent(anotherDescriptor)) {
+            return false;
+        }
+
+        return getActionType().equals(another.getActionType())
+                            && Objects.equals(getDescription(), another.getDescription())
+                            && Objects.equals(getPattern(), another.getPattern())
+                            && Objects.equals(getId(), another.getId())
+                            && Objects.equals(getName(), another.getName())
+                            && getTags().equals(another.getTags())
+                            && getMetadata().equals(another.getMetadata());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/action/ConnectorDescriptor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/ConnectorDescriptor.java
@@ -20,10 +20,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.common.model.Split;
 import io.syndesis.common.model.WithConfiguredProperties;
 import io.syndesis.common.model.WithSplit;
 import io.syndesis.common.model.connection.ConfigurationProperty;
@@ -106,5 +108,58 @@ public interface ConnectorDescriptor extends ActionDescriptor, WithConfiguredPro
     @Value.Default
     default List<String> getConnectorCustomizers() {
         return Collections.emptyList();
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link ConnectorDescriptor} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    default boolean equivalent(ConnectorDescriptor another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        //
+        // The json parser appears to create a new empty split object rather than
+        // an empty optional
+        //
+        Split split = getSplit().orElse(new Split.Builder().build());
+        Split anotherSplit = another.getSplit().orElse(new Split.Builder().build());
+
+        return split.equals(anotherSplit)
+                        && Objects.equals(getConnectorId(), another.getConnectorId())
+                        && Objects.equals(getCamelConnectorGAV(), another.getCamelConnectorGAV())
+                        && Objects.equals(getCamelConnectorPrefix(), another.getCamelConnectorPrefix())
+                        && Objects.equals(getComponentScheme(), another.getComponentScheme())
+                        && Objects.equals(getConnectorFactory(), another.getConnectorFactory())
+                        && getConnectorCustomizers().equals(another.getConnectorCustomizers())
+                        && Objects.equals(getInputDataShape(), another.getInputDataShape())
+                        && Objects.equals(getOutputDataShape(), another.getOutputDataShape())
+                        && getPropertyDefinitionSteps().equals(another.getPropertyDefinitionSteps())
+                        && getConfiguredProperties().equals(another.getConfiguredProperties());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/action/StepAction.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/StepAction.java
@@ -17,6 +17,8 @@ package io.syndesis.common.model.action;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.WithId;
+import java.util.Objects;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -46,5 +48,64 @@ public interface StepAction extends Action, WithId<StepAction> {
         STEP,
         BEAN,
         ENDPOINT
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link StepAction} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    @Override
+    default boolean equivalent(Action another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        if (! (another instanceof StepAction)) {
+            return false;
+        }
+
+        StepAction stepAction = (StepAction) another;
+
+        StepDescriptor myDescriptor = getDescriptor();
+        StepDescriptor anotherDescriptor = stepAction.getDescriptor();
+        if (myDescriptor == null) {
+            if (anotherDescriptor != null) {
+                return false;
+            }
+        } else if (! myDescriptor.equivalent(anotherDescriptor)) {
+            return false;
+        }
+
+        return getActionType().equals(another.getActionType())
+                            && Objects.equals(getDescription(), another.getDescription())
+                            && Objects.equals(getPattern(), another.getPattern())
+                            && Objects.equals(getId(), another.getId())
+                            && Objects.equals(getName(), another.getName())
+                            && getTags().equals(another.getTags())
+                            && getMetadata().equals(another.getMetadata());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/action/StepDescriptor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/StepDescriptor.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -93,4 +95,45 @@ public interface StepDescriptor extends ActionDescriptor, Serializable {
     String getEntrypoint();
 
     String getResource();
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link StepDescriptor} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    default boolean equivalent(StepDescriptor another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        return Objects.equals(getKind(), another.getKind())
+                        && Objects.equals(getEntrypoint(), another.getEntrypoint())
+                        && Objects.equals(getResource(), another.getResource())
+                        && Objects.equals(getInputDataShape(), another.getInputDataShape())
+                        && Objects.equals(getOutputDataShape(), another.getOutputDataShape())
+                        && getPropertyDefinitionSteps().equals(another.getPropertyDefinitionSteps());
+    }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/bulletin/LeveledMessage.java
@@ -43,6 +43,8 @@ public interface LeveledMessage extends WithMetadata {
         SYNDESIS008, // Validation Error
         SYNDESIS009, // Connection has been deleted
         SYNDESIS010, // Multiple extension installed
+        SYNDESIS011, // Integration is out-of-date with its connections and should be re-edited
+        SYNDESIS012, // Published integration is stale and should be republished
     }
 
     enum Level {

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/Connection.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/Connection.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.common.model.connection;
 
+import java.util.Objects;
+import java.util.Optional;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithId;
@@ -44,5 +46,63 @@ public interface Connection extends WithId<Connection>, ConnectionBase {
 
     default Builder builder() {
         return new Builder().createFrom(this);
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link Connection} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    default boolean equivalent(Connection another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        Connector myConnector = getConnector().orElse(null);
+        Connector anotherConnector = another.getConnector().orElse(null);
+
+        if (myConnector == null) {
+            if (anotherConnector != null) {
+                return false;
+            }
+        } else if (! myConnector.equivalent(anotherConnector)) {
+            return false;
+        }
+
+        return Objects.equals(getId(), another.getId())
+            && Objects.equals(getOrganization(), another.getOrganization())
+            && Objects.equals(getOrganizationId(), another.getOrganizationId())
+            && Objects.equals(getConnectorId(), another.getConnectorId())
+            && getOptions().equals(another.getOptions())
+            && Objects.equals(getIcon(), another.getIcon())
+            && Objects.equals(getDescription(), another.getDescription())
+            && Objects.equals(getUserId(), another.getUserId())
+            && isDerived() == another.isDerived()
+            && getTags().equals(another.getTags())
+            && Objects.equals(getName(), another.getName())
+            && getConfiguredProperties().equals(another.getConfiguredProperties());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import org.immutables.value.Value;
 import io.syndesis.common.model.ToJson;
 import io.syndesis.common.model.WithConfiguredProperties;
 import io.syndesis.common.model.WithName;
@@ -61,5 +62,14 @@ public interface ConnectionBase extends WithResourceId, WithTags, WithName, With
      */
     boolean isDerived();
 
+    /**
+     * Provides number of integrations using this connection
+     * <p>
+     * Note:
+     * Excluded from {@link #hashCode()} and {@link #equals(Object)}
+     *
+     * @return count of integrations
+     */
+    @Value.Auxiliary
     OptionalInt getUses();
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/extension/Extension.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/extension/Extension.java
@@ -18,6 +18,7 @@ package io.syndesis.common.model.extension;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import javax.validation.constraints.NotNull;
@@ -93,6 +94,15 @@ public interface Extension extends WithId<Extension>, WithActions<Action>, WithN
 
     String getDescription();
 
+    /**
+     * Provides number of integrations using this connection
+     * <p>
+     * Note:
+     * Excluded from {@link #hashCode()} and {@link #equals(Object)}
+     *
+     * @return count of integrations
+     */
+    @Value.Auxiliary
     OptionalInt getUses();
 
     Optional<String> getUserId();
@@ -122,5 +132,69 @@ public interface Extension extends WithId<Extension>, WithActions<Action>, WithN
     }
 
     class Builder extends ImmutableExtension.Builder {
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link Extension} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    @SuppressWarnings("PMD.NPathComplexity")
+    default boolean equivalent(Extension another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        List<Action> myActions = getActions();
+        if (myActions == null) {
+            if (another.getActions() != null) {
+                return false;
+            }
+        } else {
+            for (Action myAction : myActions) {
+                Action anotherAction = another.findActionById(myAction.getId().get()).orElse(null);
+                if (! myAction.equivalent(anotherAction)) {
+                    return false;
+                }
+            }
+        }
+
+        return Objects.equals(getExtensionId(), another.getExtensionId())
+                        && Objects.equals(getSchemaVersion(), another.getSchemaVersion())
+                        && Objects.equals(getStatus(), another.getStatus())
+                        && Objects.equals(getIcon(), another.getIcon())
+                        && Objects.equals(getDescription(), another.getDescription())
+                        && Objects.equals(getUserId(), another.getUserId())
+                        && Objects.equals(getExtensionType(), another.getExtensionType())
+                        && Objects.equals(getId(), another.getId())
+                        && Objects.equals(getName(), another.getName())
+                        && getTags().equals(another.getTags())
+                        && getProperties().equals(another.getProperties())
+                        && getConfiguredProperties().equals(another.getConfiguredProperties())
+                        && getDependencies().equals(another.getDependencies())
+                        && getMetadata().equals(another.getMetadata());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Integration.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Integration.java
@@ -15,13 +15,16 @@
  */
 package io.syndesis.common.model.integration;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.immutables.value.Value;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithId;
+import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.validation.UniquenessRequired;
 import io.syndesis.common.model.validation.integration.NoDuplicateIntegration;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
@@ -36,5 +39,77 @@ public interface Integration extends WithId<Integration>, IntegrationBase {
 
     class Builder extends ImmutableIntegration.Builder {
         // allow access to ImmutableIntegration.Builder
+    }
+
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     *<p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link Integration} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    @SuppressWarnings("PMD.NPathComplexity")
+    default boolean equivalent(Integration another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        List<Connection> myConnections = getConnections();
+        if (myConnections == null) {
+            if (another.getConnections() != null) {
+                return false;
+            }
+        } else {
+            for (Connection myConnection : myConnections) {
+                Connection anotherConnection = another.findConnectionById(myConnection.getId().get()).orElse(null);
+                if (! myConnection.equivalent(anotherConnection)) {
+                    return false;
+                }
+            }
+        }
+
+        List<Step> mySteps = getSteps();
+        if (mySteps == null) {
+            if (another.getSteps() != null) {
+                return false;
+            }
+        } else {
+            for (Step myStep : mySteps) {
+                Step anotherStep = another.findStepById(myStep.getId().get()).orElse(null);
+                if (! myStep.equivalent(anotherStep)) {
+                    return false;
+                }
+            }
+        }
+
+        return Objects.equals(getId(), another.getId())
+                            && isDeleted() == another.isDeleted()
+                            && getResources().equals(another.getResources())
+                            && Objects.equals(getScheduler(), another.getScheduler())
+                            && Objects.equals(getDescription(), another.getDescription())
+                            && getTags().equals(another.getTags())
+                            && Objects.equals(getName(), another.getName());
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.ResourceIdentifier;
 import io.syndesis.common.model.ToJson;
+import io.syndesis.common.model.WithId;
 import io.syndesis.common.model.WithModificationTimestamps;
 import io.syndesis.common.model.WithName;
 import io.syndesis.common.model.WithResourceId;
@@ -77,5 +78,29 @@ public interface IntegrationBase extends WithResourceId, WithVersion, WithModifi
             .map(a -> a.getDescriptor().getConnectorId())//
             .filter(Objects::nonNull)//
             .collect(Collectors.toSet());
+    }
+
+    default Optional<Connection> findConnectionById(String connectionId) {
+        if (getConnections() == null) {
+            return Optional.empty();
+        }
+
+        return getConnections().stream()
+            .filter(WithId.class::isInstance)
+            .filter(connection -> connection.getId().isPresent())
+            .filter(connection -> connectionId.equals(connection.getId().get()))
+            .findFirst();
+    }
+
+    default Optional<Step> findStepById(String stepId) {
+        if (getSteps() == null) {
+            return Optional.empty();
+        }
+
+        return getSteps().stream()
+            .filter(WithId.class::isInstance)
+            .filter(step -> step.getId().isPresent())
+            .filter(step -> stepId.equals(step.getId().get()))
+            .findFirst();
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
@@ -16,8 +16,9 @@
 package io.syndesis.common.model.integration;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
-
+import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
@@ -28,7 +29,6 @@ import io.syndesis.common.model.WithMetadata;
 import io.syndesis.common.model.action.Action;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.extension.Extension;
-import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = Step.Builder.class)
@@ -57,5 +57,77 @@ public interface Step extends WithId<Step>, WithConfiguredProperties, WithDepend
 
     class Builder extends ImmutableStep.Builder {
         // allow access to ImmutableStep.Builder
+    }
+
+    /**
+     * A weaker form of equality to {@link #equals(Object)}.
+     * Compares a defining subset of properties to {code}another{code}'s
+     * and in turn tests those properties for equivalence.
+     *<p>
+     * An equals test of a null field and an empty {@link Optional}
+     * will return false whilst they are equivalent so this method will return true.
+     * <p>
+     * Items not tested include:
+     * <ul>
+     * <li>Version id -
+     *        this id can be updated yet the rest of the object is still unchanged;
+     * <li>Updated Date -
+     *        an object can be modified then reverted yet the updated value will be different.
+     * </ul>
+     * <p>
+     * Note
+     * Method can result in 2 instances being equivalent even though some
+     * properties are different. Thus, this should only be used in appropriate
+     * situations.
+     *
+     * @param another a {@link Step} to compare with
+     * @return true if this is equivalent to {code}another{code}, false otherwise
+     */
+    @SuppressWarnings("PMD.NPathComplexity")
+    default boolean equivalent(Step another) {
+        if (this == another) {
+            return true;
+        }
+
+        if (another == null) {
+            return false;
+        }
+
+        Connection myConnection = getConnection().orElse(null);
+        Connection anotherConnection = another.getConnection().orElse(null);
+        if (myConnection == null) {
+            if (anotherConnection != null) {
+                return false;
+            }
+        } else if (! myConnection.equivalent(anotherConnection)) {
+            return false;
+        }
+
+        Extension myExtension = getExtension().orElse(null);
+        Extension anotherExtension = another.getExtension().orElse(null);
+        if (myExtension == null) {
+            if (anotherExtension != null) {
+                return false;
+            }
+        } else if (! myExtension.equivalent(anotherExtension)) {
+            return false;
+        }
+
+        Action myAction = getAction().orElse(null);
+        Action anotherAction = another.getAction().orElse(null);
+        if (myAction == null) {
+            if (anotherAction != null) {
+                return false;
+            }
+        } else if (! myAction.equivalent(anotherAction)) {
+            return false;
+        }
+
+        return Objects.equals(getStepKind(), another.getStepKind())
+            && Objects.equals(getName(), another.getName())
+            && Objects.equals(getId(), another.getId())
+            && getConfiguredProperties().equals(another.getConfiguredProperties())
+            && getDependencies().equals(another.getDependencies())
+            && getMetadata().equals(another.getMetadata());
     }
 }

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.update.controller.bulletin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.Validator;
+import org.junit.Test;
+import io.syndesis.common.model.ChangeEvent;
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.action.Action.Pattern;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.bulletin.IntegrationBulletinBoard;
+import io.syndesis.common.model.bulletin.LeveledMessage;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.common.model.integration.IntegrationDeploymentState;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.server.dao.manager.DataManager;
+
+public class IntegrationUpdateHandlerTest {
+
+    private static final String SQL_CONNECTOR_ACTION_ID = "sql-connector";
+
+    private static final String CONNECTION_ID = "5";
+
+    private static final String CONNECTOR_ID = "sql";
+
+    private static final String SQL_CONNECTOR_NAME = "SQL Connector";
+
+    private static final long INTEGRATION_CREATED_AT = 1533024000000L;  // 31/07/2018 09:00:00
+
+    private static final long INTEGRATION_UPDATED_AT = 1533024600000L; // 31/07/2018 09:10:00
+
+    private static final long DEPLOYMENT_CREATED_AT = 1533027600000L; // 31/07/2018 10:00:00
+
+    private static final long DEPLOYMENT_UPDATED_AT = 1533028200000L; // 31/07/2018 10:10:00
+
+    final DataManager dataManager = mock(DataManager.class);
+
+    final Validator validator = mock(Validator.class);
+
+    private Connector newSqlConnector() {
+        ConnectorAction action1 = new ConnectorAction.Builder()
+                                    .id(SQL_CONNECTOR_ACTION_ID)
+                                    .actionType("connector")
+                                    .description("Invoke SQL to obtain ...")
+                                    .name("Invoke SQL")
+                                    .addTag("dynamic")
+                                    .pattern(Pattern.To)
+                                    .build();
+
+        return new Connector.Builder()
+                                   .id(CONNECTOR_ID)
+                                   .name(SQL_CONNECTOR_NAME)
+                                   .addAction(action1)
+                                   .build();
+    }
+
+    private Connection newSqlConnection(Connector connector) {
+        assertNotNull(connector);
+
+        Map<String, String> configuredProperties = new HashMap<>();
+        configuredProperties.put("password", "password");
+        configuredProperties.put("user", "developer");
+        configuredProperties.put("schema", "sampledb");
+        configuredProperties.put("url",  "jdbc:postgresql://syndesis-db:5432/sampledb");
+
+        return new Connection.Builder()
+                                .id(CONNECTION_ID)
+                                .addTag("dynamic")
+                                .configuredProperties(configuredProperties)
+                                .connector(connector)
+                                .connectorId("sql")
+                                .description("Connection to Sampledb")
+                                .icon("fa-database")
+                                .name("PostgresDB")
+                                .build();
+    }
+
+    private Step newSqlStep(Connection connection) {
+        ConnectorAction action = new ConnectorAction.Builder()
+                                                            .actionType("connector")
+                                                            .id(SQL_CONNECTOR_ACTION_ID)
+                                                            .name("Invoke SQL")
+                                                            .pattern(Pattern.To)
+                                                            .addTag("dynamic")
+                                                            .build();
+
+        return new Step.Builder()
+                        .connection(connection)
+                        .id("SomeLongId")
+                        .action(action)
+                        .build();
+    }
+
+    private Integration newSqlIntegration(String id, Connection connection) {
+        return new Integration.Builder()
+            .id(id)
+            .name(id)
+            .addStep(newSqlStep(connection))
+            .createdAt(INTEGRATION_CREATED_AT)
+            .updatedAt(INTEGRATION_UPDATED_AT)
+            .build();
+    }
+
+    private IntegrationDeployment newIntegrationDeployment(String id, int version, Integration integration, boolean published) {
+        Map<String, String> stepsDone = new HashMap<>();
+        stepsDone.put("buildv1", "ip:port/syndesis/buildName");
+        stepsDone.put("deploy", "2");
+
+        IntegrationDeployment.Builder builder = new IntegrationDeployment.Builder()
+                        .id(id + ":" + version)
+                        .createdAt(DEPLOYMENT_CREATED_AT)
+                        .spec(integration)
+                        .integrationId(Optional.of(id))
+                        .stepsDone(stepsDone)
+                        .targetState(IntegrationDeploymentState.Published)
+                        .userId("developer")
+                        .version(version)
+                        .updatedAt(DEPLOYMENT_UPDATED_AT);
+
+        if (published)
+            builder = builder.currentState(IntegrationDeploymentState.Published);
+
+        return builder.build();
+    }
+
+    /**
+     * * Connection is created
+     * * Integration is created from Connection
+     * * Deployment is created from Integration
+     * * The connection in all the above remains equivalent
+     */
+    @Test
+    public void shouldComputeSameIntegrationAndDeployment() {
+        final IntegrationUpdateHandler updateHandler = new IntegrationUpdateHandler(dataManager, null, validator);
+
+        // integration
+        String id = "MyTestIntegration-x123456";
+
+        Connector sqlConnector = newSqlConnector();
+
+        Connection sqlConnection = newSqlConnection(sqlConnector);
+        Integration sqlIntegration = newSqlIntegration(id, sqlConnection);
+        IntegrationDeployment integrationDeployment = newIntegrationDeployment(id, 1, sqlIntegration, true);
+
+        // Returns the unchanged sql connection
+        when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(sqlConnection);
+        when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(sqlConnector);
+
+        // Returns the integration deployment
+        when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
+
+        Set<String> ids = Collections.singleton(id);
+        when(dataManager.fetchIdsByPropertyValue(IntegrationDeployment.class, "integrationId", id)).thenReturn(ids);
+
+        // Returns the unchanged integration
+        when(dataManager.fetchAll(Integration.class))
+                            .thenReturn(new ListResult.Builder<Integration>()
+                                                                .addItem(sqlIntegration).build());
+
+        ChangeEvent event = new ChangeEvent.Builder()
+                                                                    .action("updated")
+                                                                    .id(CONNECTION_ID)
+                                                                    .kind("connection")
+                                                                    .build();
+
+        List<IntegrationBulletinBoard> boards = updateHandler.compute(event);
+        assertFalse(boards.isEmpty());
+        assertEquals(1, boards.size());
+
+        IntegrationBulletinBoard board = boards.get(0);
+        assertTrue(board.getMessages().isEmpty());
+    }
+
+    /**
+     * Connection is modified after an integration is drafted and deployed
+     * * DataManager returns the modified connection
+     * * DataManager returns the original integration
+     * * DataManager returns the original deployment
+     *
+     * Both the integration and deployment and computed to be stale
+     */
+    @Test
+    public void shouldComputeStaleIntegrationAndDeployment() {
+        final IntegrationUpdateHandler updateHandler = new IntegrationUpdateHandler(dataManager, null, validator);
+
+        // integration
+        String id = "MyTestIntegration-x123456";
+        Connector sqlConnector = newSqlConnector();
+        Connection sqlConnection = newSqlConnection(sqlConnector);
+        Integration sqlIntegration = newSqlIntegration(id, sqlConnection);
+        IntegrationDeployment integrationDeployment = newIntegrationDeployment(id, 1, sqlIntegration, true);
+
+        String connectorNewName = SQL_CONNECTOR_NAME + "_new";
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("blah", "blah");
+
+        Connector modSqlConnector = new Connector.Builder()
+                                                                                .createFrom(sqlConnector)
+                                                                                .configuredProperties(properties)
+                                                                                .name(connectorNewName)
+                                                                                .build();
+
+        assertFalse(sqlConnector.equivalent(modSqlConnector));
+
+        Connection modSqlConnection = new Connection.Builder()
+                                                                                .createFrom(sqlConnection)
+                                                                                .connector(modSqlConnector)
+                                                                                .build();
+
+        assertNotEquals(sqlConnection, modSqlConnection);
+
+        // Returns the changed sql connection
+        when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
+        when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
+
+        // Returns the integration deployment
+        when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
+
+        Set<String> ids = Collections.singleton(id);
+        when(dataManager.fetchIdsByPropertyValue(IntegrationDeployment.class, "integrationId", id)).thenReturn(ids);
+
+        // Returns the ORIGINAL integration
+        when(dataManager.fetchAll(Integration.class))
+                            .thenReturn(new ListResult.Builder<Integration>()
+                                                                .addItem(sqlIntegration).build());
+
+        ChangeEvent event = new ChangeEvent.Builder()
+                                                                    .action("updated")
+                                                                    .id(CONNECTION_ID)
+                                                                    .kind("connection")
+                                                                    .build();
+
+        List<IntegrationBulletinBoard> boards = updateHandler.compute(event);
+        assertFalse(boards.isEmpty());
+        assertEquals(1, boards.size());
+
+        IntegrationBulletinBoard board = boards.get(0);
+        List<LeveledMessage> messages = board.getMessages();
+        assertFalse(messages.isEmpty());
+        assertEquals(2, messages.size());
+
+        messages.forEach(message -> {
+            switch (message.getCode()) {
+                case SYNDESIS011:
+                case SYNDESIS012:
+                    break;
+                default:
+                    fail("Expecting syndesis codes 11 & 12 only");
+            }
+        });
+    }
+
+    /**
+     * Connection is modified after an integration is drafted and deployed
+     * * DataManager returns the modified connection
+     * * DataManager returns the modified integration
+     * * DataManager returns the original deployment
+     *
+     * Only the deployment is stale while the modified integration is fine.
+     */
+    @Test
+    public void shouldComputeStaleDeploymentOnly() {
+        final IntegrationUpdateHandler updateHandler = new IntegrationUpdateHandler(dataManager, null, validator);
+
+        // integration
+        String id = "MyTestIntegration-x123456";
+        Connector sqlConnector = newSqlConnector();
+        Connection sqlConnection = newSqlConnection(sqlConnector);
+        Integration sqlIntegration = newSqlIntegration(id, sqlConnection);
+        IntegrationDeployment integrationDeployment = newIntegrationDeployment(id, 1, sqlIntegration, true);
+
+        String connectorNewName = SQL_CONNECTOR_NAME + "_new";
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("blah", "blah");
+
+        Connector modSqlConnector = new Connector.Builder()
+                                                                                .createFrom(sqlConnector)
+                                                                                .configuredProperties(properties)
+                                                                                .name(connectorNewName)
+                                                                                .build();
+
+        assertFalse(sqlConnector.equivalent(modSqlConnector));
+
+        Connection modSqlConnection = new Connection.Builder()
+                                                                                .createFrom(sqlConnection)
+                                                                                .connector(modSqlConnector)
+                                                                                .build();
+
+        assertNotEquals(sqlConnection, modSqlConnection);
+
+        Step modStep = new Step.Builder()
+                                          .createFrom(sqlIntegration.getSteps().get(0))
+                                          .connection(modSqlConnection)
+                                          .build();
+
+        Integration modSqlIntegration = new Integration.Builder()
+                                                                                .createFrom(sqlIntegration)
+                                                                                .steps(Collections.singletonList(modStep))
+                                                                                .build();
+
+        assertFalse(sqlIntegration.equivalent(modSqlIntegration));
+
+        // Returns the changed sql connection
+        when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
+        when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
+
+        // Returns the integration deployment
+        when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
+
+        Set<String> ids = Collections.singleton(id);
+        when(dataManager.fetchIdsByPropertyValue(IntegrationDeployment.class, "integrationId", id)).thenReturn(ids);
+
+        // Returns the MODIFIED integration
+        when(dataManager.fetchAll(Integration.class))
+                            .thenReturn(new ListResult.Builder<Integration>()
+                                                                .addItem(modSqlIntegration).build());
+
+        ChangeEvent event = new ChangeEvent.Builder()
+                                                                    .action("updated")
+                                                                    .id(CONNECTION_ID)
+                                                                    .kind("connection")
+                                                                    .build();
+
+        List<IntegrationBulletinBoard> boards = updateHandler.compute(event);
+        assertFalse(boards.isEmpty());
+        assertEquals(1, boards.size());
+
+        IntegrationBulletinBoard board = boards.get(0);
+        List<LeveledMessage> messages = board.getMessages();
+        assertFalse(messages.isEmpty());
+        assertEquals(1, messages.size());
+
+        messages.forEach(message -> {
+            switch (message.getCode()) {
+                case SYNDESIS012:
+                    break;
+                default:
+                    fail("Expecting syndesis code 12 only");
+            }
+        });
+    }
+
+    /**
+     * connection is updated in the integration after a deployment is created but not published
+     */
+    @Test
+    public void shouldComputeComparisonForModifiedIntegrationAndUnpubishedDeployment() {
+        final IntegrationUpdateHandler updateHandler = new IntegrationUpdateHandler(dataManager, null, validator);
+
+        // integration
+        String id = "MyTestIntegration-x123456";
+        Connector sqlConnector = newSqlConnector();
+        Connection sqlConnection = newSqlConnection(sqlConnector);
+        Integration sqlIntegration = newSqlIntegration(id, sqlConnection);
+        IntegrationDeployment integrationDeployment = newIntegrationDeployment(id, 1, sqlIntegration, false);
+
+        String connectorNewName = SQL_CONNECTOR_NAME + "_new";
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("blah", "blah");
+
+        Connector modSqlConnector = new Connector.Builder()
+                                                                                .createFrom(sqlConnector)
+                                                                                .configuredProperties(properties)
+                                                                                .name(connectorNewName)
+                                                                                .build();
+
+        assertFalse(sqlConnector.equivalent(modSqlConnector));
+
+        Connection modSqlConnection = new Connection.Builder()
+                                                                                .createFrom(sqlConnection)
+                                                                                .connector(modSqlConnector)
+                                                                                .build();
+
+        assertFalse(sqlConnection.equivalent(modSqlConnection));
+
+        Step modStep = new Step.Builder()
+                                          .createFrom(sqlIntegration.getSteps().get(0))
+                                          .connection(modSqlConnection)
+                                          .build();
+
+        Integration modSqlIntegration = new Integration.Builder()
+                                                                                .createFrom(sqlIntegration)
+                                                                                .steps(Collections.singletonList(modStep))
+                                                                                .build();
+
+        assertFalse(sqlIntegration.equivalent(modSqlIntegration));
+
+        // Returns the changed sql connection
+        when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
+        when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
+
+        // Returns the integration deployment
+        when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
+
+        Set<String> ids = Collections.singleton(id);
+        when(dataManager.fetchIdsByPropertyValue(IntegrationDeployment.class, "integrationId", id)).thenReturn(ids);
+
+        // Returns the changed integration
+        when(dataManager.fetchAll(Integration.class))
+                            .thenReturn(new ListResult.Builder<Integration>()
+                                                                .addItem(modSqlIntegration).build());
+
+        ChangeEvent event = new ChangeEvent.Builder()
+                                                                    .action("updated")
+                                                                    .id(CONNECTION_ID)
+                                                                    .kind("connection")
+                                                                    .build();
+
+        List<IntegrationBulletinBoard> boards = updateHandler.compute(event);
+        assertFalse(boards.isEmpty());
+        assertEquals(1, boards.size());
+
+        //
+        // Will not compute differences for the deployment since it is unpublished
+        //
+        IntegrationBulletinBoard board = boards.get(0);
+        List<LeveledMessage> messages = board.getMessages();
+        assertTrue(messages.isEmpty());
+    }
+}

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -223,7 +223,9 @@
       "syndesis007": "Secrets for this connection need to be updated",
       "syndesis008": "There has been a validation error",
       "syndesis009": "A connection has been deleted from this integration",
-      "syndesis010": "Multiple extensions installed"
+      "syndesis010": "Multiple extensions installed",
+      "syndesis011": "A connection associated with this integration has been modified. To incorporate the changes, please edit the integration.",
+      "syndesis012": "The published integration has become obsolete and its recommended it should be republished."
     },
     "shared": {
       "home": "Home",


### PR DESCRIPTION
 When a connection is modified, checks are performed comparing the new
 connection against the cached versions inside any draft integrations and
 deployed integrations. If an integration is found to not be equivalent,
 ie. its metadata is out-of-date, then a message is logged accordingly.

 * app/common/model...
  * Adds default equivalence methods to model interfaces that test only
    selected properties of instances. Thus, weaker than equality but does
    not produce irritating false-positives.

 * app/common/model.../ConnectionBase
 * app/common/model.../Connector
 * app/common/model.../Extension
  * Adds the Version.Auxiliary annotation to certain methods. This stops
    them from being added, by Immutables library, to hashcode and equals
    methods. The properties behind these methods are only populated on
    augmentation by the REST API hence are not critical to the object and
    including them means they always fail equality checks with the version
    of the same object fetched from the DataManager.

 * IntegrationUpdateHandler
  * On update of a connection, compares the connection to both draft and
    deployed integrations.

 * IntegrationUpdateHandlerTest
  * Provides testing for use-cases when a connection may be modified

Fixes #1032