### PR TITLE
fix(template-step) drag and drop overlay reliably displaying

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/templater/templater.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/templater/templater.component.html
@@ -28,13 +28,10 @@
         <codemirror name="templateEditor" #templateEditor [(ngModel)]="templateContent"
                     [config]="editorConfig"
                     (focus)="onEditorFocus()"
-                    (blur)="onEditorBlur()"
-                    (dragenter)="onEditorDragenter()"
-                    (dragleave)="onEditorDragleave()"
-                    (drop)="onEditorDrop()">
+                    (blur)="onEditorBlur()">
         </codemirror>
       </div>
-    
+
       <div class="templater-form-validation">
         <p *ngIf="invalidFileMsg">
           <span class="pficon-error-circle-o"></span>


### PR DESCRIPTION
* Removes the ng2-codemirror DnD event handlers and places them directly
  on the codemirror instance. The dragEnter event is handled far more
  reliably this way.

* Allows for the codemirror instance to be initialised, the AfterViewInit
  interface is employed to configure the DnD callback handlers.

* Uses @HostListener to wire up a dragenter event to the main document. This
  will fire whenever a drag is on anything other than the drop target and
  will therefore turn off the drop target's overlay.

* onEditorDragenter to stop propogation to stop the event propogating up
  to the document callback.

* onEditorDrop does NOT stop propogration since it needs to both turn off
  the overlay but also default to the native behaviour of actually dropping
  the file contents.

#3763