### PR TITLE
fix(template-step): Removes need for body prefix in template

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/MustacheTemplatePreProcessor.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/MustacheTemplatePreProcessor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.templater;
+
+import java.util.Scanner;
+import java.util.regex.Matcher;
+
+public class MustacheTemplatePreProcessor implements TemplateMustacheConstants {
+
+    @SuppressWarnings("PMD.AvoidStringBufferField")
+    private StringBuilder sb = new StringBuilder();
+
+    private boolean inSectionSymbol;
+
+    private void append(String token) {
+        sb.append(token);
+    }
+
+    private String ensurePrefix(String symbolName) {
+        return symbolName.startsWith(BODY_PREFIX) ? symbolName : BODY_PREFIX + symbolName;
+    }
+
+    private boolean isOpeningSectionSymbol(String symbol) {
+        Matcher m = SYMBOL_OPEN_SECTION_PATTERN.matcher(symbol);
+        return m.matches();
+    }
+
+    private boolean isClosingSectionSymbol(String symbol) {
+        Matcher m = SYMBOL_CLOSE_SECTION_PATTERN.matcher(symbol);
+        return m.matches();
+    }
+
+    private boolean hasSymbol(String symbol) {
+        Matcher m = SYMBOL_PATTERN.matcher(symbol);
+        return m.lookingAt();
+    }
+
+    private boolean isText(String token) {
+        return !token.contains(OPEN_BRACE + OPEN_BRACE) &&
+                        !token.contains(CLOSE_BRACE + CLOSE_BRACE);
+    }
+
+    private void parseSymbol(String symbol) {
+        //
+        // Scanner does not delineate between two symbols
+        // with no whitespace between so match and loop
+        //
+        Matcher m = SYMBOL_PATTERN.matcher(symbol);
+        while (m.find()) {
+            String aSymbol = m.group();
+
+            if (isClosingSectionSymbol(aSymbol)) {
+                inSectionSymbol = false;
+            }
+
+            if (inSectionSymbol) {
+                //
+                // Any symbol within another symbol, eg. section symbol,
+                // should not have a prefix.
+                //
+                append(aSymbol);
+            } else {
+                String replacement = m.group(1) + ensurePrefix(m.group(2)) + m.group(3);
+                StringBuffer buf = new StringBuffer();
+                m.appendReplacement(buf, replacement);
+                append(buf.toString());
+            }
+
+            if (isOpeningSectionSymbol(aSymbol)) {
+                inSectionSymbol = true;
+            }
+        }
+
+        //
+        // Get the tail of the content from the matcher.
+        // If the matcher did not match then the tail is
+        // the whole symbol so only append the tail if
+        // this is not the case
+        //
+        StringBuffer buf = new StringBuffer();
+        m.appendTail(buf);
+        if (! buf.toString().equals(symbol)) {
+            append(buf.toString());
+        }
+    }
+
+    /**
+     * Takes a mustache template and conducts checks to ensure it is compatible
+     * with the processing endpoint, eg. ensure 'body' prefix is present on each of
+     * the symbols.
+     *
+     * @param template
+     * @return pre-processed template
+     * @throws exception if processing fails
+     */
+    public String preProcess(String template) throws TemplateProcessingException {
+        Scanner lineScanner = new Scanner(template);
+        try {
+            while(lineScanner.hasNextLine()) {
+                String line = lineScanner.nextLine();
+                Scanner scanner = new Scanner(line);
+                scanner.useDelimiter(SPACE);
+
+                try {
+                    while(scanner.hasNext()) {
+                        String token = scanner.next();
+
+                        if (hasSymbol(token)) {
+                            parseSymbol(token);
+                        }
+                        else if (isText(token)) {
+                            append(token);
+                        } else {
+                            throw new TemplateProcessingException("The template is invalid due to the string '" + token + "'");
+                        }
+
+                        if (scanner.hasNext()) {
+                            append(SPACE);
+                        }
+                    }
+
+                    append(NEW_LINE);
+                } finally {
+                    scanner.close();
+                }
+            }
+
+        } finally {
+            lineScanner.close();
+        }
+
+        //
+        // Invalid template is inSectionSymbol has not been terminated
+        //
+        if (inSectionSymbol) {
+           throw new TemplateProcessingException("The template in invalid since a section has not been closed");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     *
+     */
+    public void reset() {
+        sb = new StringBuilder();
+        inSectionSymbol = false;
+    }
+}

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/TemplateMustacheConstants.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/TemplateMustacheConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.templater;
+
+import java.util.regex.Pattern;
+import io.syndesis.common.util.StringConstants;
+
+@SuppressWarnings("PMD.ConstantsInInterface")
+public interface TemplateMustacheConstants extends StringConstants {
+
+    String BODY_PREFIX = "body" + DOT;
+
+    String DOUBLE_OPEN_BRACE_PATTERN = "\\{\\{";
+
+    String DOUBLE_CLOSE_BRACE_PATTERN = "\\}\\}";
+
+    Pattern SYMBOL_PATTERN = Pattern.compile("(" + DOUBLE_OPEN_BRACE_PATTERN + "(?:\\/|#|\\^|>)?)(.*?)(" + DOUBLE_CLOSE_BRACE_PATTERN + ")");
+
+    Pattern SYMBOL_OPEN_SECTION_PATTERN = Pattern.compile(DOUBLE_OPEN_BRACE_PATTERN + "(#|\\^)(.*?)" + DOUBLE_CLOSE_BRACE_PATTERN);
+
+    Pattern SYMBOL_CLOSE_SECTION_PATTERN = Pattern.compile(DOUBLE_OPEN_BRACE_PATTERN + "\\/(.*?)" + DOUBLE_CLOSE_BRACE_PATTERN);
+}

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/TemplateProcessingException.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/templater/TemplateProcessingException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.templater;
+
+/**
+ * Exception thrown from template pre-processing classes
+ */
+public class TemplateProcessingException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public TemplateProcessingException(String message) {
+        super(message);
+    }
+}

--- a/app/ui/src/app/integration/edit-page/step-configure/templater/mustache-mode.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/templater/mustache-mode.ts
@@ -59,8 +59,8 @@ export class MustacheMode {
   private validator(text: string, options: any): any[] {
     this._errors = [];
 
-    const symRegex = /^body\.[A-Za-z_]+$/g;
-    const format = '{{body.xyz}}';
+    const symRegex = /^[A-Za-z_]+$/g;
+    const format = '{{xyz}}';
 
     let line = 0;
     let startCol = 0;
@@ -90,16 +90,6 @@ export class MustacheMode {
       startCol = endCol - 1;
 
       if (reset) {
-
-        // Check the symbol has a body prefix
-        if (theSymbol.length > 0 && ! theSymbol.match(symRegex)) {
-          const msg = this.i18NService.localize(
-            'integrations.steps.templater-wrong-symbol-format',
-            ['{{' + theSymbol + '}}', format, line, endCol]
-          );
-          this._errors.push({ message: msg, severity: 'error', from: CodeMirror.Pos(line, startCol), to: CodeMirror.Pos(line, endCol) });
-        }
-
         // Successfully parsed a symbol so reset for next
         openSymbol = 0;
         closeSymbol = 0;
@@ -189,6 +179,15 @@ export class MustacheMode {
       if (reset) {
         // Text contains at least 1 parseable symbol so at least the text is not just constants
         haveSymbol = true;
+
+        // Check the symbol conforms to the expected format
+        if (theSymbol.length > 0 && ! theSymbol.match(symRegex)) {
+          const msg = this.i18NService.localize(
+            'integrations.steps.templater-wrong-symbol-format',
+            ['{{' + theSymbol + '}}', format, line, endCol]
+          );
+          this._errors.push({ message: msg, severity: 'error', from: CodeMirror.Pos(line, startCol), to: CodeMirror.Pos(line, endCol) });
+        }
       }
     }
 


### PR DESCRIPTION
* TemplateStepHandler
 * Adds preprocessing to the template content to add in the 'body.' prefix
   to each symbol if not already present

* MustacheTemplatePreProcessor
 * Parses each token in the template string to check validity and prepend
   body prefix to symbols

* Update tests including adding extra tests that check the syntax of the
  template

* mustache-mode.ts
 * Modifies the regex for the symbol format in the UI's template step
   editor. This removes the body prefix from being required in the symbols.
 * Moves the syntax checking portion to the bottom of the loop since its
   current position means the last word / symbol is never checked.

fixes #3894