### PR TITLE
password should be marked as required (1.5.x backport)

### DIFF
--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -250,7 +250,7 @@
       "label": "common,security",
       "labelHint": "Password for the database connection.",
       "order": "3",
-      "required": false,
+      "required": true,
       "secret": true,
       "tags": [],
       "type": "string"


### PR DESCRIPTION
(cherry picked from commit 92c2e97744343d9f2df43856571478483b5f535a)