### PR TITLE
refactor(server): don't use overriding properties

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
@@ -35,7 +35,7 @@ public interface WithConfigurationProperties {
 
     @JsonIgnore
     default boolean isEndpointProperty(Entry<String, String> e) {
-        return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && !this.getProperties().get(e.getKey()).isComponentProperty();
+        return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && !this.getProperties().get(e.getKey()).componentProperty();
     }
 
     @JsonIgnore
@@ -45,7 +45,7 @@ public interface WithConfigurationProperties {
 
     @JsonIgnore
     default boolean isComponentProperty(Entry<String, String> e) {
-        return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && this.getProperties().get(e.getKey()).isComponentProperty();
+        return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && this.getProperties().get(e.getKey()).componentProperty();
     }
 
     @JsonIgnore
@@ -59,7 +59,7 @@ public interface WithConfigurationProperties {
 
     @JsonIgnore
     default boolean isSecret(String key) {
-        return this.getProperties() != null && this.getProperties().containsKey(key) && this.getProperties().get(key).isSecret();
+        return this.getProperties() != null && this.getProperties().containsKey(key) && this.getProperties().get(key).secret();
     }
 
     @JsonIgnore
@@ -108,7 +108,7 @@ public interface WithConfigurationProperties {
 
     @JsonIgnore
     default boolean isRaw(String key) {
-        return this.getProperties() != null && this.getProperties().containsKey(key) && this.getProperties().get(key).isRaw();
+        return this.getProperties() != null && this.getProperties().containsKey(key) && this.getProperties().get(key).raw();
     }
 
     @JsonIgnore

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -19,12 +19,12 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 
-import org.immutables.value.Value;
-
 import io.syndesis.common.model.Ordered;
 import io.syndesis.common.model.WithTags;
 import io.syndesis.common.model.connection.DynamicActionMetadata.ActionPropertySuggestion;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
@@ -56,7 +56,20 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
         String getValue();
     }
 
+    default boolean componentProperty() {
+        final Boolean value = getComponentProperty();
+        if (value != null) {
+            return Boolean.TRUE.equals(value);
+        }
+
+        return false;
+    }
+
     Boolean getComponentProperty();
+
+    Optional<String> getConnectorValue();
+
+    String getControlHint();
 
     String getDefaultValue();
 
@@ -64,15 +77,11 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getDescription();
 
-    String getControlHint();
-
-    String getLabelHint();
-
-    String getPlaceholder();
-
     String getDisplayName();
 
     List<PropertyValue> getEnum();
+
+    String getGenerator();
 
     String getGroup();
 
@@ -82,23 +91,22 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getLabel();
 
+    String getLabelHint();
+
+    String getPlaceholder();
+
+    Boolean getRaw();
+
+    List<PropertyRelation> getRelation();
+
     Boolean getRequired();
 
     Boolean getSecret();
 
     String getType();
 
-    Optional<String> getConnectorValue();
-
-    Boolean getRaw();
-
-    List<PropertyRelation> getRelation();
-
-    String getGenerator();
-
-    @JsonIgnore
-    default boolean isComponentProperty() {
-        Boolean value = getComponentProperty();
+    default boolean raw() {
+        final Boolean value = getRaw();
         if (value != null) {
             return Boolean.TRUE.equals(value);
         }
@@ -106,9 +114,8 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
         return false;
     }
 
-    @JsonIgnore
-    default boolean isSecret() {
-        Boolean value = getSecret();
+    default boolean required() {
+        final Boolean value = getRequired();
         if (value != null) {
             return Boolean.TRUE.equals(value);
         }
@@ -116,19 +123,8 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
         return false;
     }
 
-    @JsonIgnore
-    default boolean isRaw() {
-        Boolean value = getRaw();
-        if (value != null) {
-            return Boolean.TRUE.equals(value);
-        }
-
-        return false;
-    }
-
-    @JsonIgnore
-    default boolean isRequired() {
-        Boolean value = getRequired();
+    default boolean secret() {
+        final Boolean value = getSecret();
         if (value != null) {
             return Boolean.TRUE.equals(value);
         }

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/EncryptionComponent.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/EncryptionComponent.java
@@ -62,7 +62,7 @@ public class EncryptionComponent {
             // Let encrypt all the secrets
             for (Map.Entry<String, String> entry : values.entrySet()) {
                 ConfigurationProperty property = properties.get(entry.getKey());
-                if(property==null || !property.isSecret()) {
+                if(property==null || !property.secret()) {
                     continue;
                 }
                 result.put(entry.getKey(), encrypt(entry.getValue()));

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
@@ -173,7 +173,7 @@ abstract class AbstractResourceUpdateHandler<T extends WithId<T>> implements Res
         Supplier<LeveledMessage.Builder> supplier, Map<String, ConfigurationProperty> configurationProperties, Map<String, String> configuredProperties) {
 
         for (Map.Entry<String, ConfigurationProperty> entry: configurationProperties.entrySet()) {
-            if (entry.getValue().isRequired() && Strings.isNullOrEmpty(entry.getValue().getDefaultValue()) && !configuredProperties.containsKey(entry.getKey())) {
+            if (entry.getValue().required() && Strings.isNullOrEmpty(entry.getValue().getDefaultValue()) && !configuredProperties.containsKey(entry.getKey())) {
                 return Collections.singletonList(
                     supplier.get()
                         .level(LeveledMessage.Level.WARN)
@@ -197,7 +197,7 @@ abstract class AbstractResourceUpdateHandler<T extends WithId<T>> implements Res
 
             // We have a null value if it was an encrypted property that was
             // imported into a different system.
-            if (entry.getValue().isSecret() && val != null && encryptionComponent.decrypt(val) == null) {
+            if (entry.getValue().secret() && val != null && encryptionComponent.decrypt(val) == null) {
                 return Collections.singletonList(
                     supplier.get()
                         .level(LeveledMessage.Level.WARN)


### PR DESCRIPTION
We don't want to add methods to model interfaces that override the model property methods.

Fixes #4219