### PR TITLE
chore: Update to AtlasMap 1.37.0

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <camel.version>2.21.0.fuse-720021</camel.version>
-    <atlasmap.version>1.36.0</atlasmap.version>
+    <atlasmap.version>1.37.0</atlasmap.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,7 +37,7 @@
     <syndesis.version>${project.version}</syndesis.version>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>1.36.0</atlasmap.version>
+    <atlasmap.version>1.37.0</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser": "^6.0.3",
     "@angular/platform-browser-dynamic": "^6.0.3",
     "@angular/router": "^6.0.3",
-    "@atlasmap/atlasmap-data-mapper": "1.36.0",
+    "@atlasmap/atlasmap-data-mapper": "1.37.0",
     "@ng-dynamic-forms/core": "^5.4.6",
     "@ngrx/effects": "^6.0.1",
     "@ngrx/store": "^6.0.1",

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -191,9 +191,9 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap-data-mapper@1.36.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.36.0.tgz#53e5d84cb2b77d2acc9c854db1eb898f63a0e790"
+"@atlasmap/atlasmap-data-mapper@1.37.0":
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.37.0.tgz#172e6348ff313c98fc3b58b89fa25ff00919493a"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Contains
 * import/export mapping/document for standalone (disabled in Syndesis)
 * Allow field actions to receive whole collection (atlasmap/atlasmap#338)
 * Update to Angular 6.1 (atlasmap/atlasmap#568)
 * fixed infinite loop on recursive type in XML schema inspection (atlasmap/atlasmap#573)
 * and more bug fixes

Cc: @johnpoth 