### PR TITLE
Fixes usage count for Connections and Extensions

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+
 import org.immutables.value.Value;
 import io.syndesis.common.model.ToJson;
 import io.syndesis.common.model.WithConfiguredProperties;
@@ -28,7 +29,8 @@ import io.syndesis.common.model.WithResourceId;
 import io.syndesis.common.model.WithTags;
 import io.syndesis.common.model.environment.Organization;
 
-public interface ConnectionBase extends WithResourceId, WithTags, WithName, WithConfiguredProperties, ToJson, Serializable {
+public interface ConnectionBase
+    extends WithResourceId, WithTags, WithName, WithConfiguredProperties, ToJson, Serializable {
 
     Optional<Organization> getOrganization();
 
@@ -40,6 +42,7 @@ public interface ConnectionBase extends WithResourceId, WithTags, WithName, With
 
     /**
      * Actual options how this connection is configured
+     *
      * @return list of options
      */
     Map<String, String> getOptions();
@@ -56,17 +59,16 @@ public interface ConnectionBase extends WithResourceId, WithTags, WithName, With
 
     /**
      * A flag denoting that the some of connection properties were derived.
-     * Ostensibly used to mark the {@link #getConfiguredProperties()} being
-     * set by the OAuth flow so that the UI can alternate between full edit
-     * and reconnect OAuth views.
+     * Ostensibly used to mark the {@link #getConfiguredProperties()} being set
+     * by the OAuth flow so that the UI can alternate between full edit and
+     * reconnect OAuth views.
      */
     boolean isDerived();
 
     /**
      * Provides number of integrations using this connection
      * <p>
-     * Note:
-     * Excluded from {@link #hashCode()} and {@link #equals(Object)}
+     * Note: Excluded from {@link #hashCode()} and {@link #equals(Object)}
      *
      * @return count of integrations
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/Connector.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/Connector.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.ToJson;
@@ -101,6 +103,7 @@ public interface Connector extends WithId<Connector>, WithIdVersioned<Connector>
      * @return count of integrations
      */
     @Value.Auxiliary
+    @JsonProperty(access = Access.READ_ONLY)
     OptionalInt getUses();
 
     default Optional<String> propertyTaggedWith(final String tag) {

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandlerTest.java
@@ -157,7 +157,22 @@ public class ConnectionHandlerTest {
         final ConnectionOverview overview = handler.get("c1");
         assertThat(overview).isNotNull();
         assertThat(overview.getUses()).isPresent();
-        assertThat(overview.getUses().getAsInt()).isEqualTo(4);
+        assertThat(overview.getUses()).hasValue(4);
+    }
+
+    @Test
+    public void connectionsUsedInDeletedIntegrationsShouldNotBeCountedAsUsed() {
+        final Integration integration1 = testIntegration().withFlowConnections(c1).isDeleted(true).build();
+        final Integration integration2 = testIntegration().withFlowStepsUsingConnections(c1).isDeleted(true).build();
+        final Integration integration3 = testIntegration().addConnection(c1).isDeleted(true).build();
+
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integration1, integration2, integration3));
+        when(dataManager.fetch(Connection.class, "c1")).thenReturn(c1);
+
+        final ConnectionOverview overview = handler.get("c1");
+        assertThat(overview).isNotNull();
+        assertThat(overview.getUses()).isPresent();
+        assertThat(overview.getUses()).hasValue(0);
     }
 
     @Test

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.extension;
+
+import java.util.Collections;
+
+import io.syndesis.common.model.Dependency;
+import io.syndesis.common.model.Dependency.Type;
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.extension.Extension;
+import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.common.model.integration.IntegrationDeploymentState;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.integration.api.IntegrationResourceManager;
+import io.syndesis.server.dao.manager.DataManager;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExtensionHandlerTest {
+
+    DataManager data = mock(DataManager.class);
+
+    Extension extension = new Extension.Builder().extensionId("extension-1").build();
+
+    Integration integration = new Integration.Builder().id("integration-1").addFlow(new Flow.Builder()
+        .addStep(new Step.Builder().addDependency(new Dependency.Builder().id("extension-1").build()).build()).build())
+        .build();
+
+    IntegrationDeployment publishedDeployment = new IntegrationDeployment.Builder().spec(integration)
+        .targetState(IntegrationDeploymentState.Published).build();
+
+    IntegrationResourceManager resource = mock(IntegrationResourceManager.class);
+
+    IntegrationDeployment unpublishedDeployment = new IntegrationDeployment.Builder().spec(integration)
+        .targetState(IntegrationDeploymentState.Unpublished).build();
+
+    @Test
+    public void shouldCountUsedExtensions() {
+        final ExtensionHandler handler = new ExtensionHandler(data, null, null, null, resource);
+
+        when(data.fetchAll(Integration.class)).thenReturn(ListResult.of(integration));
+        when(data.fetchAll(IntegrationDeployment.class)).thenReturn(ListResult.of(publishedDeployment));
+        when(resource.collectDependencies(integration))
+            .thenReturn(Collections.singleton(new Dependency.Builder().id("extension-1").type(Type.EXTENSION).build()));
+
+        assertThat(handler.enhance(extension).getUses()).hasValue(1);
+    }
+
+    @Test
+    public void shouldNotCountUsedExtensionsInDeletedIntegrations() {
+        final ExtensionHandler handler = new ExtensionHandler(data, null, null, null, resource);
+
+        when(data.fetchAll(Integration.class))
+            .thenReturn(ListResult.of(new Integration.Builder().createFrom(integration).isDeleted(true).build()));
+        when(data.fetchAll(IntegrationDeployment.class)).thenReturn(ListResult.of(publishedDeployment));
+        when(resource.collectDependencies(integration))
+            .thenReturn(Collections.singleton(new Dependency.Builder().id("extension-1").type(Type.EXTENSION).build()));
+
+        assertThat(handler.enhance(extension).getUses()).hasValue(0);
+    }
+
+    @Test
+    public void shouldNotCountUsedExtensionsOfUnpublishedDeployments() {
+        final ExtensionHandler handler = new ExtensionHandler(data, null, null, null, resource);
+
+        when(data.fetchAll(Integration.class)).thenReturn(ListResult.of(integration));
+        when(data.fetchAll(IntegrationDeployment.class)).thenReturn(ListResult.of(unpublishedDeployment));
+        when(resource.collectDependencies(integration))
+            .thenReturn(Collections.singleton(new Dependency.Builder().id("extension-1").type(Type.EXTENSION).build()));
+
+        assertThat(handler.enhance(extension).getUses()).hasValue(0);
+    }
+
+    @Test
+    public void shouldNotCountUsedExtensionsWhenIntegrationDoesntDependOnIt() {
+        final ExtensionHandler handler = new ExtensionHandler(data, null, null, null, resource);
+
+        when(data.fetchAll(Integration.class)).thenReturn(ListResult.of(integration));
+        when(data.fetchAll(IntegrationDeployment.class)).thenReturn(ListResult.of(publishedDeployment));
+        when(resource.collectDependencies(integration)).thenReturn(Collections.emptyList());
+
+        assertThat(handler.enhance(extension).getUses()).hasValue(0);
+    }
+}


### PR DESCRIPTION
We counted Connections and Extensions of deleted Integrations, this should fix it at a penalty of loading all Integrations when counting Extensions.

ref #2871 