### PR TITLE
Typo fix: Make description of log step consistent with other step descriptions

### DIFF
--- a/app/ui/src/app/store/step/step.store.ts
+++ b/app/ui/src/app/store/step/step.store.ts
@@ -97,7 +97,7 @@ $\{in.body.title\} // Evaluates true when body contains title.
       action: undefined,
       name: 'Log',
       stepKind: LOG,
-      description: "Sends a message to the integration's log",
+      description: "Send a message to the integration's log.",
       configuredProperties: undefined,
       properties: {
         contextLoggingEnabled: {


### PR DESCRIPTION
This just removes an "s" from "Sends" and adds a period at the end of the sentence. 
This makes the description of the log step consistent with the descriptions of the other steps. 