### PR TITLE
Updates to AMQ to REST API tutorial

### DIFF
--- a/doc/tutorials/topics/amq2api_add_damage_reporter_step.adoc
+++ b/doc/tutorials/topics/amq2api_add_damage_reporter_step.adoc
@@ -5,7 +5,7 @@
 = Add a damage reporter step
 
 With the start and finish connections in place, you are ready to
-add the custom step that receives the messages from the AMQ broker
+add the custom step that receives the messages from the Red Hat AMQ broker
 and identifies any items that were damaged when they were received.
 
 .Prerequisite

--- a/doc/tutorials/topics/amq2api_add_mapping_step.adoc
+++ b/doc/tutorials/topics/amq2api_add_mapping_step.adoc
@@ -24,3 +24,9 @@ the API accesses.
 . In the *Source* panel, click the `task` field.
 . In the *Target* panel, expand the `body` field and click `task`.
 . In the upper right, click *Done*.
+
+.Result
+The integration is complete and it is ready to be published. 
+On the left, in the integration visualization panel, you might see a
+image:shared/images/WarningIcon.png[warning] Data Type Mismatch 
+warning icon. You can ignore it. 

--- a/doc/tutorials/topics/amq2api_add_mapping_step.adoc
+++ b/doc/tutorials/topics/amq2api_add_mapping_step.adoc
@@ -15,12 +15,12 @@ database that the REST API accesses.
 .Procedure
 . In {prodname}, in the left panel, hover over the plus sign between the damage reporter
 step and the finish connection to display a pop-up in which
-you click *Add a Step*.
+you click *Add a step*.
 . On the *Choose a Step* page, click *Data Mapper*. In the data mapper,
-the *Sources* panel on the left displays the fields in the
+the *Source* panel on the left displays the fields in the
 output from the damage reporter step. The
 *Target* panel on the right displays the fields in the database that
 the API accesses.
-. In the *Sources* panel, click the `task` field.
+. In the *Source* panel, click the `task` field.
 . In the *Target* panel, expand the `body` field and click `task`.
-. Click *Done*.
+. In the upper right, click *Done*.

--- a/doc/tutorials/topics/amq2api_choose_finish.adoc
+++ b/doc/tutorials/topics/amq2api_choose_finish.adoc
@@ -9,7 +9,7 @@ integration, after you add the start connection, you add the finish connection
 to the integration.
 
 .Prerequisites
-* You uploaded the provided OpenAPI specification to create the Todo App API 
+* You uploaded the provided OpenAPI document to create the Todo App API 
 connector. 
 * You used the Todo App API connector to create a Todo App API connection.
 

--- a/doc/tutorials/topics/amq2api_choose_start.adoc
+++ b/doc/tutorials/topics/amq2api_choose_start.adoc
@@ -8,8 +8,8 @@ In {prodname}, to create the sample AMQ to REST API sample integration,
 the first task is to choose the start connection. 
 
 .Prerequisites
-* You started the provided AMQ broker. 
-* You created an AMQ connection. 
+* You started the provided Red Hat AMQ broker. 
+* You created a connection to that message broker. 
 
 .Procedure
 
@@ -17,7 +17,7 @@ the first task is to choose the start connection.
 . Click *Create Integration*.
 . On the *Choose a Start Connection* page, click your
 AMQ connection. If you specified the example name,
-you would click *AMQ Broker 1*.
+you would click *Red Hat AMQ Broker 1*.
 . On the *Choose an Action* page, click the *Subscribe for messages* action
 to receive messages from the queue you specify.
 . In the *Destination Name* field, enter `*inventoryReceived*` for
@@ -29,7 +29,7 @@ This is not needed for this sample integration.
 . Click *Done* to add the start connection to the integration.
 
 .Next step
-When the integration is running, after connecting to AMQ, the integration watches for
+When the integration is running, after connecting to Red Hat AMQ, the integration watches for
 messages on the `inventoryReceived` queue. When a message is available,
 the integration passes it to the *Damage Reporter* step.
 However, before you can add that step to the integration, you must choose the

--- a/doc/tutorials/topics/amq2api_choose_start.adoc
+++ b/doc/tutorials/topics/amq2api_choose_start.adoc
@@ -18,7 +18,7 @@ the first task is to choose the start connection.
 . On the *Choose a Start Connection* page, click your
 AMQ connection. If you specified the example name,
 you would click *AMQ Broker 1*.
-. On the *Choose an Action* page, click the *Subscribe for Messages* action
+. On the *Choose an Action* page, click the *Subscribe for messages* action
 to receive messages from the queue you specify.
 . In the *Destination Name* field, enter `*inventoryReceived*` for
 the name of the queue to obtain data from.

--- a/doc/tutorials/topics/amq2api_confirm_works.adoc
+++ b/doc/tutorials/topics/amq2api_confirm_works.adoc
@@ -21,7 +21,7 @@ for your {prodname} environment. For example:
 . In the To Do app display, click *Show JMS Form* to display an
 input box that contains an XML message.
 . Click *Send JMS Message* to send that message
-to the AMQ broker in your OpenShift project.
+to the Red Hat AMQ broker in your OpenShift project.
 +
 Successful execution returns a task from the To Do app client API. The task
 identifies the ID of the damaged item and the contact information for its
@@ -45,7 +45,7 @@ task with the item ID that you just entered.
 unexpected result or to learn more about integration execution: 
 
 .. In {prodname}, in the left panel, click *Integrations*.
-.. Click the entry for your AMQ to API integration.
+.. Click the entry for your AMQ to REST API integration.
 .. In the integration's summary page, click the *Activity* tab.
 .. Optionally, enter date and/or keyword filters to limit the executions
 listed.

--- a/doc/tutorials/topics/amq2api_create_amq_connection.adoc
+++ b/doc/tutorials/topics/amq2api_create_amq_connection.adoc
@@ -5,9 +5,10 @@
 = Create an AMQ connection
 
 The AMQ to REST API sample integration starts by connecting to an
-AMQ broker that is provided in your OpenShift Online  project. Before you
+AMQ broker (Red Hat AMQ) that is provided in your OpenShift Online  
+project. Before you
 start to create the integration itself, you must start the broker
-and create an AMQ connection to that broker. 
+and create a connection to that broker. 
 
 .Procedure
 
@@ -24,7 +25,7 @@ Your project's name is something like `proj123456`.
 
 .. In the overview, click the *>* to the left of the first entry, 
 *broker-amq, #1*, to expand the entry for the
-provided AMQ broker.
+provided Red Hat AMQ broker.
 
 .. On the right, click the up caret to scale up to running 1 pod. This starts
 the AMQ broker.
@@ -35,7 +36,7 @@ the AMQ broker.
 available connections.
 .. In the upper right, click *Create Connection* to display
 {prodname} connectors.
-.. Click the *AMQ* connector.
+.. Click the *Red Hat AMQ* connector.
 .. Configure the connection by entering:
 +
 ... In the *Broker URL* field, enter `*tcp://broker-amq-tcp:61616*`
@@ -52,11 +53,10 @@ entered and try again.
 .. When validation is successful, in the upper right, click *Next*.
 .. In the *Connection Name* field, enter your choice of a name that
 helps you distinguish this connection from any other connections.
-For example, enter `*AMQ Broker 1*`.
+For example, enter `*Red Hat AMQ Broker 1*`.
 .. In the *Description* field, optionally enter any information that
 is helpful to know about this connection. For example,
-enter `*Sample AMQ connection
-that uses the provided broker.*`
+enter `*Connection to the provided Red Hat AMQ message broker.*`
 .. In the upper right, click *Create* to see that the connection you
 created is now available. If you entered the example name, you would
-see that *AMQ Broker 1* is now available.
+see that *Red Hat AMQ Broker 1* is now available.

--- a/doc/tutorials/topics/amq2api_create_amq_connection.adoc
+++ b/doc/tutorials/topics/amq2api_create_amq_connection.adoc
@@ -22,7 +22,8 @@ display the project's overview.
 +
 Your project's name is something like `proj123456`.
 
-.. In the overview, click the first entry, *broker-amq, #1* to expand the entry for the
+.. In the overview, click the *>* to the left of the first entry, 
+*broker-amq, #1*, to expand the entry for the
 provided AMQ broker.
 
 .. On the right, click the up caret to scale up to running 1 pod. This starts
@@ -48,7 +49,7 @@ the account that accesses this AMQ broker.
 connection and displays a message that indicates whether
 validation is successful. If validation fails, check the values you
 entered and try again.
-.. When validation is successful, click *Next*.
+.. When validation is successful, in the upper right, click *Next*.
 .. In the *Connection Name* field, enter your choice of a name that
 helps you distinguish this connection from any other connections.
 For example, enter `*AMQ Broker 1*`.

--- a/doc/tutorials/topics/amq2api_create_custom_step.adoc
+++ b/doc/tutorials/topics/amq2api_create_custom_step.adoc
@@ -27,14 +27,16 @@ https://github.com/syndesisio/fuse-online-sample-extension/releases.
 . In {prodname}, in the left panel, click *Customizations*. 
 . At the top, click *Extensions*. 
 . Click *Import Extension*. 
-. Click *Browse* and select the downloaded `.jar` file that contains the 
+. Click *Choose File* and select the downloaded `.jar` file that contains the 
 extension. 
 {prodname} validates the file, extracts and displays the extension's 
-name, ID, and description, and lists *Damage Reporter* as the custom step
+ID, name, description, and type, and lists *Damage Reporter* as the custom step
 that the extension defines.
-. Click *Import*. {prodname} makes the custom step available and displays
+. Click *Import Extension*. {prodname} makes the custom step available and displays
 the extension details page.
 
-.Additional resource
-For more information about coding an extension and creating its `.jar` file, see the
-{LinkToolingUserGuide}igniteextension/[{NameOfToolingUserGuide}].
+.Additional resources
+For information about coding an extension and creating its `.jar` file, see: 
+
+* link:{LinkToolingUserGuide}#fuseonlineextension[{NameOfToolingUserGuide} - Use Fuse toolineg to develop an extension.]
+* link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_custom[{NameOfFuseOnlineIntegrationGuide} - Manually code an extension.]

--- a/doc/tutorials/topics/amq2api_create_integration.adoc
+++ b/doc/tutorials/topics/amq2api_create_integration.adoc
@@ -15,7 +15,7 @@ To create and deploy the AMQ to REST API sample integration, the main steps are:
 . <<amq2api-name-and-publish_{context}>>
 
 .Prerequisites
-* You created a connection to the provided AMQ broker. 
+* You created a connection to the provided Red Hat AMQ broker. 
 * You created an API Client connection to the provided Todo app.
 * You uploaded the extension that provides the Damage Reporter step. 
 

--- a/doc/tutorials/topics/amq2api_create_rest_api_connection.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connection.adoc
@@ -6,10 +6,12 @@
 
 In an integration, before you can connect to a REST API, you create a REST API 
 client connector and then use that connector to create a connection. 
-Follow the instructions here to create a connection to the To Do app REST API. 
+You already created a REST API connector for the To Do app. Follow the 
+instructions here to use that connector to create a connection to the 
+To Do app REST API. 
 
 .Prerequisite
-* You created the Todo App API connector. 
+* You created the Todo App REST API connector. 
 
 .Procedure
 

--- a/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
@@ -7,7 +7,7 @@
 {prodname} can create connectors for REST APIs
 that support Hypertext Transfer Protocol (HTTP)/1.0 or HTTP/1.1.
 To do this, {prodname} requires a valid
-OpenAPI 2.0 specification that describes a REST API you want to connect to.
+OpenAPI 2.0 specification that describes a REST API that you want to connect to.
 
 Your {prodname} environment provides the To Do app, which has a REST API
 for accessing a database that contains tasks. Your environment also provides
@@ -20,7 +20,8 @@ OpenAPI specification:
 .. In the {prodname} navigation panel, click *Home*.
 .. Copy the URL into a text editor.
 .. At the beginning of the URL, insert `*todo-*`.
-.. At the end of the URL, replace `dashboard` with `*swagger.json*`.
+.. At the end of the URL, remove `dashboard` if it is present.
+.. At the end of the URL, add `*swagger.json*`.
 .. Use the `http` scheme instead of `https`.
 
 +
@@ -32,7 +33,7 @@ The result is something like this:
 . Select *Use a URL*.
 . In the input box, paste the URL for your OpenAPI specification and
 click *Next*.
-. On the *Review OpenAPI Actions* page, click *Next*. If you see
+. On the *Review Actions* page, click *Next*. If you see
 a warning, you can ignore it.
 . Click *Next* again to accept *HTTP Basic Authorization*.
 . On the *Review/Edit Connector Details* page, {prodname} populates
@@ -41,7 +42,7 @@ the fields with values from the OpenAPI specification.
 change the values in the *Connector Name* and *Description* fields.
 .. Confirm that the value in the *Host* field is correct. For example,
 it should be something like this:
-`\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
+`\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
 .. Confirm that the value in the *Base URL* field is `/api`.
 . Click *Create API Connector*.
 +

--- a/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
+++ b/doc/tutorials/topics/amq2api_create_rest_api_connector.adoc
@@ -7,16 +7,16 @@
 {prodname} can create connectors for REST APIs
 that support Hypertext Transfer Protocol (HTTP)/1.0 or HTTP/1.1.
 To do this, {prodname} requires a valid
-OpenAPI 2.0 specification that describes a REST API that you want to connect to.
+OpenAPI 2.0 document that describes a REST API that you want to connect to.
 
 Your {prodname} environment provides the To Do app, which has a REST API
 for accessing a database that contains tasks. Your environment also provides
-an OpenAPI (Swagger) specification for this API.
+an OpenAPI (Swagger) document for this API.
 
 .Procedure
 
 . Identify the URL for your {prodname} environment's copy of the
-OpenAPI specification:
+OpenAPI document:
 .. In the {prodname} navigation panel, click *Home*.
 .. Copy the URL into a text editor.
 .. At the beginning of the URL, insert `*todo-*`.
@@ -28,16 +28,24 @@ OpenAPI specification:
 The result is something like this:
 `\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/swagger.json`
 
++
+[NOTE]
+Specification of `http` rather than `https` avoids a runtime error 
+if TLS certificates are not valid.  In production 
+environments, ensure that valid certificates are in place, 
+and always specify secure URLs (`https`) to obtain an OpenAPI document. 
+
+
 . In the {prodname} navigation panel, click *Customizations*.
 . Click *Create API Connector*.
 . Select *Use a URL*.
-. In the input box, paste the URL for your OpenAPI specification and
+. In the input box, paste the URL for your OpenAPI document and
 click *Next*.
 . On the *Review Actions* page, click *Next*. If you see
 a warning, you can ignore it.
 . Click *Next* again to accept *HTTP Basic Authorization*.
 . On the *Review/Edit Connector Details* page, {prodname} populates
-the fields with values from the OpenAPI specification.
+the fields with values from the OpenAPI document.
 .. If you want to, you can
 change the values in the *Connector Name* and *Description* fields.
 .. Confirm that the value in the *Host* field is correct. For example,

--- a/doc/tutorials/topics/amq2api_intro.adoc
+++ b/doc/tutorials/topics/amq2api_intro.adoc
@@ -6,12 +6,12 @@
 = Implement an AMQ to REST API sample integration
 
 :context: amq2api
-This sample integration connects to an AMQ broker to obtain item
+This sample integration connects to a Red Hat AMQ broker to obtain item
 delivery records for a hypothetical enterprise. The integration then executes
 a custom step that operates on the records to identify any
 items that were damaged when they were received. After a simple data mapping,
 the integration connects to
-a REST API to obtain and provide contact information for vendors of
+a REST API to obtain contact information for vendors of
 damaged items.
 
 The other sample integrations use connectors and data operations that are built

--- a/doc/tutorials/topics/amq2api_name_and_publish.adoc
+++ b/doc/tutorials/topics/amq2api_name_and_publish.adoc
@@ -4,7 +4,7 @@
 [id='amq2api-name-and-publish_{context}']
 = Give the integration a name and deploy it
 
-The AMQ to REST API sample integration is complete when it has an AMQ start
+The AMQ to REST API sample integration is complete when it has a Red Hat AMQ start
 connection, a Damage Reporter step, a data mapper step, and it finishes
 with a Todo App Client API connection. Follow the instructions here to 
 deploy it. 

--- a/doc/tutorials/topics/amq2api_upload_todo_app_icon.adoc
+++ b/doc/tutorials/topics/amq2api_upload_todo_app_icon.adoc
@@ -13,7 +13,7 @@ to upload it.
 
 . Display the To Do app icon:
 
-.. In a new browser tab, paste the URL for your OpenAPI (Swagger) specification.
+.. In a new browser tab, paste the URL for your OpenAPI (Swagger) document.
 .. At the end of the URL, replace `swagger.json` with `images/todo_icon.png` 
 and click *Enter* to display the icon. For example: 
 `\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/images/todo_icon.png`.

--- a/doc/tutorials/topics/amq2api_upload_todo_app_icon.adoc
+++ b/doc/tutorials/topics/amq2api_upload_todo_app_icon.adoc
@@ -15,7 +15,7 @@ to upload it.
 
 .. In a new browser tab, paste the URL for your OpenAPI (Swagger) specification.
 .. At the end of the URL, replace `swagger.json` with `images/todo_icon.png` 
-and click *Enter*. For example: 
+and click *Enter* to display the icon. For example: 
 `\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/images/todo_icon.png`.
 
 . Save the `todo_icon.png` image.
@@ -23,9 +23,11 @@ and click *Enter*. For example:
 . In {prodname}, in the *API Client Connectors* tab, click the entry for
 the *Todo App API* to display its details.
 
-. On the *Connector Details* page, click *Browse*.
+. On the *Connector Details* page, below the *Base URL* field, click *Edit*. 
+
+. Next to the default connector icon, click *Choose File*.
 
 . Navigate to `todo_icon.png`, select it, and click *Open*.
+The icon appears near the top of the connector details page.
 
-. Refresh the display of the *Connector Details* page.
-The image now appears on the left.
+. Below the *Base URL* field, click *Save*. 

--- a/doc/tutorials/topics/comparison_of_sample_integrations.adoc
+++ b/doc/tutorials/topics/comparison_of_sample_integrations.adoc
@@ -22,7 +22,7 @@ and Salesforce creates a new contact.
 |Captures updates in Salesforce and then calls a database
 stored procedure to synchronize a particular database table
 with the Salesforce updates.
-|Obtains delivery records from an AMQ broker, executes
+|Obtains delivery records from a Red Hat AMQ broker, executes
 a custom step to identify any
 items that were damaged when they were received, and 
 connects to a REST API to provide contact information for vendors of
@@ -36,7 +36,7 @@ the next connected application in the integration can operate on, filtering data
 to determine whether to continue integration execution. 
 |Connecting to Salesforce and a SQL database, OAuth support, data mapping, 
 how to update a SQL database as part of an integration.
-|Connecting to an AMQ broker and a REST API, data mapping, 
+|Connecting to a Red Hat AMQ broker and a REST API, data mapping, 
 uploading extensions for a step and for a REST API client
 connector, using a custom step and a custom API client connection.
 


### PR DESCRIPTION
Resolves FUSEDOC-2940 which requires an update to the procedure for uploading the icon for the Todo app. Adds a note about specification of http vs. https for obtaining OpenAPI documents. Adds a note about ignoring a data type mismatch warning on the IVP. Updates references to AMQ to be to "Red Hat AMQ" where appropriate. (FUSEDOC-2950) and Syndesis 4183. 