### PR TITLE
Various api provider endpoint improvements

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
@@ -15,24 +15,25 @@
  */
 package io.syndesis.common.model.integration;
 
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.WithId;
+import io.syndesis.common.model.WithMetadata;
 import io.syndesis.common.model.WithName;
 import io.syndesis.common.model.WithTags;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.util.json.OptionalStringTrimmingConverter;
 import org.immutables.value.Value;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 @Value.Immutable
 @JsonDeserialize(builder = Flow.Builder.class)
 @SuppressWarnings("immutables")
-public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, Serializable {
+public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, WithMetadata, Serializable {
 
     class Builder extends ImmutableFlow.Builder {
         // allow access to ImmutableIntegration.Builder
@@ -47,8 +48,6 @@ public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, Seria
 
     @JsonDeserialize(converter = OptionalStringTrimmingConverter.class)
     Optional<String> getDescription();
-
-    Optional<String> getExcerpt();
 
     default Flow.Builder builder() {
         return new Flow.Builder().createFrom(this);

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
@@ -48,6 +48,8 @@ public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, Seria
     @JsonDeserialize(converter = OptionalStringTrimmingConverter.class)
     Optional<String> getDescription();
 
+    Optional<String> getExcerpt();
+
     default Flow.Builder builder() {
         return new Flow.Builder().createFrom(this);
     }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/APIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/APIGenerator.java
@@ -16,6 +16,7 @@
 package io.syndesis.server.api.generator;
 
 import io.syndesis.common.model.api.APISummary;
+import io.syndesis.common.model.integration.Integration;
 
 /**
  * This is a facade for API related operations.
@@ -25,5 +26,7 @@ public interface APIGenerator {
     APISummary info(String specification, APIValidationContext validation);
 
     APIIntegration generateIntegration(String specification, ProvidedApiTemplate template);
+
+    Integration updateFlowExcerpts(Integration integration);
 
 }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,8 @@ import static java.util.Optional.ofNullable;
 public class SwaggerAPIGenerator implements APIGenerator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerAPIGenerator.class);
+
+    private static final String EXCERPT_METADATA_KEY = "excerpt";
 
     private DataShapeGenerator dataShapeGenerator;
 
@@ -184,7 +187,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
 
                 Flow flow = new Flow.Builder()
                     .id(String.format("%s:flows:%s", integrationId, operationId))
-                    .excerpt("501 Not Implemented")
+                    .putMetadata(EXCERPT_METADATA_KEY, "501 Not Implemented")
                     .addStep(startStep)
                     .addStep(endStep)
                     .name(operationName)
@@ -257,12 +260,14 @@ public class SwaggerAPIGenerator implements APIGenerator {
             String responseDesc = decodeHttpReturnCode(steps, responseCode);
             return new Flow.Builder()
                 .createFrom(flow)
-                .excerpt(responseDesc)
+                .putMetadata(EXCERPT_METADATA_KEY, responseDesc)
                 .build();
-        } else if (flow.getExcerpt().isPresent()) {
+        } else if (flow.getMetadata(EXCERPT_METADATA_KEY).isPresent()) {
+            Map<String, String> newMetadata = new HashMap<>(flow.getMetadata());
+            newMetadata.remove(EXCERPT_METADATA_KEY);
             return new Flow.Builder()
                 .createFrom(flow)
-                .excerpt(Optional.empty())
+                .metadata(newMetadata)
                 .build();
         }
         return flow;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -72,6 +72,7 @@ import io.syndesis.common.model.integration.IntegrationOverview;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.validation.AllValidations;
 import io.syndesis.common.util.SuppressFBWarnings;
+import io.syndesis.server.api.generator.APIGenerator;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.dao.manager.operators.IdPrefixFilter;
@@ -106,15 +107,17 @@ public class IntegrationHandler extends BaseHandler
     private final OpenShiftService openShiftService;
     private final Inspectors inspectors;
     private final EncryptionComponent encryptionSupport;
+    private final APIGenerator apiGenerator;
 
     private final Validator validator;
 
-    public IntegrationHandler(final DataManager dataMgr, OpenShiftService openShiftService, final Validator validator, final Inspectors inspectors, final EncryptionComponent encryptionSupport) {
+    public IntegrationHandler(final DataManager dataMgr, OpenShiftService openShiftService, final Validator validator, final Inspectors inspectors, final EncryptionComponent encryptionSupport, final APIGenerator apiGenerator) {
         super(dataMgr);
         this.openShiftService = openShiftService;
         this.validator = validator;
         this.inspectors = inspectors;
         this.encryptionSupport = encryptionSupport;
+        this.apiGenerator = apiGenerator;
     }
 
     @Override
@@ -183,6 +186,8 @@ public class IntegrationHandler extends BaseHandler
             .version(existing.getVersion()+1)
             .updatedAt(System.currentTimeMillis())
             .build();
+
+        updatedIntegration = apiGenerator.updateFlowExcerpts(updatedIntegration);
 
         getDataManager().update(updatedIntegration);
     }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/IntegrationHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/IntegrationHandlerTest.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 
 import javax.validation.Validator;
 
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.server.api.generator.APIGenerator;
 import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.inspector.Inspectors;
@@ -33,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +49,7 @@ public class IntegrationHandlerTest {
     private IntegrationHandler handler;
     private Inspectors inspectors;
     private OpenShiftService openShiftService;
+    private APIGenerator apiGenerator;
 
     @Before
     public void setUp() {
@@ -53,7 +57,9 @@ public class IntegrationHandlerTest {
         Validator validator = mock(Validator.class);
         openShiftService = mock(OpenShiftService.class);
         inspectors = mock(Inspectors.class);
-        handler = new IntegrationHandler(manager, openShiftService, validator, inspectors, new EncryptionComponent(null));
+        apiGenerator = mock(APIGenerator.class);
+        when(apiGenerator.updateFlowExcerpts(any(Integration.class))).then(ctx -> ctx.getArguments()[0]);
+        handler = new IntegrationHandler(manager, openShiftService, validator, inspectors, new EncryptionComponent(null), apiGenerator);
     }
 
     @Test


### PR DESCRIPTION
Fix #3547.

This addresses the issues outlined in #3547.

- *Ensure the original schema is present in the response of the validation endpoint (needed if the user wants to go back and edit the integration)*

**Solution:** The implementation follows what is implemented in API consumer and the OpenAPI spec is already included.

- *Provide a endpoint to upload the schema via URL, to overcome browser restrictions*

**Solution:** like for the API consumer, just upload a URL instead of a openapi spec in the "specification" field of the form and it will be downloaded by the backend (and returned back from the call to /apis/info)

- *Add a field to the Flow object that contains the last column seen in the list of flows when editing a integration (the one reporting the current HTTP return code)*

**Solution:** I've added a "excerpt" field in the Flow object that will contain a text like "501 Not Implemented" (and other return codes)

- *Mark actions belonging to a API flow with a special "read-only" tag, so the UI does not allow to replace them*

**Solution:** I've added a "locked-action" tag to each action in the start and finish step of a generated integration. If present, the UI should prevent the user to change them (don't actually know if that was possible).


cc: @riccardo-forina , @gashcrumb 