### PR TITLE
fix(s2i): Different ordering of maven modules during packaging phase

### DIFF
--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -65,7 +65,7 @@
         <executions>
           <execution>
             <id>copy</id>
-            <phase>package</phase>
+            <phase>validate</phase>
             <goals>
               <goal>copy</goal>
             </goals>


### PR DESCRIPTION
* Both the maven-dependency-plugin and the exec-maven-plugin are set to
  be enacted during the package phase. It is expected that the dependency
  gets executed first since the exec requires it. However, sometimes they
  are reversed by maven and the build fails.

* Shifting the dependency execution to the validate phase ensure the
  sequence occurs in the correct order.