### PR TITLE
fix(ui): logout on firefox

### DIFF
--- a/app/ui/docker/nginx-syndesis.conf
+++ b/app/ui/docker/nginx-syndesis.conf
@@ -5,9 +5,14 @@ server {
     root         /usr/share/nginx/html;
 
     location = / {
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        try_files /index.html =200;
+    }
+
+    location ~ /.+ {
+        try_files $uri $uri/ /index.html;
     }
 
     location = /logout {
@@ -15,17 +20,12 @@ server {
         if ($http_syndesis_xsrf_token = "awesome") {
             set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
         }
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
-        add_header Set-Cookie $cookie;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        add_header Set-Cookie $cookie always;
         default_type "text/html; charset=ISO-8859-1";
         alias /usr/share/nginx/html/logout.html;
-    }
-
-    location / {
-        index  index.html;
-        try_files $uri $uri/ /index.html;
     }
 
 }


### PR DESCRIPTION
This changes the Nginx configuration to introduce two location blocks
one for the `/` (`/index.html`) and one for all other static resources
under `/`. Seems that `always` option is required for our use case in
the `add_header` directive.

The overall logic is that we can't let the browser to cache `/`, if it
does it will immediately show the Syndesis chrome instead of issuing the
request and this will result in bypassing the `oauth_proxy`
authentication check, i.e. not mandating the user to re-login.

I've found the easiest way to test is to test with a separate Firefox
profile (`firefox --P test`) and in that profile set the History
preference to custom and configure _Clear history when Firefox closes_
option.

Fixes #3016

(cherry picked from commit 4ac616d0da0a70ee716049b57d3fd9b2010296ac)