### PR TITLE
Fix #3515: do not override command from operator image

### DIFF
--- a/install/operator/deploy/syndesis-operator.yml
+++ b/install/operator/deploy/syndesis-operator.yml
@@ -176,8 +176,6 @@ spec:
       containers:
         - name: syndesis-operator
           image: ' '
-          command:
-          - syndesis-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Fix #3515.
Sync dev master branch (only, no need to sync 1.4 as the file is not used directly) with changes in fuse-online-install: https://github.com/syndesisio/fuse-online-install/commit/37e9d548ac56ee37cfbb876d136652f0b533e9b0