### PR TITLE
fix(tooltip glyphicon): tooltip misaligned with glyphicon.

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -154,3 +154,8 @@ body.cards-pf {
     }
   }
 }
+
+// Tooltip styling override
+.glyphicon-info-sign {
+  display: block;
+}


### PR DESCRIPTION
fixes #4094

- glyphicon css needed to be overwritten to help align itself with the tooltip on hover.

![screen shot 2018-11-19 at 3 26 03 pm](https://user-images.githubusercontent.com/1402829/48733054-71a36b80-ec0f-11e8-893b-82ac7c0d83ab.png)
