### PR TITLE
fix(server): don't consider hidden OAuth properties

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -53,9 +53,13 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
 
             if (maybeProperty.isPresent()) {
                 final Entry<String, ConfigurationProperty> property = maybeProperty.get();
-                final String propertyName = property.getKey();
 
                 final ConfigurationProperty configuration = property.getValue();
+                if ("hidden".equals(configuration.getType())) {
+                    return this;
+                }
+
+                final String propertyName = property.getKey();
                 putProperty(propertyName, configuration);
 
                 final Optional<String> maybeValue = connector.propertyTaggedWith(tag);

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
@@ -65,6 +65,32 @@ public class OAuthAppTest {
     }
 
     @Test
+    public void shouldComputeDerived() {
+        assertThat(new OAuthApp.Builder().build().isDerived()).isFalse();
+
+        assertThat(new OAuthApp.Builder()//
+            .putProperty("clientId", CLIENT_ID_PROPERTY)//
+            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
+            .build()//
+            .isDerived()).isFalse();
+
+        assertThat(new OAuthApp.Builder()//
+            .putProperty("clientId", CLIENT_ID_PROPERTY)//
+            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
+            .putConfiguredProperty("clientId", "client-id")//
+            .build()//
+            .isDerived()).isFalse();
+
+        assertThat(new OAuthApp.Builder()//
+            .putProperty("clientId", CLIENT_ID_PROPERTY)//
+            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
+            .putConfiguredProperty("clientId", "client-id")//
+            .putConfiguredProperty("clientSecret", "client-secret")//
+            .build()//
+            .isDerived()).isTrue();
+    }
+
+    @Test
     public void shouldCreateFromConnector() {
         final OAuthApp oauthApp = OAuthApp.fromConnector(connector);
 
@@ -88,6 +114,27 @@ public class OAuthAppTest {
         final OAuthApp oauthApp = OAuthApp.fromConnector(emptyConnector);
 
         final OAuthApp expected = new OAuthApp.Builder().build();
+
+        assertThat(oauthApp).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldOmitHiddenProperties() {
+        final Connector withHiddenProperty = new Connector.Builder().createFrom(connector)
+            .putProperty("theHiddenOne",
+                new ConfigurationProperty.Builder().type("hidden").addTag(Credentials.AUTHENTICATION_URL_TAG).build())
+            .build();
+        final OAuthApp oauthApp = OAuthApp.fromConnector(withHiddenProperty);
+
+        final OAuthApp expected = new OAuthApp.Builder()//
+            .id("connector-id")//
+            .name("Connector")//
+            .icon("svg-icon")//
+            .putProperty("clientId", CLIENT_ID_PROPERTY)//
+            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
+            .putConfiguredProperty("clientId", "client-id")//
+            .putConfiguredProperty("clientSecret", "client-secret")//
+            .build();
 
         assertThat(oauthApp).isEqualTo(expected);
     }
@@ -129,31 +176,5 @@ public class OAuthAppTest {
             .build();
 
         assertThat(updated).isEqualTo(expected);
-    }
-
-    @Test
-    public void shouldComputeDerived() {
-        assertThat(new OAuthApp.Builder().build().isDerived()).isFalse();
-
-        assertThat(new OAuthApp.Builder()//
-            .putProperty("clientId", CLIENT_ID_PROPERTY)//
-            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
-            .build()//
-            .isDerived()).isFalse();
-
-        assertThat(new OAuthApp.Builder()//
-            .putProperty("clientId", CLIENT_ID_PROPERTY)//
-            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
-            .putConfiguredProperty("clientId", "client-id")//
-            .build()//
-            .isDerived()).isFalse();
-
-        assertThat(new OAuthApp.Builder()//
-            .putProperty("clientId", CLIENT_ID_PROPERTY)//
-            .putProperty("clientSecret", CLIENT_SECRET_PROPERTY)//
-            .putConfiguredProperty("clientId", "client-id")//
-            .putConfiguredProperty("clientSecret", "client-secret")//
-            .build()//
-            .isDerived()).isTrue();
     }
 }


### PR DESCRIPTION
We should not send `type=hidden` properties to the UI for the OAuth
setup, it makes little sense as the UI will not be able to anything
meaningful with them.

Fixes #3674