### PR TITLE
chore(upgrade): Update release script to set the proper upgrade pod tag.

### DIFF
--- a/install/operator/pkg/syndesis/action/upgrade.go
+++ b/install/operator/pkg/syndesis/action/upgrade.go
@@ -172,7 +172,6 @@ func (a *Upgrade) getUpgradeResources(syndesis *v1alpha1.Syndesis) ([]runtime.Ob
 		InstallParams: syndesistemplate.InstallParams{
 			OAuthClientSecret: "-",
 		},
-		SyndesisVersion: a.operatorVersion,
 		UpgradeRegistry: configuration.Registry,
 	})
 

--- a/install/operator/pkg/syndesis/configuration/configuration.go
+++ b/install/operator/pkg/syndesis/configuration/configuration.go
@@ -46,7 +46,6 @@ const (
 	EnvIntegrationStateCheckInterval SyndesisEnvVar = "INTEGRATION_STATE_CHECK_INTERVAL"
 	EnvSarNamespace                  SyndesisEnvVar = "SAR_PROJECT"
 
-	EnvSyndesisVersion SyndesisEnvVar = "SYNDESIS_VERSION"
 	EnvUpgradeRegistry SyndesisEnvVar = "UPGRADE_REGISTRY"
     EnvUpgradeVolumeCapacity       SyndesisEnvVar = "UPGRADE_VOLUME_CAPACITY"
 )

--- a/install/operator/pkg/syndesis/template/upgrade.go
+++ b/install/operator/pkg/syndesis/template/upgrade.go
@@ -16,7 +16,6 @@ const (
 
 type UpgradeParams struct {
 	InstallParams
-	SyndesisVersion string
 	UpgradeRegistry        *string
 }
 
@@ -37,7 +36,6 @@ func GetUpgradeResources(syndesis *v1alpha1.Syndesis, params UpgradeParams) ([]r
 
 	paramMap := configuration.GetEnvVars(syndesis)
 	paramMap[string(configuration.EnvOpenshiftOauthClientSecret)] = params.OAuthClientSecret
-	paramMap[string(configuration.EnvSyndesisVersion)] = params.SyndesisVersion
 	paramMap[string(configuration.EnvUpgradeRegistry)] = *params.UpgradeRegistry
 
 	return processor.Process(upgrateTempl, paramMap)

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -230,7 +230,7 @@ generate_versioned_files() {
 
     echo "==== Creating templates for $tag"
     cd $dir/generator
-    sh run.sh --syndesis-tag="$tag"
+    sh run.sh --syndesis-tag="$tag" --upgrade-tag="$tag"
 
     echo "==== Updating operator deployment config"
     cd $dir/operator/deploy


### PR DESCRIPTION
Also removed the SYNDESIS_VERSION parameter for the upgrade template
used by the operator.
The version for this pod will be hardcoded and created when the template is created.
While we could assume operator version == upgrade-pod version in upstream (there everything is in sync),
this is not the case for productisation where build number might differ.

Therefore it has to be ensured already during template creating that the
proper tag (including build number) is set.

The tag for the ugrade pod needs to be provided via --upgrade-tag when
creating the templates.
This has been added for the community release and it shoud be verified
that this option is also used during productisation.

Fixes #3463.