### PR TITLE
fix(oauth): handle hidden properties defultValue

### DIFF
--- a/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
+++ b/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
@@ -10,12 +10,8 @@
     }
   ],
   "configuredProperties": {
-    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
-    "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
     "authenticationType": "oauth2",
-    "googleScopes": "https://mail.google.com/",
-    "applicationName": "gmail-syndesis",
-    "additionalOAuthQueryParameters": "{\"access_type\": \"offline\"}"
+    "applicationName": "gmail-syndesis"
   },
   "tags": [
     "verifier"
@@ -121,7 +117,8 @@
       "labelHint": "UserId",
       "tags": [
         "oauth-scope"
-      ]
+      ],
+      "defaultValue": "https://mail.google.com/"
     },
     "tokenUrl": {
       "kind": "property",
@@ -137,7 +134,8 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token"
+      "description": "The access token",
+      "defaultValue": "https://www.googleapis.com/oauth2/v4/token"
     },
     "authorizationUrl": {
       "kind": "property",
@@ -153,7 +151,8 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token"
+      "description": "The access token",
+      "defaultValue": "https://accounts.google.com/o/oauth2/v2/auth"
     },
     "authenticationType": {
       "kind": "property",
@@ -183,7 +182,8 @@
       "raw": true,
       "tags": [
         "oauth-additional-query-parameters"
-      ]
+      ],
+      "defaultValue": "{\"access_type\": \"offline\"}"
     }
   },
   "actions": [

--- a/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
+++ b/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
@@ -10,10 +10,7 @@
     }
   ],
   "configuredProperties": {
-    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
-    "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
     "authenticationType": "oauth2",
-    "googleScopes": "https://www.googleapis.com/auth/calendar",
     "applicationName": "calendar-syndesis",
     "additionalOAuthQueryParameters": "{\"access_type\": \"offline\"}"
   },
@@ -121,7 +118,8 @@
       "labelHint": "UserId",
       "tags": [
         "oauth-scope"
-      ]
+      ],
+      "defaultValue": "https://www.googleapis.com/auth/calendar"
     },
     "tokenUrl": {
       "kind": "property",
@@ -137,7 +135,8 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token"
+      "description": "The access token",
+      "defaultValue": "https://accounts.google.com/o/oauth2/token"
     },
     "authorizationUrl": {
       "kind": "property",
@@ -153,7 +152,8 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token"
+      "description": "The access token",
+      "defaultValue": "https://accounts.google.com/o/oauth2/v2/auth"
     },
     "authenticationType": {
       "kind": "property",

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
@@ -140,6 +140,17 @@ public class OAuthAppTest {
     }
 
     @Test
+    public void shouldUpdateConnectorWithDefaultValuesIfNoneGiven() {
+        final Connector withHiddenProperty = new Connector.Builder().createFrom(connector)
+            .putProperty("defaulted",
+                new ConfigurationProperty.Builder().type("hidden").addTag(Credentials.AUTHENTICATION_URL_TAG).defaultValue("I'm a default").build())
+            .build();
+        final Connector updated = OAuthApp.fromConnector(withHiddenProperty).update(withHiddenProperty);
+
+        assertThat(updated.getConfiguredProperties()).containsEntry("defaulted", "I'm a default");
+    }
+
+    @Test
     public void shouldUpdateConnectorKeepingTheSameValues() {
         final Connector updated = OAuthApp.fromConnector(connector).update(connector);
 


### PR DESCRIPTION
When we made the change in #3674 (PR #3678) not to send hidden properties to the UI -- the UI stopped caring about the values of those properties (it simply wasn't aware of them). So when the OAuth settings were changed by the user the value of the property was set to `null` overriding the previously set `configuredProperty`.

This changes the descriptors of gmail and google-calendar connectors so that the values needed to be set in `configuredProperties` are defined as `defaultValue` of the property and the logic was implemented to set the `defaultValue` to the `configuredProperty` if the recived value from the UI is `null`. Exactly as it functioned when the UI was aware of the hidden properties.

Also we were missing a tag in the tags to consider when setting `configuredProperties` of a Connector based on the input from the user and the Connector metadata in `properties`.