### PR TITLE
fix: UT010029: Stream is closed with WebHook connector

### DIFF
--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestWrapperProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestWrapperProcessor.java
@@ -23,6 +23,8 @@ import io.syndesis.connector.support.processor.util.SimpleJsonSchemaInspector;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.util.ExchangeHelper;
 import org.apache.camel.util.ObjectHelper;
 
 import java.io.InputStream;
@@ -67,7 +69,11 @@ public class HttpRequestWrapperProcessor implements Processor {
             rootNode.putPOJO("body", body);
         }
 
-        message.setBody(Json.toString(rootNode));
+        final String newBody = Json.toString(rootNode);
+        final Message replacement = new DefaultMessage(exchange.getContext());
+        replacement.copyFromWithNewBody(message, newBody);
+
+        ExchangeHelper.replaceMessage(exchange, replacement, false);
     }
 
     public Set<String> getParameters() {


### PR DESCRIPTION
This replaces the message on the exchange not only the body, so the type of the message is no longer `HttpMessage` and when copies of the message are attempted the HTTP request stream is not read the second time. At which point the HTTP request stream might be closed.

Fixes #3727