### PR TITLE
refactor: don't expose WebHook integrations via 3scale

### DIFF
--- a/app/common/model/src/test/java/io/syndesis/common/model/integration/IntegrationBaseTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/integration/IntegrationBaseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.integration;
+
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.Connection;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntegrationBaseTest {
+
+    @Test
+    public void shouldCollectConnectorIdsFromConnectorAction() {
+        assertThat(
+            new Integration.Builder().addFlow(new Flow.Builder().addStep(stepWithConnectorInAction("ctr1")).build())
+                .build().getUsedConnectorIds()).containsOnly("ctr1");
+    }
+
+    @Test
+    public void shouldCollectConnectorIdsFromHollowIntegrations() {
+        assertThat(new Integration.Builder().build().getUsedConnectorIds()).isEmpty();
+    }
+
+    @Test
+    public void shouldCollectConnectorIdsFromSteps() {
+        assertThat(new Integration.Builder().addFlow(new Flow.Builder().addStep(stepWithConnector("ctr1")).build())
+            .build().getUsedConnectorIds()).containsOnly("ctr1");
+    }
+
+    private static Step stepWithConnector(String connectorId) {
+        return new Step.Builder().connection(connectionWithConnector(connectorId)).build();
+    }
+
+    @Test
+    public void shouldCollectConnectorIdsFromStepsAndConnectorActions() {
+        assertThat(new Integration.Builder()
+            .addFlow(
+                new Flow.Builder().addStep(stepWithConnectorInAction("ctr1")).addStep(stepWithConnectorInAction("ctr2"))
+                    .addStep(stepWithConnector("ctr1")).addStep(stepWithConnector("ctr3")).build())
+            .build().getUsedConnectorIds()).containsOnly("ctr1", "ctr2", "ctr3");
+    }
+
+    private static ConnectorAction actionWithConnector(final String connectorId) {
+        return new ConnectorAction.Builder().descriptor(connectorDescriptor(connectorId)).build();
+    }
+
+    private static Connection connectionWithConnector(final String connectorId) {
+        return new Connection.Builder().connectorId(connectorId).build();
+    }
+
+    private static ConnectorDescriptor connectorDescriptor(final String connectorId) {
+        return new ConnectorDescriptor.Builder().connectorId(connectorId).build();
+    }
+
+    private static Step stepWithConnectorInAction(final String connectorId) {
+        return new Step.Builder()
+            .action(new ConnectorAction.Builder().descriptor(connectorDescriptor(connectorId)).build()).build();
+    }
+}

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/customizer/ExposureDeploymentDataCustomizer.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/customizer/ExposureDeploymentDataCustomizer.java
@@ -44,7 +44,7 @@ public final class ExposureDeploymentDataCustomizer implements DeploymentDataCus
 
     EnumSet<Exposure> determineExposure(final IntegrationDeployment integrationDeployment) {
         if (needsExposure(integrationDeployment)) {
-            if (exposeVia3scale) {
+            if (exposeVia3scale && isNotWebhook(integrationDeployment)) {
                 return EnumSet.of(Exposure.SERVICE, Exposure._3SCALE);
             }
 
@@ -52,6 +52,10 @@ public final class ExposureDeploymentDataCustomizer implements DeploymentDataCus
         }
 
         return EnumSet.noneOf(Exposure.class);
+    }
+
+    static boolean isNotWebhook(IntegrationDeployment integrationDeployment) {
+        return !integrationDeployment.getSpec().getUsedConnectorIds().contains("webhook");
     }
 
     static boolean needsExposure(final IntegrationDeployment integrationDeployment) {

--- a/app/server/controller/src/test/java/io/syndesis/server/controller/integration/online/customizer/ExposureDeploymentDataCustomizerTest.java
+++ b/app/server/controller/src/test/java/io/syndesis/server/controller/integration/online/customizer/ExposureDeploymentDataCustomizerTest.java
@@ -16,6 +16,7 @@
 package io.syndesis.server.controller.integration.online.customizer;
 
 import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.IntegrationDeployment;
@@ -68,5 +69,23 @@ public class ExposureDeploymentDataCustomizerTest {
         final ExposureDeploymentDataCustomizer customizer = new ExposureDeploymentDataCustomizer(properties);
 
         assertThat(customizer.determineExposure(exposedIntegration)).containsOnly(Exposure.SERVICE, Exposure._3SCALE);
+    }
+
+    @Test
+    public void shouldNotExposeWebHooksVia3scaleWhen3scaleIsEnabled() {
+        final ControllersConfigurationProperties properties = new ControllersConfigurationProperties();
+        properties.setExposeVia3scale(true);
+
+        final ExposureDeploymentDataCustomizer customizer = new ExposureDeploymentDataCustomizer(properties);
+
+        final IntegrationDeployment webHookIntegration = new IntegrationDeployment.Builder()
+            .spec(new Integration.Builder()
+                .addFlow(new Flow.Builder().addStep(new Step.Builder().action(new ConnectorAction.Builder()
+                    .descriptor(new ConnectorDescriptor.Builder().connectorId("webhook").build()).addTag("expose")
+                    .build()).build()).build())
+                .build())
+            .build();
+
+        assertThat(customizer.determineExposure(webHookIntegration)).containsOnly(Exposure.SERVICE, Exposure.ROUTE);
     }
 }


### PR DESCRIPTION
With this WebHook integrations will not be exposed via 3scale even if the exposure via 3scale is enabled (see #3504). I.e. WebHook integrations will allways be exposed via OpenShift Route and will not participate in 3scale service discovery.

Fixes #3731