### PR TITLE
refactor(connector): Make the channel selection for Slack Producer dy…

### DIFF
--- a/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
+++ b/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
@@ -127,6 +127,9 @@
             "description": "Send a message to a specific Slack channel.",
             "id": "io.syndesis:slack-channel-connector",
             "pattern": "To",
+            "tags": [
+                "dynamic"
+            ],
             "actionType": "connector",
             "descriptor": {
                 "connectorCustomizers": [


### PR DESCRIPTION
…namic as the Consumer

Since now WebhookURL and Token are both required in the connection configuration, we can take advantage of this and use the dynamic tag in the Slack Channel action of the producer too.