### PR TITLE
ENTESB-9439: Prevent snyk being run in prod environment

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -28,7 +28,7 @@
     "sw": "sw-precache --root=dist --config=sw-precache-config.js",
     "docker:build": "yarn ng build --aot --prod && docker build -f docker/Dockerfile -t syndesis/syndesis-ui:latest . && docker tag syndesis/syndesis-ui:latest docker.io/syndesis/syndesis-ui:latest",
     "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect; yarn snyk-protect"
+    "prepare": "if [ -z $OFFLINE_BUILD ]; then npm run snyk-protect; yarn snyk-protect; fi"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Only run the snyk tooling if the OFFLINE_BUILD environment variable hasn't been set. So snyk will still be run in the ci builds, but can be turned off in the prod environment where calls to external sites are prohibited.
Thanks to @zregvart for this solution.