### PR TITLE
chore(upgrade): Remove newlines from base64 code

### DIFF
--- a/tools/upgrade/migration/resource/any/01_ensure_sar_project_parameter.sh
+++ b/tools/upgrade/migration/resource/any/01_ensure_sar_project_parameter.sh
@@ -12,7 +12,7 @@ update_template_params_for_sar_project() {
         cat "${params}" >> ${tmp}
         mv "${tmp}" "${params}"
         set -e
-        oc patch secret syndesis-global-config -p "{\"data\": { \"params\": \"$(cat $params | base64)\" }}"
+        oc patch secret syndesis-global-config -p "{\"data\": { \"params\": \"$(cat $params | base64 | tr -d '\n')\" }}"
     fi
     set -e
     #rm "$params"


### PR DESCRIPTION
That because of a difference between Linux base64 and macOS base64.

Fixes #3840.