### PR TITLE
[fix] Fixing module name for  version for integration-runtime-springboot

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1185,7 +1185,7 @@
 
       <dependency>
         <groupId>io.syndesis.integration</groupId>
-        <artifactId>integration-routebuilder</artifactId>
+        <artifactId>integration-runtime-springboot</artifactId>
         <version>${project.version}</version>
       </dependency>
 


### PR DESCRIPTION
Fix for PR on Removing the dependency of the RouteBuilder on SpringBoot so it can be reused in CamelK #4232. First step is a simple refactoring.