### PR TITLE
fix(connector): don't set `application/json` as Accept by default

### DIFF
--- a/app/connector/rest-swagger/src/main/resources/camel-connector.json
+++ b/app/connector/rest-swagger/src/main/resources/camel-connector.json
@@ -16,8 +16,7 @@
   "outputDataType" : "json",
   "componentOptions" : [ "host", "basePath" ],
   "endpointValues" : {
-    "componentName" : "http4",
-    "consumes" : "application/json"
+    "componentName" : "http4"
   },
   "endpointOptions" : [ "operationId" ],
   "connectorProperties" : {


### PR DESCRIPTION
We had the default endpoint option `consumes` set to `application/json` that would override any `produces` content type given in the OpenAPI specification. This is now removed and the content type is taken from the `produces` parameter in the OpenAPI specification.

Fixes #3388