### PR TITLE
fix(server): remove dot characters from OpenShift object names

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/Names.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/Names.java
@@ -21,12 +21,13 @@ import static io.syndesis.common.util.Strings.truncate;
 
 public final class Names {
 
-    private static final Pattern VALID_REGEX = Pattern.compile("^[a-z0-9][-A-Za-z0-9\\\\.]+$");
+    private static final Pattern VALID_REGEX = Pattern.compile("^[a-z0-9][-A-Za-z0-9\\\\]+$");
     private static final Pattern INVALID_START_REGEX = Pattern.compile("^[^a-z0-9]+");
     private static final Pattern INVALID_CHARACTER_REGEX = Pattern.compile("[^a-zA-Z0-9-\\._]");
     private static final String SPACE = " ";
     private static final String BLANK = "";
     private static final String DASH = "-";
+    private static final String DOT = "\\.";
     private static final String UNDERSCORE = "_";
     //The actual limit is 253,
     // but individual resources have other limitations
@@ -41,9 +42,10 @@ public final class Names {
      * Sanitizes the specified name by applying the following rules:
      * 1. Replace spaces with dashes.
      * 2. Replace underscores with dashes.
-     * 3. Ensures that the first character is a alphanumeric
-     * 4. Remove invalid characters.
-     * 5. Keep the first 64 characters.
+     * 3. Replace dots with dashes
+     * 4. Ensures that the first character is a alphanumeric
+     * 5. Remove invalid characters.
+     * 6. Keep the first 64 characters.
      * @param name  The specified name.
      * @return      The sanitized string.
      */
@@ -51,6 +53,7 @@ public final class Names {
         final String firstPass = name
             .replaceAll(SPACE, DASH)
             .replaceAll(UNDERSCORE, DASH)
+            .replaceAll(DOT, DASH)
             .toLowerCase(Locale.US);
 
         final String secondPass = INVALID_START_REGEX.matcher(firstPass).replaceAll(BLANK);

--- a/app/common/util/src/test/java/io/syndesis/common/util/NamesTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/NamesTest.java
@@ -55,7 +55,8 @@ public class NamesTest {
             pair("twitter-mention-salesforce-upsert-contact-",
                 "??? Twitter Mention <-> Salesforce upsert contact !!!"),
             pair("s-p-a-c-e-the-final-frontier", "    s   p  a  c  e   , the final frontier"),
-            pair("walking-on-sunshine-", "_walking_on_sunshine_"));
+            pair("walking-on-sunshine-", "_walking_on_sunshine_"),
+            pair("dot-", "dot."));
     }
 
     private static Object[] pair(final String projectName, final String integrationName) {


### PR DESCRIPTION
Adds the replacement of `.` (dot) character with the `-` (dash) character in name sanitization.

Fixes #3925