### PR TITLE
feature(syndesis): Multistage build for operator + fix for minishift docker build

### DIFF
--- a/install/operator/Dockerfile-with-build
+++ b/install/operator/Dockerfile-with-build
@@ -1,0 +1,25 @@
+FROM syndesis/godev:1.10 as builder
+
+WORKDIR /gopath/src/github.com/syndesisio/syndesis/install/operator
+
+COPY . .
+
+RUN dep ensure -vendor-only -v
+
+ENV CGO_ENABLED=0
+
+RUN go build -o syndesis-operator ./cmd/syndesis-operator
+# ================================================================================
+# Final image
+FROM centos:7
+
+RUN adduser -r syndesis-operator
+USER syndesis-operator
+
+# Use that template for creating the operator
+ADD syndesis-template.yml /conf/syndesis-template.yml
+
+# Add the operator
+COPY --from=builder /gopath/src/github.com/syndesisio/syndesis/install/operator/syndesis-operator /usr/local/bin/syndesis-operator
+
+ENTRYPOINT [ "/usr/local/bin/syndesis-operator", "-template", "/conf/syndesis-template.yml" ]

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -20,6 +20,7 @@ build::usage() {
     -f  --flash                    Skip checks and tests execution (fastest mode)
     -i  --image                    Build Docker via s2i images, too (for those modules creating images)
         --docker                   Use a plain Docker build for creating images. Used by CI for pushing to Docker Hub
+        --multi-stage              Multi-stage Dockerfile support for operator build (experimental)
     -p  --project <project>        Specifies the project / namespace to create images
     -e  --ensure                   If building the operator , run 'dep ensure' before building. Otherwise ignored.
     -l  --local                    If building the operator, use a locally installed go
@@ -136,10 +137,21 @@ do_operator() {
     echo "Building syndesis-operator"
     echo "=============================================================================="
 
+    local operator_dir="$top_dir/install/operator"
+
+    # New multi stage build for creating the operator image all in one step
+    if [ $(hasflag -i --image --docker) ] && [ $(hasflag --multi-stage) ]; then
+        if $(is_minishift_docker_daemon); then
+            echo "ERROR: Multistage build is not supported on Minishift as the Docker daemon in Minishift is too old"
+            exit 1
+        fi
+        create_multi_stage_operator_image "$operator_dir"
+        return
+    fi
+
     if [ ! $(hasflag -l --local) ] && $(is_minishift_docker_daemon); then
         echo "Building on Minishift"
         local minishift_build_dir="/opt/syndesis"
-        local operator_source_dir="$top_dir/install/operator"
 
         if [ $(hasflag --clean-cache) ]; then
             echo "Cleaning cache on Minishift"
@@ -147,11 +159,15 @@ do_operator() {
         fi
 
         ensure_rcp_on_minishift
-        rsync_source_to_minishift $operator_source_dir $minishift_build_dir
-        build_operator_from_dir $minishift_build_dir 1000
-        rsync_binary_from_minishift $minishift_build_dir/syndesis-operator $operator_source_dir
+        rsync_source_to_minishift "$operator_dir" "$minishift_build_dir"
+        build_operator_from_dir "$minishift_build_dir" 1000
+        rsync_binary_from_minishift "$minishift_build_dir/syndesis-operator" "$operator_dir"
     else
-        build_operator_from_dir $top_dir/install/operator
+        build_operator_from_dir "$operator_dir"
+    fi
+
+    if [ "$(hasflag -i --image --docker)" ]; then
+        create_operator_image "$operator_dir" "$(hasflag --docker)"
     fi
 }
 
@@ -162,10 +178,6 @@ build_operator_from_dir() {
         dep_ensure "$operator_dir" "$(hasflag -l --local)" "$as_user"
     fi
     build_operator "$operator_dir" "$(hasflag -l --local)" "$(hasflag -i --image --images)" "$as_user"
-
-    if [ "$(hasflag -i --image --images --docker)" ]; then
-        create_operator_image "$operator_dir" "$(hasflag --docker)"
-    fi
 }
 
 is_minishift_docker_daemon() {

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -204,7 +204,7 @@ rsync_source_to_minishift() {
     mkdir_on_minishift $minishift_build_dir $minishift_build_dir/dep-cache $minishift_build_dir/vendor
 
     rsync -az \
-          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.minishift/machines/minishift/id_rsa"\
+          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no -i ~/.minishift/machines/minishift/id_rsa"\
           --progress \
           ${operator_source_dir}/ \
           docker@$(minishift ip):${minishift_build_dir}
@@ -224,7 +224,7 @@ rsync_binary_from_minishift() {
     echo "Rsync compiled $operator_bin back to $local_target_dir"
 
     rsync -az \
-          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i~/.minishift/machines/minishift/id_rsa"\
+          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no -i ~/.minishift/machines/minishift/id_rsa"\
           --progress \
           docker@$(minishift ip):${operator_bin} \
           $local_target_dir

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -204,7 +204,7 @@ rsync_source_to_minishift() {
     mkdir_on_minishift $minishift_build_dir $minishift_build_dir/dep-cache $minishift_build_dir/vendor
 
     rsync -az \
-          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i~/.minishift/machines/minishift/id_rsa"\
+          -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.minishift/machines/minishift/id_rsa"\
           --progress \
           ${operator_source_dir}/ \
           docker@$(minishift ip):${minishift_build_dir}

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -85,6 +85,19 @@ build_operator() {
     fi
 }
 
+create_multi_stage_operator_image() {
+    local operator_dir=${1}
+    local tag=${2:-latest}
+
+    local build_dir=$(prepare_multistage_docker_context "$operator_dir")
+    pushd $build_dir > /dev/null
+    trap "rm -rf $build_dir" EXIT
+
+    echo "Creating multi stage image $OPERATOR_IMAGE:$tag via Docker"
+    docker build -t $OPERATOR_IMAGE:${tag} .
+    popd
+}
+
 create_operator_image() {
     local operator_dir=${1}
     local do_docker=${2:-}
@@ -119,6 +132,20 @@ create_operator_image() {
     oc start-build --from-archive=$arch syndesis-operator
 
     popd
+}
+
+prepare_multistage_docker_context() {
+    local operator_dir="${1}"
+    local dir=$(mktemp -d)
+
+    cp $operator_dir/Dockerfile-with-build ${dir}/Dockerfile
+    cp $operator_dir/Gopkg* ${dir}/
+    for i in "cmd" "pkg" "test" "tmp"; do
+        rsync -a $operator_dir/${i} ${dir}/ 2>&1 >/dev/null
+    done
+    cp $operator_dir/../syndesis.yml ${dir}/syndesis-template.yml
+
+    echo $dir
 }
 
 prepare_docker_context() {


### PR DESCRIPTION
Multistage build were ideal for remote Docker daemon like for the Minishift exposed
Docker daemon.
Unfortunately the Docker daemon included in the latest Minishift images is too old and does
not support multi stage build ;-(

Still I keep it for the time when minishift updates the Docker daemon to at least 17.05

This PR also contains a fix for building the operator image when running on Minishift and is relateted to #3516