### PR TITLE
Changes to tooltip functionality on step icons.

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -39,7 +39,7 @@
         outsideClick="true"
         (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
         container="body"></span>
-        <ng-template #stepNameTooltip><div class="syn-nowrap">{{ stepName }}</div></ng-template>
+        <ng-template #stepNameTooltip><div class="">{{ stepName }}</div></ng-template>
     </div>
   </div>
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -22,14 +22,13 @@
   <div class="icon-container" (click)="gotoPageFor(step)">
     <div [ngClass]="'icon ' + getParentActiveClass() + ' ' + getMenuCompleteClass() + ' ' + getConnectionClass()"
       placement="right"
-      [tooltip]="stepNameTooltip"
+      [tooltip]="stepName"
       container="body">
       <i [ngClass]="getIconClass()"
           *ngIf="step.stepKind === 'endpoint' && !step.connection"></i>
       <img class="syn-icon-small"
             *ngIf="step.stepKind === 'endpoint' && step.connection"
             [src]="step.connection | synIconPath">
-        <ng-template #stepNameTooltip><div>{{ stepName }}</div></ng-template>
     </div>
     <span class="pficon pficon-warning-triangle-o data-mismatch"
         *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -29,7 +29,9 @@
       <img class="syn-icon-small"
             *ngIf="step.stepKind === 'endpoint' && step.connection"
             [src]="step.connection | synIconPath">
-      <span class="pficon pficon-warning-triangle-o data-mismatch"
+        <ng-template #stepNameTooltip><div class="syn-nowrap">{{ stepName }}</div></ng-template>
+    </div>
+    <span class="pficon pficon-warning-triangle-o data-mismatch"
         *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"
         [popover]="addDatamapper"
         #datamapperInfoPop="bs-popover"
@@ -38,9 +40,8 @@
         placement="right"
         outsideClick="true"
         (click)="toggleAddDatamapperInfo(); $event.stopPropagation();"
-        container="body"></span>
-        <ng-template #stepNameTooltip><div class="">{{ stepName }}</div></ng-template>
-    </div>
+        container="body">
+      </span>
   </div>
 
   <!-- Step Item Wrapper -->

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -29,7 +29,7 @@
       <img class="syn-icon-small"
             *ngIf="step.stepKind === 'endpoint' && step.connection"
             [src]="step.connection | synIconPath">
-        <ng-template #stepNameTooltip><div class="syn-nowrap">{{ stepName }}</div></ng-template>
+        <ng-template #stepNameTooltip><div>{{ stepName }}</div></ng-template>
     </div>
     <span class="pficon pficon-warning-triangle-o data-mismatch"
         *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -91,20 +91,19 @@
         line-height: 1.15;
       }
     }
+  }
+  .data-mismatch {
+    position: absolute;
+    background: #ec7a08;
+    border-radius: 50%;
+    padding: 5px;
+    cursor: pointer;
+    top: 0;
+    right: 0;
+    transform: translate(25%, -25%);
 
-    .data-mismatch {
-      position: absolute;
-      background: #ec7a08;
-      border-radius: 50%;
-      padding: 5px;
-      cursor: pointer;
-      top: 0;
-      right: 0;
-      transform: translate(25%, -25%);
-
-      &::before {
-        color: $color-pf-white;
-      }
+    &::before {
+      color: $color-pf-white;
     }
   }
 

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -123,11 +123,7 @@
     class="btn btn-default toggle-collapsed"
     (click)="toggleCollapsed()"
     [class.collapsed]="isCollapsed"
-    [tooltip]="toggleButtonTooltip"
+    [tooltip]="[ isCollapsed ? 'Expand' : 'Collapse' ]"
     aria-label="Integration Visualization Pane Details Toggle"
     placement="right"></button>
-    <ng-template #toggleButtonTooltip>
-      <div *ngIf="!isCollapsed">Collapse</div>
-      <div *ngIf="isCollapsed">Expand</div>
-    </ng-template>
 </div>


### PR DESCRIPTION
fixes #3745.

- Step icon and warning icon no longer share the same hover over attribute. A user must click the warning icon to shop tooltip info.

- Removed div class `syn-nowrap` from step icon tooltip. Text now wraps and does not cause awkward right padding issue in tooltip box.
