### PR TITLE
fix: use HeaderFilterStrategy with all HTTP

### DIFF
--- a/app/connector/api-provider/src/main/resources/spring.factories
+++ b/app/connector/api-provider/src/main/resources/spring.factories
@@ -1,3 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.syndesis.connector.webhook.WebhookServletAutoConfiguration,\
   io.syndesis.connector.support.processor.SyndesisHttpConfiguration

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>integration-component-proxy</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-processor</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
     </dependency>

--- a/app/connector/http/src/main/resources/META-INF/spring.factories
+++ b/app/connector/http/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.syndesis.connector.http.HttpVerifierAutoConfiguration
+  io.syndesis.connector.http.HttpVerifierAutoConfiguration,\
+  io.syndesis.connector.support.processor.SyndesisHttpConfiguration

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
@@ -201,6 +201,9 @@
       "type": "string"
     }
   },
+  "configuredProperties": {
+    "headerFilterStrategy": "syndesisHeaderStrategy"
+  },
   "tags": [
     "verifier"
   ]

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
@@ -201,6 +201,9 @@
       "type": "string"
     }
   },
+  "configuredProperties": {
+    "headerFilterStrategy": "syndesisHeaderStrategy"
+  },
   "tags": [
     "verifier"
   ]

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -37,6 +37,12 @@
       <artifactId>camel-core</artifactId>
     </dependency>
 
+    <!-- HTTP/REST component rest-swagger component delegates to -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+    </dependency>
+
     <!-- base component to use for this connector -->
     <dependency>
       <groupId>org.apache.camel</groupId>
@@ -54,13 +60,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>apt</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <!-- HTTP/REST component rest-swagger component delegates to -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-http4</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -82,6 +81,12 @@
     <dependency>
       <groupId>io.syndesis.integration</groupId>
       <artifactId>integration-component-proxy</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-processor</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/springboot/SwaggerConnectorConfiguration.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/springboot/SwaggerConnectorConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger.springboot;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Component;
+import org.apache.camel.Producer;
+import org.apache.camel.component.http4.HttpComponent;
+import org.apache.camel.component.http4.HttpEndpoint;
+import org.apache.camel.component.http4.HttpProducer;
+import org.apache.camel.impl.DefaultHeaderFilterStrategy;
+import org.apache.camel.spi.HeaderFilterStrategy;
+import org.apache.camel.spi.RestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConnectorConfiguration {
+
+    public static final class WithSyndesisHeaderFilterStrategy extends HttpComponent {
+        final String inFilterPattern;
+        final String outFilterPattern;
+
+        public WithSyndesisHeaderFilterStrategy(final DefaultHeaderFilterStrategy global) {
+            inFilterPattern = global.getInFilterPattern();
+            outFilterPattern = global.getOutFilterPattern();
+        }
+
+        @Override
+        @SuppressWarnings({"PMD.ExcessiveParameterList", "PMD.UseObjectForClearerAPI"})
+        public Producer createProducer(final CamelContext camelContext, final String host, final String verb, final String basePath, final String uriTemplate,
+            final String queryParameters, final String consumes, final String produces, final RestConfiguration configuration,
+            final Map<String, Object> parameters) throws Exception {
+
+            final HttpProducer producer = (HttpProducer) super.createProducer(camelContext, host, verb, basePath, uriTemplate, queryParameters, consumes,
+                produces, configuration, parameters);
+            final HttpEndpoint endpoint = producer.getEndpoint();
+            final DefaultHeaderFilterStrategy used = (DefaultHeaderFilterStrategy) endpoint.getHeaderFilterStrategy();
+            used.setInFilterPattern(inFilterPattern);
+            used.setOutFilterPattern(outFilterPattern);
+
+            return producer;
+        }
+    }
+
+    @Bean("connector-rest-swagger-http4")
+    public Component http4(final HeaderFilterStrategy strategy) {
+        final DefaultHeaderFilterStrategy global = (DefaultHeaderFilterStrategy) strategy;
+
+        // HttpComponent::createProducer will ignore any
+        // HttpHeaderFilterStrategy set on the component/endpoint and set it's
+        // own HttpRestHeaderFilterStrategy which cannot be influenced in any
+        // way, here we're getting the reference to the endpoint that's created
+        // in the createProducer and modifying the configured
+        // DefaultHeaderFilterStrategy with the configuration from our global
+        // HeaderFilterStrategy. This way we can filter out any HTTP headers we
+        // do not wish to receive or send via HTTP (such as Syndesis.*)
+        return new WithSyndesisHeaderFilterStrategy(global);
+    }
+
+}

--- a/app/connector/rest-swagger/src/main/resources/camel-connector.json
+++ b/app/connector/rest-swagger/src/main/resources/camel-connector.json
@@ -16,7 +16,7 @@
   "outputDataType" : "json",
   "componentOptions" : [ "host", "basePath" ],
   "endpointValues" : {
-    "componentName" : "http4"
+    "componentName" : "connector-rest-swagger-http4"
   },
   "endpointOptions" : [ "operationId" ],
   "connectorProperties" : {

--- a/app/connector/support/processor/pom.xml
+++ b/app/connector/support/processor/pom.xml
@@ -41,6 +41,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.syndesis.common</groupId>
       <artifactId>common-util</artifactId>
     </dependency>
@@ -48,6 +58,11 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http-common</artifactId>
     </dependency>
 
     <dependency>

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategy.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.processor;
+
+import org.apache.camel.http.common.HttpHeaderFilterStrategy;
+
+public class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
+
+    @Override
+    protected void initialize() {
+        super.initialize();
+
+        setOutFilterPattern("(?i)(Syndesis|Camel|org\\.apache\\.camel).*");
+        setInFilterPattern("(?i)(Syndesis|Camel|org\\.apache\\.camel).*");
+    }
+}

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHttpConfiguration.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHttpConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.processor;
+
+import org.apache.camel.spi.HeaderFilterStrategy;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Conditional(SyndesisHttpConfiguration.NeedsHeaderFilterStrategy.class)
+@AutoConfigureBefore(name = "org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration")
+public class SyndesisHttpConfiguration {
+
+    /**
+     * Condition to activate this @Configuration only when it's needed. In all
+     * the cases below, we need the SyndesisHeaderStrategy bean defined, in
+     * other cases we do not.
+     */
+    static class NeedsHeaderFilterStrategy extends AnyNestedCondition {
+        /**
+         * Checks if we're using camel-servlet (via camel-servlet-starter), this
+         * is when API provider is used.
+         */
+        @ConditionalOnClass(name = "org.apache.camel.component.servlet.springboot.ServletComponentAutoConfiguration")
+        static class CamelServletUsed {
+            // auto configuration test
+        }
+
+        /**
+         * Checks if we're using API connector-http.
+         */
+        @ConditionalOnClass(name = "io.syndesis.connector.http.HttpVerifierAutoConfiguration")
+        static class HttpUsed {
+            // auto configuration test
+        }
+
+        /**
+         * Checks if we're using API connector-rest-swagger.
+         */
+        @ConditionalOnClass(name = "io.syndesis.connector.rest.swagger.SwaggerConnectorComponent")
+        static class SyndesisApiClientUsed {
+            // auto configuration test
+        }
+
+        /**
+         * Checks if we're using API connector-webhook.
+         */
+        @ConditionalOnClass(name = "io.syndesis.connector.webhook.WebhookServletAutoConfiguration")
+        static class WebhookUsed {
+            // auto configuration test
+        }
+
+        public NeedsHeaderFilterStrategy() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HeaderFilterStrategy syndesisHeaderStrategy() {
+        return new SyndesisHeaderStrategy();
+    }
+
+}

--- a/app/connector/support/processor/src/main/resources/META-INF/spring.factories
+++ b/app/connector/support/processor/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.syndesis.connector.webhook.WebhookServletAutoConfiguration,\
   io.syndesis.connector.support.processor.SyndesisHttpConfiguration

--- a/app/connector/webhook/src/main/resources/META-INF/syndesis/connector/webhook.json
+++ b/app/connector/webhook/src/main/resources/META-INF/syndesis/connector/webhook.json
@@ -6,7 +6,8 @@
       "descriptor": {
         "componentScheme": "servlet",
         "configuredProperties": {
-          "httpMethodRestrict": "GET,POST"
+          "httpMethodRestrict": "GET,POST",
+          "headerFilterStrategy": "syndesisHeaderStrategy"
         },
         "connectorCustomizers": [
           "io.syndesis.connector.webhook.WebhookConnectorCustomizer"

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
@@ -15,7 +15,8 @@ public class RestRouteConfiguration {
             public void configure() throws Exception {
                 restConfiguration()
                 .contextPath("/")
-                .component("servlet");
+                .component("servlet")
+                .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
 
                 rest()
                     .get("/openapi.json")

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
@@ -23,6 +23,7 @@ camel.health.indicator.enabled=true
 
 # Map Camel servlet to /*
 camel.component.servlet.mapping.contextPath=/*
+camel.component.servlet.headerFilterStrategy-class-name=io.syndesis.connector.support.processor.SyndesisHeaderStrategy
 
 # disable spring boot auto configurations
 spring.autoconfigure.exclude[0] = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
@@ -15,7 +15,8 @@ public class RestRouteConfiguration {
             public void configure() throws Exception {
                 restConfiguration()
                 .contextPath("/")
-                .component("servlet");
+                .component("servlet")
+                .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
 
                 rest()
                     .get("/openapi.json")

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application.properties
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application.properties
@@ -23,6 +23,7 @@ camel.health.indicator.enabled=true
 
 # Map Camel servlet to /*
 camel.component.servlet.mapping.contextPath=/*
+camel.component.servlet.headerFilterStrategy-class-name=io.syndesis.connector.support.processor.SyndesisHeaderStrategy
 
 # disable spring boot auto configurations
 spring.autoconfigure.exclude[0] = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
Previous attempts of removing Camel message headers did not pan out successful, this is mainly because it's a race between the Activity tracing interceptor that adds this to around every interceptor and the header-removal logic.

With this, a new approach of using/configuring HeaderFilterStrategy to the servlet (webhook & API provider), HTTP and API client connector eliminates the need for removing Camel message headers and deals with the issue on the HTTP protocol binding level.

As the HTTP4 component RestProducerFactory implementation overwrites any HeaderFilterStrategy configured on the component/endpoint a subclass was necessary to make this function.

So with this fix all HTTP interactions: be it HTTP requests sent out of integrations (HTTP connector, API client connector) or any HTTP responses received from integrations (webhook, API provider) should not
contain `Syndesis.*` HTTP headers regardless of their presence in the Camel message headers.

Fixes #3865