### PR TITLE
Fixed server builder maven plugin usage

### DIFF
--- a/app/server/builder/maven-plugin/pom.xml
+++ b/app/server/builder/maven-plugin/pom.xml
@@ -294,6 +294,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -361,17 +362,13 @@
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
         <executions>
           <execution>
             <id>default-descriptor</id>
-            <phase>default-descriptor</phase>
-            <goals>
-              <goal>descriptor</goal>
-            </goals>
+            <phase>process-classes</phase>
           </execution>
           <execution>
             <id>help-goal</id>
@@ -381,7 +378,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -115,7 +115,7 @@
         <executions>
           <execution>
             <id>generate-mapper-inspections</id>
-            <phase>genrate-resources</phase>
+            <phase>generate-resources</phase>
             <goals>
               <goal>generate-mapper-inspections</goal>
             </goals>


### PR DESCRIPTION
Server builder maven plugin descriptor has not been created as descriptor generation was bound to `default-descriptor` phase which obviously does not exist in Maven.

In addition to that plugin usage in server runtime module was bound to phase `genrate-resources` which is obviously a typo.

Fixed both issues. 

Though I am wondering if we actually need this plugin as the descriptor and execution has been broken for the last 6 months.