### PR TITLE
chore: Update to AtlasMap 1.36.0

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <camel.version>2.21.0.fuse-720007</camel.version>
-    <atlasmap.version>1.35.7</atlasmap.version>
+    <atlasmap.version>1.36.0</atlasmap.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,7 +37,7 @@
     <syndesis.version>${project.version}</syndesis.version>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>1.35.7</atlasmap.version>
+    <atlasmap.version>1.36.0</atlasmap.version>
     <camel-atlasmap.version>${atlasmap.version}</camel-atlasmap.version>
 
     <!-- Image names -->

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser": "^6.0.3",
     "@angular/platform-browser-dynamic": "^6.0.3",
     "@angular/router": "^6.0.3",
-    "@atlasmap/atlasmap-data-mapper": "1.35.7",
+    "@atlasmap/atlasmap-data-mapper": "1.36.0",
     "@ng-dynamic-forms/core": "^5.4.6",
     "@ngrx/effects": "^6.0.1",
     "@ngrx/store": "^6.0.1",

--- a/app/ui/src/config.json.example
+++ b/app/ui/src/config.json.example
@@ -17,7 +17,7 @@
     "baseJavaInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "http://localhost:8080/api/v1/atlas/json/",
-    "disableMappingPreviewMode": true,
+    "disableMappingPreviewMode": false,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSources": false,

--- a/app/ui/src/config.json.minishift
+++ b/app/ui/src/config.json.minishift
@@ -22,7 +22,7 @@
     "baseJavaInspectionServiceUrl": "/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "/api/v1/atlas/json/",
-    "disableMappingPreviewMode": true,
+    "disableMappingPreviewMode": false,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSingleSource": false,

--- a/app/ui/src/config.json.staging
+++ b/app/ui/src/config.json.staging
@@ -20,7 +20,7 @@
     "baseJavaInspectionServiceUrl": "/api/v1/atlas/java/",
     "baseXMLInspectionServiceUrl": "/api/v1/atlas/xml/",
     "baseJSONInspectionServiceUrl": "/api/v1/atlas/json/",
-    "disableMappingPreviewMode": true,
+    "disableMappingPreviewMode": false,
     "discardNonMockSources": false,
     "addMockJSONMappings": false,
     "addMockJavaSingleSource": false,

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -191,9 +191,9 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap-data-mapper@1.35.7":
-  version "1.35.7"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.35.7.tgz#54144eaaf523774ac1069d1d24dbf9ea56b5a0e0"
+"@atlasmap/atlasmap-data-mapper@1.36.0":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.36.0.tgz#53e5d84cb2b77d2acc9c854db1eb898f63a0e790"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Contains:
* Data Preview with final design (atlasmap/atlasmap#451)
* Support receiving FieldActions metadata from outside (atlasmap/atlasmap#483)
* Create GenerateFieldActionsMojo (atlasmap/atlasmap#482)
* bug fixes
  * atlasmap/atlasmap#544
  * atlasmap/atlasmap#495
  * atlasmap/atlasmap#375
  * atlasmap/atlasmap#515
  * atlasmap/atlasmap#521
  * atlasmap/atlasmap#491