### PR TITLE
#4229 Add Google Sheets meta data retrieval

### DIFF
--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -110,8 +110,17 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.syndesis.common</groupId>
       <artifactId>common-util</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-model</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -241,8 +250,23 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
@@ -47,7 +47,9 @@ import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.util.ObjectHelper;
 
 public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer {
@@ -107,8 +109,8 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
             }
         }
 
-        in.setHeader("CamelGoogleSheets.spreadsheetId", spreadsheetId);
-        in.setHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest", batchUpdateRequest);
+        in.setHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID, spreadsheetId);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
     private ChartSpec createChartSpec() {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
@@ -41,7 +41,9 @@ import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.util.ObjectHelper;
 
 public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustomizer {
@@ -106,8 +108,8 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         rowData.setValues(Collections.singletonList(new CellData().setPivotTable(pivotTable)));
         updateCellsRequest.setRows(Collections.singletonList(rowData));
 
-        in.setHeader("CamelGoogleSheets.spreadsheetId", spreadsheetId);
-        in.setHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest", batchUpdateRequest);
+        in.setHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID, spreadsheetId);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
     private GridCoordinate getStartCoordinate(PivotTable pivotTable, GooglePivotTable model) {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.connector.sheets;
 
+import java.util.Collections;
+import java.util.Map;
+
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
@@ -26,11 +29,9 @@ import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
 import org.apache.camel.util.ObjectHelper;
-
-import java.util.Collections;
-import java.util.Map;
 
 public class GoogleSheetsCreateSpreadsheetCustomizer implements ComponentProxyCustomizer {
 
@@ -89,7 +90,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizer implements ComponentProxyCu
             spreadsheet.setSheets(Collections.singletonList(sheet));
         }
 
-        in.setHeader("CamelGoogleSheets.content", spreadsheet);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "content", spreadsheet);
     }
 
     private void afterProducer(Exchange exchange) {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.connector.sheets;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,7 +23,8 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.common.util.Json;
-import io.syndesis.connector.sheets.model.GoogleValueRange;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -34,7 +36,13 @@ import org.apache.camel.util.ObjectHelper;
 
 public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer {
 
+    private static final String ROW_PREFIX = "#";
+    private static final String DIMENSION_ROWS = "ROWS";
+    private static final String DIMENSION_COLUMNS = "COLUMNS";
+
     private String spreadsheetId;
+    private String range;
+    private String majorDimension;
     private boolean splitResults;
 
     @Override
@@ -45,9 +53,12 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
 
     private void setApiMethod(Map<String, Object> options) {
         spreadsheetId = (String) options.get("spreadsheetId");
-        splitResults = Boolean.valueOf(Optional.ofNullable(options.get("splitResults"))
+        range = (String) options.get("range");
+        majorDimension = (String) options.get("majorDimension");
+        splitResults = Optional.ofNullable(options.get("splitResults"))
                                                 .map(Object::toString)
-                                                .orElse("false"));
+                                                .map(Boolean::valueOf)
+                                                .orElse(false);
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName());
@@ -57,28 +68,89 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
     private void beforeConsumer(Exchange exchange) throws JsonProcessingException {
         final Message in = exchange.getIn();
 
-        final GoogleValueRange model = new GoogleValueRange();
+        final Map<String, Object> model = new HashMap<>();
+        model.put("spreadsheetId", spreadsheetId);
+
         if (splitResults) {
-            final List<?> values = in.getBody(List.class);
-            if (values != null) {
-                model.setSpreadsheetId(spreadsheetId);
-
-                if (ObjectHelper.isNotEmpty(in.getHeader(GoogleSheetsStreamConstants.RANGE))) {
-                    model.setRange(in.getHeader(GoogleSheetsStreamConstants.RANGE).toString());
-                }
-
-                model.setValues(Json.writer().writeValueAsString(values));
-            }
+            createModelFromSplitValues(model, in);
         } else {
-            final ValueRange valueRange = in.getBody(ValueRange.class);
-            if (valueRange != null) {
-                model.setSpreadsheetId(spreadsheetId);
-                model.setRange(valueRange.getRange());
-                model.setValues(Json.writer().writeValueAsString(valueRange.getValues()));
-            }
+            createModelFromValueRange(model, in);
         }
 
-        in.setBody(model);
+        in.setBody(Json.writer().writeValueAsString(model));
+    }
+
+    private void createModelFromValueRange(Map<String, Object> model, Message in) {
+        final ValueRange valueRange = in.getBody(ValueRange.class);
+        if (valueRange != null) {
+            if (ObjectHelper.isNotEmpty(valueRange.getRange())) {
+                range = valueRange.getRange();
+            }
+            RangeCoordinate rangeCoordinate = RangeCoordinate.fromRange(range);
+
+            if (ObjectHelper.isNotEmpty(valueRange.getMajorDimension())) {
+                majorDimension = valueRange.getMajorDimension();
+            }
+
+            if (ObjectHelper.equal(DIMENSION_ROWS, majorDimension)) {
+                int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
+                for (List<Object> values : valueRange.getValues()) {
+                    final Map<String, Object> rowModel = new HashMap<>();
+                    int columnIndex = rangeCoordinate.getColumnStartIndex();
+                    for (Object value : values) {
+                        rowModel.put(CellCoordinate.getColumnName(columnIndex), value);
+                        columnIndex++;
+                    }
+                    model.put(ROW_PREFIX + rowIndex, rowModel);
+                    rowIndex++;
+                }
+            } else if (ObjectHelper.equal(DIMENSION_COLUMNS, majorDimension)) {
+                int columnIndex = rangeCoordinate.getColumnStartIndex();
+                for (List<Object> values : valueRange.getValues()) {
+                    final Map<String, Object> columnModel = new HashMap<>();
+                    int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
+                    for (Object value : values) {
+                        columnModel.put(ROW_PREFIX + rowIndex, value);
+                        rowIndex++;
+                    }
+                    model.put(CellCoordinate.getColumnName(columnIndex), columnModel);
+                    columnIndex++;
+                }
+            }
+        }
+    }
+
+    private void createModelFromSplitValues(Map<String, Object> model, Message in) {
+        final List<?> values = in.getBody(List.class);
+        if (values != null) {
+            if (ObjectHelper.isNotEmpty(in.getHeader(GoogleSheetsStreamConstants.RANGE))) {
+                range = in.getHeader(GoogleSheetsStreamConstants.RANGE).toString();
+            }
+            RangeCoordinate rangeCoordinate = RangeCoordinate.fromRange(range);
+
+            if (ObjectHelper.isNotEmpty(in.getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION))) {
+                majorDimension = in.getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION).toString();
+            }
+
+            int columnIndex = rangeCoordinate.getColumnStartIndex();
+            if (ObjectHelper.equal(DIMENSION_ROWS, majorDimension)) {
+                final Map<String, Object> rowModel = new HashMap<>();
+                for (Object value : values) {
+                    rowModel.put(CellCoordinate.getColumnName(columnIndex), value);
+                    columnIndex++;
+                }
+
+                model.put(ROW_PREFIX, rowModel);
+            } else if (ObjectHelper.equal(DIMENSION_COLUMNS, majorDimension)) {
+                final Map<String, Object> columnModel = new HashMap<>();
+                int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
+                for (Object value : values) {
+                    columnModel.put(ROW_PREFIX + rowIndex, value);
+                    rowIndex++;
+                }
+                model.put("$", columnModel);
+            }
+        }
     }
 
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataAutoConfiguration.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.connector.sheets;
 
-import io.syndesis.connector.support.verifier.api.Verifier;
+import io.syndesis.connector.support.verifier.api.MetadataRetrieval;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -24,14 +24,13 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 
 @Configuration
-@ConditionalOnProperty(prefix = "io.syndesis.connector.verifier", name = "enabled")
-public class GoogleSheetsVerifierAutoConfiguration {
-
-    @Bean("sheets")
+@ConditionalOnProperty(prefix = "io.syndesis.connector.meta", name = "enabled")
+public class GoogleSheetsMetaDataAutoConfiguration {
+    @Bean("sheets-adapter")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     @Lazy
-    @ConditionalOnProperty(prefix = "io.syndesis.connector.sheets.verifier", name = "enabled", matchIfMissing = true)
-    public Verifier sheetsVerifier() {
-        return new GoogleSheetsVerifier();
+    @ConditionalOnProperty(prefix = "io.syndesis.connector.sheets.meta", name = "enabled", matchIfMissing = true)
+    public MetadataRetrieval sheetsMetaDataAdapter() {
+        return new GoogleSheetsMetadataRetrieval();
     }
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sheets;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.syndesis.connector.sheets.meta.GoogleValueRangeMetaData;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
+import org.apache.camel.component.extension.metadata.DefaultMetaData;
+import org.apache.camel.util.ObjectHelper;
+
+public class GoogleSheetsMetaDataExtension extends AbstractMetaDataExtension {
+    private static final MetaData EMPTY_METADATA = new DefaultMetaData(null, null, null);
+
+    public GoogleSheetsMetaDataExtension(CamelContext camelContext) {
+        super(camelContext);
+    }
+
+    @Override
+    public Optional<MetaData> meta(final Map<String, Object> properties) {
+        final String range = Optional.ofNullable(properties.get("range"))
+                                     .map(Object::toString)
+                                     .orElse("");
+
+        MetaData metaData = EMPTY_METADATA;
+
+        if (ObjectHelper.isNotEmpty(range)) {
+            final GoogleValueRangeMetaData valueRangeMetaData = new GoogleValueRangeMetaData();
+            valueRangeMetaData.setRange(range);
+
+            final String majorDimension = Optional.ofNullable(properties.get("majorDimension"))
+                    .map(Object::toString)
+                    .orElse("ROWS");
+
+            valueRangeMetaData.setMajorDimension(majorDimension);
+
+            final boolean split = Optional.ofNullable(properties.get("splitResults"))
+                    .map(Object::toString)
+                    .map(Boolean::valueOf)
+                    .orElse(false);
+
+            valueRangeMetaData.setSplit(split);
+
+            metaData = new DefaultMetaData(null, null, valueRangeMetaData);
+        }
+
+        return Optional.of(metaData);
+    }
+}

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sheets;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.sheets.meta.GoogleValueRangeMetaData;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.apache.camel.util.ObjectHelper;
+
+public final class GoogleSheetsMetadataRetrieval extends ComponentMetadataRetrieval {
+
+    private static final String JSON_SCHEMA_ORG_SCHEMA = "http://json-schema.org/schema#";
+
+    private static final String SHEETS_GET_VALUES_ACTION = "io.syndesis:sheets-get-values-connector";
+    private static final String SHEETS_UPDATE_VALUES_ACTION = "io.syndesis:sheets-update-values-connector";
+    private static final String SHEETS_APPEND_VALUES_ACTION = "io.syndesis:sheets-append-values-connector";
+
+    @Override
+    protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId, Map<String, Object> properties, MetaData metadata) {
+        @SuppressWarnings("unchecked")
+        final GoogleValueRangeMetaData valueRangeMetaData = (GoogleValueRangeMetaData) metadata.getPayload();
+
+        if (valueRangeMetaData != null) {
+            // build the input and output schemas
+            final ObjectSchema spec = new ObjectSchema();
+            spec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+            spec.setTitle("VALUE_RANGE");
+
+            spec.putProperty("spreadsheetId", new JsonSchemaFactory().stringSchema());
+
+            String majorDimension = Optional.ofNullable(valueRangeMetaData.getMajorDimension())
+                                            .orElse("ROWS");
+
+            RangeCoordinate coordinate = RangeCoordinate.fromRange(valueRangeMetaData.getRange());
+            if (ObjectHelper.equal("ROWS", majorDimension)) {
+                createSchemaFromRowDimension(spec, coordinate, valueRangeMetaData.isSplit());
+            } else if (ObjectHelper.equal("COLUMNS", majorDimension)) {
+                createSchemaFromColumnDimension(spec, coordinate, valueRangeMetaData.isSplit());
+            }
+
+            try {
+                DataShape.Builder inDataShapeBuilder = new DataShape.Builder().type("VALUE_RANGE_PARAM_IN");
+                if (ObjectHelper.isEqualToAny(actionId, SHEETS_UPDATE_VALUES_ACTION, SHEETS_APPEND_VALUES_ACTION)) {
+                    inDataShapeBuilder.kind(DataShapeKinds.JSON_SCHEMA)
+                            .name("ValueRange Parameter")
+                            .description(String.format("Parameters of range [%s]", valueRangeMetaData.getRange()))
+                            .specification(Json.writer().writeValueAsString(spec));
+                } else {
+                    inDataShapeBuilder.kind(DataShapeKinds.NONE);
+                }
+
+                DataShape.Builder outDataShapeBuilder = new DataShape.Builder().type("VALUE_RANGE_PARAM_OUT");
+                if (ObjectHelper.equal(actionId, SHEETS_GET_VALUES_ACTION)) {
+                    outDataShapeBuilder.kind(DataShapeKinds.JSON_SCHEMA)
+                            .name("ValueRange Result")
+                            .description(String.format("Results of range [%s]", valueRangeMetaData.getRange()))
+                            .specification(Json.writer().writeValueAsString(spec));
+                } else {
+                    outDataShapeBuilder.kind(DataShapeKinds.NONE);
+                }
+
+                return SyndesisMetadata.of(inDataShapeBuilder.build(), outDataShapeBuilder.build());
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException(e);
+            }
+        } else {
+            return SyndesisMetadata.EMPTY;
+        }
+    }
+
+    /**
+     * Create dynamic json schema from row dimension. If split only a single object "ROW" holding 1-n column values is
+     * created. Otherwise each row results in a separate object with 1-n column values as property.
+     *
+     * @param spec
+     * @param coordinate
+     * @param split
+     */
+    private void createSchemaFromRowDimension(ObjectSchema spec, RangeCoordinate coordinate, boolean split) {
+        if (split) {
+            ObjectSchema rowSpec = new ObjectSchema();
+            rowSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+            rowSpec.setTitle("ROW");
+            for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
+                rowSpec.putProperty(CellCoordinate.getColumnName(i), new JsonSchemaFactory().stringSchema());
+            }
+            spec.putProperty("#", rowSpec);
+        } else {
+            for (int rowIndex = coordinate.getRowStartIndex() + 1; rowIndex <= coordinate.getRowEndIndex(); rowIndex++) {
+                ObjectSchema rowSpec = new ObjectSchema();
+                rowSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+                rowSpec.setTitle("ROW_" + rowIndex);
+                for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
+                    rowSpec.putProperty(CellCoordinate.getColumnName(i), new JsonSchemaFactory().stringSchema());
+                }
+
+                spec.putProperty("#" + rowIndex, rowSpec);
+            }
+        }
+    }
+
+    /**
+     * Create dynamic json schema from column dimension. If split only a single object "COLUMN" holding 1-n row values is
+     * created. Otherwise each column results in a separate object with 1-n row values as property.
+     *
+     * @param spec
+     * @param coordinate
+     * @param split
+     */
+    private void createSchemaFromColumnDimension(ObjectSchema spec, RangeCoordinate coordinate, boolean split) {
+        if (split) {
+            ObjectSchema columnSpec = new ObjectSchema();
+            columnSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+            columnSpec.setTitle("COLUMN");
+            for (int i = coordinate.getRowStartIndex() + 1; i <= coordinate.getRowEndIndex(); i++) {
+                columnSpec.putProperty("#" + i, new JsonSchemaFactory().stringSchema());
+            }
+            spec.putProperty("$", columnSpec);
+        } else {
+            for (int columnIndex = coordinate.getColumnStartIndex(); columnIndex < coordinate.getColumnEndIndex(); columnIndex++) {
+                ObjectSchema columnSpec = new ObjectSchema();
+                columnSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+                columnSpec.setTitle(CellCoordinate.getColumnName(columnIndex));
+                for (int i = coordinate.getRowStartIndex() + 1; i <= coordinate.getRowEndIndex(); i++) {
+                    columnSpec.putProperty("#" + i, new JsonSchemaFactory().stringSchema());
+                }
+
+                spec.putProperty(columnSpec.getTitle(), columnSpec);
+            }
+        }
+    }
+
+    @Override
+    protected MetaDataExtension resolveMetaDataExtension(CamelContext context, Class<? extends MetaDataExtension> metaDataExtensionClass, String componentId, String actionId) {
+        return new GoogleSheetsMetaDataExtension(context);
+    }
+}

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
@@ -33,7 +33,9 @@ import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.util.ObjectHelper;
 
 public class GoogleSheetsUpdateSpreadsheetCustomizer implements ComponentProxyCustomizer {
@@ -100,8 +102,8 @@ public class GoogleSheetsUpdateSpreadsheetCustomizer implements ComponentProxyCu
             batchUpdateRequest.getRequests().add(new Request().setUpdateSheetProperties(updateSheetPropertiesRequest));
         }
 
-        in.setHeader("CamelGoogleSheets.spreadsheetId", spreadsheetId);
-        in.setHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest", batchUpdateRequest);
+        in.setHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID, spreadsheetId);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
     private void afterProducer(Exchange exchange) {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -16,14 +16,13 @@
 package io.syndesis.connector.sheets;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.common.util.Json;
-import io.syndesis.connector.sheets.model.GoogleValueRange;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -36,7 +35,6 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
 
     private String spreadsheetId;
     private String range;
-    private String values;
     private String valueInputOption;
 
     @Override
@@ -48,9 +46,6 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
     private void setApiMethod(Map<String, Object> options) {
         spreadsheetId = (String) options.get("spreadsheetId");
         range = (String) options.get("range");
-        values = Optional.ofNullable(options.get("values"))
-                         .map(Object::toString)
-                         .orElse("[[]]");
         valueInputOption = (String) options.get("valueInputOption");
 
         options.put("apiName",
@@ -68,30 +63,32 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
 
     private void beforeProducer(Exchange exchange) throws IOException {
         final Message in = exchange.getIn();
-        final GoogleValueRange model = exchange.getIn().getBody(GoogleValueRange.class);
-
-        if (model != null) {
-            if (ObjectHelper.isNotEmpty(model.getValues())) {
-                values = model.getValues();
-            }
-            if (ObjectHelper.isNotEmpty(model.getRange())) {
-                range = model.getRange();
-            }
-            if (ObjectHelper.isNotEmpty(model.getSpreadsheetId())) {
-                spreadsheetId = model.getSpreadsheetId();
-            }
-        }
-
-        if (values.charAt(0) != '[') {
-            values = "[[" + Arrays.stream(values.split(","))
-                    .map(value -> "\"" + value + "\"")
-                    .collect(Collectors.joining(",")) + "]]";
-        }
+        final String model = exchange.getIn().getBody(String.class);
 
         ValueRange valueRange = new ValueRange();
-        valueRange.setValues(Arrays.stream((Object[][]) Json.reader().forType(Object[][].class).readValue(values))
-                                    .map(Arrays::asList)
-                                    .collect(Collectors.toList()));
+        List<List<Object>> values = new ArrayList<>();
+
+        if (ObjectHelper.isNotEmpty(model)) {
+            Map<String, Object> dataShape = Json.reader().forType(Map.class).readValue(model);
+
+            if (dataShape.containsKey("spreadsheetId")) {
+                spreadsheetId = Optional.ofNullable(dataShape.remove("spreadsheetId"))
+                                .map(Object::toString)
+                                .orElse(spreadsheetId);
+            }
+
+            for(Map.Entry<String, Object> rangeEntry : dataShape.entrySet()) {
+                if (rangeEntry.getValue() instanceof Map) {
+                    List<Object> rangeValues = new ArrayList<>();
+                    for (Object value : ((Map) rangeEntry.getValue()).values()) {
+                        rangeValues.add(value);
+                    }
+                    values.add(rangeValues);
+                }
+            }
+        }
+
+        valueRange.setValues(values);
 
         in.setHeader("CamelGoogleSheets.spreadsheetId", spreadsheetId);
         in.setHeader("CamelGoogleSheets.range", range);

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -28,7 +28,9 @@ import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.util.ObjectHelper;
 
 public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomizer {
@@ -90,10 +92,10 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
 
         valueRange.setValues(values);
 
-        in.setHeader("CamelGoogleSheets.spreadsheetId", spreadsheetId);
-        in.setHeader("CamelGoogleSheets.range", range);
-        in.setHeader("CamelGoogleSheets.values", valueRange);
-        in.setHeader("CamelGoogleSheets.valueInputOption", Optional.ofNullable(valueInputOption)
+        in.setHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID, spreadsheetId);
+        in.setHeader(GoogleSheetsStreamConstants.RANGE, range);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values", valueRange);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption", Optional.ofNullable(valueInputOption)
                                                                       .orElse("USER_ENTERED"));
     }
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
@@ -13,33 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.connector.sheets.model;
 
-public class GoogleValueRange {
+package io.syndesis.connector.sheets.meta;
 
-    private String spreadsheetId;
+/**
+ * @author Christoph Deppisch
+ */
+public class GoogleValueRangeMetaData {
+
     private String range;
-    private String values;
+    private String majorDimension;
 
-    public String getSpreadsheetId() {
-        return spreadsheetId;
-    }
-
-    /**
-     * Sets the spreadsheetId.
-     *
-     * @param spreadsheetId
-     */
-    public void setSpreadsheetId(String spreadsheetId) {
-        this.spreadsheetId = spreadsheetId;
-    }
+    private boolean split;
 
     public String getRange() {
         return range;
     }
 
     /**
-     * Sets the range.
+     * Specifies the range.
      *
      * @param range
      */
@@ -47,22 +39,29 @@ public class GoogleValueRange {
         this.range = range;
     }
 
-    public String getValues() {
-        return values;
+    public String getMajorDimension() {
+        return majorDimension;
     }
 
     /**
-     * Sets the values.
+     * Specifies the majorDimension.
      *
-     * @param values
+     * @param majorDimension
      */
-    public void setValues(String values) {
-        this.values = values;
+    public void setMajorDimension(String majorDimension) {
+        this.majorDimension = majorDimension;
     }
 
-    @Override
-    public String toString() {
-        return String.format("%s [spreadsheetId=%s, range=%s, values=%s]", GoogleValueRange.class.getSimpleName(), spreadsheetId, range, values);
+    public boolean isSplit() {
+        return split;
     }
 
+    /**
+     * Specifies the split.
+     *
+     * @param split
+     */
+    public void setSplit(boolean split) {
+        this.split = split;
+    }
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
@@ -45,15 +45,17 @@ public final class RangeCoordinate extends CellCoordinate {
     public static RangeCoordinate fromRange(String range) {
         RangeCoordinate coordinate = new RangeCoordinate();
 
-        if (range.contains(":")) {
-            String[] coordinates = range.split(":", -1);
+        String rangeExpression = normalizeRange(range);
+
+        if (rangeExpression.contains(":")) {
+            String[] coordinates = rangeExpression.split(":", -1);
 
             coordinate.setRowStartIndex(getRowIndex(coordinates[0]));
             coordinate.setColumnStartIndex(getColumnIndex(coordinates[0]));
             coordinate.setRowEndIndex(getRowIndex(coordinates[1]) + 1);
             coordinate.setColumnEndIndex(getColumnIndex(coordinates[1]) + 1);
         } else {
-            CellCoordinate cellCoordinate = CellCoordinate.fromCellId(range);
+            CellCoordinate cellCoordinate = CellCoordinate.fromCellId(rangeExpression);
             coordinate.setRowIndex(cellCoordinate.getRowIndex());
             coordinate.setColumnIndex(cellCoordinate.getColumnIndex());
             coordinate.setRowStartIndex(cellCoordinate.getRowIndex());
@@ -63,6 +65,19 @@ public final class RangeCoordinate extends CellCoordinate {
         }
 
         return coordinate;
+    }
+
+    /**
+     * Removes optional sheet name from range expression if any.
+     * @param range
+     * @return
+     */
+    private static String normalizeRange(String range) {
+        if (range.contains("!")) {
+            return range.substring(range.indexOf('!') + 1);
+        } else {
+            return range;
+        }
     }
 
     public int getRowStartIndex() {

--- a/app/connector/google-sheets/src/main/resources/META-INF/spring.factories
+++ b/app/connector/google-sheets/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.syndesis.connector.sheets.GoogleSheetsVerifierAutoConfiguration
+    io.syndesis.connector.sheets.GoogleSheetsVerifierAutoConfiguration,\
+    io.syndesis.connector.sheets.GoogleSheetsMetaDataAutoConfiguration

--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -162,9 +162,7 @@
           "io.syndesis.connector.sheets.GoogleSheetsUpdateValuesCustomizer"
         ],
         "inputDataShape": {
-          "name": "ValueRange",
-          "kind": "java",
-          "type": "io.syndesis.connector.sheets.model.GoogleValueRange"
+          "kind": "json-schema"
         },
         "outputDataShape": {
           "kind": "none"
@@ -201,19 +199,6 @@
                 "secret": false,
                 "type": "string"
               },
-              "values": {
-                "deprecated": false,
-                "displayName": "Values",
-                "group": "producer",
-                "javaType": "java.lang.String",
-                "kind": "parameter",
-                "label": "producer",
-                "labelHint": "Values to write into the spreadsheet range.",
-                "order": "3",
-                "required": false,
-                "secret": false,
-                "type": "string"
-              },
               "valueInputOption": {
                 "deprecated": false,
                 "defaultValue": "USER_ENTERED",
@@ -237,7 +222,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
-                "order": "4",
+                "order": "3",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -248,7 +233,10 @@
       },
       "id": "io.syndesis:sheets-update-values-connector",
       "name": "Update sheet values",
-      "pattern": "To"
+      "pattern": "To",
+      "tags": [
+        "dynamic"
+      ]
     },
     {
       "actionType": "connector",
@@ -259,9 +247,7 @@
           "io.syndesis.connector.sheets.GoogleSheetsAppendValuesCustomizer"
         ],
         "inputDataShape": {
-          "name": "ValueRange",
-          "kind": "java",
-          "type": "io.syndesis.connector.sheets.model.GoogleValueRange"
+          "kind": "json-schema"
         },
         "outputDataShape": {
           "kind": "none"
@@ -294,20 +280,7 @@
                 "label": "producer",
                 "labelHint": "The target range. Operation will append the values to that range.",
                 "order": "2",
-                "required": false,
-                "secret": false,
-                "type": "string"
-              },
-              "values": {
-                "deprecated": false,
-                "displayName": "Values",
-                "group": "producer",
-                "javaType": "java.lang.String",
-                "kind": "parameter",
-                "label": "producer",
-                "labelHint": "Values to append into the spreadsheet.",
-                "order": "3",
-                "required": false,
+                "required": true,
                 "secret": false,
                 "type": "string"
               },
@@ -334,7 +307,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
-                "order": "4",
+                "order": "3",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -345,7 +318,10 @@
       },
       "id": "io.syndesis:sheets-append-values-connector",
       "name": "Append values to a sheet",
-      "pattern": "To"
+      "pattern": "To",
+      "tags": [
+        "dynamic"
+      ]
     },
     {
       "actionType": "connector",
@@ -359,9 +335,7 @@
           "kind": "none"
         },
         "outputDataShape": {
-          "name": "ValueRange",
-          "kind": "java",
-          "type": "io.syndesis.connector.sheets.model.GoogleValueRange"
+          "kind": "json-schema"
         },
         "propertyDefinitionSteps": [
           {
@@ -391,7 +365,7 @@
                 "kind": "parameter",
                 "label": "consumer,scheduler",
                 "labelHint": "Time interval between polls for value changes.",
-                "order": "4",
+                "order": "5",
                 "required": false,
                 "secret": false,
                 "tags": [],
@@ -407,6 +381,30 @@
                 "label": "producer",
                 "labelHint": "Value range in a spreadsheet to obtain.",
                 "order": "2",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "majorDimension": {
+                "deprecated": false,
+                "defaultValue": "ROWS",
+                "displayName": "Major Dimension",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "enum": [
+                  {
+                    "label": "Rows",
+                    "value": "ROWS"
+                  },
+                  {
+                    "label": "Columns",
+                    "value": "COLUMNS"
+                  }
+                ],
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The major dimension that results should use. Indicates which dimension results apply to.",
+                "order": "3",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -430,7 +428,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "When enabled value range is split into multiple results where each result represents a single row or column.",
-                "order": "3",
+                "order": "4",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -444,7 +442,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "Maximum number of values to return.",
-                "order": "5",
+                "order": "6",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -455,7 +453,10 @@
       },
       "id": "io.syndesis:sheets-get-values-connector",
       "name": "Get sheet values",
-      "pattern": "From"
+      "pattern": "From",
+      "tags": [
+        "dynamic"
+      ]
     },
     {
       "actionType": "connector",

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
@@ -30,7 +30,9 @@ import com.google.api.services.sheets.v4.model.PieChartSpec;
 import io.syndesis.connector.sheets.model.GoogleChart;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,10 +65,10 @@ public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCust
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("batchUpdate", options.get("methodName"));
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         AddChartRequest addChartRequest = batchUpdateRequest.getRequests().get(0).getAddChart();
@@ -102,10 +104,10 @@ public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCust
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         AddChartRequest addChartRequest = batchUpdateRequest.getRequests().get(0).getAddChart();
@@ -164,7 +166,7 @@ public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCust
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         AddChartRequest addChartRequest = batchUpdateRequest.getRequests().get(0).getAddChart();
@@ -212,7 +214,7 @@ public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCust
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         AddChartRequest addChartRequest = batchUpdateRequest.getRequests().get(0).getAddChart();

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
@@ -26,7 +26,9 @@ import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 import io.syndesis.connector.sheets.model.GooglePivotTable;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -57,10 +59,10 @@ public class GoogleSheetsAddPivotTableCustomizerTest extends AbstractGoogleSheet
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("batchUpdate", options.get("methodName"));
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         UpdateCellsRequest updateCellsRequest = batchUpdateRequest.getRequests().get(0).getUpdateCells();
@@ -114,10 +116,10 @@ public class GoogleSheetsAddPivotTableCustomizerTest extends AbstractGoogleSheet
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         UpdateCellsRequest updateCellsRequest = batchUpdateRequest.getRequests().get(0).getUpdateCells();

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
@@ -16,8 +16,10 @@
 
 package io.syndesis.connector.sheets;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.GoogleValueRange;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -25,9 +27,6 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -43,7 +42,6 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
         Map<String, Object> options = new HashMap<>();
         options.put("spreadsheetId", getSpreadsheetId());
         options.put("range", "A1");
-        options.put("values", "a1");
         options.put("valueInputOption", "RAW");
 
         customizer.customize(getComponent(), options);
@@ -59,21 +57,25 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals("RAW", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
 
         ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
-        Assert.assertEquals(1L, valueRange.getValues().size());
-        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertEquals(0L, valueRange.getValues().size());
     }
 
     @Test
     public void testBeforeProducerFromModel() throws Exception {
         Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B1");
+
         customizer.customize(getComponent(), options);
 
         Exchange inbound = new DefaultExchange(createCamelContext());
 
-        GoogleValueRange model = new GoogleValueRange();
-        model.setSpreadsheetId(getSpreadsheetId());
-        model.setRange("A1:B1");
-        model.setValues("a1,b1");
+        String model = "{" +
+                    "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                    "\"#1\": {" +
+                        "\"A\": \"a1\"," +
+                        "\"B\": \"b1\"" +
+                    "}" +
+                "}";
         inbound.getIn().setBody(model);
 
         getComponent().getBeforeProducer().process(inbound);
@@ -94,14 +96,23 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
     @Test
     public void testBeforeProducerMultipleRows() throws Exception {
         Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B2");
+
         customizer.customize(getComponent(), options);
 
         Exchange inbound = new DefaultExchange(createCamelContext());
 
-        GoogleValueRange model = new GoogleValueRange();
-        model.setSpreadsheetId(getSpreadsheetId());
-        model.setRange("A1:B2");
-        model.setValues("[[\"a1\",\"b1\"],[\"a2\",\"b2\"]]");
+        String model = "{" +
+                    "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                    "\"#1\": {" +
+                        "\"A\": \"a1\"," +
+                        "\"B\": \"b1\"" +
+                    "}," +
+                    "\"#2\": {" +
+                        "\"A\": \"a2\"," +
+                        "\"B\": \"b2\"" +
+                    "}" +
+                "}";
         inbound.getIn().setBody(model);
 
         getComponent().getBeforeProducer().process(inbound);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
@@ -22,7 +22,9 @@ import java.util.Map;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,11 +54,11 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("append", options.get("methodName"));
 
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals("A1", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("RAW", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("RAW", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(0L, valueRange.getValues().size());
     }
 
@@ -83,11 +85,11 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("append", options.get("methodName"));
 
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals("A1:B1", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals("A1:B1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(1L, valueRange.getValues().size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
         Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));
@@ -117,10 +119,10 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals("A1:B2", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals("A1:B2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(2L, valueRange.getValues().size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
         Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
@@ -16,6 +16,10 @@
 
 package io.syndesis.connector.sheets;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
@@ -24,15 +28,12 @@ import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -61,7 +62,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleS
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("create", options.get("methodName"));
 
-        Spreadsheet spreadsheet = (Spreadsheet) inbound.getIn().getHeader("CamelGoogleSheets.content");
+        Spreadsheet spreadsheet = (Spreadsheet) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "content");
         Assert.assertNull(spreadsheet.getSpreadsheetId());
         Assert.assertEquals("SyndesisTest", spreadsheet.getProperties().getTitle());
         Assert.assertEquals("America/New_York", spreadsheet.getProperties().getTimeZone());
@@ -91,7 +92,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleS
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        Spreadsheet spreadsheet = (Spreadsheet) inbound.getIn().getHeader("CamelGoogleSheets.content");
+        Spreadsheet spreadsheet = (Spreadsheet) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "content");
         Assert.assertNull(spreadsheet.getSpreadsheetId());
         Assert.assertEquals("SyndesisTest", spreadsheet.getProperties().getTitle());
         Assert.assertEquals("America/New_York", spreadsheet.getProperties().getTimeZone());

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.GoogleValueRange;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -35,6 +34,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -62,10 +63,14 @@ public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCus
                                                             Collections.singletonList("a2"),
                                                             Collections.singletonList("a3"),
                                                             Collections.singletonList("a4"),
-                                                            Collections.singletonList("a5")), "[[\"a1\"],[\"a2\"],[\"a3\"],[\"a4\"],[\"a5\"]]"},
-                { "A1:A5", "Sheet1", "COLUMNS", Collections.singletonList(Arrays.asList("a1", "a2", "a3", "a4", "a5")), "[[\"a1\",\"a2\",\"a3\",\"a4\",\"a5\"]]"},
-                { "A1:B2", "Sheet1", "ROWS", Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")), "[[\"a1\",\"b1\"],[\"a2\",\"b2\"]]"},
-                { "A1:B2", "Sheet1", "COLUMNS", Arrays.asList(Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2")), "[[\"a1\",\"a2\"],[\"b1\",\"b2\"]]"}
+                                                            Collections.singletonList("a5")),
+                        "{\"#1\": {\"A\":\"a1\"},\"#2\": {\"A\":\"a2\"}, \"#3\": {\"A\":\"a3\"}, \"#4\": {\"A\":\"a4\"}, \"#5\": {\"A\":\"a5\"},\"spreadsheetId\":\"%s\"}"},
+                { "A1:A5", "Sheet1", "COLUMNS", Collections.singletonList(Arrays.asList("a1", "a2", "a3", "a4", "a5")),
+                        "{\"A\": {\"#1\":\"a1\",\"#2\":\"a2\",\"#3\":\"a3\",\"#4\":\"a4\",\"#5\":\"a5\"},\"spreadsheetId\":\"%s\"}"},
+                { "A1:B2", "Sheet1", "ROWS", Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")),
+                        "{\"#1\": {\"A\":\"a1\",\"B\":\"b1\"},\"#2\": {\"A\":\"a2\",\"B\":\"b2\"},\"spreadsheetId\":\"%s\"}"},
+                { "A1:B2", "Sheet1", "COLUMNS", Arrays.asList(Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2")),
+                        "{\"A\": {\"#1\":\"a1\",\"#2\":\"a2\"},\"B\": {\"#1\":\"b1\",\"#2\":\"b2\"},\"spreadsheetId\":\"%s\"}"}
         });
     }
 
@@ -99,9 +104,7 @@ public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCus
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("get", options.get("methodName"));
 
-        GoogleValueRange model = (GoogleValueRange) inbound.getIn().getBody();
-        Assert.assertEquals(getSpreadsheetId(), model.getSpreadsheetId());
-        Assert.assertEquals(sheetName + "!" + range, model.getRange());
-        Assert.assertEquals(expectedValueModel, model.getValues());
+        String model = (String) inbound.getIn().getBody();
+        JSONAssert.assertEquals(String.format(expectedValueModel, getSpreadsheetId()), model, JSONCompareMode.STRICT);
     }
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sheets;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static org.junit.Assert.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class GoogleSheetsMetadataAdapterTest {
+
+    private final String range;
+    private final String actionId;
+    private final String majorDimension;
+    private final String expectedJson;
+    private final boolean split;
+
+    public GoogleSheetsMetadataAdapterTest(String range, String actionId, String majorDimension, String expectedJson, boolean split) {
+        this.range = range;
+        this.actionId = actionId;
+        this.majorDimension = majorDimension;
+        this.expectedJson = expectedJson;
+        this.split = split;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", "ROWS", "/meta/get_rows_split_metadata.json", true },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", "ROWS", "/meta/get_rows_metadata.json", false },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", "", "/meta/get_rows_metadata.json", false },
+                { "A1:C5", "io.syndesis:sheets-get-values-connector", "COLUMNS", "/meta/get_columns_split_metadata.json", true },
+                { "A1:A5", "io.syndesis:sheets-get-values-connector", "COLUMNS", "/meta/get_columns_metadata.json", false },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", "ROWS", "/meta/update_rows_metadata.json", false },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", "COLUMNS", "/meta/update_columns_metadata.json", false },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", "ROWS", "/meta/append_rows_metadata.json", false },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", "COLUMNS", "/meta/append_columns_metadata.json", false }
+        });
+    }
+
+    @Test
+    public void adaptForMetadataTest() throws IOException, JSONException {
+        CamelContext camelContext = new DefaultCamelContext();
+        GoogleSheetsMetaDataExtension ext = new GoogleSheetsMetaDataExtension(camelContext);
+        Map<String,Object> parameters = new HashMap<>();
+
+        if (ObjectHelper.isNotEmpty(majorDimension)) {
+            parameters.put("majorDimension", majorDimension);
+        }
+
+        if (split) {
+            parameters.put("splitResults", true);
+        }
+
+        parameters.put("range", range);
+        Optional<MetaData> metadata = ext.meta(parameters);
+        assertTrue(metadata.isPresent());
+
+        GoogleSheetsMetadataRetrieval adapter = new GoogleSheetsMetadataRetrieval();
+        SyndesisMetadata syndesisMetaData = adapter.adapt(camelContext, "sheets", actionId, parameters, metadata.get());
+        String expectedMetadata = IOUtils.toString(this.getClass().getResource(expectedJson), StandardCharsets.UTF_8).trim();
+        ObjectWriter writer = Json.writer();
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+    }
+}

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
@@ -32,7 +32,9 @@ import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,10 +68,10 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("batchUpdate", options.get("methodName"));
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(1, batchUpdateRequest.getRequests().size());
 
         UpdateSpreadsheetPropertiesRequest updateSpreadsheetPropertiesRequest = batchUpdateRequest.getRequests().get(0).getUpdateSpreadsheetProperties();
@@ -101,10 +103,10 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertNotNull(inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
+        Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
-        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader("CamelGoogleSheets.batchUpdateSpreadsheetRequest");
+        BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
         Assert.assertEquals(2, batchUpdateRequest.getRequests().size());
 
         UpdateSpreadsheetPropertiesRequest updateSpreadsheetPropertiesRequest = batchUpdateRequest.getRequests().get(0).getUpdateSpreadsheetProperties();

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -22,7 +22,9 @@ import java.util.Map;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,11 +54,11 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("update", options.get("methodName"));
 
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals("A1", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("RAW", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("RAW", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(0L, valueRange.getValues().size());
     }
 
@@ -83,11 +85,11 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("update", options.get("methodName"));
 
-        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader("CamelGoogleSheets.spreadsheetId"));
-        Assert.assertEquals("A1:B1", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
+        Assert.assertEquals("A1:B1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(1L, valueRange.getValues().size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
         Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));
@@ -118,10 +120,10 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals("A1:B2", inbound.getIn().getHeader("CamelGoogleSheets.range"));
-        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
+        Assert.assertEquals("A1:B2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
 
-        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(2L, valueRange.getValues().size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
         Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -16,8 +16,10 @@
 
 package io.syndesis.connector.sheets;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.GoogleValueRange;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -25,9 +27,6 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -43,7 +42,6 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Map<String, Object> options = new HashMap<>();
         options.put("spreadsheetId", getSpreadsheetId());
         options.put("range", "A1");
-        options.put("values", "a1");
         options.put("valueInputOption", "RAW");
 
         customizer.customize(getComponent(), options);
@@ -59,21 +57,25 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals("RAW", inbound.getIn().getHeader("CamelGoogleSheets.valueInputOption"));
 
         ValueRange valueRange = (ValueRange) inbound.getIn().getHeader("CamelGoogleSheets.values");
-        Assert.assertEquals(1L, valueRange.getValues().size());
-        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertEquals(0L, valueRange.getValues().size());
     }
 
     @Test
     public void testBeforeProducerFromModel() throws Exception {
         Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B1");
+
         customizer.customize(getComponent(), options);
 
         Exchange inbound = new DefaultExchange(createCamelContext());
 
-        GoogleValueRange model = new GoogleValueRange();
-        model.setSpreadsheetId(getSpreadsheetId());
-        model.setRange("A1:B1");
-        model.setValues("a1,b1");
+        String model = "{" +
+                    "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                    "\"#1\": {" +
+                        "\"A\": \"a1\"," +
+                        "\"B\": \"b1\"" +
+                    "}" +
+                "}";
         inbound.getIn().setBody(model);
 
         getComponent().getBeforeProducer().process(inbound);
@@ -94,14 +96,24 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
     @Test
     public void testBeforeProducerMultipleRows() throws Exception {
         Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B2");
+
         customizer.customize(getComponent(), options);
 
         Exchange inbound = new DefaultExchange(createCamelContext());
 
-        GoogleValueRange model = new GoogleValueRange();
-        model.setSpreadsheetId(getSpreadsheetId());
-        model.setRange("A1:B2");
-        model.setValues("[[\"a1\",\"b1\"],[\"a2\",\"b2\"]]");
+        String model = "{" +
+                    "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                    "\"#1\": {" +
+                        "\"A\": \"a1\"," +
+                        "\"B\": \"b1\"" +
+                    "}," +
+                    "\"#2\": {" +
+                        "\"A\": \"a2\"," +
+                        "\"B\": \"b2\"" +
+                    "}" +
+                "}";
+
         inbound.getIn().setBody(model);
 
         getComponent().getBeforeProducer().process(inbound);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
@@ -31,30 +31,43 @@ import org.junit.runners.Parameterized;
 public class CellCoordinateTest {
 
     private String cellId;
-    private int rowIndex;
-    private int columnIndex;
+    private String columnName;
+    private int rowIndexCheck;
+    private int columnIndexCheck;
 
-    public CellCoordinateTest(String cellId, int rowIndex, int columnIndex) {
-        this.cellId = cellId;
-        this.rowIndex = rowIndex;
-        this.columnIndex = columnIndex;
+    public CellCoordinateTest(String columnName, String rowIndex, int rowIndexCheck, int columnIndexCheck) {
+        this.cellId = columnName + rowIndex;
+        this.columnName = columnName;
+        this.rowIndexCheck = rowIndexCheck;
+        this.columnIndexCheck = columnIndexCheck;
     }
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-            { "A1", 0, 0},
-            { "C5", 4, 2},
-            { "B10", 9, 1},
-            { "A", 0, 0},
-            { "E", 0, 4}
+            { "A", "1", 0, 0},
+            { "C", "5", 4, 2},
+            { "B", "10", 9, 1},
+            { "A", "", 0, 0},
+            { "E", "", 0, 4},
+            { "Z", "1", 0, 25},
+            { "AA", "1", 0, 26},
+            { "AZ", "10", 9, 51},
+            { "BA", "1", 0, 52},
+            { "CC", "1", 0, 80},
+            { "ZZ", "1", 0, 27 * 26 - 1}
         });
     }
 
     @Test
     public void testFromCellId() {
         CellCoordinate coordinate = CellCoordinate.fromCellId(cellId);
-        Assert.assertEquals(rowIndex, coordinate.getRowIndex());
-        Assert.assertEquals(columnIndex, coordinate.getColumnIndex());
+        Assert.assertEquals(rowIndexCheck, coordinate.getRowIndex());
+        Assert.assertEquals(columnIndexCheck, coordinate.getColumnIndex());
+    }
+
+    @Test
+    public void testGetColumnName() {
+        Assert.assertEquals(columnName, CellCoordinate.getColumnName(columnIndexCheck));
     }
 }

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/AbstractGoogleSheetsTestSupport.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/AbstractGoogleSheetsTestSupport.java
@@ -34,6 +34,7 @@ import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.server.GoogleSheetsApiTestServer;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.camel.util.IntrospectionSupport;
@@ -102,12 +103,12 @@ public class AbstractGoogleSheetsTestSupport extends CamelTestSupport {
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", spreadsheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", spreadsheet.getSpreadsheetId());
         // parameter type is String
-        headers.put("CamelGoogleSheets.range", TEST_SHEET + "!A1:B2");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "range", TEST_SHEET + "!A1:B2");
 
         // parameter type is String
-        headers.put("CamelGoogleSheets.valueInputOption", "USER_ENTERED");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption", "USER_ENTERED");
 
         requestBodyAndHeaders("google-sheets://data/update?inBody=values", valueRange, headers);
     }

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsIntegrationTest.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsIntegrationTest.java
@@ -28,6 +28,7 @@ import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import com.google.api.services.sheets.v4.model.UpdateSpreadsheetPropertiesRequest;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -104,9 +105,9 @@ public class SheetsSpreadsheetsIntegrationTest extends AbstractGoogleSheetsTestS
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", testSheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", testSheet.getSpreadsheetId());
         // parameter type is com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest
-        headers.put("CamelGoogleSheets.batchUpdateSpreadsheetRequest", new BatchUpdateSpreadsheetRequest()
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", new BatchUpdateSpreadsheetRequest()
                                                                             .setIncludeSpreadsheetInResponse(true)
                                                                             .setRequests(Collections.singletonList(new Request().setUpdateSpreadsheetProperties(new UpdateSpreadsheetPropertiesRequest()
                                                                                     .setProperties(new SpreadsheetProperties().setTitle(updateTitle))

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIntegrationTest.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIntegrationTest.java
@@ -30,6 +30,7 @@ import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
 import org.apache.camel.util.ObjectHelper;
 import org.junit.Test;
@@ -61,9 +62,9 @@ public class SheetsSpreadsheetsValuesIntegrationTest extends AbstractGoogleSheet
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", testSheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", testSheet.getSpreadsheetId());
         // parameter type is String
-        headers.put("CamelGoogleSheets.range", TEST_SHEET + "!A1:B2");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "range", TEST_SHEET + "!A1:B2");
 
         final ValueRange result = (ValueRange) requestBodyAndHeaders("direct://GET", null, headers);
 
@@ -97,14 +98,14 @@ public class SheetsSpreadsheetsValuesIntegrationTest extends AbstractGoogleSheet
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", testSheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", testSheet.getSpreadsheetId());
         // parameter type is String
-        headers.put("CamelGoogleSheets.range", TEST_SHEET + "!A1:B2");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "range", TEST_SHEET + "!A1:B2");
         // parameter type is com.google.api.services.sheets.v4.model.ValueRange
-        headers.put("CamelGoogleSheets.values", values);
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "values", values);
 
         // parameter type is String
-        headers.put("CamelGoogleSheets.valueInputOption", "USER_ENTERED");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption", "USER_ENTERED");
 
         final UpdateValuesResponse result = (UpdateValuesResponse) requestBodyAndHeaders("direct://UPDATE", null, headers);
 
@@ -134,14 +135,14 @@ public class SheetsSpreadsheetsValuesIntegrationTest extends AbstractGoogleSheet
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", testSheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", testSheet.getSpreadsheetId());
         // parameter type is String
-        headers.put("CamelGoogleSheets.range", TEST_SHEET + "!A10");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "range", TEST_SHEET + "!A10");
         // parameter type is com.google.api.services.sheets.v4.model.ValueRange
-        headers.put("CamelGoogleSheets.values", new ValueRange().setValues(data));
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "values", new ValueRange().setValues(data));
 
         // parameter type is String
-        headers.put("CamelGoogleSheets.valueInputOption", "USER_ENTERED");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption", "USER_ENTERED");
 
         final AppendValuesResponse result = (AppendValuesResponse) requestBodyAndHeaders("direct://APPEND", null, headers);
 
@@ -175,11 +176,11 @@ public class SheetsSpreadsheetsValuesIntegrationTest extends AbstractGoogleSheet
 
         final Map<String, Object> headers = new HashMap<>();
         // parameter type is String
-        headers.put("CamelGoogleSheets.spreadsheetId", testSheet.getSpreadsheetId());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", testSheet.getSpreadsheetId());
         // parameter type is String
-        headers.put("CamelGoogleSheets.range", TEST_SHEET + "!A1:B2");
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "range", TEST_SHEET + "!A1:B2");
         // parameter type is com.google.api.services.sheets.v4.model.ClearValuesRequest
-        headers.put("CamelGoogleSheets.clearValuesRequest", new ClearValuesRequest());
+        headers.put(GoogleSheetsConstants.PROPERTY_PREFIX + "clearValuesRequest", new ClearValuesRequest());
 
         final ClearValuesResponse result = (ClearValuesResponse) requestBodyAndHeaders("direct://CLEAR", null, headers);
 

--- a/app/connector/google-sheets/src/test/resources/meta/append_columns_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/append_columns_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_IN",
+    "name" : "ValueRange Parameter",
+    "description" : "Parameters of range [A1:G3]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"A\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"A\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"B\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"B\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"C\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"C\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"D\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"D\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"E\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"E\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"F\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"F\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}},\"G\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"G\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true}}}}}"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_OUT"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/append_rows_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/append_rows_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_IN",
+    "name" : "ValueRange Parameter",
+    "description" : "Parameters of range [A1:G3]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"#1\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW_1\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true},\"D\":{\"type\":\"string\",\"required\":true},\"E\":{\"type\":\"string\",\"required\":true},\"F\":{\"type\":\"string\",\"required\":true},\"G\":{\"type\":\"string\",\"required\":true}}},\"#2\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW_2\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true},\"D\":{\"type\":\"string\",\"required\":true},\"E\":{\"type\":\"string\",\"required\":true},\"F\":{\"type\":\"string\",\"required\":true},\"G\":{\"type\":\"string\",\"required\":true}}},\"#3\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW_3\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true},\"D\":{\"type\":\"string\",\"required\":true},\"E\":{\"type\":\"string\",\"required\":true},\"F\":{\"type\":\"string\",\"required\":true},\"G\":{\"type\":\"string\",\"required\":true}}}}}"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_OUT"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/get_columns_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/get_columns_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:A5]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"A\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"A\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true},\"#4\":{\"type\":\"string\",\"required\":true},\"#5\":{\"type\":\"string\",\"required\":true}}}}}"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/get_columns_split_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/get_columns_split_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:C5]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"$\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"COLUMN\",\"properties\":{\"#1\":{\"type\":\"string\",\"required\":true},\"#2\":{\"type\":\"string\",\"required\":true},\"#3\":{\"type\":\"string\",\"required\":true},\"#4\":{\"type\":\"string\",\"required\":true},\"#5\":{\"type\":\"string\",\"required\":true}}}}}"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/get_rows_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/get_rows_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:D1]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"#1\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW_1\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true},\"D\":{\"type\":\"string\",\"required\":true}}}}}"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/get_rows_split_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/get_rows_split_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:D1]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"#\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true},\"D\":{\"type\":\"string\",\"required\":true}}}}}"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/update_columns_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/update_columns_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_IN",
+    "name" : "ValueRange Parameter",
+    "description" : "Parameters of range [A5:C5]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"A\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"A\",\"properties\":{\"#5\":{\"type\":\"string\",\"required\":true}}},\"B\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"B\",\"properties\":{\"#5\":{\"type\":\"string\",\"required\":true}}},\"C\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"C\",\"properties\":{\"#5\":{\"type\":\"string\",\"required\":true}}}}}"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_OUT"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/update_rows_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/update_rows_metadata.json
@@ -1,0 +1,13 @@
+{
+  "inputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_IN",
+    "name" : "ValueRange Parameter",
+    "description" : "Parameters of range [A5:C5]",
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"#5\":{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"required\":true,\"title\":\"ROW_5\",\"properties\":{\"A\":{\"type\":\"string\",\"required\":true},\"B\":{\"type\":\"string\",\"required\":true},\"C\":{\"type\":\"string\",\"required\":true}}}}}"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_OUT"
+  }
+}

--- a/app/meta/src/main/java/io/syndesis/connector/meta/v1/ConnectorEndpoint.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/v1/ConnectorEndpoint.java
@@ -15,14 +15,13 @@
  */
 package io.syndesis.connector.meta.v1;
 
-import java.util.Map;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Map;
 
 import io.syndesis.connector.support.verifier.api.MetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
@@ -59,7 +58,7 @@ public class ConnectorEndpoint {
         try {
             adapter = applicationContext.getBean(connectorId + "-adapter", MetadataRetrieval.class);
         } catch (NoSuchBeanDefinitionException | NoSuchBeanException ignored) {
-            LOGGER.debug("No bean of type: {} with id: {} found in application context, switch to factory finder",
+            LOGGER.debug("No bean of type: {} with id: '{}-adapter' found in application context, switch to factory finder",
                 MetadataRetrieval.class.getName(), connectorId);
 
             try {
@@ -74,7 +73,7 @@ public class ConnectorEndpoint {
         }
 
         if (adapter == null) {
-            throw new IllegalStateException("Unable to find adapter for:" + connectorId);
+            throw new IllegalStateException("Unable to find adapter for: " + connectorId);
         }
 
         try {


### PR DESCRIPTION
Adding meta data retrieval to Google Sheets connector so we have dynamic json schema data shapes when reading writing value range data with Google Sheets. 

Each user defined range (e.g. "A1:D3") is represented in a dynamic object tree where each column is named with its capital letter (e.g. "A") and each row with its number (e.g. "#1").

The user is then presented with a dynamic json object schema when mapping data to that range so each cell in the range can be set with a separate mapping.