### PR TITLE
[#3655] Tune IRC connector

### DIFF
--- a/app/connector/irc/pom.xml
+++ b/app/connector/irc/pom.xml
@@ -47,13 +47,29 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-irc</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration</groupId>
+      <artifactId>integration-component-proxy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>connector-support-verifier</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <!-- test -->

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.irc;
+
+import java.util.Map;
+
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+
+public class IrcConnector extends ComponentProxyComponent {
+    public IrcConnector(String componentId, String componentScheme) {
+        super(componentId, componentScheme);
+    }
+
+    @Override
+    protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
+        Map<String, String> endpointOptions = super.buildEndpointOptions(remaining, options);
+        if (options.get("channels") != null) {
+            endpointOptions.put("channels", (String)options.get("channels"));
+        }
+        return endpointOptions;
+    }
+}

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnectorFactory.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnectorFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.irc;
+
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyFactory;
+
+public class IrcConnectorFactory implements ComponentProxyFactory {
+    @Override
+    public ComponentProxyComponent newInstance(String componentId, String componentScheme) {
+        return new IrcConnector(componentId, componentScheme);
+    }
+}

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifier.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.irc;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.ComponentVerifierExtension;
+
+import io.syndesis.connector.support.verifier.api.ComponentVerifier;
+
+public class IrcVerifier extends ComponentVerifier {
+    public IrcVerifier() {
+        super("irc", IrcVerifierExtension.class);
+    }
+
+    @Override
+    protected ComponentVerifierExtension resolveComponentVerifierExtension(CamelContext context, String scheme) {
+        return new IrcVerifierExtension(scheme, context);
+    }
+}

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierAutoConfiguration.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierAutoConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.irc;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+
+import io.syndesis.connector.support.verifier.api.Verifier;
+
+@Configuration
+@ConditionalOnProperty(prefix = "io.syndesis.connector.verifier", name = "enabled")
+public class IrcVerifierAutoConfiguration {
+    @Bean("irc")
+    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+    @Lazy
+    @ConditionalOnProperty(prefix = "io.syndesis.connector.irc.verifier", name = "enabled", matchIfMissing = true)
+    public Verifier ircVerifier() {
+        return new IrcVerifier();
+    }
+}

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierExtension.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierExtension.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.irc;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
+import org.apache.camel.component.extension.verifier.ResultBuilder;
+import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+public class IrcVerifierExtension extends DefaultComponentVerifierExtension {
+    protected IrcVerifierExtension(String defaultScheme, CamelContext context) {
+        super(defaultScheme, context);
+    }
+
+    @Override
+    public Result verify(Scope scope, Map<String, Object> parameters) {
+        final String hostname = (String) parameters.get("hostname");
+        final int port = Integer.parseInt((String) parameters.get("port"));
+        final Socket s = new Socket();
+        try {
+            s.connect(new InetSocketAddress(hostname,port), 5000);
+            s.setSoTimeout(5000);
+            s.close();
+            return ResultBuilder.withStatusAndScope(Result.Status.OK, scope).build();
+        } catch (UnknownHostException e) {
+            return ResultBuilder.withStatusAndScope(Result.Status.ERROR, scope)
+                    .error(ResultErrorBuilder.withIllegalOption("Hostname", hostname).build()).build();
+        } catch (IOException ex) {
+                return ResultBuilder.withStatusAndScope(Result.Status.ERROR, scope).error(new ResultErrorBuilder().code(VerificationError.StandardCode.GENERIC).description("Unable to connect to specified IRC server").build()).build();
+        }
+    }
+}

--- a/app/connector/irc/src/main/resources/META-INF/spring.factories
+++ b/app/connector/irc/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+    io.syndesis.connector.irc.IrcVerifierAutoConfiguration

--- a/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
+++ b/app/connector/irc/src/main/resources/META-INF/syndesis/connector/irc.json
@@ -2,7 +2,7 @@
   "actions": [
     {
       "actionType": "connector",
-      "description": "React to privmsg",
+      "description": "Receive a private message",
       "descriptor": {
         "componentScheme": "irc",
         "configuredProperties": {
@@ -14,7 +14,8 @@
           "onPart": false,
           "onPrivmsg": true,
           "onQuit": false,
-          "onTopic": false
+          "onTopic": false,
+          "commandTimeout": 15000
         },
         "inputDataShape": {
           "kind": "any"
@@ -24,70 +25,118 @@
         },
         "propertyDefinitionSteps": [
           {
-            "description": "Properties",
-            "name": "properties",
+            "description": "Specify the channels to join",
+            "name": "Specify IRC channels",
             "properties": {
-              "channels": {
-                "componentProperty": false,
-                "deprecated": false,
-                "description": "IRC channels to join",
-                "displayName": "Channels",
-                "enum": [],
-                "javaType": "string",
-                "kind": "parameter",
-                "required": true,
-                "secret": false,
-                "tags": [],
-                "type": "string"
-              },
-              "hostname": {
-                "componentProperty": false,
-                "deprecated": false,
-                "description": "IRC Server hostname",
-                "displayName": "Hostname",
-                "enum": [],
-                "javaType": "string",
-                "kind": "parameter",
-                "required": true,
-                "secret": false,
-                "tags": [],
-                "type": "string"
-              },
-              "nickname": {
-                "componentProperty": false,
-                "deprecated": false,
+             "nickname": {
                 "description": "Nickname for IRC connector user",
                 "displayName": "Nickname",
-                "enum": [],
                 "javaType": "string",
                 "kind": "parameter",
+                "labelHint": "Desired nickname for the integration user",
                 "required": true,
                 "secret": false,
                 "tags": [],
                 "type": "string"
               },
-              "port": {
-                "componentProperty": false,
-                "deprecated": false,
-                "description": "IRC Server port",
-                "displayName": "Port",
-                "enum": [],
-                "javaType": "int",
-                "kind": "parameter",
-                "required": true,
+               "channels": {
+                "description": "IRC channels to join",
+                "displayName": "Channels",
+                "javaType": "string",
+                "kind": "path",
+                "labelHint": "If the integration should connect to the IRC channels, you can specify multiple channels delimited by comma",
+                "required": false,
                 "secret": false,
                 "tags": [],
-                "type": "int"
+                "type": "string"
+              },
+              "nicknamePassword": {
+                "description": "Password for IRC connector user",
+                "displayName": "NickServ password",
+                "javaType": "string",
+                "kind": "parameter",
+                "labelHint": "If the integration user nickname is registered with IRC NickServ, you can specify its password here",
+                "required": false,
+                "secret": true,
+                "tags": [],
+                "type": "string"
               }
             }
           }
         ]
       },
-      "id": "io.syndesis:irc-privmsg",
-      "name": "IRC PRIVMSG",
+      "id": "io.syndesis.connector:connector-irc-privmsg",
+      "name": "IRC Receive Private Message",
       "pattern": "From"
+    },
+    {
+      "actionType": "connector",
+      "description": "Sends message to given IRC channel(s)",
+      "descriptor": {
+        "componentScheme": "irc",
+        "configuredProperties": {
+          "autoRejoin": true,
+          "onJoin": false,
+          "onKick": false,
+          "onMode": false,
+          "onNick": false,
+          "onPart": false,
+          "onPrivmsg": false,
+          "onQuit": false,
+          "onTopic": false,
+          "commandTimeout": 15000
+        },
+        "inputDataShape": {
+          "kind": "any"
+        },
+        "outputDataShape": {
+          "kind": "any"
+        },
+        "propertyDefinitionSteps": [
+          {
+            "description": "Specify the channels to join",
+            "name": "Specify IRC channels",
+            "properties": {
+             "nickname": {
+                "description": "Nickname for IRC connector user",
+                "displayName": "Nickname",
+                "javaType": "string",
+                "kind": "parameter",
+                "labelHint": "Desired nickname for the integration user",
+                "required": true,
+                "secret": false,
+                "type": "string"
+              },
+               "channels": {
+                "description": "IRC channels to join",
+                "displayName": "Channels",
+                "javaType": "string",
+                "kind": "path",
+                "labelHint": "You can specify multiple channels delimited by comma",
+                "required": true,
+                "secret": false,
+                "type": "string"
+              },
+              "nicknamePassword": {
+                "description": "Password for IRC connector user",
+                "displayName": "NickServ password",
+                "javaType": "string",
+                "kind": "parameter",
+                "labelHint": "If the integration user nickname is registered with IRC NickServ, you can specify its password here",
+                "required": false,
+                "secret": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "id": "io.syndesis.connector:connector-irc-sendmsg",
+      "name": "IRC Send Message To Channel",
+      "pattern": "To"
     }
   ],
+  "connectorFactory": "io.syndesis.connector.irc.IrcConnectorFactory",
   "dependencies": [
     {
       "id": "@project.groupId@:@project.artifactId@:@project.version@",
@@ -96,9 +145,56 @@
   ],
   "description": "Send and receive messages to/from an IRC chat",
   "icon": "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHg9IjAiIHk9IjAiIHZpZXdCb3g9IjAgMCAzMDAgMzAwIiB4bWw6c3BhY2U9InByZXNlcnZlIj48c3R5bGU+LnN0MzV7ZmlsbDojNmM0MTk5fTwvc3R5bGU+PHBhdGggY2xhc3M9InN0MzUiIGQ9Ik0xNTUuMiAxLjFjLTE3My03LjUtMjMyLjkgMjE2LjctNC4zIDIzOC43bC0yMSA1OS4yczEyMS40LTY1IDE1MS43LTExMkMzMTguMiAxMzAuNCAzMDMuOCA3LjYgMTU1LjIgMS4xek0yMTkgMTQwLjhjNS42IDAgMTAuMiA0LjUgMTAuMiAxMC4ycy00LjUgMTAuMi0xMC4yIDEwLjJoLTMwLjN2MzEuMmMwIDUuNi00LjUgMTAuMi0xMC4yIDEwLjItNS42IDAtMTAuMi00LjUtMTAuMi0xMC4ydi0zMS4yaC0zNi43djMxLjJjMCA1LjYtNC41IDEwLjItMTAuMiAxMC4yLTUuNiAwLTEwLjItNC41LTEwLjItMTAuMnYtMzEuMkg4MWMtNS42IDAtMTAuMi00LjUtMTAuMi0xMC4yczQuNS0xMC4yIDEwLjItMTAuMmgzMC4zdi0zNUg4MWMtNS42IDAtMTAuMi00LjUtMTAuMi0xMC4yIDAtNS42IDQuNS0xMC4yIDEwLjItMTAuMmgzMC4zdi0zMWMwLTUuNiA0LjUtMTAuMiAxMC4yLTEwLjIgNS42IDAgMTAuMiA0LjUgMTAuMiAxMC4ydjMxLjJoMzYuN1Y1NC40YzAtNS42IDQuNS0xMC4yIDEwLjItMTAuMiA1LjYgMCAxMC4yIDQuNSAxMC4yIDEwLjJ2MzEuMkgyMTljNS42IDAgMTAuMiA0LjUgMTAuMiAxMC4yIDAgNS42LTQuNSAxMC4yLTEwLjIgMTAuMmgtMzAuM3YzNUgyMTl6Ii8+PHBhdGggY2xhc3M9InN0MzUiIGQ9Ik0xMzEuNyAxMDUuOWgzNi43djM1aC0zNi43eiIvPjwvc3ZnPg==",
-  "id": "irc",
-  "metadata": {
-    "tech-preview": true
+  "properties": {
+    "hostname": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "IRC Server hostname",
+      "displayName": "Hostname",
+      "enum": [],
+      "javaType": "string",
+      "kind": "parameter",
+      "labelHint": "Hostname of the IRC server to connect to",
+      "order": "1",
+      "required": true,
+      "secret": false,
+      "tags": [],
+      "type": "string"
+    },
+    "password": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "IRC Server password",
+      "displayName": "Password",
+      "enum": [],
+      "javaType": "string",
+      "kind": "parameter",
+      "labelHint": "Password is required only when the IRC server requires password to join",
+      "order": "3",
+      "required": false,
+      "secret": true,
+      "tags": [],
+      "type": "string"
+    },
+    "port": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "IRC Server port",
+      "displayName": "Port",
+      "enum": [],
+      "javaType": "int",
+      "kind": "parameter",
+      "labelHint": "Port of the IRC server to connect to",
+      "order": "2",
+      "required": true,
+      "secret": false,
+      "tags": [],
+      "type": "int"
+    }
   },
-  "name": "IRC"
+  "id": "irc",
+  "name": "IRC",
+  "tags": [
+    "verifier"
+  ]
 }


### PR DESCRIPTION
- extract common parameters to connection level
- add irc verifier
- add new action to send messages to channel

This will require this commit from camel to be present in our camel version: https://github.com/apache/camel/commit/c29f083d86f53c18ca46c7de9f4ee99f26f4b114

currently there is one outstanding issue that the `channels` parameter is not passed to the endpoint - the `channels` property is [not defined as endpoint property at camel level](https://github.com/apache/camel/blob/master/components/camel-irc/src/main/java/org/apache/camel/component/irc/IrcConfiguration.java#L47) and thus it is ignored by [this code](https://github.com/syndesisio/syndesis/blob/master/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java#L333-L342) resulting in not connecting to any channel

@zregvart do you know if I can force syndesis to append the parameter event if it is not part of the endpoint definition on the camel side?

Fixes #3655 