### PR TITLE
fix(tooltip): adding CSS override for tooltip on hover above and below parent div.

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -159,3 +159,15 @@ body.cards-pf {
 .glyphicon-info-sign {
   display: block;
 }
+
+// Centering tooltip styling above and below parent div
+.bs-tooltip-top .arrow,
+.bs-tooltip-bottom .arrow {
+  margin: 0 !important;
+  transform: translateX(-50%);
+}
+.bs-tooltip-left .arrow,
+.bs-tooltip-right .arrow {
+  margin: 0 !important;
+  transform: translateY(-50%);
+}


### PR DESCRIPTION
fixes #4094.

- Culprit with the misalignment was due to margin settings. It needed an override.

**before css override**
<img width="360" alt="screen shot 2018-11-20 at 3 24 07 pm" src="https://user-images.githubusercontent.com/1402829/48803597-61a78c80-ece0-11e8-98dd-dcc288e724a1.png">

**after css override**
<img width="272" alt="screen shot 2018-11-20 at 3 21 47 pm" src="https://user-images.githubusercontent.com/1402829/48803618-6bc98b00-ece0-11e8-8aa7-13afe71b35ac.png">
