### PR TITLE
fix(template step) - Add variable symbol validation

### DIFF
--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -113,6 +113,7 @@
         "templater-editor-placeholder": "Drop a file, paste in text, or start typing",
         "templater-editor-drag-enter": "Drop file here to upload",
         "templater-validation-errors": "Vaidation errors",
+        "templater-wrong-symbol-format": "'{{0}}' does not conform to the format {{1}} at line: {{2}}, column: {{3}}",
         "templater-illegal-open-symbol": "Illegal open symbol at line: {{0}}, column: {{1}}",
         "templater-too-many-open-symbols": "Too many open symbols at line: {{0}}, column: {{1}}",
         "templater-illegal-close-symbol": "Illegal close symbol at line: {{0}}, column: {{1}}",


### PR DESCRIPTION
* The mustache symbols need to be prefixed with 'body.' and should not
  include other punctuation in order to be valid. Updates the validation
  routine to display errors if this format is not being followed.

#3854