### PR TITLE
fix(step-icons): revert step icons in integration details and editor IVP

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -37,9 +37,6 @@
       <img class="syn-icon-small"
             *ngIf="step.stepKind === 'endpoint' && step.connection"
             [src]="step.connection | synIconPath">
-      <img class="syn-icon-small"
-            *ngIf="step.stepKind && step.stepKind !== 'endpoint'"
-            [src]="step | synIconPath">
     </div>
     <span class="pficon pficon-warning-triangle-o data-mismatch"
         *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -90,6 +90,10 @@
 
     &.not-connection {
       background-color: #ffffff;
+      border-width: 10px;
+      border-radius: 50%;
+      height: 32px;
+      width: 32px;
     }
 
     .connection-icon {

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.html
@@ -47,6 +47,7 @@
        class="text-center connection"
        (click)="onClick"
        title="{{ connectionName }}&nbsp;{{ actionName }}">
+    <div [class]="'step-line ' + class"></div>
     <div class="icon">
       <img class="syn-icon-small" [src]="iconSrc" alt="{{ connectionName }}">
     </div>
@@ -57,8 +58,9 @@
 <ng-template #stepDefault let-id="id" let-name="name"  let-iconSrc="iconSrc">
   <div [id]="id"
        class="text-center step">
-    <div class="icon">
-      <img class="syn-icon-small" [src]="iconSrc" alt="{{ name }}">
+    <div class="step-line"></div>
+    <div class="icon not-connection">
+      <div class="icon-line"></div>
     </div>
     <div>{{ name }}</div>
   </div>

--- a/app/ui/src/app/integration/integration_detail/integration-description.component.scss
+++ b/app/ui/src/app/integration/integration_detail/integration-description.component.scss
@@ -13,6 +13,28 @@
 
   & > .text-center {
     position: relative;
+
+    &.step {
+      padding-top: 12px;
+      .icon {
+        margin-bottom: 15px;
+      }
+    }
+  }
+  .step-line {
+    position: absolute;
+    height: 3px;
+    top: 27px;
+    z-index: -5;
+    left: -2px;
+    right: -2px;
+    background-color: $color-pf-black-600;
+    &.start {
+      left: 50px;
+    }
+    &.finish {
+      right: 50px;
+    }
   }
 
   .icon {
@@ -35,9 +57,20 @@
       border-width: 10px;
       padding: 5px 0px;
       border-radius: 100px;
-      height: 33px;
+      height: 32px;
       margin-bottom: 15px;
       width: 32px;
+
+      .icon-line {
+        position: absolute;
+        height: 3px;
+        background-color: $color-pf-white;
+        top: 50%;
+        transform: translateY(-50%);
+        left: -8px;
+        right: -8px;
+        border-radius: 1px;
+      }
     }
 
     .connection-icon {


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/3920

@gashcrumb I left the business logic in, and just reverted the view since @dongniwang said the goal is to re-introduce the icons at a later point. feel free to remove any of that as you see fit.