### PR TITLE
fix(performance) Reduce CPU usage of syndesis server

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/validation/TargetWithDomain.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/validation/TargetWithDomain.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.validation;
+
+import java.util.Collection;
+import java.util.Optional;
+import io.syndesis.common.model.Kind;
+import io.syndesis.common.model.WithId;
+
+/**
+ * An object paired with a search domain allowing then to be passed
+ * around as single objects.
+ *
+ * @param <T>
+ */
+public abstract class TargetWithDomain<T extends WithId<T>> implements WithId<T> {
+
+    private T target;
+
+    private Collection<T> domain;
+
+    public TargetWithDomain(T target, Collection<T> domain) {
+        this.target = target;
+        this.domain = domain;
+    }
+
+    public T getTarget() {
+        return target;
+    }
+
+    public Collection<T> getDomain() {
+        return domain;
+    }
+
+    @Override
+    public Optional<String> getId() {
+        return target.getId();
+    }
+
+    @Override
+    public Kind getKind() {
+        return target.getKind();
+    }
+
+    @Override
+    public T withId(String id) {
+        return target.withId(id);
+    }
+}

--- a/app/common/model/src/main/java/io/syndesis/common/model/validation/connection/ConnectionWithDomain.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/validation/connection/ConnectionWithDomain.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.validation.connection;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.SortedSet;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.environment.Organization;
+import io.syndesis.common.model.validation.TargetWithDomain;
+
+public class ConnectionWithDomain extends TargetWithDomain<Connection> implements Connection {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConnectionWithDomain(Connection target, Collection<Connection> domain) {
+        super(target, domain);
+    }
+
+    @Override
+    public Optional<Organization> getOrganization() {
+        return getTarget().getOrganization();
+    }
+
+    @Override
+    public Optional<String> getOrganizationId() {
+        return getTarget().getOrganizationId();
+    }
+
+    @Override
+    public Optional<Connector> getConnector() {
+        return getTarget().getConnector();
+    }
+
+    @Override
+    public String getConnectorId() {
+        return getTarget().getConnectorId();
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return getTarget().getOptions();
+    }
+
+    @Override
+    public String getIcon() {
+        return getTarget().getIcon();
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return getTarget().getDescription();
+    }
+
+    @Override
+    public Optional<String> getUserId() {
+        return getTarget().getUserId();
+    }
+
+    @Override
+    public Optional<Date> getLastUpdated() {
+        return getTarget().getLastUpdated();
+    }
+
+    @Override
+    public Optional<Date> getCreatedDate() {
+        return getTarget().getCreatedDate();
+    }
+
+    @Override
+    public boolean isDerived() {
+        return getTarget().isDerived();
+    }
+
+    @Override
+    public OptionalInt getUses() {
+        return getTarget().getUses();
+    }
+
+    @Override
+    public SortedSet<String> getTags() {
+        return getTarget().getTags();
+    }
+
+    @Override
+    public String getName() {
+        return getTarget().getName();
+    }
+
+}

--- a/app/common/model/src/main/java/io/syndesis/common/model/validation/extension/ExtensionWithDomain.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/validation/extension/ExtensionWithDomain.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.validation.extension;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.SortedSet;
+import io.syndesis.common.model.action.Action;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.extension.Extension;
+import io.syndesis.common.model.validation.TargetWithDomain;
+
+public class ExtensionWithDomain extends TargetWithDomain<Extension> implements Extension {
+
+    private static final long serialVersionUID = 1L;
+
+    public ExtensionWithDomain(Extension target, Collection<Extension> domain) {
+        super(target, domain);
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return getTarget().getActions();
+    }
+
+    @Override
+    public String getName() {
+        return getTarget().getName();
+    }
+
+    @Override
+    public SortedSet<String> getTags() {
+        return getTarget().getTags();
+    }
+
+    @Override
+    public Map<String, ConfigurationProperty> getProperties() {
+        return getTarget().getProperties();
+    }
+
+    @Override
+    public String getVersion() {
+        return getTarget().getVersion();
+    }
+
+    @Override
+    public String getExtensionId() {
+        return getTarget().getExtensionId();
+    }
+
+    @Override
+    public String getSchemaVersion() {
+        return getTarget().getSchemaVersion();
+    }
+
+    @Override
+    public Optional<Status> getStatus() {
+        return getTarget().getStatus();
+    }
+
+    @Override
+    public String getIcon() {
+        return getTarget().getIcon();
+    }
+
+    @Override
+    public String getDescription() {
+        return getTarget().getDescription();
+    }
+
+    @Override
+    public OptionalInt getUses() {
+        return getTarget().getUses();
+    }
+
+    @Override
+    public Optional<String> getUserId() {
+        return getTarget().getUserId();
+    }
+
+    @Override
+    public Optional<Date> getLastUpdated() {
+        return getTarget().getLastUpdated();
+    }
+
+    @Override
+    public Optional<Date> getCreatedDate() {
+        return getTarget().getCreatedDate();
+    }
+
+    @Override
+    public Type getExtensionType() {
+        return getTarget().getExtensionType();
+    }
+
+}

--- a/app/common/model/src/main/java/io/syndesis/common/model/validation/integration/IntegrationWithDomain.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/validation/integration/IntegrationWithDomain.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.validation.integration;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.validation.TargetWithDomain;
+
+public class IntegrationWithDomain extends TargetWithDomain<Integration> implements Integration {
+
+    private static final long serialVersionUID = 1L;
+
+    public IntegrationWithDomain(Integration target, Collection<Integration> domain) {
+        super(target, domain);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return getTarget().getDescription();
+    }
+
+    @Override
+    public Map<String, ConfigurationProperty> getProperties() {
+        return getTarget().getProperties();
+    }
+
+    @Override
+    public SortedSet<String> getTags() {
+        return getTarget().getTags();
+    }
+
+    @Override
+    public String getName() {
+        return getTarget().getName();
+    }
+
+}

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/validation/NoDuplicateValidatorTest.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/validation/NoDuplicateValidatorTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.dao.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
+import org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator;
+import org.junit.Test;
+import org.mockito.Mock;
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.action.Action.Pattern;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.validation.AllValidations;
+import io.syndesis.common.model.validation.extension.NoDuplicateExtension;
+import io.syndesis.common.model.validation.integration.IntegrationWithDomain;
+import io.syndesis.common.model.validation.integration.NoDuplicateIntegration;
+import io.syndesis.common.util.StringConstants;
+import io.syndesis.server.dao.manager.DataManager;
+import io.syndesis.server.dao.validation.extension.NoDuplicateExtensionValidator;
+import io.syndesis.server.dao.validation.integration.NoDuplicateIntegrationValidator;
+
+public class NoDuplicateValidatorTest implements StringConstants {
+
+    private static final String SQL_CONNECTOR_ACTION_ID = "sql-connector";
+
+    private static final String CONNECTION_ID = "5";
+
+    private static final String CONNECTOR_ID = "sql";
+
+    private static final String SQL_CONNECTOR_NAME = "SQL Connector";
+
+    private static final long INTEGRATION_CREATED_AT = 1533024000000L;  // 31/07/2018 09:00:00
+
+    private static final long INTEGRATION_UPDATED_AT = 1533024600000L; // 31/07/2018 09:10:00
+
+    @Mock
+    private final DataManager dataManager = mock(DataManager.class);
+
+    private Validator validator;
+
+    private class InjectionConstraintValidatorFactory implements ConstraintValidatorFactory {
+
+        private NoDuplicateIntegrationValidator noDupIntValidator = new NoDuplicateIntegrationValidator();
+
+        private NoDuplicateExtensionValidator noDupExtValidator = new NoDuplicateExtensionValidator();
+
+        public InjectionConstraintValidatorFactory(DataManager dataManager) {
+            setDataManager(noDupIntValidator, dataManager);
+            setDataManager(noDupExtValidator, dataManager);
+        }
+
+        private void setDataManager(Object target, DataManager dataManager) {
+            try {
+                Field privateField = target.getClass().getDeclaredField("dataManager");
+                privateField.setAccessible(true);
+                privateField.set(target, dataManager);
+            } catch(Exception e){
+                throw new RuntimeException(e);
+            }
+        }
+
+        @SuppressWarnings( "unchecked" )
+        @Override
+        public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+            if (key == NotNullValidator.class) {
+                return (T) new NotNullValidator();
+            } else if (key == NoDuplicateIntegrationValidator.class) {
+                return (T) noDupIntValidator;
+            } else if (key == NoDuplicateExtensionValidator.class) {
+                return (T) noDupExtValidator;
+            }
+
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseInstance(ConstraintValidator<?, ?> instance) {
+            // Nothing to do
+        }
+    }
+
+    private InjectionConstraintValidatorFactory constraintValidatorFactory = new InjectionConstraintValidatorFactory(dataManager);
+
+    public NoDuplicateValidatorTest() {
+
+        final DefaultConstraintMapping mapping = new DefaultConstraintMapping();
+        mapping.constraintDefinition(NoDuplicateExtension.class).validatedBy(NoDuplicateExtensionValidator.class);
+        mapping.constraintDefinition(NoDuplicateIntegration.class).validatedBy(NoDuplicateIntegrationValidator.class);
+
+        final ValidatorFactory validatorFactory = Validation.byProvider(HibernateValidator.class).configure()
+            .constraintValidatorFactory(constraintValidatorFactory)
+            .addMapping(mapping).buildValidatorFactory();
+
+        validator = validatorFactory.getValidator();
+
+    }
+
+    private Connector newSqlConnector() {
+        ConnectorAction action1 = new ConnectorAction.Builder()
+            .id(SQL_CONNECTOR_ACTION_ID)
+            .actionType("connector")
+            .description("Invoke SQL to obtain ...")
+            .name("Invoke SQL")
+            .addTag("dynamic")
+            .pattern(Pattern.To)
+            .build();
+
+        return new Connector.Builder()
+           .id(CONNECTOR_ID)
+           .name(SQL_CONNECTOR_NAME)
+           .addAction(action1)
+           .build();
+    }
+
+    private Connection newSqlConnection(Connector connector) {
+        assertNotNull(connector);
+
+        Map<String, String> configuredProperties = new HashMap<>();
+        configuredProperties.put("password", "password");
+        configuredProperties.put("user", "developer");
+        configuredProperties.put("schema", "sampledb");
+        configuredProperties.put("url",  "jdbc:postgresql://syndesis-db:5432/sampledb");
+
+        return new Connection.Builder()
+            .id(CONNECTION_ID)
+            .addTag("dynamic")
+            .configuredProperties(configuredProperties)
+            .connector(connector)
+            .connectorId("sql")
+            .description("Connection to Sampledb")
+            .icon("fa-database")
+            .name("PostgresDB")
+            .build();
+    }
+
+    private Step newSqlStep(Connection connection) {
+        ConnectorAction action = new ConnectorAction.Builder()
+            .actionType("connector")
+            .id(SQL_CONNECTOR_ACTION_ID)
+            .name("Invoke SQL")
+            .pattern(Pattern.To)
+            .addTag("dynamic")
+            .build();
+
+        return new Step.Builder()
+            .connection(connection)
+            .id("SomeLongId")
+            .action(action)
+            .build();
+    }
+
+    private Integration newSqlIntegration(String id, Connection connection) {
+        return new Integration.Builder()
+            .id(id)
+            .name(id)
+            .addFlow(new Flow.Builder().id(id + ":flow").addStep(newSqlStep(connection)).build())
+            .createdAt(INTEGRATION_CREATED_AT)
+            .updatedAt(INTEGRATION_UPDATED_AT)
+            .build();
+    }
+
+    /**
+     * Tests an integration can be validated either using a domain or without.
+     */
+    @Test
+    public void shouldValidateSameWayWithOrWithoutDomain() {
+        String idPrefix = "MyTestIntegration-x123456";
+        Connector sqlConnector = newSqlConnector();
+        Connection sqlConnection = newSqlConnection(sqlConnector);
+
+        List<Integration> integrations = new ArrayList<>();
+        for (int i = 0; i < 10; ++i) {
+            String id = idPrefix + HYPHEN + i;
+            integrations.add(newSqlIntegration(id, sqlConnection));
+        }
+
+        Integration theIntegration = new Integration.Builder()
+            .createFrom(integrations.get(0))
+            .description("I am a copy")
+            .id(integrations.get(0).getId().get() + "new")
+            .build();
+
+        when(dataManager.fetchAll(Integration.class))
+            .thenReturn(new ListResult.Builder<Integration>().addAllItems(integrations).build());
+
+        List<IntegrationDeployment> emptyList = Collections.emptyList();
+        when(dataManager.fetchAll(IntegrationDeployment.class))
+            .thenReturn(new ListResult.Builder<IntegrationDeployment>().addAllItems(emptyList).build());
+
+        Set<ConstraintViolation<Integration>> violations = validator.validate(theIntegration, AllValidations.class);
+        assertEquals(1, violations.size());
+        ConstraintViolation<Integration> violation = violations.iterator().next();
+
+        IntegrationWithDomain target = new IntegrationWithDomain(theIntegration, integrations);
+        Set<ConstraintViolation<IntegrationWithDomain>> domainViolations = validator.validate(target, AllValidations.class);
+        assertEquals(1, domainViolations.size());
+        ConstraintViolation<IntegrationWithDomain> domainViolation = domainViolations.iterator().next();
+
+        assertEquals(violation.getMessage(), domainViolation.getMessage());
+        assertEquals(violation.getPropertyPath(), domainViolation.getPropertyPath());
+    }
+}

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
@@ -177,10 +177,16 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
         IntegrationDeployment integrationDeployment = newIntegrationDeployment(id, 1, sqlIntegration, true);
 
         // Returns the unchanged sql connection
+        when(dataManager.fetchAll(Connection.class)).thenReturn(
+                                                                new ListResult.Builder<Connection>()
+                                                                .addItem(sqlConnection).build());
         when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(sqlConnection);
         when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(sqlConnector);
 
         // Returns the integration deployment
+        when(dataManager.fetchAll(IntegrationDeployment.class)).thenReturn(
+                                                                new ListResult.Builder<IntegrationDeployment>()
+                                                                .addItem(integrationDeployment).build());
         when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
 
         Set<String> ids = Collections.singleton(id);
@@ -245,10 +251,16 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
         assertNotEquals(sqlConnection, modSqlConnection);
 
         // Returns the changed sql connection
+        when(dataManager.fetchAll(Connection.class)).thenReturn(
+                                                                           new ListResult.Builder<Connection>()
+                                                                           .addItem(modSqlConnection).build());
         when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
         when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
 
         // Returns the integration deployment
+        when(dataManager.fetchAll(IntegrationDeployment.class)).thenReturn(
+                                                                           new ListResult.Builder<IntegrationDeployment>()
+                                                                           .addItem(integrationDeployment).build());
         when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
 
         Set<String> ids = Collections.singleton(id);
@@ -346,10 +358,16 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
         assertFalse(equiv.equivalent(null, sqlIntegration, modSqlIntegration));
 
         // Returns the changed sql connection
+        when(dataManager.fetchAll(Connection.class)).thenReturn(
+                                                                new ListResult.Builder<Connection>()
+                                                                .addItem(modSqlConnection).build());
         when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
         when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
 
         // Returns the integration deployment
+        when(dataManager.fetchAll(IntegrationDeployment.class)).thenReturn(
+                                                                new ListResult.Builder<IntegrationDeployment>()
+                                                                .addItem(integrationDeployment).build());
         when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
 
         Set<String> ids = Collections.singleton(id);
@@ -433,10 +451,16 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
         assertFalse(equiv.equivalent(null, sqlIntegration, modSqlIntegration));
 
         // Returns the changed sql connection
+        when(dataManager.fetchAll(Connection.class)).thenReturn(
+                                                                new ListResult.Builder<Connection>()
+                                                                .addItem(modSqlConnection).build());
         when(dataManager.fetch(Connection.class, CONNECTION_ID)).thenReturn(modSqlConnection);
         when(dataManager.fetch(Connector.class, CONNECTOR_ID)).thenReturn(modSqlConnector);
 
         // Returns the integration deployment
+        when(dataManager.fetchAll(IntegrationDeployment.class)).thenReturn(
+                                                                new ListResult.Builder<IntegrationDeployment>()
+                                                                .addItem(integrationDeployment).build());
         when(dataManager.fetch(IntegrationDeployment.class, id)).thenReturn(integrationDeployment);
 
         Set<String> ids = Collections.singleton(id);

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -143,8 +143,10 @@
           resources:
             limits:
               memory: ${SERVER_MEMORY_LIMIT}
+              cpu: 750m
             requests:
               memory: 256Mi
+              cpu: 450m
         volumes:
         - name: config-volume
           configMap:

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -1145,8 +1145,10 @@ objects:
           resources:
             limits:
               memory: ${SERVER_MEMORY_LIMIT}
+              cpu: 750m
             requests:
               memory: 256Mi
+              cpu: 450m
         volumes:
         - name: config-volume
           configMap:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1141,8 +1141,10 @@ objects:
           resources:
             limits:
               memory: ${SERVER_MEMORY_LIMIT}
+              cpu: 750m
             requests:
               memory: 256Mi
+              cpu: 450m
         volumes:
         - name: config-volume
           configMap:

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -177,6 +177,7 @@ EOT
       resources:
         limits:
           memory: $memory_server
+          cpu: 750m
 EOT
 )
         syndesis="${syndesis}${extra}"


### PR DESCRIPTION
* install/...
* tools/...
 * Limit the cpu requirements of the syndesis server to 3/4 of a single
   CPU, stopping it taking advantage of 3-4 CPUs otherwise.

* app/...
 * Reduce the number of calls to the DataManager by fetching all the items
   from it once at the beginning of each compute then pass these collections
   into the requisite method calls using the TargetWithVector class.
 * TargetWithVector pairs up the target with its search vector to allow
   for Validator classes to not have to use the DataManager.

fixes #3717