### PR TITLE
fix(IVP): odd overlap over tooltip feature

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.html
@@ -126,5 +126,7 @@
     [class.collapsed]="isCollapsed"
     [tooltip]="[ isCollapsed ? 'Expand' : 'Collapse' ]"
     aria-label="Integration Visualization Pane Details Toggle"
-    placement="right"></button>
+    placement="right" 
+    container="body">
+  </button>
 </div>


### PR DESCRIPTION
fixes #3954.

fix(IVP): adding a configuration change to the button div that will prevent odd overlap on the tooltip from other sections of the site.

## The problem
<img width="378" alt="screen shot 2018-10-25 at 4 24 14 pm" src="https://user-images.githubusercontent.com/1402829/47531394-893f3c80-d87b-11e8-8a1e-b0b0cf7812e9.png">

## Fixed (visual)
<img width="377" alt="screen shot 2018-10-25 at 5 29 54 pm" src="https://user-images.githubusercontent.com/1402829/47531426-a116c080-d87b-11e8-898e-7897175176a5.png">
