### PR TITLE
Update Twitter field names and hints on Settings page (#4096)

### DIFF
--- a/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
+++ b/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
@@ -139,12 +139,14 @@
     "consumerKey": {
       "componentProperty": true,
       "deprecated": false,
-      "displayName": "Consumer Key",
+      "displayName": "Consumer API Key",
       "group": "security",
       "javaType": "java.lang.String",
       "kind": "property",
       "label": "security",
-      "labelHint": "The consumer key",
+      "labelHint": "The Consumer API key that Twitter provides when you register a client application.
+
+",
       "required": true,
       "secret": true,
       "tags": [
@@ -155,12 +157,14 @@
     "consumerSecret": {
       "componentProperty": true,
       "deprecated": false,
-      "displayName": "Consumer Secret",
+      "displayName": "Consumer API Secret Key",
       "group": "security",
       "javaType": "java.lang.String",
       "kind": "property",
       "label": "security",
-      "labelHint": "The consumer secret",
+      "labelHint": "The Consumer API secret key that Twitter provides when you register a client application.
+
+",
       "required": true,
       "secret": true,
       "tags": [


### PR DESCRIPTION
This updates the display names as well as the hints for Twitter fields on the Settings page. 
In the staging site, in the Settings page, Twitter entry, the field order is:

Consumer Secret
Concumer Key

This should be reversed, but I don't know how to do that. 