### PR TITLE
fix: consider all container objects when unwrapping response (1.5.x)

### DIFF
--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessor.java
@@ -69,7 +69,7 @@ public final class HttpRequestUnwrapperProcessor implements Processor {
                     return;
                 }
 
-                if (bodyData.isObject()) {
+                if (bodyData.isContainerNode()) {
                     message.setBody(Json.toString(bodyData));
                     return;
                 }

--- a/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessorTest.java
+++ b/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/HttpRequestUnwrapperProcessorTest.java
@@ -52,6 +52,17 @@ public class HttpRequestUnwrapperProcessorTest {
     }
 
     @Test
+    public void shouldUnwrapArrayResponses() throws Exception {
+        final Message in = new DefaultMessage(camelContext);
+        exchange.setIn(in);
+        in.setBody("{\"body\":[{\"b1\":\"c1\"},{\"b2\":\"c2\"}]}");
+
+        processor.process(exchange);
+
+        assertThat(in.getBody()).isEqualTo("[{\"b1\":\"c1\"},{\"b2\":\"c2\"}]");
+    }
+
+    @Test
     public void shouldUnwrapResponses() throws Exception {
         final Message in = new DefaultMessage(camelContext);
         exchange.setIn(in);


### PR DESCRIPTION
When unwrapping, i.e. converting from Syndesis wrapped format with body and parameters, we should consider arrays as well as objects for JSON serialization of the body.

Fixes #3788

(cherry picked from commit 36e66918914f479f764faadde0ad25cb5e957c5c)