### PR TITLE
fix(server): optimize database reset

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/cache/CacheManager.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/cache/CacheManager.java
@@ -18,5 +18,9 @@ package io.syndesis.common.util.cache;
 import java.util.Map;
 
 public interface CacheManager {
-    <K,V > Map<K, V> getCache(String name);
+
+    void evictAll();
+
+    <K, V> Map<K, V> getCache(String name);
+
 }

--- a/app/common/util/src/main/java/io/syndesis/common/util/cache/LRUCacheManager.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/cache/LRUCacheManager.java
@@ -22,21 +22,26 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class LRUCacheManager implements CacheManager {
-    private final int maxElements;
     private final ConcurrentMap<String, Map<?, ?>> maps;
+    private final int maxElements;
 
-    public LRUCacheManager(int maxElements) {
+    public LRUCacheManager(final int maxElements) {
         this.maxElements = maxElements;
-        this.maps = new ConcurrentHashMap<>();
+        maps = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void evictAll() {
+        maps.clear();
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <K, V> Map<K, V> getCache(String name) {
+    public <K, V> Map<K, V> getCache(final String name) {
         return Map.class.cast(maps.computeIfAbsent(name, this::newCache));
     }
 
-    private <K, V> Map<K, V> newCache(@SuppressWarnings("PMD.UnusedFormalParameter") String name) {
+    private <K, V> Map<K, V> newCache(@SuppressWarnings("PMD.UnusedFormalParameter") final String name) {
         return Collections.synchronizedMap(new LinkedHashMap<K, V>() {
             @Override
             protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -119,6 +119,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jdbi</groupId>
+      <artifactId>jdbi</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>


### PR DESCRIPTION
This uses `TRUNCATE` statement to remove all rows from `jsondb`,
`filestore` and `config` tables instead of looping through the database
entities and deleting each row individually or using `DELETE ... LIKE`.

This should eliminate database log use and speed up the database reset.

Fixes #4308