### PR TITLE
chore: update the Docker download URL and version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2
 
 common_env: &common_env
   MAVEN_OPTS: -Xmx1024m
-  DOCKER_VERSION: 17.04.0-ce
+  DOCKER_VERSION: 18.06.1-ce
 
 job_default: &job_defaults
   working_directory: /workspace
@@ -32,7 +32,7 @@ push_images: &push_images
       fi
 
       if [ ! -x /usr/bin/docker ]; then
-        curl -fsSL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
+        curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
       fi
 
       if [ "${CIRCLE_BRANCH}" == "master" ]; then
@@ -350,7 +350,7 @@ jobs:
           name: Install Docker
           command: |
             if [ ! -x /usr/bin/docker ]; then
-              curl -fsSL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
+              curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
             fi
       - run:
           name: Build CLI jar


### PR DESCRIPTION
This updates the `curl`-ed Docker CE URL and version (17.04.0-ce) is no
longer available and `get.docker.com` serves a shell script.