### PR TITLE
Removed camel-atlasmap.version property

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -38,7 +38,6 @@
 
     <!-- Atlasmap version -->
     <atlasmap.version>1.36.0</atlasmap.version>
-    <camel-atlasmap.version>${atlasmap.version}</camel-atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>


### PR DESCRIPTION
Using a version property without a corresponding dependency referencing it has caused alignment problems in the past. If this property is no longer used, can we remove the property entirely?

See https://issues.jboss.org/browse/ENTESB-9440