### PR TITLE
Fix #3800: choose a specific rest implementation

### DIFF
--- a/app/connector/rest-swagger/src/main/resources/camel-connector.json
+++ b/app/connector/rest-swagger/src/main/resources/camel-connector.json
@@ -16,6 +16,7 @@
   "outputDataType" : "json",
   "componentOptions" : [ "host", "basePath" ],
   "endpointValues" : {
+    "componentName" : "http4",
     "consumes" : "application/json"
   },
   "endpointOptions" : [ "operationId" ],


### PR DESCRIPTION
Fix #3800 by choosing the rest implementation explicitly in API consumer.

Thanks @zregvart for the hint. The library is transitively imported.