### PR TITLE
WIP: user doc: Update to refer to Red Hat AMQ (#4183)

### DIFF
--- a/doc/connecting/topics/adding_amq_connection_finish.adoc
+++ b/doc/connecting/topics/adding_amq_connection_finish.adoc
@@ -4,11 +4,11 @@
 [id='adding-amq-connection-finish_{context}']
 = Finish an integration by publishing AMQ messages
 
-To finish an integration by publishing messages to an AMQ broker, 
-add an AMQ connection as the finish connection.
+To finish an integration by publishing messages to a Red Hat AMQ broker, 
+add a Red Hat AMQ connection as the finish connection.
 
 .Prerequisites
-* You created a connection to the AMQ broker that you want to publish 
+* You created a connection to the Red Hat AMQ broker that you want to publish 
 messages to.
 * You are creating an integration and {prodname} is prompting you
 to choose the 
@@ -17,7 +17,7 @@ connection.
 
 .Procedure
 
-. On the *Choose a Finish Connection* page, click the AMQ connection that
+. On the *Choose a Finish Connection* page, click the Red Hat AMQ connection that
 you want to use to finish the integration. 
 . On the *Choose an Action* page, click the *Publish messages* action to
 publish messages to the queue or topic you specify. 

--- a/doc/connecting/topics/adding_amq_connection_middle.adoc
+++ b/doc/connecting/topics/adding_amq_connection_middle.adoc
@@ -4,12 +4,12 @@
 [id='adding-amq-connection-middle_{context}']
 = Publish AMQ messages in the middle of an integration
 
-In the middle of an integration, to publish messages to an AMQ broker, 
-add an AMQ connection between the start and
+In the middle of an integration, to publish messages to a Red Hat AMQ broker, 
+add a Red Hat AMQ connection between the start and
 finish connections. 
 
 .Prerequisites
-* You created a connection to the AMQ broker that you want to publish messages to.
+* You created a connection to the Red Hat AMQ broker that you want to publish messages to.
 * You are creating or editing an integration.
 * The integration's start and finish connections have already been
 added. 
@@ -20,7 +20,7 @@ added.
 that is in the location where you want to add the connection.
 . Click *Add a connection*. 
 
-. On the *Choose a Connection* page, click the AMQ connection that you
+. On the *Choose a Connection* page, click the Red Hat AMQ connection that you
 want the integration to use after the start connection and before
 the finish connection.
 

--- a/doc/connecting/topics/adding_amq_connection_start.adoc
+++ b/doc/connecting/topics/adding_amq_connection_start.adoc
@@ -5,17 +5,17 @@
 = Start an integration based on receiving AMQ messages
 
 To trigger execution of an integration based on receiving a message
-from an AMQ broker, add an AMQ connection as the start connection.
+from a Red Hat AMQ broker, add a Red Hat AMQ connection as the start connection.
 
 .Prerequisite
-You created an AMQ connection to the broker that you want to obtain
+You created a Red Hat AMQ connection to the Red Hat AMQ broker that you want to obtain
 messages from. 
 
 .Procedure
 
 . In the {prodname} panel on the left, click *Integrations*.
 . Click *Create Integration*.
-. On the *Choose a Start Connection* page, click the AMQ connection that
+. On the *Choose a Start Connection* page, click the Red Hat AMQ connection that
 you want to use to start the integration. 
 . On the *Choose an Action* page, click the *Subscribe for messages* action
 to receive messages from the queue or topic you specify. 

--- a/doc/connecting/topics/connecting_to_amq.adoc
+++ b/doc/connecting/topics/connecting_to_amq.adoc
@@ -5,11 +5,11 @@
 = Connect to AMQ
 :context: amq
 
-In an integration, you can obtain messages from an 
-ApacheMQ (AMQ) broker or publish messages to 
-an AMQ broker. AMQ uses the OpenWire protocol for communication
+In an integration, you can obtain messages from a
+Red Hat AMQ broker or publish messages to 
+a Red Hat AMQ broker. Red Hat AMQ uses the OpenWire protocol for communication
 between clients and message brokers. To communicate with the following 
-broker types, use the AMQ connector to create a connection to the
+broker types, use the Red Hat AMQ connector to create a connection to the
 broker of interest:
 
 * Apache ActiveMQ broker that does not support AMQP
@@ -24,7 +24,7 @@ to create a connection to the broker of interest:
 * AMQ 7 broker
 * EnMasse, which is an open source messaging platform
 
-To use the AMQ connector, see:
+To use the Red Hat AMQ connector, see:
 
 * <<create-amq-connection_{context}>>
 * <<adding-amq-connection-start_{context}>>

--- a/doc/connecting/topics/connecting_to_amqp.adoc
+++ b/doc/connecting/topics/connecting_to_amqp.adoc
@@ -18,7 +18,7 @@ broker of interest:
 * EnMasse, which is an open source messaging platform
 
 To communicate with one of the following broker types, 
-link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_amq[use the AMQ connector] 
+link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_amq[use the Red Hat AMQ connector] 
 to create a connection to the broker of interest:
 
 * Apache ActiveMQ broker that does not support AMQP

--- a/doc/connecting/topics/create_amq_connection.adoc
+++ b/doc/connecting/topics/create_amq_connection.adoc
@@ -4,12 +4,16 @@
 [id='create-amq-connection_{context}']
 = Create an AMQ connection
 
-In an integration, to obtain messages from or to publish messages to 
-an Apache ActiveMQ broker that does not support AMQP or an AMQ 6 broker, 
-create an AMQ connection, which you can add to an integration.
+In an integration, to obtain messages from or to publish messages to: 
+
+* An Apache ActiveMQ broker that does not support AMQP
+* An  AMQ 6 broker
+
+Create a Red Hat AMQ connection, which you can add to an integration.
 
 .Prerequisites
-For the AMQ broker that you want to connect to, you have the following:
+For the Red Hat AMQ broker that you want to connect to, you have the following:
+
 * Broker URL
 * User account credentials
 * Broker's PEM certificate text
@@ -20,7 +24,7 @@ For the AMQ broker that you want to connect to, you have the following:
 display any available connections.
 . In the upper right, click *Create Connection* to display
 connectors.  
-. Click the *AMQ Message Broker* connector.
+. Click the *Red Hat AMQ* connector.
 . Configure the connection by entering: 
 +
 .. In the *Broker URL* field, enter the location that you want to send data
@@ -36,10 +40,10 @@ environment, you can save some time by disabling
 *Check Certificates*. Disabling the checking of certificates is a convenience for
 development environments. For secure production environments, always enable 
 *Check Certificates*.
-.. In the *Broker Certificate* field, paste the broker's PEM certificate text.
+.. In the *Broker Certificate* field, paste the Red Hat AMQ broker's PEM certificate text.
 This is required except when you disable
 checking the certificates. 
-.. In the *Client Certificate* field, paste the client's PEM certificate text. 
+.. In the *Client Certificate* field, paste the Red Hat client's PEM certificate text. 
 Content in this field is always optional. 
 . Click *Validate*. {prodname} immediately tries to validate the 
 connection and displays a message that indicates whether 
@@ -48,13 +52,13 @@ details as needed and try again.
 . If validation is successful, click *Next*.
 . In the *Connection Name* field, enter your choice of a name that
 helps you distinguish this connection from any other connections.
-For example, you might enter `AMQ 1`.
+For example, you might enter `Red Hat AMQ 1`.
 . In the *Description* field, optionally enter any information that
 is helpful to know about this connection. For example,
-enter `*Sample AMQ connection
+enter `*Sample Red Hat AMQ connection
 that uses a provided broker.*`
 . In the upper right, click *Create* to see that the connection you 
 created is now available. If you
 entered the example name, you would 
-see that *AMQ 1* appears as a connection that you can 
+see that *Red Hat AMQ 1* appears as a connection that you can 
 choose to add to an integration.

--- a/doc/connecting/topics/supported_connectors.adoc
+++ b/doc/connecting/topics/supported_connectors.adoc
@@ -16,8 +16,8 @@
 |Retrieve data from an Amazon S3 bucket or copy data into a bucket. 
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_connectors[AMQ]
-|Obtain messages from an ApacheMQ broker or publish messages to an ApacheMQ
-broker. 
+|Obtain messages from a Red Hat AMQ (ApacheMQ) broker or publish messages to 
+a Red Hat AMQ (ApacheMQ) broker. 
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-amqp_connectors[AMQP]
 |Obtain messages from an Advanced Message Queue Protocol broker or
@@ -101,6 +101,7 @@ If {prodname} does not provide a connector that you need, an
 experienced developer can create an extension that defines a custom
 connector. For information about coding the 
 extension and creating its `.jar` file, which you upload to 
-{prodname}, see 
-link:{LinkToolingUserGuide}#IgniteExtension[{NameOfToolingUserGuide},Develop extensions for {prodname} integrations] and 
-link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_dev-extension[{NameOfFuseOnlineIntegrationGuide}, Develop extensions].
+{prodname}, see:
+
+* link:{LinkToolingUserGuide}#fuseonlineextension[{NameOfToolingUserGuide}, how to use Fuse tooling to develop extensions]
+* link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_dev-extension[{NameOfFuseOnlineIntegrationGuide}, how to code extensions]


### PR DESCRIPTION
I updated the connectors guide to refer to Red Hat AMQ. 
@gaughan or @gashcrumb could you review the updates and let me know if they are okay?
Thanks!
I updated instances in the tutorial in a different PR. 
In the integration guide, there are a bunch of generic AMQ references, which I think are okay, so not changes there. 