### PR TITLE
Fix #4123: "syndesis install" accidentally fails

### DIFF
--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -6,7 +6,7 @@ OC_MIN_VERSION=3.9.0
 check_oc_version()
 {
     local minimum=${OC_MIN_VERSION}
-    local test=$(oc version | grep oc | tr -d oc\ v | cut -f1 -d "+")
+    local test=$(oc version | grep "^oc" | tr -d oc\ v | cut -f1 -d "+")
 
     echo $(compare_oc_version $test $minimum)
 }


### PR DESCRIPTION
 "syndesis install" accidentally fails when Server URL contains "oc"