### PR TITLE
[fix] Inform user when integration limit is reached when attempting t…

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Kind.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Kind.java
@@ -56,6 +56,7 @@ public enum Kind {
     Permission(io.syndesis.common.model.user.Permission.class),
     Role(io.syndesis.common.model.user.Role.class),
     User(io.syndesis.common.model.user.User.class),
+    //Quota(io.syndesis.common.model.user.Quota.class),
 
     ConnectionBulletinBoard(io.syndesis.common.model.bulletin.ConnectionBulletinBoard.class),
     IntegrationBulletinBoard(io.syndesis.common.model.bulletin.IntegrationBulletinBoard.class),

--- a/app/common/model/src/main/java/io/syndesis/common/model/user/Quota.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/user/Quota.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.user;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.syndesis.common.model.ToJson;
+
+@Value.Immutable
+@JsonDeserialize(builder = Quota.Builder.class)
+@SuppressWarnings("immutables")
+public interface Quota extends ToJson, Serializable {
+
+    class Builder extends ImmutableQuota.Builder {
+        // allow access to ImmutableQuota.Builder
+    }
+
+    Optional<Integer> getMaxIntegrationsPerUser();
+
+    Optional<Integer> getMaxDeploymentsPerUser();
+
+    Optional<Integer> getUsedIntegrationsPerUser();
+
+    Optional<Integer> getUsedDeploymentsPerUser();
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserConfigurationProperties.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserConfigurationProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.user;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Let's grab the settings from the 'controllers' section, since
+ * they are already defined there.
+ *
+ */
+@Configuration
+@ConfigurationProperties("controllers")
+public class UserConfigurationProperties {
+
+    // Default values ....
+    public static final int UNLIMITED = 0;
+
+    private int maxIntegrationsPerUser = 1;
+    private int maxDeploymentsPerUser  = 1;
+
+    public UserConfigurationProperties() {
+        super();
+    }
+
+    public UserConfigurationProperties(int maxIntegrationsPerUser, int maxDeploymentsPerUser) {
+        super();
+        this.maxIntegrationsPerUser = maxIntegrationsPerUser;
+        this.maxDeploymentsPerUser = maxDeploymentsPerUser;
+    }
+
+    public int getMaxIntegrationsPerUser() {
+        return maxIntegrationsPerUser;
+    }
+
+    public void setMaxIntegrationsPerUser(int maxIntegrationsPerUser) {
+        this.maxIntegrationsPerUser = maxIntegrationsPerUser;
+    }
+
+    public int getMaxDeploymentsPerUser() {
+        return maxDeploymentsPerUser;
+    }
+
+    public void setMaxDeploymentsPerUser(int maxDeploymentsPerUser) {
+        this.maxDeploymentsPerUser = maxDeploymentsPerUser;
+    }
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserHandler.java
@@ -18,11 +18,17 @@ package io.syndesis.server.endpoint.v1.handler.user;
 import io.swagger.annotations.Api;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.common.model.Kind;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.common.model.integration.IntegrationDeploymentState;
+import io.syndesis.common.model.user.Quota;
 import io.syndesis.common.model.user.User;
+import io.syndesis.common.util.Labels;
 import io.syndesis.server.openshift.OpenShiftService;
 import io.syndesis.server.endpoint.v1.handler.BaseHandler;
 import io.syndesis.server.endpoint.v1.operations.Getter;
 import io.syndesis.server.endpoint.v1.operations.Lister;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
@@ -33,6 +39,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Path("/users")
@@ -41,10 +49,13 @@ import java.util.Optional;
 public class UserHandler extends BaseHandler implements Lister<User>, Getter<User> {
 
     private final OpenShiftService openShiftService;
+    private final UserConfigurationProperties properties;
 
-    public UserHandler(DataManager dataMgr, OpenShiftService openShiftService) {
+    @Autowired
+    public UserHandler(DataManager dataMgr, OpenShiftService openShiftService, UserConfigurationProperties properties) {
         super(dataMgr);
         this.openShiftService = openShiftService;
+        this.properties = properties;
     }
 
     @Override
@@ -59,10 +70,55 @@ public class UserHandler extends BaseHandler implements Lister<User>, Getter<Use
         String username = sec.getUserPrincipal().getName();
         io.fabric8.openshift.api.model.User openShiftUser = this.openShiftService.whoAmI(username);
         Assert.notNull(openShiftUser, "A valid user is required");
-        return new User.Builder()
-            .username(openShiftUser.getMetadata().getName())
-            .fullName(Optional.ofNullable(openShiftUser.getFullName()))
-            .name(Optional.ofNullable(openShiftUser.getFullName()))
-            .build();
+        return new User.Builder().username(openShiftUser.getMetadata().getName())
+                .fullName(Optional.ofNullable(openShiftUser.getFullName()))
+                .name(Optional.ofNullable(openShiftUser.getFullName())).build();
+    }
+
+    @Path("~/quota")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Quota quota(@Context SecurityContext sec) {
+        String username = sec.getUserPrincipal().getName();
+        io.fabric8.openshift.api.model.User openShiftUser = this.openShiftService.whoAmI(username);
+        Assert.notNull(openShiftUser, "A valid user is required");
+        return new Quota.Builder()
+                .maxDeploymentsPerUser(properties.getMaxDeploymentsPerUser())
+                .maxIntegrationsPerUser(properties.getMaxIntegrationsPerUser())
+                .usedDeploymentsPerUser(countDeployments(username))
+                .usedIntegrationsPerUser(countActiveIntegrations(username))
+                .build();
+    }
+
+    /**
+     * Counts active integrations (in DB) of the owner of the specified integration.
+     *
+     * @param deployment The specified IntegrationDeployment.
+     * @return The number of integrations (excluding the current).
+     */
+    private int countActiveIntegrations(String username) {
+
+        return (int) getDataManager().fetchAll(IntegrationDeployment.class).getItems()
+            .stream()
+            .filter(i -> IntegrationDeploymentState.Published == i.getCurrentState())
+            .filter(i -> i.getUserId().map(username::equals).orElse(Boolean.FALSE))
+            .count();
+    }
+
+    /**
+     * Count the deployments of the owner of the specified integration.
+     *
+     * @param username The specified user
+     * @return The number of deployed integrations.
+     */
+    private int countDeployments(String username) {
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(OpenShiftService.USERNAME_LABEL, Labels.sanitize(username));
+
+        return (int) this.openShiftService.getDeploymentsByLabel(labels)
+            .stream()
+            .filter(d -> d.getSpec().getReplicas() > 0)
+            .count();
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/user/UserHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/user/UserHandlerTest.java
@@ -68,7 +68,9 @@ public class UserHandlerTest {
 
         SecurityContextHolder.getContext().setAuthentication(new PreAuthenticatedAuthenticationToken("testuser", "doesn'tmatter"));
 
-        UserHandler userHandler = new UserHandler(null, new OpenShiftServiceImpl(client, null));
+        UserConfigurationProperties properties = new UserConfigurationProperties();
+        properties.setMaxDeploymentsPerUser(1);
+        UserHandler userHandler = new UserHandler(null, new OpenShiftServiceImpl(client, null), properties);
         io.syndesis.common.model.user.User whoAmI = userHandler.whoAmI(sec);
         Assertions.assertThat(whoAmI).isNotNull();
         Assertions.assertThat(whoAmI.getUsername()).isEqualTo("testuser");

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -98,8 +98,6 @@
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
-          - name: MAX_INTEGRATIONS_PER_USER
-            value: ${MAX_INTEGRATIONS_PER_USER}
           - name: INTEGRATION_STATE_CHECK_INTERVAL
             value: ${INTEGRATION_STATE_CHECK_INTERVAL}
           - name: CONTROLLERS_EXPOSE_VIA3SCALE

--- a/install/syndesis-dev.yml
+++ b/install/syndesis-dev.yml
@@ -1097,8 +1097,6 @@ objects:
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
-          - name: MAX_INTEGRATIONS_PER_USER
-            value: ${MAX_INTEGRATIONS_PER_USER}
           - name: INTEGRATION_STATE_CHECK_INTERVAL
             value: ${INTEGRATION_STATE_CHECK_INTERVAL}
           - name: CONTROLLERS_EXPOSE_VIA3SCALE

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1095,8 +1095,6 @@ objects:
                 key: clientStateEncryptionKey
           - name: CLIENT_STATE_TID
             value: "1"
-          - name: MAX_INTEGRATIONS_PER_USER
-            value: ${MAX_INTEGRATIONS_PER_USER}
           - name: INTEGRATION_STATE_CHECK_INTERVAL
             value: ${INTEGRATION_STATE_CHECK_INTERVAL}
           - name: CONTROLLERS_EXPOSE_VIA3SCALE


### PR DESCRIPTION
…o publish or activate #246 

partial fix #246 
- Adds a /users/~/quota

```
{
maxIntegrationsPerUser: 2,
maxDeploymentsPerUser: 2,
usedIntegrationsPerUser: 2,
usedDeploymentsPerUser: 2
}
```

- Sets populates the statusMessage in the Integration deployment entity that is returned on the PUT to https://syndesis.192.168.42.91.nip.io/api/v1/integrations/{id}/deployments

<img width="691" alt="screen shot 2018-11-09 at 2 54 45 pm" src="https://user-images.githubusercontent.com/35576/48266656-4a3ee880-e430-11e8-89f6-f742bfe4b54c.png">

@gashcrumb Maybe you can use the statusMessage and display it in the UI?
