### PR TITLE
fix(runtime): don't add log step when logging parameters not specified

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/LogStepHandler.java
@@ -34,16 +34,21 @@ public class LogStepHandler implements IntegrationStepHandler {
 
     @Override
     public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String flowIndex, String stepIndex) {
-        if( step.getId().isPresent() ) {
-            String stepId = step.getId().get();
-            return Optional.of(route.log(LoggingLevel.INFO, (String) null, stepId, createMessage(step)));
-        } else {
-            return Optional.of(route.log(LoggingLevel.INFO, createMessage(step)));
+        final String message = createMessage(step);
+        if (message.isEmpty()) {
+            return Optional.empty();
         }
+
+        if (step.getId().isPresent()) {
+            String stepId = step.getId().get();
+            return Optional.of(route.log(LoggingLevel.INFO, (String) null, stepId, message));
+        }
+
+        return Optional.of(route.log(LoggingLevel.INFO, message));
     }
 
 
-    private static String createMessage(Step l) {
+    static String createMessage(Step l) {
         StringBuilder sb = new StringBuilder(128);
         String customText = getCustomText(l.getConfiguredProperties());
         Boolean isContextLoggingEnabled = isContextLoggingEnabled(l.getConfiguredProperties());

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.handlers;
+
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.integration.runtime.IntegrationRouteBuilder;
+
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class LogStepHandlerTest {
+
+    final LogStepHandler handler = new LogStepHandler();
+
+    final IntegrationRouteBuilder NOT_USED = null;
+
+    final ProcessorDefinition<?> route = spy(new RouteDefinition());
+
+    @Test
+    public void shouldAddLogProcessorWithCustomMessage() {
+        final Step step = new Step.Builder().putConfiguredProperty("customText", "Log me baby one more time").build();
+
+        assertThat(handler.handle(step, route, NOT_USED, "1", "2")).contains(route);
+
+        verify(route).log(LoggingLevel.INFO, "Log me baby one more time");
+    }
+
+    @Test
+    public void shouldAddLogProcessorWithCustomMessageAndStepId() {
+        final Step step = new Step.Builder().id("step-id")
+            .putConfiguredProperty("customText", "Log me baby one more time").build();
+
+        assertThat(handler.handle(step, route, NOT_USED, "1", "2")).contains(route);
+
+        verify(route).log(LoggingLevel.INFO, (String) null, "step-id", "Log me baby one more time");
+    }
+
+    @Test
+    public void shouldGenerateMessages() {
+        final Step step = new Step.Builder().putConfiguredProperty("customText", "Log me baby one more time").build();
+
+        assertThat(LogStepHandler.createMessage(step)).isEqualTo("Log me baby one more time");
+
+        final Step withContext = new Step.Builder().createFrom(step)
+            .putConfiguredProperty("contextLoggingEnabled", "true").build();
+        assertThat(LogStepHandler.createMessage(withContext))
+            .isEqualTo("Message Context: [${in.headers}] Log me baby one more time");
+
+        final Step withBody = new Step.Builder().createFrom(step).putConfiguredProperty("bodyLoggingEnabled", "true")
+            .build();
+        assertThat(LogStepHandler.createMessage(withBody)).isEqualTo("Body: [${body}] Log me baby one more time");
+
+        final Step withContextAndBody = new Step.Builder().createFrom(step)
+            .putConfiguredProperty("contextLoggingEnabled", "true").putConfiguredProperty("bodyLoggingEnabled", "true")
+            .build();
+        assertThat(LogStepHandler.createMessage(withContextAndBody))
+            .isEqualTo("Message Context: [${in.headers}] Body: [${body}] Log me baby one more time");
+    }
+
+    @Test
+    public void shouldNotAddLogProcessorWhenNotingIsSpecifiedToLog() {
+        final Step step = new Step.Builder().build();
+
+        assertThat(handler.handle(step, route, NOT_USED, "1", "2")).isEmpty();
+
+        verifyZeroInteractions(route);
+    }
+}


### PR DESCRIPTION
Prevents `IllegalArgumentException` on integratino startup by not adding a `log` processor to route when no parameters are given to log.

Fixes #3786