### PR TITLE
[fix] Failed to stop integration #3405

### DIFF
--- a/app/ui/src/app/core/providers/integration-support-provider.service.ts
+++ b/app/ui/src/app/core/providers/integration-support-provider.service.ts
@@ -57,7 +57,7 @@ export class IntegrationSupportProviderService extends IntegrationSupportService
     return this.apiHttpService
       .setEndpointUrl(integrationEndpoints.updateState, {
         id: integration.id,
-        version: integration.deploymentVersion
+        version: integration.version
       })
       .post({
         targetState: UNPUBLISHED


### PR DESCRIPTION
Fixes https://github.com/syndesisio/syndesis/issues/3405

In the PR review I'd like to understand what the difference is between the deploymentVersion and the version. The deploymentVersion is undefined, but the version contains the correct version. Using that instead fixes the issue but I'm unclear why we have two pieces of data that seem to contain the same information. Maybe I'm missing something, or maybe there is larger issue.

@gashcrumb, @seanforyou23 maybe one of you can shed a light on this?