### PR TITLE
refactor(integration list items): relocating cursor pointer

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -75,7 +75,6 @@ body.cards-pf {
 
 // Override the background that seems off with patternfly-ng's list
 .list-pf {
-  cursor: pointer;
   .list-pf-item {
     background: $color-pf-white;
     //cursor: pointer;

--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -75,11 +75,20 @@ body.cards-pf {
 
 // Override the background that seems off with patternfly-ng's list
 .list-pf {
+  cursor: pointer;
   .list-pf-item {
     background: $color-pf-white;
-    cursor: pointer;
+    //cursor: pointer;
     &:hover {
       background: $color-pf-blue-50;
+    }
+    .list-pf-container {
+      .list-pf-content {
+        // added cursor area minus the kebab to the right of the list item
+        .list-pf-content {
+          cursor: pointer;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
fixes: #4036 

- removing the cursor pointer to a lower div level. This is a UX improvement that alleviates registered click confusion on listed integration items.

![integration-list-item-ux-improvement](https://user-images.githubusercontent.com/1402829/48277898-004b0800-e41a-11e8-808f-1dc6de03a781.gif)

**NOTE:**
This has been a known issue with Patternfly-ng since the beginning. The level of effort required to overhaul and correct the list items (JavaScript based) would cause a cascade of UI bugs through the system. For now, a minor UX improvement is the best solution. We can place greater attention to the list items when we build out and apply PF4 to Syndesis. Thanks to @seanforyou23 and @mcoker on their feedback for this issue.

@dongniwang, please verify the fix on your end and please delegate the shelf life of this ticket. Thanks!

