### PR TITLE
chore: refactor out the meat of the event handlers in current flow service

### DIFF
--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -60,9 +60,19 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   }
 
   goBack() {
-    const step = this.currentFlowService.getStep(this.position);
-    step.action = undefined;
-    this.flowPageService.goBack(['action-select', this.position], this.route);
+    const { action: omit, ...step } = this.currentFlowService.getStep(
+      this.position
+    );
+    this.currentFlowService.events.emit({
+      kind: 'integration-set-step',
+      position: this.position,
+      step,
+      onSave: () =>
+        this.flowPageService.goBack(
+          ['action-select', this.position],
+          this.route
+        )
+    });
   }
 
   buildData(data: any) {
@@ -84,13 +94,14 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
           /* All done configuring this action... */
           this.router.navigate(['save-or-add-step'], {
             queryParams: { validate: true },
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
         } else {
           /* Go to the previous configuration page... */
           this.router.navigate(
-            ['action-configure', this.position, this.page - 1], {
-              relativeTo: this.route.parent,
+            ['action-configure', this.position, this.page - 1],
+            {
+              relativeTo: this.route.parent
             }
           );
         }
@@ -113,7 +124,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
       metadata: { configured: 'true' },
       onSave: () => {
         this.router.navigate(['describe-data', this.position, direction], {
-          relativeTo: this.route.parent,
+          relativeTo: this.route.parent
         });
       }
     });
@@ -122,21 +133,24 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   continue() {
     this.loading = true;
     this.error = undefined;
-    const data = this.buildData({});
+    const configuredProperties = this.buildData({});
     this.currentFlowService.events.emit({
       kind: 'integration-set-properties',
       position: this.position,
-      properties: data,
+      properties: configuredProperties,
       onSave: () => {
+        const step = (this.step = this.currentFlowService.getStep(
+          this.position
+        ));
         if (!this.lastPage || this.page >= this.lastPage) {
           /**
            * If there are action properties that depend on having other action
            * properties defined in previous steps we need to fetch metadata one
            * more time and apply those action property values that we get
            */
-          if (Object.keys(this.step.configuredProperties).length > 0) {
+          if (Object.keys(step.configuredProperties).length > 0) {
             this.integrationSupport
-              .fetchMetadata(this.step.connection, this.step.action, data)
+              .fetchMetadata(step.connection, step.action, configuredProperties)
               .toPromise()
               .then((descriptor: ActionDescriptor) => {
                 this.currentFlowService.events.emit({
@@ -160,8 +174,9 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
         } else {
           /* Go to the next wizard page... */
           this.router.navigate(
-            ['action-configure', this.position, this.page + 1], {
-              relativeTo: this.route.parent,
+            ['action-configure', this.position, this.page + 1],
+            {
+              relativeTo: this.route.parent
             }
           );
         }
@@ -171,17 +186,11 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
 
   setError(error) {
     // the message is in the _meta attribute in the response
-    const message = error.data._meta
-      ? error.data._meta.message
-      : null;
+    const message = error.data._meta ? error.data._meta.message : null;
     this.error = {
       class: 'alert alert-warning',
       icon: 'pficon pficon-warning-triangle-o',
-      message:
-        message ||
-        error.message ||
-        error.userMsg ||
-        error.developerMsg
+      message: message || error.message || error.userMsg || error.developerMsg
     };
   }
 
@@ -190,13 +199,13 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
     const step = this.currentFlowService.getStep(this.position);
     if (!step || !step.connection) {
       this.router.navigate(['connection-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
     if (!step.action) {
       this.router.navigate(['action-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
@@ -280,9 +289,12 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
   }
 
   hasNoActionPropertiesToDisplay(descriptor: ActionDescriptor) {
-    return !descriptor || descriptor === undefined ||
+    return (
+      !descriptor ||
+      descriptor === undefined ||
       descriptor.propertyDefinitionSteps === undefined ||
-      Object.keys(descriptor.propertyDefinitionSteps[0]).length === 0;
+      Object.keys(descriptor.propertyDefinitionSteps[0]).length === 0
+    );
   }
 
   configuredPropertiesForMetadataCall(action: Action) {
@@ -315,7 +327,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
       (params: ParamMap) => {
         if (!params.has('page')) {
           this.router.navigate(['0'], {
-            relativeTo: this.route,
+            relativeTo: this.route
           });
           return;
         }

--- a/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
+++ b/app/ui/src/app/integration/edit-page/describe-data/describe-data.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { CurrentFlowService, FlowPageService, FlowEvent } from '@syndesis/ui/integration/edit-page';
+import {
+  CurrentFlowService,
+  FlowPageService,
+  FlowEvent
+} from '@syndesis/ui/integration/edit-page';
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
 import {
   Step,
@@ -114,7 +118,7 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
   finishUp() {
     this.router.navigate(['save-or-add-step'], {
       queryParams: { validate: true },
-      relativeTo: this.route.parent,
+      relativeTo: this.route.parent
     });
   }
 
@@ -207,7 +211,7 @@ export class IntegrationDescribeDataComponent implements OnInit, OnDestroy {
     const step = this.currentFlowService.getStep(this.position);
     if (!step.action) {
       this.router.navigate(['action-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.ts
@@ -2,12 +2,7 @@ import { Component, Input, ViewChild, OnChanges } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PopoverDirective } from 'ngx-bootstrap';
 
-import {
-  Action,
-  Step,
-  DataShape,
-  DataShapeKinds
-} from '@syndesis/ui/platform';
+import { Action, Step, DataShape, DataShapeKinds } from '@syndesis/ui/platform';
 import {
   CurrentFlowService,
   FlowPageService
@@ -392,7 +387,11 @@ export class FlowViewStepComponent implements OnChanges {
     }
     switch (step.stepKind) {
       case 'endpoint':
-        if (this.isApiProvider && this.getPosition() === 0 && !this.isApiProviderOperationsPage) {
+        if (
+          this.isApiProvider &&
+          this.getPosition() === 0 &&
+          !this.isApiProviderOperationsPage
+        ) {
           return this.getFlowName();
         }
         if (step.action && step.action.name) {

--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -33,9 +33,7 @@ import {
   ActionDescriptor,
   Action
 } from '@syndesis/ui/platform';
-import {
-  CurrentFlowService
-} from '@syndesis/ui/integration/edit-page';
+import { CurrentFlowService } from '@syndesis/ui/integration/edit-page';
 /*
  * Example host component:
  *
@@ -52,7 +50,8 @@ const MAPPING_KEY = 'atlasmapping';
     </div>
   `,
   styles: [
-    `.data-mapper-host {
+    `
+      .data-mapper-host {
         /* TODO probably a better way to set this height to the viewport */
         height: calc(100vh - 140px);
       }
@@ -93,7 +92,7 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
     public configService: ConfigService,
     public initializationService: InitializationService,
     public support: IntegrationSupportService
-  ) { }
+  ) {}
 
   initialize() {
     this.resetConfig();
@@ -465,8 +464,10 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
     );
 
     try {
-      this.cfg.initCfg.disableMappingPreviewMode =
-        this.configService.getSettings('datamapper', 'disableMappingPreviewMode');
+      this.cfg.initCfg.disableMappingPreviewMode = this.configService.getSettings(
+        'datamapper',
+        'disableMappingPreviewMode'
+      );
     } catch (err) {
       this.cfg.initCfg.disableMappingPreviewMode = true;
     }


### PR DESCRIPTION
relates to #4294

@riccardo-forina FYI, feedback welcome!

planning on finishing up the last 4 event handler blocks that mutate the step array directly, then there's all the positional functions in the current flow service that controllers use to examine neighboring steps etc. like `filterConnectionsByPosition` and `getStartStep`, `getEndStep`, `getSubsequentConnections` and so on...