### PR TITLE
Fix for Issue 3495 API connector wizzard has no back buttons

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.html
@@ -71,9 +71,14 @@
     </fieldset>
 
     <fieldset>
-      <syndesis-button type="submit" [disabled]="authSetupForm.invalid">
-        Next
-      </syndesis-button>
+      <div class="list-pf-actions">
+        <syndesis-button theme="default" type="button" (click)="onBackPressed()">
+          &lt; {{ 'shared.back' | synI18n }}
+        </syndesis-button>
+        <syndesis-button type="submit" [disabled]="authSetupForm.invalid">
+          {{ 'shared.next' | synI18n }}
+        </syndesis-button>
+      </div>
     </fieldset>
   </form>
 </div>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-auth/api-connector-auth.component.ts
@@ -21,6 +21,7 @@ export class ApiConnectorAuthComponent implements OnInit, OnDestroy {
   authSetupFormValueSubscription: Subscription;
   @Input() customConnectorRequest: CustomConnectorRequest;
   @Output() authSetup = new EventEmitter();
+  @Output() backPressed = new EventEmitter();
 
   constructor(private formBuilder: FormBuilder) {}
 
@@ -29,18 +30,27 @@ export class ApiConnectorAuthComponent implements OnInit, OnDestroy {
       authenticationType,
       authorizationEndpoint,
       tokenEndpoint
-    } = this.customConnectorRequest.properties;
+    } = this.customConnectorRequest.configuredProperties;
 
-    const defaultAuthenticationType = (authenticationType && authenticationType.defaultValue)
-          || (authenticationType.enum.length > 0 && authenticationType.enum[0].value);
+    const properties = this.customConnectorRequest.properties;
+    const defaultAuthenticationType =
+      authenticationType ? authenticationType
+                         : (properties.authenticationType && properties.authenticationType.defaultValue)
+                           || (properties.authenticationType.enum.length > 0 && properties.authenticationType.enum[0].value);
     this.authSetupForm = this.formBuilder.group({
       authenticationType: [
-        defaultAuthenticationType
+        authenticationType ? authenticationType : defaultAuthenticationType
       ],
       authorizationEndpoint: [
-        authorizationEndpoint ? authorizationEndpoint.defaultValue : ''
+        authorizationEndpoint ? authorizationEndpoint
+                              : properties.authorizationEndpoint ? properties.authorizationEndpoint.defaultValue
+                                                                 : ''
       ],
-      tokenEndpoint: [tokenEndpoint ? tokenEndpoint.defaultValue : '']
+      tokenEndpoint: [
+        tokenEndpoint ? tokenEndpoint
+                      : properties.tokenEndpoint ? properties.tokenEndpoint.defaultValue
+                                                 : ''
+      ]
     });
 
     this.authSetupFormValueSubscription = this.authSetupForm
@@ -56,6 +66,10 @@ export class ApiConnectorAuthComponent implements OnInit, OnDestroy {
 
   get tokenUrl() {
     return this.authSetupForm.get( 'tokenEndpoint' );
+  }
+
+  onBackPressed() {
+    this.backPressed.emit();
   }
 
   onSubmit({ value, valid }): void {

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.html
@@ -45,6 +45,12 @@
           <syndesis-api-connector-swagger-upload
             [apiConnectorState]="apiConnectorState$ | async"
             *ngIf="currentActiveStep == 1"
+            [apiFileImport]="useApiFileImport"
+            (useFileImportChanged)="onApiFileImportChanged($useFileImport)"
+            [apiFile]="apiFile"
+            (apiFileChanged)="onApiFileChanged($event)"
+            [apiUrl]="apiUrl"
+            (apiUrlChanged)="onApiUrlChanged($event)"
             (request)="onValidationRequest($event)">
           </syndesis-api-connector-swagger-upload>
           <syndesis-api-connector-review *ngIf="currentActiveStep == 2 && displayDefinitionEditor === false"
@@ -52,15 +58,18 @@
             [apiConnectorData]="(apiConnectorState$ | async)?.createRequest"
             [showNextButton]="true"
             [enableEditButton]="true"
-            (reviewComplete)="onReviewComplete($event)">
+            (reviewComplete)="onReviewComplete($event)"
+            (backPressed)="onBackPressed()">
           </syndesis-api-connector-review>
           <syndesis-api-connector-auth *ngIf="currentActiveStep == 3"
             [customConnectorRequest]="(apiConnectorState$ | async)?.createRequest"
-            (authSetup)="onAuthSetup($event)">
+            (authSetup)="onAuthSetup($event)"
+            (backPressed)="onBackPressed()">
           </syndesis-api-connector-auth>
           <syndesis-api-connector-info *ngIf="currentActiveStep == 4"
             [apiConnectorState]="apiConnectorState$ | async"
-            (update)="onCreateComplete($event)">
+            (update)="onCreateComplete($event)"
+            (backPressed)="onBackPressed()">
           </syndesis-api-connector-info>
         </div>
 

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -27,7 +27,12 @@
       <div class="form-group row">
         <div class="col-xs-12 radio">
           <label>
-            <input type="radio" checked="checked" name="connectorSource" #uploadFileOption>
+            <input type="radio"
+                   checked="checked"
+                   name="connectorSource"
+                   (click)="uploadMethodChanged(true)"
+                   [checked]="apiFileImport"
+                   #uploadFileOption>
             {{ 'customizations.api-client-connectors.api-file-upload' | synI18n }}
           </label>
         </div>
@@ -73,21 +78,26 @@
       <div class="form-group row">
         <div class="col-xs-12 radio">
           <label>
-            <input type="radio" name="connectorSource" #fetchUrlOption>
+            <input type="radio"
+                   name="connectorSource"
+                   (click)="uploadMethodChanged(false)"
+                   [checked]="!apiFileImport"
+                   #fetchUrlOption>
             {{ 'customizations.api-client-connectors.api-url-upload' | synI18n }}
           </label>
         </div>
       </div>
       <div class="container-fluid">
         <div class="form-group row"
-          [class.syn-visuallyhidden]="!fetchUrlOption.checked">
+          [class.syn-visuallyhidden]="apiFileImport">
           <div class="col-xs-12">
             <input type="text"
               class="form-control"
               [class.syn-invalid]="validationError"
               name="swaggerFileUrl"
               [(ngModel)]="swaggerFileUrl"
-              [requiredIf]="fetchUrlOption.checked"
+              (ngModelChange)="onUrlChanged($event)"
+              [requiredIf]="!apiFileImport"
               #swaggerFileUrlInput="ngModel">
             <em class="text-muted">
               {{ 'customizations.api-client-connectors.api-url-upload-note' | synI18n }}
@@ -100,7 +110,7 @@
     <fieldset>
       <syndesis-button type="submit"
         [loading]="apiConnectorState.loading"
-        [disabled]="(!uploadFileOption.checked && !swaggerFileUrlInput.value) || (uploadFileOption.checked && !fileToUpload)">
+        [disabled]="(!apiFileImport && !swaggerFileUrlInput.value) || (apiFileImport && !fileToUpload)">
         {{ 'next' | synI18n }}
       </syndesis-button>
     </fieldset>

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.html
@@ -73,11 +73,15 @@
     </fieldset>
 
     <div class="form-group">
-      <fieldset class="col-sm-9 col-sm-offset-3">
+      <fieldset class="list-pf-actions">
+        <syndesis-button *ngIf="createMode" theme="default" type="button" (click)="onBackPressed()">
+          &lt; {{ 'shared.back' | synI18n }}
+        </syndesis-button>
         <syndesis-button *ngIf="createMode"
-                          type="submit"
-                          [loading]="apiConnectorState.loading"
-                          [disabled]="apiConnectorDataForm.invalid">
+                         class="create-api-btn"
+                         type="submit"
+                         [loading]="apiConnectorState.loading"
+                         [disabled]="apiConnectorDataForm.invalid">
           Create API Connector
         </syndesis-button>
         <ng-container *ngIf="!createMode">

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.scss
@@ -59,3 +59,7 @@
     }
   }
 }
+
+.create-api-btn {
+  margin-left: 200px;
+}

--- a/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-info/api-connector-info.component.ts
@@ -16,6 +16,7 @@ export class ApiConnectorInfoComponent implements OnInit {
   @Input() apiConnectorState: ApiConnectorState;
   @Input() apiConnectorData: ApiConnectorData;
   @Output() update = new EventEmitter<CustomConnectorRequest>();
+  @Output() backPressed = new EventEmitter();
 
   @ViewChild('connectorIconImg') connectorIconImg: ElementRef;
   @ViewChild('connectorIconInput') connectorIconInput: ElementRef;
@@ -105,6 +106,10 @@ export class ApiConnectorInfoComponent implements OnInit {
         this.iconFile = fileList[0];
       }
     }
+  }
+
+  onBackPressed() {
+    this.backPressed.emit();
   }
 
   onSubmit(): void {

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.html
@@ -50,27 +50,35 @@
     </ol>
   </div>
 
-  <button *ngIf="showNextButton"
-          (click)="reviewComplete.emit({event: event, displayEditor: false})"
-          type="button"
-          class="connector-form__submit btn btn-primary">
-    {{ 'shared.next' | synI18n }}
-  </button>
+  <fieldset class="list-pf-actions">
+    <syndesis-button *ngIf="showNextButton" type="button" theme="default" (click)="onBackPressed()">
+      &lt; {{ 'shared.back' | synI18n }}
+    </syndesis-button>
 
-  <ng-template #editTooltip>
-    {{ 'customizations.api-client-connectors.edit-tooltip' | synI18n }}
-  </ng-template>
-  <button *ngIf="showNextButton"
-          (click)="reviewComplete.emit({event: event, displayEditor: true})"
-          [disabled]="!enableEditButton"
-          type="button"
-          class="connector-form__submit btn btn-default apicurio pull-right">
-    <span [tooltip]="editTooltip"
-          [tooltipEnable]="enableEditButton"
-          placement="top">
-      {{ 'customizations.api-client-connectors.api-review-edit-button' | synI18n }}
-    </span>
-  </button>
+    <syndesis-button *ngIf="showNextButton"
+                     (click)="reviewComplete.emit({event: event, displayEditor: false})"
+                     type="button"
+                     theme="primary">
+      {{ 'shared.next' | synI18n }}
+    </syndesis-button>
+
+    <ng-template #editTooltip>
+      {{ 'customizations.api-client-connectors.edit-tooltip' | synI18n }}
+    </ng-template>
+    <syndesis-button
+            *ngIf="showNextButton"
+            (click)="reviewComplete.emit({event: event, displayEditor: true})"
+            [disabled]="!enableEditButton"
+            type="button"
+            class="review-edit-btn"
+            theme="default">
+      <span [tooltip]="editTooltip"
+            [tooltipEnable]="enableEditButton"
+            placement="top">
+        {{ 'customizations.api-client-connectors.api-review-edit-button' | synI18n }}
+      </span>
+    </syndesis-button>
+  </fieldset>
 </div>
 <ng-template #validationFallback>
   <h5 class="connector-fallback">

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.scss
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.scss
@@ -50,3 +50,7 @@ button.connector-form__submit.btn.btn-default.apicurio.pull-right {
 .btn {
   @extend %syn-cta-btn;
 }
+
+.review-edit-btn {
+  margin-left: 200px;
+}

--- a/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-review/api-connector-review.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
-import { ApiConnectorData } from '@syndesis/ui/customizations/api-connector';
+import { ApiConnectorData, CustomConnectorRequest } from '@syndesis/ui/customizations/api-connector';
 
 @Component({
   selector: 'syndesis-api-connector-review',
@@ -24,5 +24,10 @@ export class ApiConnectorReviewComponent {
     }));
   }
 
+  @Output() backPressed = new EventEmitter();
   @Output() reviewComplete = new EventEmitter();
+
+  onBackPressed() {
+    this.backPressed.emit();
+  }
 }


### PR DESCRIPTION
- added back button to the ApiConnectorAuthComponent
- ApiConnectorAuthComponent now initializes state to values in the CustomConnectorRequest if they exist or to the default values
- ApiConnectorCreateComponent handles all back pressed events emitted by the steps of the wizard
- added click listeners to ApiConnectorSwaggerUploadComponent for the upload method radio buttons
- ApiConnectorSwaggerUploadComponent now initializes state to values in the CustomConnectorRequest if they exist
- added back button to the ApiConnectorInfoComponent
- added back button to the ApiConnectorReviewComponent
- added i18n where needed