### PR TITLE
feat: enable all the other input field types from ng-dynamic-forms

### DIFF
--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -47,9 +47,20 @@ export class FormFactoryProviderService extends FormFactoryService {
       let type = (field.type || '').toLowerCase();
       // first normalize the type
       switch (type) {
+        // these have native input field types
+        case 'time':
         case 'date':
-          break;
         case 'duration':
+        case 'color':
+        case 'datetime-local':
+        case 'email':
+        case 'file':
+        case 'month':
+        case 'range':
+        case 'tel':
+        case 'url':
+        case 'week':
+        case 'search':
           break;
         case 'boolean':
         case 'checkbox':


### PR DESCRIPTION
Follow on for #3577 enables all the other input types for the regular text input from ng-dynamic-forms.

@oscerd FYI