### PR TITLE
Match ascii-doctor-version with the version in app/pom.xml

### DIFF
--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.7.1</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>


### PR DESCRIPTION
Getting an error building doc 

[INFO] --- dependency-management-maven-plugin:0.7:analyze (default) @ syndesis-docs ---
[WARNING] Version mismatch for plugin org.asciidoctor:asciidoctor-maven-plugin, managed version 1.5.7.1 does not match project version 1.5.3

Should align asciidoctor-maven-plugin versions.