### PR TITLE
refactor(IVP): multistep step icon lines no longer overlap

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.scss
@@ -58,6 +58,7 @@
           justify-content: center;
           position: relative;
           flex-shrink: 0;
+          z-index: 4;
           cursor: pointer;
         }
 


### PR DESCRIPTION
fixes #3806.

- multistep step icon lines no longer overlap parent step icon.

**Visual Fix**
<img width="205" alt="screen shot 2018-10-11 at 4 54 24 pm" src="https://user-images.githubusercontent.com/1402829/46833319-5a52a200-cd76-11e8-9005-2f58025418fa.png">