### PR TITLE
fix: remove the workaround to fetch a remote OpenAPI file

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -51,7 +51,7 @@
             [apiConnectorTemplateName]="'OpenAPI'"
             [apiConnectorData]="(apiConnectorState$ | async)?.createRequest"
             [showNextButton]="true"
-            [enableEditButton]="enableEditor"
+            [enableEditButton]="true"
             (reviewComplete)="onReviewComplete($event)">
           </syndesis-api-connector-review>
           <syndesis-api-connector-auth *ngIf="currentActiveStep == 3"

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
@@ -44,7 +44,6 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
   displayDefinitionEditor = false;
   editorHasChanges = false;
   validationResponse: CustomConnectorRequest;
-  enableEditor = true;
 
   @ViewChild('_apiEditor') _apiEditor: ApiEditorComponent;
   apiDef: ApiDefinition;
@@ -111,16 +110,7 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
 
           reader.readAsText( apiConnectorState.specificationFile );
         } else {
-          this.enableEditor = false;
-
-          const fetch$ = Observable
-            .from(fetch(apiConnectorState.configuredProperties.specification))
-            .flatMap(response => response.json());
-
-          fetch$.subscribe(spec => {
-            this.apiDef.spec = spec;
-            this.enableEditor = true;
-          });
+          this.apiDef.spec = apiConnectorState.configuredProperties.specification;
         }
       });
 

--- a/app/ui/src/polyfills.ts
+++ b/app/ui/src/polyfills.ts
@@ -73,8 +73,6 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
 // import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import 'rxjs/add/observable/from';
 // import 'rxjs/add/operator/mergeMap';
 // import 'rxjs/add/operator/share';
 // import 'rxjs/add/operator/switchMap';


### PR DESCRIPTION
Remove the workaround to fetch a remote OpenAPI file and use the spec as returned by the backend instead.