### PR TITLE
fix(tools): fix pod list passing

### DIFF
--- a/tools/bin/commands/dev
+++ b/tools/bin/commands/dev
@@ -133,7 +133,7 @@ dev::run() {
         echo -n Removing stale pods...
         local old_pods=$(oc get pods --field-selector=status.phase=Succeeded -o=jsonpath='{range .items[*]}{.metadata.name} ')
         if [ -n "$old_pods" ]; then
-            oc delete pods "$old_pods"
+            oc delete pods $old_pods
         fi
         echo -e -n 'done\nRemoving stale builds...'
         oc --as system:admin adm prune builds --confirm


### PR DESCRIPTION
Removes the quotes around $old_pods so that the list of pods is not
given as a single argument. Fixing the issue when there are more than
one stale pods to remove.