### PR TITLE
fix: show the number of integrate flows, not the total count

### DIFF
--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -2,7 +2,7 @@
   <ng-container [ngSwitch]="integration.type">
     <ng-container *ngSwitchCase="IntegrationType.ApiProvider">
       <div *ngTemplateOutlet="multiflowApiProvider;context:{
-        flowsCount: integration.flows.length
+        flowsCount: integration.getFlowsCount()
       }"></div>
     </ng-container>
     <ng-container *ngSwitchDefault>
@@ -105,7 +105,7 @@
   <div class="step-block inline-block text-center">
     <div *ngTemplateOutlet="stepConnection;context:{
       id: 'multi-flow',
-      connectionName: flowsCount + ' Flows',
+      connectionName: flowsCount + ' Flow' + (flowsCount === 1 ? '' : 's'),
       badge: flowsCount,
       actionName: '',
       onClick: onApiProviderFlowsClick.bind(this),

--- a/app/ui/src/app/integration/list/list.component.html
+++ b/app/ui/src/app/integration/list/list.component.html
@@ -34,7 +34,7 @@
           <span class="fa fa-angle-right"></span>
           <span class="icon">
             <img class="syn-icon-small" src="./../../assets/icons/multi-flow.connection.png" aria-hidden="true">
-            <span class="syn-badge" tooltip="{{ integration.flows.length }} implemented flows" container="body" placement="right">{{ integration.flows.length }}</span>
+            <span class="syn-badge" tooltip="{{ integration.getFlowsCount() }} implemented flow{{ integration.getFlowsCount() === 1 ? '' : 's'}}" container="body" placement="right">{{ integration.getFlowsCount() }}</span>
           </span>
         </ng-template>
       </div>

--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -42,7 +42,8 @@ export type IntegrationStatus =
 
 export enum IntegrationType {
   SingleFlow = 'SingleFlow',
-  ApiProvider = 'ApiProvider'
+  ApiProvider = 'ApiProvider',
+  MultiFlow = 'MultiFlow'
 }
 
 export interface IntegrationOverview extends BaseEntity, WithLeveledMessages {
@@ -75,6 +76,7 @@ export interface Integration extends IntegrationOverview {
   type: IntegrationType;
   properties: StringMap<ConfigurationProperty>;
   configuredProperties: StringMap<string>;
+  getFlowsCount(): number;
 }
 
 export type Integrations = Array<Integration>;

--- a/app/ui/src/app/store/integration/integration.service.ts
+++ b/app/ui/src/app/store/integration/integration.service.ts
@@ -14,12 +14,23 @@ import { RESTService } from '@syndesis/ui/store/entity';
 import { log } from '@syndesis/ui/logging';
 import { ConfigService } from '@syndesis/ui/config.service';
 
+function getFlowsCount(integration: Integration) {
+  return integration.type === IntegrationType.ApiProvider
+    ? integration.flows.filter(flow => flow.metadata.excerpt !== '501 Not Implemented').length
+    : integration.flows.length;
+}
+
 function transform(integration: Integration): Integration {
   if (integration.flows.length > 1) {
-    integration.type = IntegrationType.ApiProvider;
+    if (integration.tags.indexOf('api-provider') >= 0) {
+      integration.type = IntegrationType.ApiProvider;
+    } else {
+      integration.type = IntegrationType.MultiFlow;
+    }
   } else {
     integration.type = IntegrationType.SingleFlow;
   }
+  integration.getFlowsCount = getFlowsCount.bind(null, integration);
   return integration;
 }
 


### PR DESCRIPTION
Fixes #3601

## Changes


### List page
<img width="230" alt="screen shot 2018-10-17 at 10 32 25" src="https://user-images.githubusercontent.com/966316/47073233-0a516080-d1f8-11e8-9952-9aa68410c14c.png">
Only 1 of 12 operations is implemented

### Details page
<img width="260" alt="screen shot 2018-10-17 at 10 32 34" src="https://user-images.githubusercontent.com/966316/47073231-0a516080-d1f8-11e8-8a2a-c5e5d0630e66.png">
Only 1 of 12 operations is implemented

### Operations page
<img width="1077" alt="screen shot 2018-10-17 at 10 32 42" src="https://user-images.githubusercontent.com/966316/47073230-0a516080-d1f8-11e8-8450-30cf14c4bbd0.png">
All operations are visible in the Operations page

