### PR TITLE
fix(ui): enable gzip for the most relevant mimetypes

### DIFF
--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -24,6 +24,9 @@ features:
     enabled: true
 
 server:
+  compression:
+    enabled: true
+    mime-types: text/html,text/css,application/javascript,application/json
   useForwardHeaders: true
   undertow:
     ioThreads: 2

--- a/app/ui/docker/nginx-syndesis.conf
+++ b/app/ui/docker/nginx-syndesis.conf
@@ -1,7 +1,16 @@
 server {
     listen       8080;
     server_name  localhost;
+
     gzip         on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
+
     root         /usr/share/nginx/html;
 
     location = / {


### PR DESCRIPTION
Gzip wasn't properly enabled on our server(s). This enables it on both the server and the UI's nginx proxy.

## Before

<img width="944" alt="gzip-off" src="https://user-images.githubusercontent.com/966316/47508194-ec2cd580-d873-11e8-83c7-096b6dcb56e7.png">

13.6Mb downloaded to show the dashboard with 4 integrations present in the system (not running).

## After
<img width="949" alt="gzip-on" src="https://user-images.githubusercontent.com/966316/47508200-ee8f2f80-d873-11e8-8650-677ff42ad1d3.png">

4.0Mb for the same data, with gzip enabled.

_Hint: look at the `Size` and `Content-...` columns._