### PR TITLE
fix: ignore hidden required fields on the oauth settings page

### DIFF
--- a/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
+++ b/app/ui/src/app/settings/oauth-apps/oauth-apps.component.ts
@@ -67,10 +67,10 @@ export class OAuthAppsComponent implements OnInit, OnDestroy {
   subscription: Subscription;
 
   constructor(
-    public store: OAuthAppStore,
-    public config: ConfigService
+    public oauthAppStore: OAuthAppStore,
+    public configService: ConfigService
   ) {
-    this.loading$ = store.loading;
+    this.loading$ = oauthAppStore.loading;
   }
 
   // Returns whether or not this item has stored credentials
@@ -83,7 +83,7 @@ export class OAuthAppsComponent implements OnInit, OnDestroy {
     }
     return Object.keys(properties).find(key => {
       const property = properties[key];
-      if (!property.required) {
+      if (!property.required || property.type === 'hidden') {
         return false;
       }
       const value = configuredProperties[key];
@@ -106,7 +106,7 @@ export class OAuthAppsComponent implements OnInit, OnDestroy {
 
   // view initialization
   ngOnInit() {
-    this.subscription = this.store.list.subscribe((apps: OAuthApps) => {
+    this.subscription = this.oauthAppStore.list.subscribe((apps: OAuthApps) => {
       const oldItems = this.items;
       this.items = [];
       for (const app of apps) {
@@ -121,7 +121,7 @@ export class OAuthAppsComponent implements OnInit, OnDestroy {
       }
       this.oauthApps$.next(this.items);
     });
-    this.store.loadAll();
+    this.oauthAppStore.loadAll();
     this.callbackURL =
       window.location.protocol +
       '//' +

--- a/app/ui/src/app/store/entity/entity.store.ts
+++ b/app/ui/src/app/store/entity/entity.store.ts
@@ -93,6 +93,11 @@ export abstract class AbstractStore<
   loadAll(retries = 0) {
     if (!retries && this.listSubscription) {
       return;
+    } else {
+      // forcing a reload in this case
+      if (this.listSubscription) {
+        this.listSubscription.unsubscribe();
+      }
     }
     this._loading.next(true);
     this.listSubscription = observableMerge(

--- a/app/ui/src/app/store/oauthApp/oauth-app.store.ts
+++ b/app/ui/src/app/store/oauthApp/oauth-app.store.ts
@@ -17,4 +17,9 @@ export class OAuthAppStore extends AbstractStore<
   protected get kind() {
     return 'OAuthApp';
   }
+
+  loadAll() {
+    // Force a reload as no events get generated for oauth apps
+    super.loadAll(1);
+  }
 }


### PR DESCRIPTION
fixes #3672

Also renames some class variables and forces a re-fetch of oauth clients when visiting the settings page, since updates to this endpoint doesn't appear to trigger change events.