### PR TITLE
fix(connector): set exchange if missing

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
@@ -22,6 +22,7 @@ import io.syndesis.integration.runtime.logging.IntegrationLoggingConstants;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.camel.impl.MessageSupport;
 
 /**
  * Used to capture the out messages of processors with configured ids.  The messages are placed into
@@ -39,6 +40,9 @@ public class OutMessageCaptureProcessor implements Processor {
         if (id != null) {
             Message copy = message.copy();
             Map<String, Message> outMessagesMap = getCapturedMessageMap(exchange);
+            if (copy instanceof MessageSupport && copy.getExchange() == null) {
+                ((MessageSupport) copy).setExchange(message.getExchange());
+            }
 
             outMessagesMap.put(id, copy);
         }


### PR DESCRIPTION
When a copy of the Camel message is created some implementations of
`Message` don't copy over the `Exchange`; without `Exchange` set on the
message type conversion can't work.

This sets the `Exchange` from the original message on the copy so that
type conversion is possible.

Fixes #3382