### PR TITLE
[CI] Automatic pull request opened by the Fuse 7 dev pipeline to synchronize versions

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -45,26 +45,26 @@
     <image.meta>syndesis/syndesis-meta:%l</image.meta>
     <image.ui>syndesis/syndesis-ui:%l</image.ui>
 
-    <fabric8.maven.plugin.version>3.5.38</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.5.33.fuse-720012</fabric8.maven.plugin.version>
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
     <node.version>v8.11.2</node.version>
     <yarn.version>v1.2.1</yarn.version>
 
-    <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
+    <hibernate.validator.version>5.3.5.Final-redhat-2</hibernate.validator.version>
 
     <jackson.version>2.8.11</jackson.version>
     <json-patch.version>1.9</json-patch.version>
-    <kubernetes.client.version>3.1.4.fuse-710001</kubernetes.client.version>
+    <kubernetes.client.version>3.1.4.fuse-720016</kubernetes.client.version>
 
-    <spring.version>4.3.12.RELEASE</spring.version>
+    <spring.version>4.3.17.RELEASE</spring.version>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <spring-cloud.version>Dalston.SR5</spring-cloud.version>
 
     <swagger.version>1.5.19</swagger.version>
 
-    <activemq.version>5.15.4</activemq.version>
+    <activemq.version>5.11.0.redhat-630343</activemq.version>
 
     <arquillian.version>1.4.0.Final</arquillian.version>
     <arquillian.cube.version>1.15.2</arquillian.cube.version>
@@ -74,7 +74,7 @@
     <errorprone.version>2.3.1</errorprone.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.21.0.fuse-720021</camel.version>
+    <camel.version>2.21.0.fuse-720023</camel.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
     <dep.plugin.pmd.version>3.8</dep.plugin.pmd.version>
@@ -93,7 +93,7 @@
 
     <!-- Plugin versions -->
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-    <docker.maven.plugin.version>0.23.0</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.23.0.fuse-720015</docker.maven.plugin.version>
 
     <!-- Maven versions -->
     <maven-archetype-packaging.version>2.0</maven-archetype-packaging.version>


### PR DESCRIPTION
@janstey @zregvart

I'd like to start to automatically open PRs into syndesis master after a Fuse 7 pipeline build.    Here's the initial run, I think there are some issues here that we probably need to be squared away  ...

- we're building jboss-fuse/f-m-p 3.5.x.redhat-7-x, which is based off of 3.5.33, but syndesis is using 3.5.38 - do we need to update the product branch of f-m-p?

- what activemq version should we be using in the Fuse 7 build?   Right now we're set to 5.11.0.redhat-630343, and syndesis is using 5.15

Everything else looks pretty reasonable, I think (correct me if I'm wrong)

