### PR TITLE
Updated OpenAPI spec upload to also accept YAML files

### DIFF
--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-create.component.ts
@@ -112,7 +112,14 @@ export class ApiConnectorCreateComponent implements OnInit, OnDestroy {
               const reader = new FileReader();
 
               reader.onload = () => {
-                this.apiDef.spec = reader.result;
+                if ( apiConnectorState.specificationFile.name.endsWith( '.json' ) ) {
+                  this.apiDef.spec = reader.result;
+                } else {
+                  // Uploading YAML file. Apicurio only accepts JSON string but does accept YAML JS object so convert.
+                  const spec = YAML.parse( reader.result );
+                  this.apiDef.spec = spec;
+                }
+
                 this.apiDef.name = apiConnectorState.name;
               };
 

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.html
@@ -54,7 +54,6 @@
                     <input #fileSelect
                       class="api-file-chooser"
                       type="file"
-                      accept="application/json"
                       ng2FileSelect
                       [uploader]="uploader">
                   </p>

--- a/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
+++ b/app/ui/src/app/customizations/api-connector/api-connector-create/api-connector-swagger-upload/api-connector-swagger-upload.component.ts
@@ -59,12 +59,13 @@ export class ApiConnectorSwaggerUploadComponent implements OnInit {
 
     this.uploader = new FileUploader(
       {
-        allowedMimeType: [ 'application/json' ],
         filters: [
           {
             name: 'filename filter',
             fn: ( item: FileLikeObject, options: FileUploaderOptions ) => {
-              return item.name.endsWith( '.json' );
+              return item.name.endsWith( '.json' )
+                     || item.name.endsWith( '.yaml' )
+                     || item.name.endsWith( '.yml' );
             }
           }
         ]
@@ -91,10 +92,11 @@ export class ApiConnectorSwaggerUploadComponent implements OnInit {
     this.uploader.onWhenAddingFileFailed = (
       file: FileLikeObject
     ): any => {
-      // occurs when not a *.json file
+      // occurs when not a *.json, *.yaml, or *.yml file
       this.invalidFileMsg = this.i18NService.localize( 'customizations.api-client-connectors.api-upload-invalid-file',
                                                        [ file.name ] );
       this.fileSelect.nativeElement.value = '';
+      this.fileToUpload = null;
       this.uploader.clearQueue();
     };
   }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -55,8 +55,8 @@
         "api-upload-choose-method": "Choose how you want to create your connector:",
         "url-upload-instructions": "Upload the OpenAPI 2.0 file for your custom API client connector. Custom APIs are RESTful APIs and can be hosted anywhere, as long as a well-documented API specification is available and conforms to the OpenAPI standard.",
         "api-upload-valid-file": "Successfully uploaded '{{0}}'.",
-        "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json' can be uploaded.",
-        "api-upload-helper-text": "Accepted file type: .json",
+        "api-upload-invalid-file": "'{{0}}' is not a valid file. Only files that end in '.json', '.yaml', or '.yml' can be uploaded.",
+        "api-upload-helper-text": "Accepted file types: .json, .yaml, and .yml",
         "api-url-upload": "Use a URL",
         "api-url-upload-note": "* Note: After uploading this specification, Syndesis/Fuse Online does not automatically obtain any updates to it. You would have to upload an updated specification and create a new API client connector that incorporates the updates.",
         "url-validation-error": "You must enter a valid URL before submitting the form."


### PR DESCRIPTION
- See #3578
- removed accepted mime type of json from file chooser as there was no way to add YAML files
- added *.yaml and *.yml files to the DND accepted files
- changed helper text and invalid file message