### PR TITLE
#4229 Auto fill missing values in value ranges

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
@@ -37,8 +37,6 @@ import org.apache.camel.util.ObjectHelper;
 public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer {
 
     private static final String ROW_PREFIX = "#";
-    private static final String DIMENSION_ROWS = "ROWS";
-    private static final String DIMENSION_COLUMNS = "COLUMNS";
 
     private String spreadsheetId;
     private String range;
@@ -54,7 +52,8 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
     private void setApiMethod(Map<String, Object> options) {
         spreadsheetId = (String) options.get("spreadsheetId");
         range = (String) options.get("range");
-        majorDimension = (String) options.get("majorDimension");
+        majorDimension = (String) Optional.ofNullable(options.get("majorDimension"))
+                                          .orElse(RangeCoordinate.DIMENSION_ROWS);
         splitResults = Optional.ofNullable(options.get("splitResults"))
                                                 .map(Object::toString)
                                                 .map(Boolean::valueOf)
@@ -92,7 +91,7 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
                 majorDimension = valueRange.getMajorDimension();
             }
 
-            if (ObjectHelper.equal(DIMENSION_ROWS, majorDimension)) {
+            if (ObjectHelper.equal(RangeCoordinate.DIMENSION_ROWS, majorDimension)) {
                 int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
                 for (List<Object> values : valueRange.getValues()) {
                     final Map<String, Object> rowModel = new HashMap<>();
@@ -104,7 +103,7 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
                     model.put(ROW_PREFIX + rowIndex, rowModel);
                     rowIndex++;
                 }
-            } else if (ObjectHelper.equal(DIMENSION_COLUMNS, majorDimension)) {
+            } else if (ObjectHelper.equal(RangeCoordinate.DIMENSION_COLUMNS, majorDimension)) {
                 int columnIndex = rangeCoordinate.getColumnStartIndex();
                 for (List<Object> values : valueRange.getValues()) {
                     final Map<String, Object> columnModel = new HashMap<>();
@@ -132,8 +131,8 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
                 majorDimension = in.getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION).toString();
             }
 
-            int columnIndex = rangeCoordinate.getColumnStartIndex();
-            if (ObjectHelper.equal(DIMENSION_ROWS, majorDimension)) {
+            if (ObjectHelper.equal(RangeCoordinate.DIMENSION_ROWS, majorDimension)) {
+                int columnIndex = rangeCoordinate.getColumnStartIndex();
                 final Map<String, Object> rowModel = new HashMap<>();
                 for (Object value : values) {
                     rowModel.put(CellCoordinate.getColumnName(columnIndex), value);
@@ -141,7 +140,7 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
                 }
 
                 model.put(ROW_PREFIX, rowModel);
-            } else if (ObjectHelper.equal(DIMENSION_COLUMNS, majorDimension)) {
+            } else if (ObjectHelper.equal(RangeCoordinate.DIMENSION_COLUMNS, majorDimension)) {
                 final Map<String, Object> columnModel = new HashMap<>();
                 int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
                 for (Object value : values) {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.syndesis.connector.sheets.meta.GoogleValueRangeMetaData;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.DefaultMetaData;
@@ -45,7 +46,7 @@ public class GoogleSheetsMetaDataExtension extends AbstractMetaDataExtension {
 
             final String majorDimension = Optional.ofNullable(properties.get("majorDimension"))
                     .map(Object::toString)
-                    .orElse("ROWS");
+                    .orElse(RangeCoordinate.DIMENSION_ROWS);
 
             valueRangeMetaData.setMajorDimension(majorDimension);
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.connector.sheets.meta;
+
+import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * @author Christoph Deppisch
+ */
+public final class GoogleSheetsMetaDataHelper {
+
+    private static final String JSON_SCHEMA_ORG_SCHEMA = "http://json-schema.org/schema#";
+
+    /**
+     * Prevent instantiation for utility class.
+     */
+    private GoogleSheetsMetaDataHelper() {
+        super();
+    }
+
+    public static ObjectSchema createSchema(String range, String majorDimension, boolean split) {
+        ObjectSchema spec = new ObjectSchema();
+        spec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+        spec.setTitle("VALUE_RANGE");
+
+        spec.putProperty("spreadsheetId", new JsonSchemaFactory().stringSchema());
+
+        RangeCoordinate coordinate = RangeCoordinate.fromRange(range);
+        if (ObjectHelper.equal(RangeCoordinate.DIMENSION_ROWS, majorDimension)) {
+            createSchemaFromRowDimension(spec, coordinate, split);
+        } else if (ObjectHelper.equal(RangeCoordinate.DIMENSION_COLUMNS, majorDimension)) {
+            createSchemaFromColumnDimension(spec, coordinate, split);
+        }
+
+        return spec;
+    }
+
+    /**
+     * Create dynamic json schema from row dimension. If split only a single object "ROW" holding 1-n column values is
+     * created. Otherwise each row results in a separate object with 1-n column values as property.
+     *
+     * @param spec
+     * @param coordinate
+     * @param split
+     */
+    private static void createSchemaFromRowDimension(ObjectSchema spec, RangeCoordinate coordinate, boolean split) {
+        if (split) {
+            ObjectSchema rowSpec = new ObjectSchema();
+            rowSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+            rowSpec.setTitle("ROW");
+            for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
+                rowSpec.putProperty(CellCoordinate.getColumnName(i), new JsonSchemaFactory().stringSchema());
+            }
+            spec.putProperty("#", rowSpec);
+        } else {
+            for (int rowIndex = coordinate.getRowStartIndex() + 1; rowIndex <= coordinate.getRowEndIndex(); rowIndex++) {
+                ObjectSchema rowSpec = new ObjectSchema();
+                rowSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+                rowSpec.setTitle("ROW_" + rowIndex);
+                for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
+                    rowSpec.putProperty(CellCoordinate.getColumnName(i), new JsonSchemaFactory().stringSchema());
+                }
+
+                spec.putProperty("#" + rowIndex, rowSpec);
+            }
+        }
+    }
+
+    /**
+     * Create dynamic json schema from column dimension. If split only a single object "COLUMN" holding 1-n row values is
+     * created. Otherwise each column results in a separate object with 1-n row values as property.
+     *
+     * @param spec
+     * @param coordinate
+     * @param split
+     */
+    private static void createSchemaFromColumnDimension(ObjectSchema spec, RangeCoordinate coordinate, boolean split) {
+        if (split) {
+            ObjectSchema columnSpec = new ObjectSchema();
+            columnSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+            columnSpec.setTitle("COLUMN");
+            for (int i = coordinate.getRowStartIndex() + 1; i <= coordinate.getRowEndIndex(); i++) {
+                columnSpec.putProperty("#" + i, new JsonSchemaFactory().stringSchema());
+            }
+            spec.putProperty("$", columnSpec);
+        } else {
+            for (int columnIndex = coordinate.getColumnStartIndex(); columnIndex < coordinate.getColumnEndIndex(); columnIndex++) {
+                ObjectSchema columnSpec = new ObjectSchema();
+                columnSpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
+                columnSpec.setTitle(CellCoordinate.getColumnName(columnIndex));
+                for (int i = coordinate.getRowStartIndex() + 1; i <= coordinate.getRowEndIndex(); i++) {
+                    columnSpec.putProperty("#" + i, new JsonSchemaFactory().stringSchema());
+                }
+
+                spec.putProperty(columnSpec.getTitle(), columnSpec);
+            }
+        }
+    }
+}

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
@@ -21,6 +21,9 @@ package io.syndesis.connector.sheets.model;
  */
 public final class RangeCoordinate extends CellCoordinate {
 
+    public static final String DIMENSION_ROWS = "ROWS";
+    public static final String DIMENSION_COLUMNS = "COLUMNS";
+
     private int rowStartIndex;
     private int rowEndIndex;
 

--- a/app/connector/google-sheets/src/main/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConfiguration.java
+++ b/app/connector/google-sheets/src/main/java/org/apache/camel/component/google/sheets/stream/GoogleSheetsStreamConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.api.services.sheets.v4.SheetsScopes;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.spi.UriParam;
 import org.apache.camel.spi.UriParams;
@@ -68,8 +69,8 @@ public class GoogleSheetsStreamConfiguration implements Cloneable {
     @UriParam
     private boolean splitResults;
 
-    @UriParam(enums = "ROWS,COLUMNS,DIMENSION_UNSPECIFIED", defaultValue = "ROWS")
-    private String majorDimension = "ROWS";
+    @UriParam(enums = "ROWS,COLUMNS,DIMENSION_UNSPECIFIED", defaultValue = RangeCoordinate.DIMENSION_ROWS)
+    private String majorDimension = RangeCoordinate.DIMENSION_ROWS;
 
     @UriParam(enums = "FORMATTED_VALUE,UNFORMATTED_VALUE,FORMULA", defaultValue = "FORMATTED_VALUE")
     private String valueRenderOption = "FORMATTED_VALUE";

--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -199,6 +199,30 @@
                 "secret": false,
                 "type": "string"
               },
+              "majorDimension": {
+                "deprecated": false,
+                "defaultValue": "ROWS",
+                "displayName": "Major Dimension",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "enum": [
+                  {
+                    "label": "Rows",
+                    "value": "ROWS"
+                  },
+                  {
+                    "label": "Columns",
+                    "value": "COLUMNS"
+                  }
+                ],
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The major dimension that results should use. Indicates which dimension results apply to.",
+                "order": "3",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
               "valueInputOption": {
                 "deprecated": false,
                 "defaultValue": "USER_ENTERED",
@@ -222,7 +246,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
-                "order": "3",
+                "order": "4",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -284,6 +308,30 @@
                 "secret": false,
                 "type": "string"
               },
+              "majorDimension": {
+                "deprecated": false,
+                "defaultValue": "ROWS",
+                "displayName": "Major Dimension",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "enum": [
+                  {
+                    "label": "Rows",
+                    "value": "ROWS"
+                  },
+                  {
+                    "label": "Columns",
+                    "value": "COLUMNS"
+                  }
+                ],
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The major dimension that results should use. Indicates which dimension results apply to.",
+                "order": "3",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
               "valueInputOption": {
                 "deprecated": false,
                 "defaultValue": "USER_ENTERED",
@@ -307,7 +355,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
-                "order": "3",
+                "order": "4",
                 "required": false,
                 "secret": false,
                 "type": "string"

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -59,17 +60,17 @@ public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCus
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "A1:A5", "Sheet1", "ROWS", Arrays.asList(Collections.singletonList("a1"),
+                { "A1:A5", "Sheet1", RangeCoordinate.DIMENSION_ROWS, Arrays.asList(Collections.singletonList("a1"),
                                                             Collections.singletonList("a2"),
                                                             Collections.singletonList("a3"),
                                                             Collections.singletonList("a4"),
                                                             Collections.singletonList("a5")),
                         "{\"#1\": {\"A\":\"a1\"},\"#2\": {\"A\":\"a2\"}, \"#3\": {\"A\":\"a3\"}, \"#4\": {\"A\":\"a4\"}, \"#5\": {\"A\":\"a5\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:A5", "Sheet1", "COLUMNS", Collections.singletonList(Arrays.asList("a1", "a2", "a3", "a4", "a5")),
+                { "A1:A5", "Sheet1", RangeCoordinate.DIMENSION_COLUMNS, Collections.singletonList(Arrays.asList("a1", "a2", "a3", "a4", "a5")),
                         "{\"A\": {\"#1\":\"a1\",\"#2\":\"a2\",\"#3\":\"a3\",\"#4\":\"a4\",\"#5\":\"a5\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:B2", "Sheet1", "ROWS", Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")),
+                { "A1:B2", "Sheet1", RangeCoordinate.DIMENSION_ROWS, Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")),
                         "{\"#1\": {\"A\":\"a1\",\"B\":\"b1\"},\"#2\": {\"A\":\"a2\",\"B\":\"b2\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:B2", "Sheet1", "COLUMNS", Arrays.asList(Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2")),
+                { "A1:B2", "Sheet1", RangeCoordinate.DIMENSION_COLUMNS, Arrays.asList(Arrays.asList("a1", "a2"), Arrays.asList("b1", "b2")),
                         "{\"A\": {\"#1\":\"a1\",\"#2\":\"a2\"},\"B\": {\"#1\":\"b1\",\"#2\":\"b2\"},\"spreadsheetId\":\"%s\"}"}
         });
     }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -58,13 +59,13 @@ public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoo
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "A1", "Sheet1", "ROWS", Collections.singletonList("a1"),
+                { "A1", "Sheet1", RangeCoordinate.DIMENSION_ROWS, Collections.singletonList("a1"),
                         "{\"#\": {\"A\":\"a1\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:A5", "Sheet1", "COLUMNS", Arrays.asList("a1", "a2", "a3", "a4", "a5"),
+                { "A1:A5", "Sheet1", RangeCoordinate.DIMENSION_COLUMNS, Arrays.asList("a1", "a2", "a3", "a4", "a5"),
                         "{\"$\": {\"#1\":\"a1\",\"#2\":\"a2\",\"#3\":\"a3\",\"#4\":\"a4\",\"#5\":\"a5\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:B2", "Sheet1", "ROWS", Arrays.asList("a1", "b1"),
+                { "A1:B2", "Sheet1", RangeCoordinate.DIMENSION_ROWS, Arrays.asList("a1", "b1"),
                         "{\"#\": {\"A\":\"a1\",\"B\":\"b1\"},\"spreadsheetId\":\"%s\"}"},
-                { "A1:B2", "Sheet1", "COLUMNS", Arrays.asList("a1", "a2"),
+                { "A1:B2", "Sheet1", RangeCoordinate.DIMENSION_COLUMNS, Arrays.asList("a1", "a2"),
                         "{\"$\": {\"#1\":\"a1\",\"#2\":\"a2\"},\"spreadsheetId\":\"%s\"}"}
         });
     }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.syndesis.common.util.Json;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
@@ -60,15 +61,15 @@ public class GoogleSheetsMetadataAdapterTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "A1:D1", "io.syndesis:sheets-get-values-connector", "ROWS", "/meta/get_rows_split_metadata.json", true },
-                { "A1:D1", "io.syndesis:sheets-get-values-connector", "ROWS", "/meta/get_rows_metadata.json", false },
                 { "A1:D1", "io.syndesis:sheets-get-values-connector", "", "/meta/get_rows_metadata.json", false },
-                { "A1:C5", "io.syndesis:sheets-get-values-connector", "COLUMNS", "/meta/get_columns_split_metadata.json", true },
-                { "A1:A5", "io.syndesis:sheets-get-values-connector", "COLUMNS", "/meta/get_columns_metadata.json", false },
-                { "A5:C5", "io.syndesis:sheets-update-values-connector", "ROWS", "/meta/update_rows_metadata.json", false },
-                { "A5:C5", "io.syndesis:sheets-update-values-connector", "COLUMNS", "/meta/update_columns_metadata.json", false },
-                { "A1:G3", "io.syndesis:sheets-append-values-connector", "ROWS", "/meta/append_rows_metadata.json", false },
-                { "A1:G3", "io.syndesis:sheets-append-values-connector", "COLUMNS", "/meta/append_columns_metadata.json", false }
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_split_metadata.json", true },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_metadata.json", false },
+                { "A1:C5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_split_metadata.json", true },
+                { "A1:A5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_metadata.json", false },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/update_rows_metadata.json", false },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/update_columns_metadata.json", false },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/append_rows_metadata.json", false },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/append_columns_metadata.json", false }
         });
     }
 

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -125,9 +126,141 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
 
         ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
         Assert.assertEquals(2L, valueRange.getValues().size());
+        Assert.assertEquals(2L, valueRange.getValues().get(0).size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
         Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));
+        Assert.assertEquals(2L, valueRange.getValues().get(1).size());
         Assert.assertEquals("a2", valueRange.getValues().get(1).get(0));
         Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
+    }
+
+    @Test
+    public void testBeforeProducerAutoFillValues() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:C2");
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        String model = "{" +
+                "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                "\"#1\": {" +
+                    "\"A\": \"a1\"," +
+                    "\"C\": \"c1\"" +
+                "}," +
+                "\"#2\": {" +
+                    "\"A\": \"a2\"," +
+                    "\"B\": \"b2\"" +
+                "}" +
+                "}";
+
+        inbound.getIn().setBody(model);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals("A1:C2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assert.assertEquals(2L, valueRange.getValues().size());
+        Assert.assertEquals(3L, valueRange.getValues().get(0).size());
+        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertNull(valueRange.getValues().get(0).get(1));
+        Assert.assertEquals("c1", valueRange.getValues().get(0).get(2));
+        Assert.assertEquals(3L, valueRange.getValues().get(1).size());
+        Assert.assertEquals("a2", valueRange.getValues().get(1).get(0));
+        Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
+        Assert.assertNull(valueRange.getValues().get(1).get(2));
+    }
+
+    @Test
+    public void testBeforeProducerAutoFillRows() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:C3");
+        options.put("majorDimension", RangeCoordinate.DIMENSION_ROWS);
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        String model = "{" +
+                "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                "\"#1\": {" +
+                    "\"A\": \"a1\"," +
+                    "\"C\": \"c1\"" +
+                "}," +
+                "\"#3\": {" +
+                    "\"A\": \"a3\"," +
+                    "\"B\": \"b3\"" +
+                "}" +
+                "}";
+
+        inbound.getIn().setBody(model);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals("A1:C3", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assert.assertEquals(3L, valueRange.getValues().size());
+        Assert.assertEquals(3L, valueRange.getValues().get(0).size());
+        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertNull(valueRange.getValues().get(0).get(1));
+        Assert.assertEquals("c1", valueRange.getValues().get(0).get(2));
+        Assert.assertEquals(3L, valueRange.getValues().get(1).size());
+        Assert.assertNull(valueRange.getValues().get(1).get(0));
+        Assert.assertNull(valueRange.getValues().get(1).get(1));
+        Assert.assertNull(valueRange.getValues().get(1).get(2));
+        Assert.assertEquals(3L, valueRange.getValues().get(2).size());
+        Assert.assertEquals("a3", valueRange.getValues().get(2).get(0));
+        Assert.assertEquals("b3", valueRange.getValues().get(2).get(1));
+        Assert.assertNull(valueRange.getValues().get(2).get(2));
+    }
+
+    @Test
+    public void testBeforeProducerAutoFillColumns() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:C2");
+        options.put("majorDimension", RangeCoordinate.DIMENSION_COLUMNS);
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        String model = "{" +
+                "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                "\"A\": {" +
+                    "\"#1\": \"a1\"," +
+                    "\"#2\": \"a2\"" +
+                "}," +
+                "\"C\": {" +
+                    "\"#1\": \"c1\"," +
+                    "\"#2\": \"c2\"" +
+                "}" +
+                "}";
+
+        inbound.getIn().setBody(model);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals("A1:C2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_COLUMNS, inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assert.assertEquals(3L, valueRange.getValues().size());
+        Assert.assertEquals(2L, valueRange.getValues().get(0).size());
+        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertEquals("a2", valueRange.getValues().get(0).get(1));
+        Assert.assertEquals(2L, valueRange.getValues().get(1).size());
+        Assert.assertNull(valueRange.getValues().get(1).get(0));
+        Assert.assertNull(valueRange.getValues().get(1).get(1));
+        Assert.assertEquals(2L, valueRange.getValues().get(2).size());
+        Assert.assertEquals("c1", valueRange.getValues().get(2).get(0));
+        Assert.assertEquals("c2", valueRange.getValues().get(2).get(1));
     }
 }

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIntegrationTest.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
@@ -76,7 +77,7 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
         Assert.assertEquals(testSheet.getSpreadsheetId(), exchange.getIn().getHeaders().get(SPREADSHEET_ID));
         Assert.assertEquals(range, exchange.getIn().getHeaders().get(RANGE));
         Assert.assertEquals(1, exchange.getIn().getHeaders().get(RANGE_INDEX));
-        Assert.assertEquals("ROWS", exchange.getIn().getHeaders().get(MAJOR_DIMENSION));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, exchange.getIn().getHeaders().get(MAJOR_DIMENSION));
 
         ValueRange values = (ValueRange) exchange.getIn().getBody();
         Assert.assertEquals(2L, values.getValues().size());
@@ -127,7 +128,7 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
         Assert.assertEquals(range, exchange.getIn().getHeaders().get(RANGE));
         Assert.assertEquals(1, exchange.getIn().getHeaders().get(RANGE_INDEX));
         Assert.assertEquals(1, exchange.getIn().getHeaders().get(VALUE_INDEX));
-        Assert.assertEquals("ROWS", exchange.getIn().getHeaders().get(MAJOR_DIMENSION));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, exchange.getIn().getHeaders().get(MAJOR_DIMENSION));
 
         List<?> values = (List) exchange.getIn().getBody();
         Assert.assertEquals(2L, values.size());


### PR DESCRIPTION
When data mapper does not set all values in a data range we need to auto fill in those gaps with "null" values in order to ensure proper value propagation to Google Sheets API. 

If not filling those gaps the update will result in a different outcome and the updated range does not match the required range.

**Example no AutoFill**
Range: A1:E1
Values: ["Test A", "Test B", "Test E"]
Result: 
```
A        B        C       D       E
Test A   Test B   Test E
```
UpdatedRange: A1:C1

**Example with AutoFill**
Range: A1:E1
Values: ["Test A", "Test B", null, null, "Test E"]
Result: 
```
A        B        C       D       E
Test A   Test B                   Test E
```
UpdatedRange: A1:E1
