### PR TITLE
fix: restore broken console logging functionality

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -71,7 +71,7 @@
     "snyk": "^1.88.1",
     "tether": "1.4.0",
     "ts-helpers": "1.1.2",
-    "typescript-logging": "0.4.0",
+    "typescript-logging": "0.4.2",
     "url": "^0.11.0",
     "yamljs": "^0.3.0",
     "zone.js": "^0.8.26"

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -71,7 +71,7 @@
     "snyk": "^1.88.1",
     "tether": "1.4.0",
     "ts-helpers": "1.1.2",
-    "typescript-logging": "0.4.2",
+    "typescript-logging": "0.6.2",
     "url": "^0.11.0",
     "yamljs": "^0.3.0",
     "zone.js": "^0.8.26"

--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -159,7 +159,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   resetDB() {
     this.testSupport
       .resetDB()
-      .subscribe(() => log.debugc(() => 'DB has been reset'));
+      .subscribe(() => log.debug(() => 'DB has been reset'));
   }
 
   /**
@@ -179,7 +179,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       if (modal.result) {
         return this.testSupport
           .restoreDB(modal['json'])
-          .subscribe(() => log.debugc(() => 'DB has been imported'));
+          .subscribe(() => log.debug(() => 'DB has been imported'));
       }
     });
   }

--- a/app/ui/src/app/config.service.ts
+++ b/app/ui/src/app/config.service.ts
@@ -29,7 +29,7 @@ export class ConfigService {
       .get(configJson)
       .toPromise()
       .then(config => {
-        log.debugc(
+        log.debug(
           () => 'Received config: ' + JSON.stringify(config, undefined, 2),
           category
         );
@@ -41,7 +41,7 @@ export class ConfigService {
 
         this.settingsSubject.next(this.settingsRepository);
 
-        log.debugc(
+        log.debug(
           () =>
             'Using merged config: ' +
             JSON.stringify(this.settingsRepository, undefined, 2),
@@ -51,7 +51,7 @@ export class ConfigService {
         return this;
       })
       .catch(() => {
-        log.warnc(
+        log.warn(
           () =>
             'Error: Configuration service unreachable! Using defaults: ' +
             JSON.stringify(this.settingsRepository),

--- a/app/ui/src/app/connections/create-page/current-connection.ts
+++ b/app/ui/src/app/connections/create-page/current-connection.ts
@@ -58,7 +58,7 @@ export class CurrentConnectionService {
   }
 
   handleEvent(event: ConnectionEvent) {
-    // log.infoc(() => 'connection event: ' + JSON.stringify(event), category);
+    // log.info(() => 'connection event: ' + JSON.stringify(event), category);
     switch (event.kind) {
       case 'connection-check-connector':
         if (!this.fetchConnector(this._connection.connectorId)) {
@@ -109,7 +109,7 @@ export class CurrentConnectionService {
     return this.connectorStore.acquireCredentials(connectorId)
       .pipe(
         mergeMap((resp: any) => {
-          log.infoc(() => 'Got response: ' + JSON.stringify(resp));
+          log.info(() => 'Got response: ' + JSON.stringify(resp));
           return resp;
         }),
         catchError((error: any) => {
@@ -120,7 +120,7 @@ export class CurrentConnectionService {
           this._oauthStatus = {
             message: message
           };
-          log.infoc(() => 'Error response initiating oauth flow:' + JSON.stringify(error));
+          log.info(() => 'Error response initiating oauth flow:' + JSON.stringify(error));
           return error;
         })
       );
@@ -199,7 +199,7 @@ export class CurrentConnectionService {
           });
         },
         error => {
-          log.infoc(
+          log.info(
             () =>
               'Failed to fetch connector credentials: ' + JSON.stringify(error),
             category
@@ -234,12 +234,12 @@ export class CurrentConnectionService {
         },
         error => {
           try {
-            log.infoc(
+            log.info(
               () => 'Failed to fetch connector: ' + JSON.stringify(error),
               category
             );
           } catch (err) {
-            log.infoc(() => 'Failed to fetch connector: ' + error, category);
+            log.info(() => 'Failed to fetch connector: ' + error, category);
           }
           this.events.emit({
             kind: 'connection-check-credentials',

--- a/app/ui/src/app/connections/create-page/review/review.component.ts
+++ b/app/ui/src/app/connections/create-page/review/review.component.ts
@@ -73,7 +73,7 @@ export class ConnectionsReviewComponent
           this.router.navigate(['connections']);
         },
         error: (reason: any) => {
-          log.debugc(
+          log.debug(
             () =>
               'Error creating connection: ' +
               JSON.stringify(reason, undefined, 2),

--- a/app/ui/src/app/connections/list/list.component.ts
+++ b/app/ui/src/app/connections/list/list.component.ts
@@ -43,7 +43,7 @@ export class ConnectionsListComponent implements OnInit {
   //----- Initialization ------------------->>
 
   ngOnInit() {
-    log.debugc(
+    log.debug(
       () =>
         'Got connections: ' + JSON.stringify(this.connections, undefined, 2),
       category
@@ -77,7 +77,7 @@ export class ConnectionsListComponent implements OnInit {
 
   // Open modal to confirm delete
   requestDelete(connection: Connection, $event) {
-    log.debugc(() => 'Selected connection for delete: ' + connection.id);
+    log.debug(() => 'Selected connection for delete: ' + connection.id);
     this.selectedForDelete = connection;
     this.modalService
       .show()
@@ -87,7 +87,7 @@ export class ConnectionsListComponent implements OnInit {
   //-----  Selecting a Connection ------------------->>
   onSelect(connection: Connection) {
     if (connection) {
-      log.debugc(
+      log.debug(
         () => 'Selected connection (list): ' + connection.name,
         category
       );

--- a/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.ts
+++ b/app/ui/src/app/dashboard/dashboard_connections/dashboard-connections.component.ts
@@ -20,7 +20,7 @@ export class DashboardConnectionsComponent implements OnInit {
   truncateTrail = '…';
 
   onSelect(connection: Connection) {
-    log.debugc(
+    log.debug(
       () => 'Selected connection (list): ' + connection.name,
       category
     );
@@ -29,7 +29,7 @@ export class DashboardConnectionsComponent implements OnInit {
   }
 
   ngOnInit() {
-    log.debugc(
+    log.debug(
       () =>
         'Got connections: ' + JSON.stringify(this.connections, undefined, 2),
       category

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.ts
@@ -54,7 +54,7 @@ export class IntegrationSelectActionComponent implements OnInit, OnDestroy {
   }
 
   onSelected(action: Action) {
-    log.debugc(() => 'Selected action: ' + action.name, category);
+    log.debug(() => 'Selected action: ' + action.name, category);
     this.currentFlowService.events.emit({
       kind: 'integration-set-action',
       position: this.position,

--- a/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
+++ b/app/ui/src/app/integration/edit-page/connection-select/connection-select.component.ts
@@ -63,7 +63,7 @@ export class IntegrationSelectConnectionComponent implements OnInit, OnDestroy {
       return this.gotoCreateConnection();
     }
 
-    log.debugc(() => 'Selected connection: ' + connection.name, category);
+    log.debug(() => 'Selected connection: ' + connection.name, category);
 
     this.currentFlowService.events.emit({
       kind: 'integration-set-connection',

--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -438,7 +438,7 @@ export class CurrentFlowService implements OnDestroy {
           this.steps[position].id = key();
         }
         this.maybeDoAction(event['onSave']);
-        log.debugc(() => 'Set step at position: ' + position, category);
+        log.debug(() => 'Set step at position: ' + position, category);
         break;
       }
       case 'integration-set-metadata': {
@@ -456,7 +456,7 @@ export class CurrentFlowService implements OnDestroy {
         step.configuredProperties = properties;
         this.steps[position] = step;
         this.maybeDoAction(event['onSave']);
-        log.debugc(
+        log.debug(
           () =>
             'Set properties at position: ' +
             position +
@@ -479,7 +479,7 @@ export class CurrentFlowService implements OnDestroy {
         step.stepKind = stepKind;
         this.steps[position] = step;
         this.maybeDoAction(event['onSave']);
-        log.debugc(
+        log.debug(
           () => 'Set action ' + action.name + ' at position: ' + position,
           category
         );
@@ -552,7 +552,7 @@ export class CurrentFlowService implements OnDestroy {
         step.connection = connection;
         this.steps[position] = step;
         this.maybeDoAction(event['onSave']);
-        log.debugc(
+        log.debug(
           () =>
             'Set connection ' + connection.name + ' at position: ' + position,
           category
@@ -569,7 +569,7 @@ export class CurrentFlowService implements OnDestroy {
         this.maybeDoAction(event['onSave']);
         break;
       case 'integration-save': {
-        log.debugc(() => 'Saving integration: ' + this.integration);
+        log.debug(() => 'Saving integration: ' + this.integration);
         // ensure that all steps have IDs before saving
         this.steps.forEach(s => {
           if (!s.id) {
@@ -588,7 +588,7 @@ export class CurrentFlowService implements OnDestroy {
           }
         });
         const finishUp = (i: Integration, subscription: Subscription) => {
-          log.debugc(
+          log.debug(
             () => 'Saved integration: ' + JSON.stringify(i, undefined, 2),
             category
           );
@@ -616,7 +616,7 @@ export class CurrentFlowService implements OnDestroy {
             }
           },
           (reason: any) => {
-            log.infoc(
+            log.info(
               () =>
                 'Error saving integration: ' +
                 JSON.stringify(reason, undefined, 2),
@@ -634,7 +634,7 @@ export class CurrentFlowService implements OnDestroy {
       default:
         break;
     }
-    // log.debugc(() => 'integration: ' + JSON.stringify(this._integration, undefined, 2), category);
+    // log.debug(() => 'integration: ' + JSON.stringify(this._integration, undefined, 2), category);
   }
 
   getIntegrationClone(): Integration {

--- a/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -173,11 +173,11 @@ export class BasicFilterComponent implements OnChanges, OnDestroy {
       })
       .catch(error => {
         try {
-          log.infoc(
+          log.info(
             () => 'Failed to fetch filter form data: ' + JSON.parse(error)
           );
         } catch (err) {
-          log.infoc(() => 'Failed to fetch filter form data: ' + error);
+          log.info(() => 'Failed to fetch filter form data: ' + error);
         }
         // we can handle this for now using default values
         this.initForm();

--- a/app/ui/src/app/integration/integration-actions-provider.service.ts
+++ b/app/ui/src/app/integration/integration-actions-provider.service.ts
@@ -189,7 +189,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
   // TODO: Refactor into single method for both cases
   // Open modal to confirm activation
   requestActivate(integration: Integration | IntegrationOverview) {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for activation: ' +
         JSON.stringify(integration['id'])
@@ -200,7 +200,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
 
   // Open modal to confirm deactivation
   requestDeactivate(integration: Integration | IntegrationOverview) {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for deactivation: ' +
         JSON.stringify(integration['id'])
@@ -211,7 +211,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
 
   // Open modal to confirm delete
   requestDelete(integration: Integration | IntegrationOverview) {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for delete: ' + JSON.stringify(integration['id'])
     );
@@ -222,7 +222,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
   // TODO: Refactor into single method for both cases
   // Actual activate/deactivate action once the user confirms
   activateAction(integration: Integration | IntegrationOverview): Promise<any> {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for activation: ' +
         JSON.stringify(integration['id'])
@@ -234,7 +234,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
   deactivateAction(
     integration: Integration | IntegrationOverview
   ): Promise<any> {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for deactivation: ' +
         JSON.stringify(integration['id'])
@@ -246,7 +246,7 @@ export class IntegrationActionsProviderService extends IntegrationActionsService
 
   // Actual delete action once the user confirms
   deleteAction(integration: Integration | IntegrationOverview): Promise<any> {
-    log.debugc(
+    log.debug(
       () =>
         'Selected integration for delete: ' + JSON.stringify(integration['id'])
     );

--- a/app/ui/src/app/logging.ts
+++ b/app/ui/src/app/logging.ts
@@ -7,9 +7,14 @@ import {
 } from 'typescript-logging';
 
 // TODO typescript-logging will support a console API to change this at runtime in the future, for now we'll use localStorage
-const storedLogLevel =
-  typeof localStorage !== 'undefined' && localStorage.getItem('logLevel');
-const logLevel = LogLevel[storedLogLevel] || LogLevel.Info;
+let logLevel = LogLevel.Info;
+try {
+  const storedLogLevel =
+    typeof localStorage !== 'undefined' && localStorage.getItem('logLevel');
+  logLevel = LogLevel.fromString(storedLogLevel);
+} catch (e) {
+  // probably nothing has been set in the localStorage
+}
 
 // default configuration
 CategoryServiceFactory.setDefaultConfiguration(

--- a/app/ui/src/app/logging.ts
+++ b/app/ui/src/app/logging.ts
@@ -2,7 +2,7 @@ import {
   Category,
   CategoryLogger,
   CategoryServiceFactory,
-  CategoryDefaultConfiguration,
+  CategoryConfiguration,
   LogLevel
 } from 'typescript-logging';
 
@@ -18,7 +18,7 @@ try {
 
 // default configuration
 CategoryServiceFactory.setDefaultConfiguration(
-  new CategoryDefaultConfiguration(logLevel)
+  new CategoryConfiguration(logLevel)
 );
 
 const rootCategory = new Category('root');

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -121,7 +121,7 @@ export abstract class AbstractStore<
       },
       error => {
         error = this.massageError(error);
-        log.debugc(
+        log.debug(
           () => 'Error retrieving ' + plural(this.kind) + ': ' + error,
           category,
         );
@@ -172,7 +172,7 @@ export abstract class AbstractStore<
       },
       error => {
         error = this.massageError(error);
-        log.debugc(
+        log.debug(
           () => 'Error retrieving ' + this.kind + ': ' + error,
           category,
         );
@@ -198,7 +198,7 @@ export abstract class AbstractStore<
       },
       error => {
         error = this.massageError(error);
-        log.debugc(
+        log.debug(
           () =>
             'Error creating ' +
             this.kind +
@@ -231,7 +231,7 @@ export abstract class AbstractStore<
       },
       error => {
         error = this.massageError(error);
-        log.debugc(
+        log.debug(
           () =>
             'Error updating ' +
             this.kind +
@@ -268,7 +268,7 @@ export abstract class AbstractStore<
       },
       error => {
         error = this.massageError(error);
-        log.debugc(
+        log.debug(
           () =>
             'Error updating ' +
             this.kind +

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -8744,9 +8744,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-logging@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.4.2.tgz#5439f1dfb820a20f9af54fb7405cedb2729e3738"
+typescript-logging@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.6.2.tgz#4961ce03d69eaab4f5999ac9ee094fa695e0a551"
   dependencies:
     stacktrace-js "1.3.1"
 

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -8744,9 +8744,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-logging@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.4.0.tgz#6af44f01fea961d511e7c5f61415d580132efc2a"
+typescript-logging@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.4.2.tgz#5439f1dfb820a20f9af54fb7405cedb2729e3738"
   dependencies:
     stacktrace-js "1.3.1"
 


### PR DESCRIPTION
## Changes

* fixed the way we read the `logLevel` key from the `localStorage`
* `typescript-logging` upgraded to v0.6.2 from v0.4.0
* renamed the deprecated methods with the new names

Closes #3617
