### PR TITLE
[Upgrade] Fix regex in preflight.sh

### DIFF
--- a/tools/upgrade/migration/preflight.sh
+++ b/tools/upgrade/migration/preflight.sh
@@ -56,13 +56,8 @@ extract_minor_version() {
         echo "latest"
         return
     fi
-    if [[ $version == [0-9]\.[0-9] ]]; then
-        # Already minor version, no need to parse
-        echo $version
-        return
-    fi
-    local minor_version=$(echo $version | sed 's/^\([0-9]*\.[0-9]*\)\.[0-9]*\(-.*\)*$/\1/')
-    if [ "$minor_version" = "$version" ]; then
+    local minor_version=$(echo "$version"XX | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')
+    if [ $minor_version = "${version}XX" ]; then
         echo "ERROR: Cannot extract minor version from '$version'"
         return
     fi


### PR DESCRIPTION
Hopefully, this one will be alright:

```
/tmp :: ./test.sh "1.X"
ERROR: Cannot extract minor version from '1.X'
➤  /tmp :: ./test.sh "1.1.X"
1.1
➤  /tmp :: ./test.sh "1.5.0"
1.5
➤  /tmp :: ./test.sh "1.5.0-20190128"
1.5
➤  /tmp :: ./test.sh "1.5.0-redhat-123"
1.5
➤  /tmp :: ./test.sh "1.1"
1.1
➤  /tmp :: ./test.sh "10.1"
10.1
➤  /tmp :: ./test.sh "1.10"
1.10
➤  /tmp :: ./test.sh "1.101"
1.101

```