### PR TITLE
fix: no need to commit anything from app/connector

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -350,7 +350,6 @@ git_commit_files() {
     echo "==== Committing files to local git"
     cd $dir
     git_commit pom.xml "Update pom.xmls to $version"
-    git_commit ^app/connector/ "Update generated connector files"
     git_commit ^install/ "Update OpenShift templates for Syndesis $version"
 }
 


### PR DESCRIPTION
Removes the `git commit` call for files within `app/connector` as there
are no more changes there when we run the build.

see #4104 