### PR TITLE
[fix] Missing icon custom connector after import #4055

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Dependency.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Dependency.java
@@ -26,7 +26,8 @@ public interface Dependency {
     enum Type {
         MAVEN,
         EXTENSION,
-        EXTENSION_TAG
+        EXTENSION_TAG,
+        ICON
     }
 
     /**
@@ -64,6 +65,11 @@ public interface Dependency {
     }
 
     @JsonIgnore
+    default boolean isIcon() {
+        return isOfType(Type.ICON);
+    }
+
+    @JsonIgnore
     static Dependency from(Type type, String id) {
         return new Builder().type(type).id(id).build();
     }
@@ -81,6 +87,11 @@ public interface Dependency {
     @JsonIgnore
     static Dependency libraryTag(String id) {
         return from(Type.EXTENSION_TAG, id);
+    }
+
+    @JsonIgnore
+    static Dependency icon(String id) {
+        return from(Type.ICON, id);
     }
 
     // *****************

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
@@ -115,7 +115,7 @@ public final class ConnectorIconHandler extends BaseHandler {
                 } else {
                     icon = getDataManager().create(iconBuilder.build());
                 }
-
+                //write icon to (Sql)FileStore
                 iconDao.write(icon.getId().get(), iconStream);
 
                 Connector updatedConnector = new Connector.Builder().createFrom(connector).icon("db:" + icon.getId().get()).build();
@@ -141,7 +141,7 @@ public final class ConnectorIconHandler extends BaseHandler {
             if (icon == null) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
-
+            //grab icon file from the (Sql)FileStore
             final StreamingOutput streamingOutput = (out) -> {
                 try (BufferedSink sink = Okio.buffer(Okio.sink(out));
                     Source source = Okio.source(iconDao.read(connectorIconId))) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -178,13 +178,9 @@ public class IntegrationSupportHandler {
                     .flatMap(flow -> flow.getSteps().stream())
                     .collect(Collectors.toList()), true);
             dependencies.stream()
-                .filter(Dependency::isExtension)
+                .filter(d -> d.isExtension() || d.isIcon() )
                 .map(Dependency::getId)
                 .forEach(extensions::add);
-            dependencies.stream()
-            .filter(Dependency::isIcon)
-            .map(Dependency::getId)
-            .forEach(icons::add);
         }
         LOG.debug("Extensions: {}", extensions);
         LOG.debug("Icons: {}", icons);

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -18,6 +18,7 @@ package io.syndesis.server.endpoint.v1.handler.integration.support;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -65,6 +66,7 @@ import io.syndesis.common.model.WithResourceId;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.extension.Extension;
+import io.syndesis.common.model.icon.Icon;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.IntegrationDeployment;
 import io.syndesis.common.model.integration.IntegrationOverview;
@@ -75,6 +77,7 @@ import io.syndesis.common.util.Names;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.dao.file.FileDataManager;
+import io.syndesis.server.dao.file.IconDao;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.endpoint.v1.handler.integration.IntegrationHandler;
 import io.syndesis.server.jsondb.CloseableJsonDB;
@@ -108,6 +111,7 @@ public class IntegrationSupportHandler {
     private final IntegrationResourceManager resourceManager;
     private final IntegrationHandler integrationHandler;
     private final FileDataManager extensionDataManager;
+    private final IconDao iconDao;
 
     public IntegrationSupportHandler(
         final Migrator migrator,
@@ -116,7 +120,8 @@ public class IntegrationSupportHandler {
         final DataManager dataManager,
         final IntegrationResourceManager resourceManager,
         final IntegrationHandler integrationHandler,
-        final FileDataManager extensionDataManager) {
+        final FileDataManager extensionDataManager,
+        final IconDao iconDao) {
         this.migrator = migrator;
         this.jsondb = jsondb;
 
@@ -125,6 +130,7 @@ public class IntegrationSupportHandler {
         this.resourceManager = resourceManager;
         this.integrationHandler = integrationHandler;
         this.extensionDataManager = extensionDataManager;
+        this.iconDao = iconDao;
     }
 
     public DataManager getDataManager() {
@@ -156,7 +162,6 @@ public class IntegrationSupportHandler {
             throw new ClientErrorException("No 'integration' query parameter specified.", Response.Status.BAD_REQUEST);
         }
 
-        LinkedHashSet<String> extensions = new LinkedHashSet<>();
         CloseableJsonDB memJsonDB = MemorySqlJsonDB.create(jsondb.getIndexes());
         if( ids.contains("all") ) {
             ids = new ArrayList<>();
@@ -164,19 +169,26 @@ public class IntegrationSupportHandler {
                 ids.add(integration.getId().get());
             }
         }
+        LinkedHashSet<String> extensions = new LinkedHashSet<>();
+        LinkedHashSet<String> icons = new LinkedHashSet<>();
         for (String id : ids) {
             Integration integration = integrationHandler.getIntegration(id);
             addToExport(memJsonDB, integration);
-            resourceManager.collectDependencies(integration.getFlows().stream()
+            Collection<Dependency> dependencies = resourceManager.collectDependencies(integration.getFlows().stream()
                     .flatMap(flow -> flow.getSteps().stream())
-                    .collect(Collectors.toList()), true)
-                .stream()
+                    .collect(Collectors.toList()), true);
+            dependencies.stream()
                 .filter(Dependency::isExtension)
                 .map(Dependency::getId)
                 .forEach(extensions::add);
+            dependencies.stream()
+            .filter(Dependency::isIcon)
+            .map(Dependency::getId)
+            .forEach(icons::add);
         }
         LOG.debug("Extensions: {}", extensions);
-
+        LOG.debug("Icons: {}", icons);
+        
         return out -> {
             try (ZipOutputStream tos = new ZipOutputStream(out) ) {
                 ModelExport exportObject = ModelExport.of(Schema.VERSION);
@@ -187,6 +199,13 @@ public class IntegrationSupportHandler {
                     addEntry(tos, "extensions/" + Names.sanitize(extensionId) + ".jar", IOUtils.toByteArray(
                         extensionDataManager.getExtensionBinaryFile(extensionId)
                     ));
+                }
+                for (String iconId : icons) {
+                    Icon icon = getDataManager().fetch(Icon.class, iconId);
+                    String ext = MediaType.valueOf(icon.getMediaType()).getSubtype();
+                    String name = iconId.substring(3);
+                    byte[] bytes = IOUtils.toByteArray(iconDao.read(name));
+                    addEntry(tos, "icons/" + name + "." + ext, bytes);
                 }
             }
         };
@@ -203,6 +222,10 @@ public class IntegrationSupportHandler {
                 Connector connector = integrationHandler.getDataManager().fetch(Connector.class, connection.getConnectorId());
                 if (connector != null) {
                     addModelToExport(export, connector);
+                    if (connector.getIcon() != null && connector.getIcon().startsWith("db:")) {
+                        Icon icon = integrationHandler.getDataManager().fetch(Icon.class, connector.getIcon().substring(3));
+                        addModelToExport(export, icon);
+                    }
                 }
             }
             Optional<Extension> e = step.getExtension();
@@ -274,6 +297,19 @@ public class IntegrationSupportHandler {
                                 existing.close();
                             }
                         }
+                    }
+                }
+
+                // import custom icons
+                if( entry.getName().startsWith("icons/") ) {
+                    String fileName = entry.getName().substring(6);
+                    String id = fileName.substring(0, fileName.indexOf('.'));
+                    InputStream existing = iconDao.read(id);
+                    if( existing == null) {
+                        // write the icon to the (Sql)FileStore
+                        iconDao.write(id, zis);
+                    } else {
+                        existing.close();
                     }
                 }
 
@@ -349,6 +385,13 @@ public class IntegrationSupportHandler {
             }
         }, (a, n) -> new OpenApi.Builder().createFrom(a).name(n).build(), new HashMap<>(), result);
 
+        importModels(new JsonDbDao<Icon>(given) {
+            @Override
+            public Class<Icon> getType() {
+                return Icon.class;
+            }
+        }, result);
+        
         return result;
     }
 
@@ -433,6 +476,17 @@ public class IntegrationSupportHandler {
         return newName;
     }
 
+    private <T extends WithId<T>> void importModels(JsonDbDao<T> export, Map<String, List<WithResourceId>> result) {
+        for (T item : export.fetchAll().getItems()) {
+            String id = item.getId().get();
+            if (dataManager.fetch(export.getType(), id) == null) {
+                // create new item
+                dataManager.create(item);
+
+                addImportedItemResult(result, item);
+            }
+        }
+    }
     private <T extends WithId<T> & WithName> void importModels(JsonDbDao<T> export, BiFunction<T, String, T> renameFunc,
                                                                Map<String, String> renames, Map<String, List<WithResourceId>> result) {
         final Set<String> names = getAllPropertyValues(export.getType(), o -> o.getName());
@@ -460,7 +514,7 @@ public class IntegrationSupportHandler {
         }
     }
 
-    private static <T extends WithId<T> & WithName> void addImportedItemResult(Map<String, List<WithResourceId>> result,
+    private static <T extends WithId<T>> void addImportedItemResult(Map<String, List<WithResourceId>> result,
         T item) {
         final Kind kind = item.getKind();
         final List<WithResourceId> imported = result.computeIfAbsent(kind.getPluralModelName(), (key) -> new ArrayList<>());


### PR DESCRIPTION
Fixes issue 4055. With this fix it exports the icon model as well as the image as file. On integration import the model is restored into the JSONDB and the image is restored into the (Sql)FileStore if it didn't exist already.