### PR TITLE
refactor: set the phases on for Syndesis Maven plugins

### DIFF
--- a/app/connector/activemq/pom.xml
+++ b/app/connector/activemq/pom.xml
@@ -203,6 +203,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/amqp/pom.xml
+++ b/app/connector/amqp/pom.xml
@@ -127,6 +127,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/api-provider/pom.xml
+++ b/app/connector/api-provider/pom.xml
@@ -146,6 +146,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/aws-s3/pom.xml
+++ b/app/connector/aws-s3/pom.xml
@@ -178,6 +178,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/dropbox/pom.xml
+++ b/app/connector/dropbox/pom.xml
@@ -94,6 +94,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/fhir/pom.xml
+++ b/app/connector/fhir/pom.xml
@@ -112,6 +112,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/ftp/pom.xml
+++ b/app/connector/ftp/pom.xml
@@ -96,6 +96,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/gmail/pom.xml
+++ b/app/connector/gmail/pom.xml
@@ -175,6 +175,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/google-calendar/pom.xml
+++ b/app/connector/google-calendar/pom.xml
@@ -179,6 +179,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -113,7 +113,7 @@
       <groupId>io.syndesis.common</groupId>
       <artifactId>common-util</artifactId>
       <scope>provided</scope>
-    </dependency>  
+    </dependency>
 
     <!-- ToDo add once camel component made it into the fuse build -->
     <!--dependency>
@@ -322,6 +322,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -177,6 +177,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/irc/pom.xml
+++ b/app/connector/irc/pom.xml
@@ -123,6 +123,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/kafka/pom.xml
+++ b/app/connector/kafka/pom.xml
@@ -140,6 +140,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/log/pom.xml
+++ b/app/connector/log/pom.xml
@@ -118,6 +118,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/mqtt/pom.xml
+++ b/app/connector/mqtt/pom.xml
@@ -107,6 +107,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/salesforce/pom.xml
+++ b/app/connector/salesforce/pom.xml
@@ -170,6 +170,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/servicenow/pom.xml
+++ b/app/connector/servicenow/pom.xml
@@ -153,6 +153,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/sftp/pom.xml
+++ b/app/connector/sftp/pom.xml
@@ -95,6 +95,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/slack/pom.xml
+++ b/app/connector/slack/pom.xml
@@ -153,6 +153,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -207,6 +207,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
+++ b/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
@@ -50,7 +50,7 @@ import java.util.Optional;
 
 @Mojo(
     name = "generate-connector-inspections",
-    defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+    defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
     requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class GenerateConnectorInspectionsMojo extends AbstractMojo {

--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -130,6 +130,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/timer/pom.xml
+++ b/app/connector/timer/pom.xml
@@ -121,6 +121,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/twitter/pom.xml
+++ b/app/connector/twitter/pom.xml
@@ -91,6 +91,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -144,6 +144,7 @@
         <executions>
           <execution>
             <id>inspections</id>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-connector-inspections</goal>
             </goals>

--- a/app/extension/example/log-step/pom.xml
+++ b/app/extension/example/log-step/pom.xml
@@ -162,8 +162,21 @@
         <version>${syndesis.version}</version>
         <executions>
           <execution>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.syndesis.extension</groupId>
+        <artifactId>extension-maven-plugin</artifactId>
+        <version>${syndesis.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
               <goal>repackage-extension</goal>
             </goals>
           </execution>


### PR DESCRIPTION
This helps with invoking maven goals that do not require Syndesis Maven
plugins (like `mvn clean`) when the said Maven plugins are not available
from the local repository (or for download).

I don't see us hosting a repository with SNAPSHOTS (we'll not at least
in the short-to-medium time), this at least helps invoking some Maven
phases when the Syndesis Maven plugins are not required.

Depending on Maven plugins from the same project/reactor is usually not
a good idea.

Fixes #1501 (sort of)