### PR TITLE
fix: invoking syndesis without arguments

### DIFF
--- a/tools/bin/syndesis
+++ b/tools/bin/syndesis
@@ -10,15 +10,15 @@
 # Fail on a single failed command in a pipeline (if supported)
 set -o pipefail
 
-# Fail on error and undefined vars (please don't use global vars, but evaluation of functions for return values)
-set -eu
-
 # Save global script args, use "build" as default
 if [ -z "$1" ]; then
     ARGS=("build")
 else
     ARGS=("$@")
 fi
+
+# Fail on error and undefined vars (please don't use global vars, but evaluation of functions for return values)
+set -eu
 
 # Display a help message.
 display_help() {


### PR DESCRIPTION
When `tools/bin/syndesis` is invoked without arguments the default
`build` command is not invoked but an error is reported:

    bin/syndesis: line 17: $1: unbound variable

This is caused by `set -eu` on the preceding line. This moves the
`set -eu` after the check if `$1` is defined.