### PR TITLE
fix(connector): remove quotes from simple body values

### DIFF
--- a/app/connector/support/processor/pom.xml
+++ b/app/connector/support/processor/pom.xml
@@ -32,6 +32,11 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
@@ -43,6 +48,11 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessor.java
@@ -15,64 +15,90 @@
  */
 package io.syndesis.connector.support.processor;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
 import io.syndesis.common.util.Json;
 import io.syndesis.connector.support.processor.util.SimpleJsonSchemaInspector;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.util.Set;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 
-public class HttpRequestUnwrapperProcessor implements Processor {
+public final class HttpRequestUnwrapperProcessor implements Processor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpRequestUnwrapperProcessor.class);
+
     private final Set<String> parameters;
 
-    private static final ObjectReader READER = Json.reader().forType(JsonNode.class);
-
-    public HttpRequestUnwrapperProcessor(JsonNode schema) {
-        this.parameters = SimpleJsonSchemaInspector.getProperties(schema, "parameters");
+    public HttpRequestUnwrapperProcessor(final JsonNode schema) {
+        parameters = SimpleJsonSchemaInspector.getProperties(schema, "parameters");
     }
 
     @Override
-    public void process(Exchange exchange) throws Exception {
+    public void process(final Exchange exchange) throws Exception {
         final Message message = exchange.getIn();
         final Object body = message.getBody();
 
-        JsonNode data = null;
+        final JsonNode data = parseBody(body);
+
+        if (data != null) {
+            final JsonNode paramMap = data.get("parameters");
+            final JsonNode bodyData = data.get("body");
+
+            if (paramMap != null || bodyData != null) {
+                if (paramMap != null) {
+                    for (final String key : parameters) {
+                        final JsonNode valueNode = paramMap.get(key);
+                        if (valueNode != null) {
+                            final String val = valueNode.asText();
+                            message.setHeader(key, val);
+                        }
+                    }
+                }
+
+                if (bodyData == null) {
+                    message.setBody(null);
+                    return;
+                }
+
+                if (bodyData.isObject()) {
+                    message.setBody(Json.toString(bodyData));
+                    return;
+                }
+
+                message.setBody(bodyData.asText());
+            }
+        }
+    }
+
+    static JsonNode parseBody(final Object body) throws IOException, JsonProcessingException {
+        if (body == null) {
+            return null;
+        }
+
         if (body instanceof String) {
             final String string = (String) body;
             if (ObjectHelper.isNotEmpty(string)) {
-                data = READER.readTree(string);
+                return Json.reader().readTree(string);
             }
         } else if (body instanceof InputStream) {
             try (InputStream stream = (InputStream) body) {
                 if (stream.available() > 0) {
-                    data = READER.readTree(stream);
+                    return Json.reader().readTree(stream);
                 }
             }
         }
 
-        if (data != null) {
-            JsonNode paramMap = data.get("parameters");
-            JsonNode bodyData = data.get("body");
+        LOG.warn("Unable to parse given body as JSON, unsupported body given: {}", body.getClass());
 
-            if (paramMap != null || bodyData != null) {
-                if (paramMap != null) {
-                    for (String key : this.parameters) {
-                        String val = paramMap.asText(key);
-                        exchange.getIn().setHeader(key, val);
-                    }
-                }
-
-                message.setBody(bodyData != null ? Json.toString(bodyData) : null);
-            }
-        }
-    }
-
-    public Set<String> getParameters() {
-        return parameters;
+        return null;
     }
 }

--- a/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessorTest.java
+++ b/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.processor;
+
+import java.util.HashMap;
+
+import io.syndesis.common.util.Json;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.spi.HeadersMapFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpRequestUnwrapperProcessorTest {
+
+    CamelContext camelContext = mock(CamelContext.class);
+
+    Exchange exchange = new DefaultExchange(camelContext);
+
+    HttpRequestUnwrapperProcessor processor = new HttpRequestUnwrapperProcessor(schema());
+
+    @Before
+    public void setupMocks() {
+        final HeadersMapFactory factory = mock(HeadersMapFactory.class);
+        when(camelContext.getHeadersMapFactory()).thenReturn(factory);
+        when(factory.newMap()).thenReturn(new HashMap<>());
+    }
+
+    @Test
+    public void shouldUnwrapResponses() throws Exception {
+        final Message in = new DefaultMessage(camelContext);
+        exchange.setIn(in);
+        in.setBody("{\"parameters\":{\"h1\":\"v1\",\"h3\":\"v3\"},\"body\":{\"b1\":\"c1\",\"b2\":\"c2\"}}");
+
+        processor.process(exchange);
+
+        assertThat(in.getHeaders()).containsOnly(entry("h1", "v1"), entry("h3", "v3"));
+        assertThat(in.getBody()).isEqualTo("{\"b1\":\"c1\",\"b2\":\"c2\"}");
+    }
+
+    @Test
+    public void simpleNonStringValuesShouldBeUnwrappedVerbatim() throws Exception {
+        final Message in = new DefaultMessage(camelContext);
+        exchange.setIn(in);
+        in.setBody("{\"body\":123}");
+
+        processor.process(exchange);
+
+        assertThat(in.getHeaders()).isEmpty();
+        assertThat(in.getBody()).isEqualTo("123");
+    }
+
+    @Test
+    public void simpleValuesShouldBeUnwrappedVerbatim() throws Exception {
+        final Message in = new DefaultMessage(camelContext);
+        exchange.setIn(in);
+        in.setBody("{\"body\":\"simple\"}");
+
+        processor.process(exchange);
+
+        assertThat(in.getHeaders()).isEmpty();
+        assertThat(in.getBody()).isEqualTo("simple");
+    }
+
+    private static JsonNode schema() {
+        final ObjectNode schema = Json.copyObjectMapperConfiguration().createObjectNode();
+        final ObjectNode parameters = schema.putObject("properties").putObject("parameters").putObject("properties");
+        parameters.putObject("h1");
+        parameters.putObject("h2");
+        parameters.putObject("h3");
+
+        return schema;
+    }
+}


### PR DESCRIPTION
Removes quoting of body values within unified JSON schema. So

```json
{
  "body": "value"
}
```

Is not returned as `"value"` with quotes, but rather as `value` without
quotes.

Fixes #3909