### PR TITLE
Upgrades Jackson to 2.9.7

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -54,7 +54,7 @@
 
     <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
 
-    <jackson.version>2.8.11</jackson.version>
+    <jackson.version>2.9.7</jackson.version>
     <json-patch.version>1.9</json-patch.version>
     <kubernetes.client.version>3.1.4.fuse-710001</kubernetes.client.version>
 
@@ -974,6 +974,14 @@
       </dependency>
 
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
@@ -987,14 +995,6 @@
         <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.8.11.20180608</version>
-        <scope>import</scope>
-        <type>pom</type>
       </dependency>
 
       <dependency>
@@ -1564,7 +1564,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.8.11.2</version>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>

--- a/app/server/api-generator/src/test/resources/swagger/invalid/warning-petstore.swagger.json
+++ b/app/server/api-generator/src/test/resources/swagger/invalid/warning-petstore.swagger.json
@@ -64,7 +64,7 @@
             "description": "Pet object that needs to be added to the store",
             "required": true,
             "schema": {
-
+              "type": "object"
             }
           }
         ],

--- a/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
@@ -72,7 +72,7 @@
           "kind": "json-schema",
           "name": "Response",
           "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\",  \"$id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"category\":{\"properties\":{\"id\":{\"format\":\"int64\",\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Category\"}},\"id\":{\"format\":\"int64\",\"type\":\"integer\"},\"name\":{\"example\":\"doggie\",\"type\":\"string\"},\"photoUrls\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true}},\"status\":{\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"],\"type\":\"string\"},\"tags\":{\"items\":{\"properties\":{\"id\":{\"format\":\"int64\",\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Tag\"}},\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true}}},\"required\":[\"name\",\"photoUrls\"],\"type\":\"object\",\"xml\":{\"name\":\"Pet\"}},\"type\":\"array\" }}, \"type\":\"object\" }"
-         }
+        }
       },
       "id": "io.syndesis.connector:connector-rest-swagger:@project.version@:_id_:findPetsByStatus",
       "name": "Finds Pets by status",
@@ -577,7 +577,6 @@
       "componentProperty": true,
       "deprecated": false,
       "description": "Seconds in UTC when the access token expires",
-      "displayName": "",
       "group": "producer",
       "javaType": "java.lang.Long",
       "kind": "property",

--- a/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
@@ -715,7 +715,6 @@
       "componentProperty": true,
       "deprecated": false,
       "description": "Seconds in UTC when the access token expires",
-      "displayName": "",
       "group": "producer",
       "javaType": "java.lang.Long",
       "kind": "property",

--- a/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
@@ -5498,7 +5498,6 @@
       "componentProperty": true,
       "deprecated": false,
       "description": "Seconds in UTC when the access token expires",
-      "displayName": "",
       "group": "producer",
       "javaType": "java.lang.Long",
       "kind": "property",

--- a/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonDBTest.java
+++ b/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonDBTest.java
@@ -49,7 +49,7 @@ public class JsonDBTest {
 
     private SqlJsonDB jsondb;
     private ObjectMapper mapper = new ObjectMapper()
-        .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+        .setSerializationInclusion(JsonInclude.Include.ALWAYS);
 
     private GetOptions prettyPrint = new GetOptions().prettyPrint(true);
 


### PR DESCRIPTION
Bit of detail in the commit messages:

fix: include all nodes in JSONDB test

Seems that the test was written with the idea that all nodes, even
`null` ones will be included in serialization/deserialization, so this
configures the right inclusion. As surfaced by Jackson upgrade.

fix: preloads the Swagger 2.0 JSON schema

Seems that Jackson upgrade triggered Swagger 2.0 schema download from
`http://swagger.io/v2/schema.json#`, this is unwanted we provide the
schema file embeded in the artefact.


fix: remove accessTokenExpiresAt.description

It is empty and in `io.syndesis.common.util.Json` we serialize only non
empty nodes. Change introduced with Jackson 2.9.7