### PR TITLE
fix(server): make CORS great again

### DIFF
--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCorsConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCorsConfiguration.java
@@ -15,15 +15,13 @@
  */
 package io.syndesis.server.runtime;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.filter.CorsFilter;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableConfigurationProperties
@@ -39,23 +37,4 @@ public class SyndesisCorsConfiguration {
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
     }
-
-    @Bean
-    public CorsFilter corsFilter() {
-        return new CorsFilter(request -> {
-            String pathInfo = request.getPathInfo();
-            if (pathInfo != null &&
-                (pathInfo.endsWith("/swagger.json") ||
-                 pathInfo.endsWith("/swagger.yaml"))) {
-                return new CorsConfiguration().applyPermitDefaultValues();
-            }
-
-            CorsConfiguration config = new CorsConfiguration();
-            config.setAllowedOrigins(allowedOrigins);
-            config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
-            config.applyPermitDefaultValues();
-            return config;
-        });
-    }
-
 }


### PR DESCRIPTION
While working on some experiment, I noticed that the current implementation of CORS was broken due to CORS checks being handled through a filter instead of using the HttpSecurity model.

Long story short: using a filter it's not possible to skip some of the checks performed as by the HttpSecurity configuration; preflight requests (OPTIONS) where being refused because the CSRF check was performed on them (which is wrong).

Now cors checks are chained to other checks, and preflight requests are permitted as by the `CorsConfigurationSource` rules.

This doesn't mean that it's now possible to do CORS requests against the default entrypoint of the app (eg. https://syndesis.192.168.64.16.nip.io), since the oauth-proxy is doing something weird I haven't grasped yet.
If one needs to talk directly with the server, it's required to expose it with a public route from the Openshift console, writing the authentication e CSRF headers as the oauth-proxy would do (eg. use the `X-Forwarded-Access-Token: token` header in place of the `Authentication: Bearer token` one).
And potentially, also a new oauth client needs to be created to allow implicit flows login against Openshift.

I'm not suggesting to do this by default, but it's very useful for a FE developer to be able to interact with the server outside the cluster...

_Screen of the "Routes - external traffic" configuration mentioned above_
![server-external-traffic](https://user-images.githubusercontent.com/966316/47350350-fd2fe800-d6b5-11e8-8e94-49662e3d9960.png)
