### PR TITLE
refactor: handling of hidden OAuth connector properties

### DIFF
--- a/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
+++ b/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
@@ -10,8 +10,12 @@
     }
   ],
   "configuredProperties": {
+    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+    "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
     "authenticationType": "oauth2",
-    "applicationName": "gmail-syndesis"
+    "googleScopes": "https://mail.google.com/",
+    "applicationName": "gmail-syndesis",
+    "additionalOAuthQueryParameters": "{\"access_type\": \"offline\"}"
   },
   "tags": [
     "verifier"
@@ -117,8 +121,7 @@
       "labelHint": "UserId",
       "tags": [
         "oauth-scope"
-      ],
-      "defaultValue": "https://mail.google.com/"
+      ]
     },
     "tokenUrl": {
       "kind": "property",
@@ -134,8 +137,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token",
-      "defaultValue": "https://www.googleapis.com/oauth2/v4/token"
+      "description": "The access token"
     },
     "authorizationUrl": {
       "kind": "property",
@@ -151,8 +153,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token",
-      "defaultValue": "https://accounts.google.com/o/oauth2/v2/auth"
+      "description": "The access token"
     },
     "authenticationType": {
       "kind": "property",
@@ -182,8 +183,7 @@
       "raw": true,
       "tags": [
         "oauth-additional-query-parameters"
-      ],
-      "defaultValue": "{\"access_type\": \"offline\"}"
+      ]
     }
   },
   "actions": [

--- a/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
+++ b/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
@@ -10,7 +10,10 @@
     }
   ],
   "configuredProperties": {
+    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+    "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
     "authenticationType": "oauth2",
+    "googleScopes": "https://www.googleapis.com/auth/calendar",
     "applicationName": "calendar-syndesis",
     "additionalOAuthQueryParameters": "{\"access_type\": \"offline\"}"
   },
@@ -118,8 +121,7 @@
       "labelHint": "UserId",
       "tags": [
         "oauth-scope"
-      ],
-      "defaultValue": "https://www.googleapis.com/auth/calendar"
+      ]
     },
     "tokenUrl": {
       "kind": "property",
@@ -135,8 +137,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token",
-      "defaultValue": "https://accounts.google.com/o/oauth2/token"
+      "description": "The access token"
     },
     "authorizationUrl": {
       "kind": "property",
@@ -152,8 +153,7 @@
       "deprecated": false,
       "secret": true,
       "componentProperty": true,
-      "description": "The access token",
-      "defaultValue": "https://accounts.google.com/o/oauth2/v2/auth"
+      "description": "The access token"
     },
     "authenticationType": {
       "kind": "property",

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -125,13 +125,20 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
 
             if (maybeProperty.isPresent()) {
                 final Entry<String, ConfigurationProperty> property = maybeProperty.get();
+                final ConfigurationProperty propertyDefinition = property.getValue();
                 final String propertyName = property.getKey();
 
                 final String configuredValue = configuredProperties.get(propertyName);
                 final String value;
-                if (configuredValue == null) {
-                    final ConfigurationProperty configuration = property.getValue();
-                    value = configuration.getDefaultValue();
+                if (configuredValue == null && "hidden".equals(propertyDefinition.getType())) {
+                    final ConfigurationProperty configuration = propertyDefinition;
+
+                    final String currentValue = current.get(propertyName);
+                    if (currentValue == null) {
+                        value = configuration.getDefaultValue();
+                    } else {
+                        value = currentValue;
+                    }
                 } else {
                     value = configuredValue;
                 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppTest.java
@@ -27,9 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OAuthAppTest {
 
-    static final ConfigurationProperty CLIENT_ID_PROPERTY = new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_ID_TAG).build();
+    static final ConfigurationProperty CLIENT_ID_PROPERTY = new ConfigurationProperty.Builder()
+        .addTag(Credentials.CLIENT_ID_TAG).build();
 
-    static final ConfigurationProperty CLIENT_SECRET_PROPERTY = new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_SECRET_TAG).build();
+    static final ConfigurationProperty CLIENT_SECRET_PROPERTY = new ConfigurationProperty.Builder()
+        .addTag(Credentials.CLIENT_SECRET_TAG).build();
 
     final Connector connector = new Connector.Builder()//
         .id("connector-id")//
@@ -142,12 +144,35 @@ public class OAuthAppTest {
     @Test
     public void shouldUpdateConnectorWithDefaultValuesIfNoneGiven() {
         final Connector withHiddenProperty = new Connector.Builder().createFrom(connector)
-            .putProperty("defaulted",
-                new ConfigurationProperty.Builder().type("hidden").addTag(Credentials.AUTHENTICATION_URL_TAG).defaultValue("I'm a default").build())
+            .putProperty("defaulted", new ConfigurationProperty.Builder().type("hidden")
+                .addTag(Credentials.AUTHENTICATION_URL_TAG).defaultValue("I'm a default").build())
             .build();
         final Connector updated = OAuthApp.fromConnector(withHiddenProperty).update(withHiddenProperty);
 
         assertThat(updated.getConfiguredProperties()).containsEntry("defaulted", "I'm a default");
+    }
+
+    @Test
+    public void shouldKeepConnectorConfiguredPropertiesIfNoneGiven() {
+        final Connector withConfiguredProperty = new Connector.Builder().createFrom(connector)
+            .putProperty("configured",
+                new ConfigurationProperty.Builder().type("hidden").addTag(Credentials.AUTHENTICATION_URL_TAG).build())
+            .putConfiguredProperty("configured", "initial").build();
+        final Connector updated = OAuthApp.fromConnector(withConfiguredProperty).update(withConfiguredProperty);
+
+        assertThat(updated.getConfiguredProperties()).containsEntry("configured", "initial");
+    }
+
+    @Test
+    public void shouldSetConfiguredPropertyIfGivenEvenIfConfiguredPropertyOrDefaultExists() {
+        final Connector withHiddenProperty = new Connector.Builder().createFrom(connector)
+            .putProperty("prop", new ConfigurationProperty.Builder().type("hidden")
+                .addTag(Credentials.AUTHENTICATION_URL_TAG).defaultValue("I'm a default").build())
+            .putConfiguredProperty("prop", "initial").build();
+        final Connector updated = OAuthApp.fromConnector(withHiddenProperty).update(
+            new Connector.Builder().createFrom(withHiddenProperty).putConfiguredProperty("prop", "new-value").build());
+
+        assertThat(updated.getConfiguredProperties()).containsEntry("prop", "new-value");
     }
 
     @Test


### PR DESCRIPTION
With this we can configure in the Connector metadata hidden `configuredProperties` or give `defaultValue`s where appropriate. The change makes the OAuth-tagged `properties` that have `type=hidden` and for which values from the UI are not received (as the UI has no knowledge of them, from #3674 (PR #3678)) take values from `configuredProperties` of the connector or from `defaultValue` of the `property`, whichever is defined first (in that order).