### PR TITLE
Fix #3460: co-locate upgrade pod with database and add service account

### DIFF
--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1634,6 +1634,14 @@ objects:
     metadata:
       name: syndesis-upgrade-latest
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                "syndesis.io/app": "syndesis"
+                "syndesis.io/component": "syndesis-db"
+            topologyKey: "kubernetes.io/hostname"
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade


### PR DESCRIPTION
This is to co-locate the upgrade pod with the database so that the upgrade process can mount the same (RWO) volume to perform backup in a real cluster.

@rhuss can you have a look? If it is ok, I'll apply it also to 1.4.x and fuse-online-install.
Discussion in #3460.