### PR TITLE
chore: use `http` instead of `https`

### DIFF
--- a/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
@@ -21,10 +21,11 @@ OpenAPI specification:
 .. Copy the URL into a text editor.
 .. At the beginning of the URL, insert `*todo-*`.
 .. At the end of the URL, replace `dashboard` with `*swagger.json*`.
+.. Use the `http` scheme instead of `https`
 
 +
 The result is something like this:
-`\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/swagger.json`
+`\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/swagger.json`
 
 . In the {prodname} navigation panel, click *Customizations*.
 . Click *Create API Connector*.
@@ -35,13 +36,13 @@ click *Next*.
 a warning, you can ignore it.
 . Click *Next* again to accept *HTTP Basic Authorization*.
 . On the *Review/Edit Connector Details* page, {prodname} populates
-the fields with values from the OpenAPI specification. 
-.. If you want to, you can 
-change the values in the *Connector Name* and *Description* fields. 
-.. Confirm that the value in the *Host* field is correct. For example, 
+the fields with values from the OpenAPI specification.
+.. If you want to, you can
+change the values in the *Connector Name* and *Description* fields.
+.. Confirm that the value in the *Host* field is correct. For example,
 it should be something like this:
-`\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
-.. Confirm that the value in the *Base URL* field is `/api`. 
+`\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
+.. Confirm that the value in the *Base URL* field is `/api`.
 . Click *Create API Connector*.
 +
 {prodname} displays the *API Client Connectors* tab with an entry for


### PR DESCRIPTION
When OpenShift is running without a trusted CA issuing the certificates REST API connector will fail with TLS error as the certificate for the TODO route will not be valid. This changes the scheme from `https` to `http` and adds a step to prompt the users to change it on their end also.