### PR TITLE
 fix(db): increase `autovacuum_vacuum_cost_limit` 

### DIFF
--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -83,7 +83,7 @@
       autovacuum_analyze_threshold = 10
       autovacuum_analyze_scale_factor = 0.05
       autovacuum_vacuum_cost_delay = 10ms
-      autovacuum_vacuum_cost_limit = 1000
+      autovacuum_vacuum_cost_limit = 2000
 
 - apiVersion: v1
   kind: Service

--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -76,6 +76,8 @@
   data:
     syndesis-postgresql.conf: |
       log_autovacuum_min_duration = 0
+      log_line_prefix = '%t %a %i %e %c '
+      logging_collector = off
       autovacuum_max_workers = 6
       autovacuum_naptime = 15s
       autovacuum_vacuum_threshold = 25

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -537,6 +537,8 @@ objects:
   data:
     syndesis-postgresql.conf: |
       log_autovacuum_min_duration = 0
+      log_line_prefix = '%t %a %i %e %c '
+      logging_collector = off
       autovacuum_max_workers = 6
       autovacuum_naptime = 15s
       autovacuum_vacuum_threshold = 25

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -544,7 +544,7 @@ objects:
       autovacuum_analyze_threshold = 10
       autovacuum_analyze_scale_factor = 0.05
       autovacuum_vacuum_cost_delay = 10ms
-      autovacuum_vacuum_cost_limit = 1000
+      autovacuum_vacuum_cost_limit = 2000
 
 - apiVersion: v1
   kind: Service

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -537,6 +537,8 @@ objects:
   data:
     syndesis-postgresql.conf: |
       log_autovacuum_min_duration = 0
+      log_line_prefix = '%t %a %i %e %c '
+      logging_collector = off
       autovacuum_max_workers = 6
       autovacuum_naptime = 15s
       autovacuum_vacuum_threshold = 25

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -544,7 +544,7 @@ objects:
       autovacuum_analyze_threshold = 10
       autovacuum_analyze_scale_factor = 0.05
       autovacuum_vacuum_cost_delay = 10ms
-      autovacuum_vacuum_cost_limit = 1000
+      autovacuum_vacuum_cost_limit = 2000
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
This doubles th `autovacuum_vacuum_cost_limit` from `1000` to `2000`
which empirically looks like a good value so that the autovacuum is not
throttled.

Before (with 1000):
```
LOG:  automatic vacuum of table "syndesis.public.jsondb": index scans: 0
	pages: 0 removed, 72236 remain, 1996 skipped due to pins
	tuples: 0 removed, 855896 remain, 797779 are dead but not yet removable
	buffer usage: 89805 hits, 70138 misses, 359 dirtied
	avg read rate: 4.438 MB/s, avg write rate: 0.023 MB/s
	system usage: CPU 0.55s/0.25u sec elapsed 123.46 sec
```

After (with 2000):
```
LOG:  automatic vacuum of table "syndesis.public.jsondb": index scans: 1
        pages: 0 removed, 1859 remain, 0 skipped due to pins
        tuples: 2915 removed, 22780 remain, 0 are dead but not yet removable
        buffer usage: 2611 hits, 431 misses, 6 dirtied
        avg read rate: 81.327 MB/s, avg write rate: 1.132 MB/s
        system usage: CPU 0.00s/0.01u sec elapsed 0.04 sec
```

Fixes #3922 

Also:

chore(db): improve PostgreSQL logging

This turns off the logging collector so the log messages are logged to
`stderr` making it more 12-factory. Also configures the log prefix to
include the timesatmp, application, command, SQLSTATE and session id.

For example:
```
2018-10-23 08:54:55 UTC psql CREATE ROLE 42710 5bcee1df.3c ERROR: role "sampledb" already exists
```