### PR TITLE
Fusedoc 2841 amq tutorial

### DIFF
--- a/doc/integrating_applications/topics/combine_multiple_source_fields_into_one_target_field.adoc
+++ b/doc/integrating_applications/topics/combine_multiple_source_fields_into_one_target_field.adoc
@@ -9,7 +9,7 @@ fields to the `CustomerName` field.
 For the target field, you must know what type of content is in each
 part of this compound field, the order and index of each part of the content, 
 and the separator between parts, such as a space or comma. See
-<<example-missing-unwanted-data>. 
+<<example-missing-unwanted-data>>. 
 
 .Procedure
 

--- a/doc/integrating_applications/topics/separate_one_source_field_into_multiple_target_fields.adoc
+++ b/doc/integrating_applications/topics/separate_one_source_field_into_multiple_target_fields.adoc
@@ -9,7 +9,7 @@ target fields. For  example, map the `Name` field to the `FirstName` and
 For the source field, you must know what type of content is in each
 part of this compound field, the order and index of each part of the content, 
 and the separator between parts, such as a space or comma. See
-<<example-missing-unwanted-data>. 
+<<example-missing-unwanted-data>>. 
 
 .Procedure
 

--- a/doc/tutorials/topics/amq2api_confirm_works.adoc
+++ b/doc/tutorials/topics/amq2api_confirm_works.adoc
@@ -19,7 +19,8 @@ to the AMQ broker in your OpenShift project.
 +
 Successful execution returns a task from the To Do app client API. The task
 identifies the ID of the damaged item and the contact information for its
-vendor.
+vendor. If the task does not appear in a moment or two, try reloading the
+page. 
 . Edit the XML message to specify two damaged items:
 .. Click *Show JMS Form* to display the message input box again.
 .. In the XML message, change the entry for the undamaged item to
@@ -27,10 +28,9 @@ specify `damaged="true"`.
 .. Click *Send JMS Message*. The To Do app client API returns a new
 task that contains IDs for two damaged items and contact information for
 the two vendors.
-. Edit the XML message to specify an unknown vendor:
+. Edit the XML message to specify an ID that you make up:
 .. Click *Show JMS Form*.
-.. In the XML message, for an item that has `damaged="true"`, change the name
-of the vendor.
+.. In the XML message, for the item that has `damaged="true"`, change the item
+ID, for example, to `1234`.
 .. Click *Send JMS Message*. The To Do app client API returns a new
-task that indicates that there is no contact information for the vendor of
-a damaged item. The To Do app accesses a database that has only two vendors.
+task with the item ID that you just entered.

--- a/doc/tutorials/topics/amq2api_create_rest_api_connection.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connection.adoc
@@ -11,9 +11,9 @@ available connectors.
 . In the *Todo App API Configuration*, notice that {prodname} populates the
 *Authentication Type*, *Base Path*, and *Host* fields from the
 connector information.
-. In the *Password* field, enter any value. For this sample integration,
-password and user name values are required but they are not used.
-. In the *Username* field, enter any value.
+. In the *Username* field, enter any value. For this sample integration,
+user name and password values are required but they are not used.
+. In the *Password* field, enter any value. 
 . Click *Next*.
 . In the *Connection Name* field, enter your choice of a name that
 helps you distinguish this connection from any other connections.

--- a/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
@@ -39,7 +39,7 @@ change the values in the *Connector Name* and *Description* fields.
 it should be something like this:
 `\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
 .. Confirm that the value in the *Base URL* field is `/api`. 
-. Click *Create Connector*.
+. Click *Create API Connector*.
 
 {prodname} displays the *API Client Connectors* tab with an entry for
 the *Todo App API* that you just created.

--- a/doc/tutorials/topics/amq2api_start_the_broker.adoc
+++ b/doc/tutorials/topics/amq2api_start_the_broker.adoc
@@ -8,15 +8,13 @@ To start the AMQ broker:
 https://console.fuse-ignite.openshift.com/console/[OpenShift Web Console, window="_blank"]. 
 Your {prodname} environment runs on OpenShift Online.
 
-. In the console, click the name of your {prodname} project, which is
-something like `proj123456`.
+. In the console, on the right, under *My Projects*, click *Fuse Online* to
+display the project's overview. 
++
+Your project's name is something like `proj123456`.
 
-. In the *Overview* page, scroll down to *Other Resources* to
-see the provided AMQ broker.
+. In the overview, click the first entry, *broker-amq, #1* to expand the entry for the
+provided AMQ broker.
 
-. To the left of *broker-amq, #1*, click the caret to display more
-information.
-
-. In the additional information, all the way to the right,
-click the up caret to scale up to running 1 pod. This starts
+. On the right, click the up caret to scale up to running 1 pod. This starts
 the AMQ broker.


### PR DESCRIPTION
Update the AMQ to REST API tutorial to simplify one of the steps for confirming that the tutorial works as defined and to correct the steps for starting the AMQ broker. 
This PR also fixes two xrefs that were broken because of a missing character. 