### PR TITLE
user doc: Tweaks to tutorials to make them easier to use

### DIFF
--- a/doc/tutorials/topics/amq2api_choose_start.adoc
+++ b/doc/tutorials/topics/amq2api_choose_start.adoc
@@ -14,6 +14,8 @@ to receive messages from the queue you specify.
 the name of the queue to obtain data from.
 . Click in the *Destination Type* field and select *Queue*.
 . Leave the other fields blank.
+. Click *Next*. {prodname} prompts you to specify the output data type. 
+This is not needed for this sample integration. 
 . Click *Done* to add the start connection to the integration.
 
 After connecting to AMQ, the integration watches for

--- a/doc/tutorials/topics/amq2api_intro.adoc
+++ b/doc/tutorials/topics/amq2api_intro.adoc
@@ -20,6 +20,9 @@ and extending {prodname} by leading you through the procedures for:
 
 {prodname} provides the extension file and the OpenAPI file.
 
+To create this integration, you must be logged in to {prodname}.
+See <<logging-in-and-out>>. 
+
 To implement the AMQ to REST API sample integration, the main steps are:
 
 . <<amq2api-create-amq-connection>>

--- a/doc/tutorials/topics/amq2api_start_the_broker.adoc
+++ b/doc/tutorials/topics/amq2api_start_the_broker.adoc
@@ -1,10 +1,12 @@
 [id='amq2api-start-the-broker']
 = Start the provided AMQ broker
+:linkattrs:
 
 To start the AMQ broker:
 
-. In a browser, go to the OpenShift Web Console at
-https://console.fuse-ignite.openshift.com/console/. Your installation of
+. In a browser, go to the 
+https://console.fuse-ignite.openshift.com/console/[OpenShift Web Console, window="_blank"]. 
+Your installation of
 {prodname} runs on OpenShift Online.
 
 . In the console, click the name of your {prodname} project, which is

--- a/doc/tutorials/topics/comparison_of_sample_integrations.adoc
+++ b/doc/tutorials/topics/comparison_of_sample_integrations.adoc
@@ -1,15 +1,15 @@
 [id='comparison-of-sample-integrations']
-= Comparison of sample integrations
+= Choose the sample integration to create first
 
 You can create the sample integrations in any order. To help you decide
 which one to try first, the following table compares them.
 
 [cols="4*"]
 |===
-|*Comparison Point*
-|*Twitter to Salesforce*
-|*Salesforce to Database*
-|*AMQ to REST API*
+|&nbsp;
+|<<twitter-to-salesforce,Twitter to Salesforce>>
+|<<salesforce-to-db,Salesforce to Database>>
+|<<amq-to-rest-api,AMQ to REST API>>
 
 |Average time to complete
 |25 minutes. This includes the time needed to obtain Twitter and Salesforce accounts.

--- a/doc/tutorials/topics/sf2db_prereqs.adoc
+++ b/doc/tutorials/topics/sf2db_prereqs.adoc
@@ -7,3 +7,6 @@ This account must have Salesforce API access, which is available in a
 Salesforce Enterprise account or a Salesforce Developer account. To obtain
 a free developer account, visit https://developer.salesforce.com/signup.
 It takes less than two minutes to obtain a Salesforce account.
+
+Also, you must be logged in to your {prodname} environment. 
+See <<logging-in-and-out>>.

--- a/doc/tutorials/topics/t2sf_prereqs.adoc
+++ b/doc/tutorials/topics/t2sf_prereqs.adoc
@@ -15,6 +15,8 @@ Salesforce Enterprise account or a Salesforce Developer account. To obtain
 a free developer account, visit https://developer.salesforce.com/signup.
 It takes less than two minutes to obtain a Salesforce account.
 
+* You must be logged in to your {prodname} environment. See <<logging-in-and-out>>. 
+
 ////
 * Add the `TwitterScreenName` custom field to the Salesforce
 contact object. See the


### PR DESCRIPTION
Added a prereq to each tutorial that you must have logged in to Syndesis.
Make the tutorial names links in the comparison.
Updates some headers to clarify content. 
Tried to create one link that would open in a new tab. I don't expect this to work. This link is in the AMQ to REST API tutorial, Start the broker, topic. 