### PR TITLE
refactor(api): POST /api/v1/integration-support/import response

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Kind.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Kind.java
@@ -120,6 +120,10 @@ public enum Kind {
         return modelName;
     }
 
+    public String getPluralModelName() {
+        return modelName + "s";
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends WithId<T>> Class<T> getModelClass() {
         return (Class<T>) modelClass;


### PR DESCRIPTION
Changes the response from `POST /api/v1/integration-support/import` to return the objects that were imported. Imported objects are returned in JSON object with the keys being the plural forms of the object kind, and the values an JSON array of imported objects grouped by kind.

![screenshot from 2018-10-05 13-23-28](https://user-images.githubusercontent.com/1306050/46532799-ab5c2500-c8a2-11e8-8c6c-47cb2dea25ac.png)

Fixes #3167