### PR TITLE
[Google Sheets] Add initial draft of user docs

### DIFF
--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -67,7 +67,7 @@
         ]
       },
       "id": "io.syndesis:sheets-create-spreadsheet-connector",
-      "name": "Create spreadsheets",
+      "name": "Create spreadsheet",
       "pattern": "To"
     },
     {
@@ -373,7 +373,7 @@
     },
     {
       "actionType": "connector",
-      "description": "Obtain sheet grid data values from a spreadsheet on your the Google Sheets account that this connection is authorized to access.",
+      "description": "Obtain data range values from a spreadsheet on your the Google Sheets account that this connection is authorized to access.",
       "descriptor": {
         "componentScheme": "google-sheets-stream",
         "connectorCustomizers": [
@@ -585,7 +585,7 @@
         ]
       },
       "id": "io.syndesis:sheets-get-spreadsheet-connector",
-      "name": "Get spreadsheets",
+      "name": "Get spreadsheet properties",
       "pattern": "From"
     },
     {

--- a/doc/connecting/master.adoc
+++ b/doc/connecting/master.adoc
@@ -11,7 +11,7 @@ include::topics/shared/attributes.adoc[]
 :context: connectors
 
 [id='connecting-to-applications-and-services']
-= Connecting {prodname} to Applications and Services 
+= Connecting {prodname} to Applications and Services
 
 To integrate applications, you create a connection to each application
 or service that you want to integrate. You then create an integration and
@@ -19,7 +19,7 @@ add a connection to it for each integration or service that you want
 to integrate.
 
 {prodname} <<supported-connectors_{context},supports numerous connectors>> that serve
-as templates for creating connections. The following topics provide 
+as templates for creating connections. The following topics provide
 details for creating connections and adding them to integrations:
 
 * <<connecting-to-s3_{context}>>
@@ -29,9 +29,10 @@ details for creating connections and adding them to integrations:
 * <<connecting-to-ftp_{context}>>
 * <<connecting-to-gmail_{context}>>
 * <<connecting-to-google-calendar_{context}>>
+* <<connecting-to-google-sheets{context}>>
 * <<connecting-to-http_{context}>>
 * <<connecting-to-log_{context}>>
-* <<connecting-to-kafka_{context}>> 
+* <<connecting-to-kafka_{context}>>
 * <<connecting-to-mqtt_{context}>>
 * <<connecting-to-rest-apis_{context}>>
 * <<connecting-to-sf_{context}>>
@@ -60,6 +61,8 @@ include::topics/as_connecting-to-ftp.adoc[leveloffset=+1]
 include::topics/as_connecting-to-gmail.adoc[leveloffset=+1]
 
 include::topics/as_connecting-to-google-calendar.adoc[leveloffset=+1]
+
+include::topics/as_connecting-to-google-sheets.adoc[leveloffset=+1]
 
 include::topics/as_connecting-to-http.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-google-sheets.adoc
+++ b/doc/connecting/topics/as_connecting-to-google-sheets.adoc
@@ -1,0 +1,54 @@
+// This assembly is included in the following assemblies:
+// Upstream: connecting/master.adoc
+// Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
+
+:context: connectors
+[id='connecting-to-google-sheets_{context}']
+= Connect to Google Sheets
+:context: sheets
+
+You can add a Google Sheets connection to an integration as its start
+connection to trigger execution of an integration. These integration start connections
+are periodic queries of spreadsheet data. You can add a Google
+Sheets connection to an integration as its finish connection when you want
+to update spreadsheet properties, update data in a spreadsheet, create charts, create pivot tables. In the middle of an integration, you can add a
+Google Sheets connection when you want to create a new spreadsheet, obtain particular spreadsheet properties,
+add or update data in a spreadsheet, create charts or create pivot tables.
+
+Details for connecting to Google Sheets are in the following topics:
+
+* <<register-with-google-sheets_{context}>>
+* <<enable-google-sheets-api_{context}>>
+* <<create-google-sheets-connection_{context}>>
+* <<add-google-sheets-connection-create-spreadsheet_{context}>>
+* <<add-google-sheets-connection-get-spreadsheet_{context}>>
+* <<add-google-sheets-connection-get-spreadsheet_{context}>>
+* <<add-google-sheets-connection-get-sheet-values_{context}>>
+* <<add-google-sheets-connection-update-sheet-values_{context}>>
+* <<add-google-sheets-connection-append-sheet-values_{context}>>
+* <<add-google-sheets-connection-add-charts_{context}>>
+* <<add-google-sheets-connection-add-pivot-tables_{context}>>
+
+include::p_register-with-google-sheets.adoc[leveloffset=+1]
+
+include::p_enable-google-sheets-api.adoc[leveloffset=+1]
+
+include::p_create-google-sheets-connection.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-create-spreadsheet.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connectionget-spreadsheet-get-spreadsheet.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connectionget-spreadsheet-update-spreadsheet.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-get-sheet-values.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-update-sheet-values.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-append-sheet-values.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-add-charts.adoc[leveloffset=+1]
+
+include::p_add-google-sheets-connection-add-pivot-tables.adoc[leveloffset=+1]
+
+:context: connectors

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-charts.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-charts.adoc
@@ -1,0 +1,82 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-add-charts_{context}']
+= Add charts to a spreadsheet on your Google Sheets account
+
+In an integration, you can add charts to a Google Sheets spreadsheet
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+[IMPORTANT]
+====
+In this release, the *Add charts* action supports charts of type *BasicChart* or *PieChart*. Each of these chart types
+provides individual options and fields for creating a new chart in a spreadsheet on your Google Sheets account. The chart options
+must be set on a data mapping step prior to the *Add Charts* action.
+====
+
+[IMPORTANT]
+====
+In this release, the *Add charts* action requires a spreadsheetId in order to
+identify the target spreadsheet that is updated with newly added charts. In most if not all cases, this means that you must add a Google
+Sheets connection that
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[creates] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-get-spreadsheet_google-sheets[obtains] the spreadsheet that you want to add charts to,
+then add the Google Sheets connection that add charts to the spreadsheet, and then
+insert a data mapper step between the two Google Sheets connections.
+====
+
+.Prerequisites
+* A Google Sheets connection is available and this connection
+is authorized to access the Google spreadsheet that
+you want to add charts to.
+* You have access to a spreadsheetId on your Google Sheets account that you want to add charts to
+* In the integration, there is an earlier connection to Google Sheets
+and that connection obtains the spreadsheetId that you want to add charts to.
+* You are creating or editing an integration and {prodname} is prompting you
+to add a finish connection or select the connection that you want to add
+in the middle of an integration.
+
+.Procedure
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Add charts*.
+. To configure the *Add charts* action:
++
+.. In the *SpreadsheetId* field, enter the identifier of the spreadsheet that you want to add charts to. If you do not have it
+you might want to link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[create] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[obtain] the spreadsheet that
+you want to update first and map the spreadsheet identifier in the data mapping step.
+.. In the *Chart Title* field, enter the chart title.
+.. In the *Subtitle* field, enter the subtitle of the chart to add.
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+. In the integration visualization flow, hover over the plus sign that is
+just before the connection that you just added and click *Add a step*.
+. Click *Data Mapper*.
+. In the data mapper, you are able to map fields from the Google Sheets connection that
+obtained the spreadsheet to the corresponding field in the Google Sheets connection that adds charts to the spreadsheet (e.g. spreadsheetId).
+In addition to that the chart options are represented as fields in the target data shape.
++
+.. To configure a new chart
+... In the *overlayPosition* field, set the cell identifier where the chart is to be placed in the spreadsheet. This field uses the Google Sheets A1 notation. The chart is
+placed at this very specific position in the spreadsheet. In case left empty the chart is added as a completely new sheet in the spreadsheet.
+... In the *spreadsheetId* field, provide a target spreadsheet identifier on your Google Sheets account that the chart is added to. You can map this from previous steps in your integration.
+... In the *title* field, specify the chart title to use when add ing the chart. Do not set this field when providing the subtitle in the connection properties.
+... In the *subtitle* field, set the chart subtitle. Do not set this field when providing the subtitle in the connection properties.
+... In the *sheetId* field, specify the target sheet identifier where the chart will be added to in the spreadsheet on your Google Sheets account.
+... In the *sourceSheetId* field, specify the source sheet identifier where the chart sources are located within the spreadsheet on your Google Sheets account.
+.. To configure a basic chart type
+... In the *type* field, set the basic chart type (one of `BAR`, `LINE`, `AREA`, `COLUMN`). The default is `COLUMN`.
+... In the *axisTitleBottom* field, set the title for the bottom axis.
+... In the *axisTitleLeft* field, set the title for the left axis.
+... In the *domainRange* field, specify the domain range of the chart. This field uses the Google Sheets A1 notation.
+... In the *dataRange* field, specify  the data range defining a single series of data in the chart. This field uses the Google Sheets A1 notation.
+.. To configure a pie chart type
+... In the *legendPosition* field, set position of the generated chart legend (one of `BOTTOM_LEGEND`, `LEFT_LEGEND`, `RIGHT_LEGEND`, `TOP_LEGEND`, `NO_LEGEND`). The default is `LEFT_LEGEND`.
+... In the *domainRange* field, specify the domain range of the chart. This field uses the Google Sheets A1 notation.
+... In the *dataRange* field, specify  the data range defining a single series of data in the chart. This field uses the Google Sheets A1 notation.
+. In the upper right, click *Done* to add the data mapper step.

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-tables.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-tables.adoc
@@ -1,0 +1,93 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-add-pivot-tables_{context}']
+= Add pivot tables to a spreadsheet on your Google Sheets account
+
+In an integration, you can add pivot tables to a Google Sheets spreadsheet
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+[IMPORTANT]
+====
+In this release, the *Add pivot tables* action supports pivot tables of type *BasicChart* or *PieChart*. Each of these pivot table types
+provides individual options and fields for creating a new pivot table in a spreadsheet on your Google Sheets account. The pivot table options
+must be set on a data mapping step prior to the *Add Charts* action.
+====
+
+[IMPORTANT]
+====
+In this release, the *Add pivot tables* action requires a spreadsheetId in order to
+identify the target spreadsheet that is updated with newly added pivot tables. In most if not all cases, this means that you must add a Google
+Sheets connection that
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[creates] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-get-spreadsheet_google-sheets[obtains] the spreadsheet that you want to add pivot tables to,
+then add the Google Sheets connection that add pivot tables to the spreadsheet, and then
+insert a data mapper step between the two Google Sheets connections.
+====
+
+.Prerequisites
+* A Google Sheets connection is available and this connection
+is authorized to access the Google spreadsheet that
+you want to add pivot tables to.
+* You have access to a spreadsheetId on your Google Sheets account that you want to add pivot tables to
+* In the integration, there is an earlier connection to Google Sheets
+and that connection obtains the spreadsheetId that you want to add pivot tables to.
+* You are creating or editing an integration and {prodname} is prompting you
+to add a finish connection or select the connection that you want to add
+in the middle of an integration.
+
+.Procedure
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Add pivot tables*.
+. To configure the *Add pivot tables* action:
++
+.. In the *SpreadsheetId* field, enter the identifier of the spreadsheet that you want to add pivot tables to. If you do not have it
+you might want to link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[create] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[obtain] the spreadsheet that
+you want to update first and map the spreadsheet identifier in the data mapping step.
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+. In the integration visualization flow, hover over the plus sign that is
+just before the connection that you just added and click *Add a step*.
+. Click *Data Mapper*.
+. In the data mapper, you are able to map fields from the Google Sheets connection that
+obtained the spreadsheet to the corresponding field in the Google Sheets connection that adds pivot tables to the spreadsheet (e.g. spreadsheetId).
+In addition to that the pivot table options are represented as fields in the target data shape.
++
+.. To configure a new pivot table
+... In the *spreadsheetId* field, provide a target spreadsheet identifier on your Google Sheets account that the pivot table is added to. You can map this from previous steps in your integration.
+... In the *sheetId* field, specify the target sheet identifier where the pivot table will be added to in the spreadsheet on your Google Sheets account.
+... In the *sourceSheetId* field, specify the source sheet identifier where the pivot table sources are located within the spreadsheet on your Google Sheets account.
+... In the *sourceRange* field, specify the source data range with series of data to build the pivot table from. This field uses the Google Sheets A1 notation.
+... In the *valueLayout* field, set the value layout to be used on the pivot table (one of `HORIZONTAL`, `VERTICAL`). The default `HORIZONTAL` defines values are laid out as columns.
+... In the *start* field, enter the cell coordinate where to start the newly created pivot table. This will be the upper left first cell of the pivot table. In case you leave this empty the pivot table it placed
+right below the source table in the very same sheet in the spreadsheet on your Google Sheets account.
+.. To add a value group
+... In the *name* field, specify the value group name
+... In the *function* field, specify a function to apply on the value group (one of `SUM`, `COUNT`, `AVERAGE`, `MAX`, `MIN`, `CUSTOM`). Default is `SUM`. Choose `CUSTOM` when defining a formula.
+... In the *formula* field, enter a custom formula that is applied to the value group. Needs the *function* to specify `CUSTOM`.
+... In the *sourceColumn* field, the column name as coordinate that builds the value group.
+.. To add a row pivot group
+... In the *label* field, enter the pivot group name
+... In the *sortOrder* field, specify a sort order that is applied to the pivot group (one of `ASCENDING`, `DESCENDING`). Default is `ASCENDING`.
+... In the *showTotals* field, enable or disable the display of the totals for this pivot group (choose one of `true` or `false`). Default is `true`.
+... In the *sourceColumn* field, the column name as coordinate that builds the pivot group.
+.. To add a column pivot group
+... In the *label* field, enter the pivot group name
+... In the *sortOrder* field, specify a sort order that is applied to the pivot group (one of `ASCENDING`, `DESCENDING`). Default is `ASCENDING`.
+... In the *showTotals* field, enable or disable the display of the totals for this pivot group (choose one of `true` or `false`). Default is `true`.
+... In the *sourceColumn* field, the column name as coordinate that builds the pivot group.
+. In the upper right, click *Done* to add the data mapper step.
+
+[IMPORTANT]
+====
+In this release, the *Add pivot table* action is limited to defining a single value group, row pivot group and column pivot group. Support for multiple groups in a single action is about to
+be added within upcoming releases. Though you can use several *Add pivot table* actions in an integration to create multiple groups on the same source.
+====
+
+

--- a/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
@@ -1,0 +1,62 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-append-sheet-values_{context}']
+= Append data to a Google Sheets spreadsheet
+
+In an integration, you can append data in a Google Sheets spreadsheet
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+[IMPORTANT]
+====
+In this release, the *Append values to a sheet* action requires a spreadsheetId in order to
+identify the target spreadsheet that this data is written to. In most if not all cases, this means that you must add a Google
+Sheets connection that
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[creates] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-get-spreadsheet_google-sheets[obtains] the spreadsheet that you want to update,
+then add the Google Sheets connection that appends values to the spreadsheet, and then
+insert a data mapper step between the two Google Sheets connections.
+====
+
+.Prerequisites
+* A Google Sheets connection is available and this connection
+is authorized to access the Google spreadsheet that
+you want to append values to.
+* You have access to a spreadsheetId on your Google Sheets account that you want to append values to
+* In the integration, there is an earlier connection to Google Sheets
+and that connection obtains the spreadsheetId that you want to append values to.
+* You are creating or editing an integration and {prodname} is prompting you
+to add a finish connection or select the connection that you want to add
+in the middle of an integration.
+
+.Procedure
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Append values to a sheet*.
+. To configure the *Append values to a sheet* action:
++
+.. In the *SpreadsheetId* field, enter the identifier of the spreadsheet that you want to append values to. If you do not have access to it
+you might want to link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[create] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[obtain] the spreadsheet that
+you want to update first and map the spreadsheet identifier in a data mapping step later on.
+.. In the *Range* field, specify the target range in the spreadsheet that you want to append values to. This field uses the Google Sheets
+A1 notation where you specify start and end coordinates including multiple rows and columns.
+.. In the *Major Dimension* field, choose the dimension (one of "ROWS" or "COLUMNS") that indicates which dimension your values apply to first
+when building the set of values to append. Major dimension *ROWS* means that the values hold a collection of rows with each row holding multiple column values.
+Major dimension *COLUMNS* means that the values hold a collection of columns with each column holding multiple row values.
+.. In the *Value Input Option* field, choose how Google Sheets should interpret the input data. Choose one of *Unspecified*, *Raw* or *User entered* (default).
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+. In the integration visualization flow, hover over the plus sign that is
+just before the connection that you just added and click *Add a step*.
+. Click *Data Mapper*.
+. In the data mapper, you are able to map fields from the Google Sheets connection that
+obtained the spreadsheet to the corresponding field in the Google Sheets connection that appends values to the spreadsheet (e.g. spreadsheetId).
+In addition to that the values to append are represented with respective fields in the target data shape.
++
+If you change the *Range* or *Major Dimension* field settings in the *Append values to a sheet* action you will be presented with different mapping options here.
+. In the upper right, click *Done* to add the data mapper step.

--- a/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
@@ -1,0 +1,32 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-create-spreadsheet_{context}']
+= Create a new spreadsheet on your Google Sheets account
+
+In an integration, you can create a new spreadsheet on your Google Sheets account
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+.Prerequisite
+You created a Google Sheets connection.
+
+.Procedure
+
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Create spreadsheet*.
+. To configure the *Create spreadsheet* action:
++
+.. In the *Title* field, enter the title of the spreadsheet to create.
+.. In the *Time Zone* field, enter the time zone the newly created spreadsheet should follow.
+.. In the *Locale* field, enter the locale of the newly created spreadsheet.
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+
+The *Create spreadsheet* returns the spreadsheet identifier for the newly created spreadsheet on your Google Sheets account.
+You can use this *SpreadsheetId* field in all following steps in your integration in order to access the newly created spreadsheet
+(e.g. when updating or appending values to that spreadsheet).

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
@@ -1,0 +1,57 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-get-sheet-values_{context}']
+= Trigger an integration when polling returns Google Sheets spreadsheet data
+
+To trigger execution of an integration upon obtaining value range data from
+a Google Sheets spreadsheet that you specify, add a Google Sheets connection to an integration as
+its start connection. When the integration is running, the Google Sheets
+connection loads data of a specific spreadsheet on your Google Sheets account at intervals that you
+control. When the connection finds some data that comply with the selected Google Sheets *Get sheet values* action, the connection
+passes the data to the next step in the integration.
+
+When a Google Sheets connection returns a range of data representing multiple rows in a spreadsheet,
+{prodname} executes the integration for each returned row.
+For example, if the poll returns a data range of 5 rows then {prodname} executes
+the integration five times.
+
+This split results functionality can be disabled with the *splitResults* option on the Google Sheets *Get sheet values* action.
+
+.Prerequisite
+You created a Google Sheets connection.
+
+.Procedure
+
+. In the {prodname} panel on the left, click *Integrations*.
+. Click *Create Integration*.
+. On the *Choose a Start Connection* page, click the Google Sheets
+connection that you want to use to start the integration.
+. On the *Choose an Action* page, click the *Get sheet values* action.
+. To configure the *Get sheet values* action:
+.. In the *SpreadsheetId* field, enter the name of a Google sheet that is
+accessible from the Google account that this Google Sheets connection
+is authorized to access.
+.. In the *Range* field, specify the target value range in a spreadsheet to obtain. This field uses the spreadsheet A1 notation
+where coordinates include a column name and a row index. The range holds a start coordinate and an end coordinate to define a set of
+rows and columns to select (e.g. "A1:C10", "A:C").
+.. In the *Major Dimension* field, describes the dimension of the returned values (one of "ROWS" or "COLUMNS") where
+the major dimension indicates which dimension results apply to first when building the set of values returned. Major dimension *ROWS* means that results will
+hold a collection of rows with each row holding multiple column values. Major dimension *COLUMNS* means that results will
+hold a collection of columns with each column holding multiple row values.
+.. In the *Split Results* field, enable or disable the automatic split of returned range values
+representing multiple rows in a spreadsheet. When enabled the connection passes each entry in the data range
+as a separate integration to the next step in the integration. When disabled the complete data range is passed as a collection
+fo values to the next step in the integration.
+.. In the *Delay* field, accept the default of 30 seconds or
+specify how often you want the integration to check the sheets.
+.. In the *Max Results* field, accept the default of *5* or
+indicate the maximum number of events that the connection
+can return for each poll.
+
+. Click *Done* to add this Google Sheets connection as the integration's
+start connection. The connection appears as the
+first step in the integration.
+
+The connection automatically inspects the specified range to obtain. Out of that range value the resulting output data shape is built
+as dynamic data shape. Following up data mapping steps are able to access the output data shape object according to the specified range value and major dimension.

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-spreadsheet.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-spreadsheet.adoc
@@ -1,0 +1,38 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-get-spreadsheet_{context}']
+= Trigger an integration when polling returns Google Sheets spreadsheet properties
+
+To trigger execution of an integration upon obtaining properties from
+a Google Sheets spreadsheet that you specify, add a Google Sheets connection to an integration as
+its start connection. When the integration is running, the Google Sheets
+connection loads properties of a specific spreadsheet on your Google Sheets account at intervals that you
+control. When the connection finds some data that comply with the selected Google Sheets *Get spreadsheet properties* action, the connection
+passes the data to the next step in the integration.
+
+.Prerequisite
+You created a Google Sheets connection.
+
+.Procedure
+
+. In the {prodname} panel on the left, click *Integrations*.
+. Click *Create Integration*.
+. On the *Choose a Start Connection* page, click the Google Sheets
+connection that you want to use to start the integration.
+. On the *Choose an Action* page, click the *Get spreadsheet properties* action.
+. To configure the *Get spreadsheet properties* action:
+.. In the *SpreadsheetId* field, enter the name of a Google sheet that is
+accessible from the Google account that this Google Sheets connection
+is authorized to access.
+.. In the *Include grid data* field, enabled or disable the inclusion of the sheet's grid data in the result. In case this option
+is enabled the returned spreadsheet data includes the sheet values as value range objects.
+.. In the *Delay* field, accept the default of 30 seconds or
+specify how often you want the integration to check the sheets.
+
+. Click *Done* to add this Google Sheets connection as the integration's
+start connection. The connection appears as the
+first step in the integration.
+
+The connection automatically inspects the specified range to obtain. Out of that range value the resulting output data shape is built
+as dynamic data shape. Following up data mapping steps are able to access the output data shape object according to the specified range value and major dimension.

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
@@ -1,0 +1,62 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-update-sheet-values_{context}']
+= Update data in a Google Sheets spreadsheet
+
+In an integration, you can update data in a Google Sheets spreadsheet
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+[IMPORTANT]
+====
+In this release, the *Update sheet values* action requires a spreadsheetId in order to
+identify the target spreadsheet that this data is written to. In most if not all cases, this means that you must add a Google
+Sheets connection that
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[creates] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-get-spreadsheet_google-sheets[obtains] the spreadsheet that you want to update,
+then add the Google Sheets connection that updates the spreadsheet, and then
+insert a data mapper step between the two Google Sheets connections.
+====
+
+.Prerequisites
+* A Google Sheets connection is available and this connection
+is authorized to access the Google spreadsheet that
+you want to update.
+* You have access to a spreadsheetId on your Google Sheets account that you want to update
+* In the integration, there is an earlier connection to Google Sheets
+and that connection obtains the spreadsheetId that you want to update.
+* You are creating or editing an integration and {prodname} is prompting you
+to add a finish connection or select the connection that you want to add
+in the middle of an integration.
+
+.Procedure
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Update sheet values*.
+. To configure the *Update sheet values* action:
++
+.. In the *SpreadsheetId* field, enter the identifier of the spreadsheet that you want to update. If you do not have access to it
+you might want to link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[create] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[obtain] the spreadsheet that
+you want to update first and map the spreadsheet identifier in a data mapping step later on.
+.. In the *Range* field, specify the target range in the spreadsheet that you want to update. This field uses the Google Sheets
+A1 notation where you specify start and end coordinates including multiple rows and columns.
+.. In the *Major Dimension* field, choose the dimension (one of "ROWS" or "COLUMNS") that indicates which dimension your values apply to first
+when building the set of values to update. Major dimension *ROWS* means that the values hold a collection of rows with each row holding multiple column values.
+Major dimension *COLUMNS* means that the values hold a collection of columns with each column holding multiple row values.
+.. In the *Value Input Option* field, choose how Google Sheets should interpret the input data. Choose one of *Unspecified*, *Raw* or *User entered* (default).
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+. In the integration visualization flow, hover over the plus sign that is
+just before the connection that you just added and click *Add a step*.
+. Click *Data Mapper*.
+. In the data mapper, you are able to map fields from the Google Sheets connection that
+obtained the spreadsheet to the corresponding field in the Google Sheets connection that updates the spreadsheet (e.g. spreadsheetId).
+In addition to that the values to update are represented with respective fields in the target data shape.
++
+If you change the *Range* or *Major Dimension* field settings in the *Update sheet values* action you will be presented with different mapping options here.
+. In the upper right, click *Done* to add the data mapper step.

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-spreadsheet.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-spreadsheet.adoc
@@ -1,0 +1,57 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='add-google-sheets-connection-update-spreadsheet_{context}']
+= Update properties of a spreadsheet on your Google Sheets account
+
+In an integration, you can update a Google Sheets spreadsheet properties
+in the middle of the integration or to finish the integration.
+To do this, add a Google Sheets connection to the middle of an integration
+or as the integration's finish connection.
+
+[IMPORTANT]
+====
+In this release, the *Update spreadsheet properties* action requires a spreadsheetId in order to
+identify the target spreadsheet that is updated. In most if not all cases, this means that you must add a Google
+Sheets connection that
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[creates] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-get-spreadsheet_google-sheets[obtains] the spreadsheet that you want to update,
+then add the Google Sheets connection that updates the spreadsheet, and then
+insert a data mapper step between the two Google Sheets connections.
+====
+
+.Prerequisites
+* A Google Sheets connection is available and this connection
+is authorized to access the Google spreadsheet that
+you want to update.
+* You have access to a spreadsheetId on your Google Sheets account that you want to update
+* In the integration, there is an earlier connection to Google Sheets
+and that connection obtains the spreadsheetId that you want to update.
+* You are creating or editing an integration and {prodname} is prompting you
+to add a finish connection or select the connection that you want to add
+in the middle of an integration.
+
+.Procedure
+. Click a Google Sheets connection that is authorized to access
+the spreadsheet that you want to connect to.
+. On the *Choose an Action* page, click *Update spreadsheet properties*.
+. To configure the *Update spreadsheet properties* action:
++
+.. In the *SpreadsheetId* field, enter the identifier of the spreadsheet that you want to update. If you do not have it
+you might want to link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[create] or
+link:{LinkFuseOnlineConnectorGuide}#add-google-sheets-connection-create-spreadsheet_google-sheets[obtain] the spreadsheet that
+you want to update first and map the spreadsheet identifier in the data mapping step.
+.. In the *Title* field, enter the title of the spreadsheet to create.
+.. In the *Time Zone* field, enter the time zone the newly created spreadsheet should follow.
+.. In the *Locale* field, enter the locale of the newly created spreadsheet.
+
+. Click *Done* to add the connection to the integration.
+The connection appears in the integration visualization flow in the
+location where you added it.
+. In the integration visualization flow, hover over the plus sign that is
+just before the connection that you just added and click *Add a step*.
+. Click *Data Mapper*.
+. In the data mapper, you are able to map fields from the Google Sheets connection that
+obtained the spreadsheet to the corresponding field in the Google Sheets connection that updates the spreadsheet (e.g. spreadsheetId).
+In addition to that the spreadsheet properties you can update are represented as fields in the target data shape.
+. In the upper right, click *Done* to add the data mapper step.

--- a/doc/connecting/topics/p_create-google-sheets-connection.adoc
+++ b/doc/connecting/topics/p_create-google-sheets-connection.adoc
@@ -1,0 +1,56 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='create-google-sheets-connection_{context}']
+= Create a Google Sheets connection
+
+When you create a Google Sheets connection, you authorize the connection to access
+the Google Sheets that are associated with one
+particular Google account. After you create a Google Sheets connection, you can
+add it to multiple integrations.
+
+.Prerequisite
+You registered your {prodname} environment as a Google client
+application as described in
+link:{LinkFuseOnlineConnectorGuide}#register-with-google-sheets_google-sheets[Register as a Google Sheets client application].
+
+.Procedure
+
+. In {prodname}, in the left panel, click *Connections* to
+display any available connections.
+. In the upper right, click *Create Connection* to display
+the available connectors. A connector is a template that
+you use to create one or more connections.
+. Click the *Google Sheets* connector.
+. In the *Configure Connection* page, click *Connect Google Sheets*,
+which takes you to a Google sign-in page.
++
+[NOTE]
+====
+If *Connect Google Sheets* does not appear, then your {prodname} environment
+is not registered as a Google client application with the Google Sheets API
+enabled. See
+link:{LinkFuseOnlineConnectorGuide}#register-with-google-sheets_google-sheets[Register as a Google Sheets client application].
+When your environment is not registered with
+Google, then when you try to create a Google Sheets connection, {prodname} displays
+multiple fields that prompt for authorization information. While you can
+create a Google Sheets connection by entering values in these fields,
+you should register with Google first, enable the Google Sheets API,
+and then create a Google Sheets connection.
+====
+. In the Google sign-in page,
+select the Google account that you want this connection to
+access from {prodname} and click *Next*.
+. In response to the *openshiftapps.com wants to access your Google Account*
+prompt, click *Allow* to return to {prodname}.
+. In the {prodname} *Connection Name* field, enter your choice of a name that
+helps you distinguish this connection from other connections.
+For example, enter `*Google Sheets Work Connection*`.
+. In the *Description* field, optionally enter any information that
+is helpful to know about this connection. For example,
+enter `*Sample Google Sheets connection
+that uses my Google work account.*`
+. In the upper right, click *Create* to see that the connection you
+created is now available. If you entered the example name, you would
+see that *Google Sheets Work Connection* appears as a connection that you can
+choose to add to an integration.

--- a/doc/connecting/topics/p_enable-gmail-api.adoc
+++ b/doc/connecting/topics/p_enable-gmail-api.adoc
@@ -4,50 +4,50 @@
 [id='enable-gmail-api_{context}']
 = Enable access to the Gmail API
 
-To be able to connect to Gmail in an integration, 
-you must register your {prodname} environment as a Google client application. 
+To be able to connect to Gmail in an integration,
+you must register your {prodname} environment as a Google client application.
 During registration, you enable the Gmail API and create credentials that
-{prodname} uses to access Google APIs that you have enabled.  
+{prodname} uses to access Google APIs that you have enabled.
 
-If you already created a connection to Google Calendar, then 
+If you already created a connection to Google Calendar or Google Sheets, then
 {prodname} has the credentials for access to enabled Google
 APIs. To be able to create a Gmail connection, you just need to
 enable the Gmail API and then in the {prodname} *Settings* page,
-copy the Google Calendar client ID and client secret to the Gmail
+copy the Google Calendar  or Google Sheets client ID and client secret to the Gmail
 settings for client ID and client secret.
 
-If you already registered your {prodname} environment as a Google client 
+If you already registered your {prodname} environment as a Google client
 application and during registration you enabled the Gmail API, then you do
 not need to follow the procedure provided here. You are ready to
-create a Gmail connection. 
+create a Gmail connection.
 
 .Prerequisite
 In the *Settings* page in your {prodname} environment, the Google
 Calendar entry displays *Edit* and *Remove*, which
-indicate that {prodname} has the credentials to access 
+indicate that {prodname} has the credentials to access
 enabled Google APIs. If *Register* appears in the Google
-Calendar entry and the Gmail entry, then you must 
-link:{LinkFuseOnlineConnectorGuide}#register-with-gmail_gmail[register your {prodname} environment as a Google client application]. 
+Calendar entry and the Gmail entry, then you must
+link:{LinkFuseOnlineConnectorGuide}#register-with-gmail_gmail[register your {prodname} environment as a Google client application].
 
 .Procedure
 
 . In a browser, go to `https://console.developers.google.com`.
 . Confirm that you are signed in to the Google account that you used
-to register your {prodname} environment as a Google client. If you 
-are not, sign in to that account.  
+to register your {prodname} environment as a Google client. If you
+are not, sign in to that account.
 . Ensure that the current Google project is the one you used for
-registration. If it is not, change to that project. 
+registration. If it is not, change to that project.
 . You should see the *APIs and Services* dashboard. If you do not, then
-in the upper left, click 
+in the upper left, click
 image:images/Hamburger.png[Navigation menu icon] and select
-*APIs and Services* > *Dashboard*. 
+*APIs and Services* > *Dashboard*.
 . Click the *Gmail API* card.
-. In the *Gmail API* page, click *ENABLE*.  
-. In the {prodname} *Settings* page: 
+. In the *Gmail API* page, click *ENABLE*.
+. In the {prodname} *Settings* page:
 .. Expand the Google Calendar entry
-.. Expand the Gmail entry. 
-.. Copy the Google Calendar client ID to the input field for the Gmail 
-client ID. 
+.. Expand the Gmail entry.
+.. Copy the Google Calendar client ID to the input field for the Gmail
+client ID.
 .. Copy the Google Calendar client secret to the input field for the Gmail
 client secret.
 .. Click *Save*,and then click *Ok*.

--- a/doc/connecting/topics/p_enable-google-calendar-api.adoc
+++ b/doc/connecting/topics/p_enable-google-calendar-api.adoc
@@ -4,52 +4,52 @@
 [id='enable-google-calendar-api_{context}']
 = Enable access to the Google Calendar API
 
-To be able to connect to Google Calendar in an integration, 
-you must register your {prodname} environment as a Google client application. 
+To be able to connect to Google Calendar in an integration,
+you must register your {prodname} environment as a Google client application.
 During registration, you enable the Google Calendar API and create credentials that
-{prodname} uses to access Google APIs that you have enabled.  
+{prodname} uses to access Google APIs that you have enabled.
 
-If you already created a connection to Gmail, then 
+If you already created a connection to Gmail or Google Sheets, then
 {prodname} has the credentials for access to enabled Google
 APIs. To be able to create a Google Calendar connection, you just need to
-enable the Google Calendar API and then copy {prodname} settings from Gmail 
+enable the Google Calendar API and then copy {prodname} settings from Gmail or Google Sheets
 to Google Calendar.
 
-If you already registered your {prodname} environment as a Google client 
+If you already registered your {prodname} environment as a Google client
 application and during registration you enabled the Google Calendar API, then you do
 not need to follow the procedure provided here. You are ready to
-create a Google Calendar connection. 
+create a Google Calendar connection.
 
 .Prerequisite
 In the *Settings* page in your {prodname} environment, the Gmail
 entry displays *Edit* and *Remove*, which
-indicate that {prodname} has the credentials to access 
+indicate that {prodname} has the credentials to access
 enabled Google APIs. If *Register* appears in the Gmail
-entry, then you must 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google-calendar_google-calendar[register your {prodname} environment as a Google client application]. 
+entry, then you must
+link:{LinkFuseOnlineConnectorGuide}#register-with-google-calendar_google-calendar[register your {prodname} environment as a Google client application].
 
 .Procedure
 
-. In a browser, go to `https://console.developers.google.com` and do the 
+. In a browser, go to `https://console.developers.google.com` and do the
 following:
 .. Confirm that you are signed in to the Google account that you used
-to register your {prodname} environment as a Google client. If you 
-are not, sign in to that account.  
+to register your {prodname} environment as a Google client. If you
+are not, sign in to that account.
 .. Ensure that the current Google project is the one you used for
-registration. If it is not, change to that project. 
+registration. If it is not, change to that project.
 .. You should see the *APIs and Services* dashboard. If you do not, then
-in the upper left, click 
+in the upper left, click
 image:images/Hamburger.png[Navigation menu icon] and select
-*APIs and Services* > *Dashboard*. 
-.. At the top of the page, click *ENABLE APIS AND SERVICES*. 
-.. In the page that appears, in the search field, enter `*Google Calendar*`. 
-.. In the search results, click the *Google Calendar* card. 
+*APIs and Services* > *Dashboard*.
+.. At the top of the page, click *ENABLE APIS AND SERVICES*.
+.. In the page that appears, in the search field, enter `*Google Calendar*`.
+.. In the search results, click the *Google Calendar* card.
 .. In the *Google Calendar API* page, click *ENABLE*.
 . In the {prodname} *Settings* page, do the following:
 .. Expand the Gmail entry.
-.. Expand the Google Calendar entry. 
-.. Copy the Gmail client ID to the input field for the Google Calendar 
-client ID. 
+.. Expand the Google Calendar entry.
+.. Copy the Gmail client ID to the input field for the Google Calendar
+client ID.
 .. Copy the Gmail client secret to the input field for the Google Calendar
 client secret.
 .. Click *Save*,and then click *Ok*.

--- a/doc/connecting/topics/p_enable-google-sheets-api.adoc
+++ b/doc/connecting/topics/p_enable-google-sheets-api.adoc
@@ -1,0 +1,58 @@
+// This module is included in the following assemblies:
+// as_connecting-to-google-sheets.adoc
+
+[id='enable-google-sheets-api_{context}']
+= Enable access to the Google Sheets API
+
+To be able to connect to Google Sheets in an integration,
+you must register your {prodname} environment as a Google client application.
+During registration, you enable the Google Sheets API and create credentials that
+{prodname} uses to access Google APIs that you have enabled.
+
+If you already created a connection to Gmail or Google Calendar, then
+{prodname} has the credentials for access to enabled Google
+APIs. To be able to create a Google Sheets connection, you just need to
+enable the Google Sheets API and then copy {prodname} settings from Gmail or Google Calendar
+to Google Sheets.
+
+If you already registered your {prodname} environment as a Google client
+application and during registration you enabled the Google Sheets API, then you do
+not need to follow the procedure provided here. You are ready to
+create a Google Sheets connection.
+
+.Prerequisite
+In the *Settings* page in your {prodname} environment, the Gmail or Google Calendar
+entry displays *Edit* and *Remove*, which
+indicate that {prodname} has the credentials to access
+enabled Google APIs. If *Register* appears in the Gmail or Google Calendar
+entry, then you must
+link:{LinkFuseOnlineConnectorGuide}#register-with-google-sheets_google-sheets[register your {prodname} environment as a Google client application].
+
+.Procedure
+
+. In a browser, go to `https://console.developers.google.com` and do the
+following:
+.. Confirm that you are signed in to the Google account that you used
+to register your {prodname} environment as a Google client. If you
+are not, sign in to that account.
+.. Ensure that the current Google project is the one you used for
+registration. If it is not, change to that project.
+.. You should see the *APIs and Services* dashboard. If you do not, then
+in the upper left, click
+image:images/Hamburger.png[Navigation menu icon] and select
+*APIs and Services* > *Dashboard*.
+.. At the top of the page, click *ENABLE APIS AND SERVICES*.
+.. In the page that appears, in the search field, enter `*Google Sheets*`.
+.. In the search results, click the *Google Sheets* card.
+.. In the *Google Sheets API* page, click *ENABLE*.
+. In the {prodname} *Settings* page, do the following:
+.. Expand the Gmail or Google Calendar entry.
+.. Expand the Google Sheets entry.
+.. Copy the Gmail or Google Calendar client ID to the input field for the Google Sheets
+client ID.
+.. Copy the Gmail or Google Calendar client secret to the input field for the Google Sheets
+client secret.
+.. Click *Save*,and then click *Ok*.
+
+.Result
+You can now create a Google Sheets connection.

--- a/doc/connecting/topics/p_register-with-gmail.adoc
+++ b/doc/connecting/topics/p_register-with-gmail.adoc
@@ -4,106 +4,106 @@
 [id='register-with-gmail_{context}']
 = Register {prodname} as a Gmail client application
 
-In an integration, to be able to connect to Gmail, 
-you must register your {prodname} environment as a Google client application. 
+In an integration, to be able to connect to Gmail,
+you must register your {prodname} environment as a Google client application.
 During registration, you enable the Gmail API and create credentials that
-{prodname} uses to access Google APIs that you have enabled. 
+{prodname} uses to access Google APIs that you have enabled.
 
 With registration in place, you can create any number of Gmail
 connections and any number of integrations that connect
-to Gmail. While each Gmail connection uses the 
-same registration, each connection can 
-access the mail for a different Google account. 
+to Gmail. While each Gmail connection uses the
+same registration, each connection can
+access the mail for a different Google account.
 
 [NOTE]
-If you already created a Google Calendar connection, then you already 
+If you already created a Google Calendar or Google Sheets connection, then you already
 created the credentials that your {prodname} environment needs to access
 enabled Google APIs. You do not need to follow the procedure documented here.
 To be able to create a Gmail connection, you
 just need to
-link:{LinkFuseOnlineConnectorGuide}#enable-gmail-api_gmail[enable the Gmail API]. 
+link:{LinkFuseOnlineConnectorGuide}#enable-gmail-api_gmail[enable the Gmail API].
 
 .Prerequisite
-You must be able to sign in to the Google account that you want to 
-use to register {prodname} as a Gmail client application. 
+You must be able to sign in to the Google account that you want to
+use to register {prodname} as a Gmail client application.
 
 .Procedure
 
-. In {prodname}, do the following:  
-.. In the left navigation panel, click *Settings*. 
-.. On the *Settings* page, near the top, to the right of the callback URL, 
+. In {prodname}, do the following:
+.. In the left navigation panel, click *Settings*.
+.. On the *Settings* page, near the top, to the right of the callback URL,
 click
-image:shared/images/CopyCallback.png[Copy Callback URL] to 
-copy the callback URL for your {prodname} environment to the clipboard. 
-You will need this URL later in this procedure. 
-. In another browser tab, go to `https://console.developers.google.com` 
+image:shared/images/CopyCallback.png[Copy Callback URL] to
+copy the callback URL for your {prodname} environment to the clipboard.
+You will need this URL later in this procedure.
+. In another browser tab, go to `https://console.developers.google.com`
 and do the following:
 .. Confirm that you are signed in to the Google account that you want to
-use to register {prodname} as a Google client application. 
-Or, choose a different Google account and sign in to that account. 
+use to register {prodname} as a Google client application.
+Or, choose a different Google account and sign in to that account.
 .. Ensure that you want to use the current Google project to grant
-authorization to {prodname}. Or, choose or create another project. 
+authorization to {prodname}. Or, choose or create another project.
 If this Google account does not already
 have a project, you must create one. For information about Google projects
 and how you might want to organize your use of projects, click the Google help
-icon in the upper right. 
-.. Enable the Gmail API as follows: 
+icon in the upper right.
+.. Enable the Gmail API as follows:
 ... You should see the *APIs and Services* dashboard. If you do not, then
 in the upper left corner, click the
 image:images/Hamburger.png[Navigation menu icon] and select
-*APIs and Services* > *Dashboard*. 
+*APIs and Services* > *Dashboard*.
 ... Click the *Gmail API* card.
-... In the *Gmail API* page, click *ENABLE*. 
-.. Give your client application a name as follows: 
-... In the page that appears, in the left navigation panel, click 
+... In the *Gmail API* page, click *ENABLE*.
+.. Give your client application a name as follows:
+... In the page that appears, in the left navigation panel, click
 *Credentials* and then on the right, click *Credentials in APIs & Services*.
-... Click the *OAuth consent screen* tab. 
+... Click the *OAuth consent screen* tab.
 ... In the page that appears, in the *Application Name* field, enter a name for the {prodname}
-client application. For example, enter `*{prodname} client application*`. 
-... Skip the other fields. 
-... Click *Save*. 
+client application. For example, enter `*{prodname} client application*`.
+... Skip the other fields.
+... Click *Save*.
 .. Obtain client application credentials as follows:
-... To the right of *Create Credentials*, click the down arrow to 
-display a menu and select *OAuth client ID*. 
+... To the right of *Create Credentials*, click the down arrow to
+display a menu and select *OAuth client ID*.
 ... In the page that appears, select *Web application* to display more content.
-... In the *Name* field, enter a name for the OAuth client ID for 
-your {prodname} environment. This is different from the name that you 
-entered for the client application itself. For example, enter 
-`OAuth client ID for {prodname}`. 
-... Skip *Authorized JavaScript origins*. 
-... In the *Authorized redirect URIs* field, paste the callback URL 
-that you copied from your {prodname} environment at the beginning of 
-this procedure. 
-... Click *Create* to display the client ID and client secret for your 
-{prodname} environment. 
+... In the *Name* field, enter a name for the OAuth client ID for
+your {prodname} environment. This is different from the name that you
+entered for the client application itself. For example, enter
+`OAuth client ID for {prodname}`.
+... Skip *Authorized JavaScript origins*.
+... In the *Authorized redirect URIs* field, paste the callback URL
+that you copied from your {prodname} environment at the beginning of
+this procedure.
+... Click *Create* to display the client ID and client secret for your
+{prodname} environment.
 .. To the right of the client ID field, click
 image:images/copy_icon.png[the Copy icon] to copy the client ID
 to your clipboard.
 
-. Return to the {prodname} *Settings* page, expand the Gmail entry, and 
-in the Gmail *Client ID* field, 
-paste the consumer client ID that you just copied. 
+. Return to the {prodname} *Settings* page, expand the Gmail entry, and
+in the Gmail *Client ID* field,
+paste the consumer client ID that you just copied.
 
-. Return to the Google developers site and to the right of the 
-client secret field, click 
+. Return to the Google developers site and to the right of the
+client secret field, click
 image:images/copy_icon.png[the Copy icon] to copy the client secret to
 your clipboard.
 
 . Return to {prodname} and do the following:
-.. In the *Settings* page, in the 
-Gmail *Client Secret* field, paste the Gmail client secret that you 
-just copied. 
-.. Click *Save*. You should get a *Registration Successful!* notification. 	
-.. Click *Ok* to collapse the fields. 
+.. In the *Settings* page, in the
+Gmail *Client Secret* field, paste the Gmail client secret that you
+just copied.
+.. Click *Save*. You should get a *Registration Successful!* notification.
+.. Click *Ok* to collapse the fields.
 
 .Results
-You can now create a Gmail connection. 
+You can now create a Gmail connection.
 
 [IMPORTANT]
-The Google client ID and Google client secret contain token refresh 
-information that ensures that your Gmail connections, and integrations 
+The Google client ID and Google client secret contain token refresh
+information that ensures that your Gmail connections, and integrations
 that have Gmail connections continuously work correctly.
 Consequently, you should *not* obtain new credentials. If you do, then you
 would need to recreate each Gmail connection, replace the old Gmail
 connections with new Gmail connections, and re-publish each
-integration that uses a Gmail connection. 
+integration that uses a Gmail connection.

--- a/doc/connecting/topics/p_register-with-google-sheets.adoc
+++ b/doc/connecting/topics/p_register-with-google-sheets.adoc
@@ -1,28 +1,28 @@
 // This module is included in the following assemblies:
-// as_connecting-to-google-calendar.adoc
+// as_connecting-to-google-sheets.adoc
 
-[id='register-with-google-calendar_{context}']
-= Register {prodname} as a Google Calendar client application
+[id='register-with-google-sheets_{context}']
+= Register {prodname} as a Google Sheets client application
 
-In an integration, to be able to connect to Google Calendar,
+In an integration, to be able to connect to Google Sheets,
 you must register your {prodname} environment as a  Google client application.
 During registration, you enable the Google
-Calendar API and create credentials that {prodname} uses to access
+Sheets API and create credentials that {prodname} uses to access
 Google APIs that you have enabled.
 
 With registration in place, you can create any number of Google
-Calendar connections and any number of integrations that connect
-to Google Calendar. While each Google Calendar connection uses the
+Sheets connections and any number of integrations that connect
+to Google Sheets. While each Google Sheets connection uses the
 same registration, each connection can
-access the calendars that belong to a different Google account.
+access the sheets that belong to a different Google account.
 
 [NOTE]
-If you already created a Gmail or Google Sheets connection, then you already
+If you already created a Gmail or Google Calendar connection, then you already
 created the credentials that your {prodname} environment needs to access
 enabled Google APIs. You do not need to follow the procedure documented here.
-To be able to create a Google Calendar connection, you just need to
-link:{LinkFuseOnlineConnectorGuide}#enable-google-calendar-api_google-calendar[enable the Google Calendar API]
-and then copy {prodname} settings from Gmail or Google Sheets to Google Calendar.
+To be able to create a Google Sheets connection, you just need to
+link:{LinkFuseOnlineConnectorGuide}#enable-google-sheets-api_google-sheets[enable the Google Sheets API]
+and then copy {prodname} settings from Gmail or Google Calendar to Google Sheets.
 
 .Procedure
 
@@ -48,11 +48,11 @@ icon in the upper right.
 in the upper left corner, click the
 image:images/Hamburger.png[Navigation menu icon] and select
 *APIs and Services* > *Dashboard*.
-.. Enable the Google Calendar API as follows:
+.. Enable the Google Sheets API as follows:
 ... At the top of the page, click *ENABLE APIS AND SERVICES*.
-... In the page that appears, in the search field, enter `*Google Calendar*`.
-... In the search results, click the *Google Calendar* card.
-... In the *Google Calendar API* page, click *ENABLE*.
+... In the page that appears, in the search field, enter `*Google Sheets*`.
+... In the search results, click the *Google Sheets* card.
+... In the *Google Sheets API* page, click *ENABLE*.
 .. Give your client application a name as follows:
 ... In the page that appears, in the left navigation panel, click
 *Credentials* and then on the right, click *Credentials in APIs & Services*.
@@ -80,8 +80,8 @@ this procedure.
 image:images/copy_icon.png[the Copy icon] to copy the client ID
 to your clipboard.
 
-. Return to the {prodname} *Settings* page, expand the Google Calendar entry,
-and in the Google Calendar *Client ID* field,
+. Return to the {prodname} *Settings* page, expand the Google Sheets entry,
+and in the Google Sheets *Client ID* field,
 paste the consumer client ID that you just copied.
 
 . Return to the Google developers site and to the right of the
@@ -90,18 +90,18 @@ image:images/copy_icon.png[the Copy icon] to copy the client secret to
 your clipboard.
 
 . Return to the {prodname} *Settings* page and do the following:
-.. In the Google Calendar *Client Secret* field, paste the Google Calendar
+.. In the Google Sheets *Client Secret* field, paste the Google Sheets
 client secret that you just copied.
 .. Click *Save*. You should get a *Registration Successful!* notification.
 .. Click *Ok* to collapse the fields.
 
 .Results
-You can now create a Google Calendar connection.
+You can now create a Google Sheets connection.
 
 [IMPORTANT]
 The Google client ID and Google client secret contain token refresh
-information that ensures that  your Google Calendar connections and integrations
-that have Google Calendar connections continuously work correctly.
+information that ensures that your Google Sheets connections and integrations
+that have Google Sheets connections continuously work correctly.
 Consequently, you should *not* obtain new credentials. If you do, then you
-would need to recreate each Google Calendar connection and re-publish each
-integration that uses a Google Calendar connection.
+would need to recreate each Google Sheets connection and re-publish each
+integration that uses a Google Sheets connection.

--- a/doc/connecting/topics/r_supported-connectors.adoc
+++ b/doc/connecting/topics/r_supported-connectors.adoc
@@ -4,27 +4,27 @@
 [id='supported-connectors_{context}']
 = Connectors that are supported by {prodname}
 
-{prodname} supports the following connectors. 
+{prodname} supports the following connectors.
 
 [options="header"]
 [cols="1,3"]
 |===
-|Name 
+|Name
 |Description
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-s3_connectors[Amazon S3]
-|Retrieve data from an Amazon S3 bucket or copy data into a bucket. 
+|Retrieve data from an Amazon S3 bucket or copy data into a bucket.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_connectors[AMQ]
-|Obtain messages from a Red Hat AMQ (ApacheMQ) broker or publish messages to 
-a Red Hat AMQ (ApacheMQ) broker. 
+|Obtain messages from a Red Hat AMQ (ApacheMQ) broker or publish messages to
+a Red Hat AMQ (ApacheMQ) broker.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-amqp_connectors[AMQP]
 |Obtain messages from an Advanced Message Queue Protocol broker or
-publish messages to an AMQP broker. 
+publish messages to an AMQP broker.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-dropbox_connectors[Dropbox]
-|Download files from Dropbox or upload files to Dropbox. 
+|Download files from Dropbox or upload files to Dropbox.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-ftp_connectors[FTP/SFTP]
 |Download files from an FTP or SFTP server or upload files to an
@@ -32,11 +32,15 @@ FTP or SFTP server.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-gmail_connectors[Gmail]
 |Obtain messages sent to a particular Gmail account and send messages
-from a particular Gmail account. 
+from a particular Gmail account.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-google-calendar_connectors[Google Calendar]
 |Obtain events from a Google Calendar that you specify or add/update
-events in a Google Calendar that you specify.  
+events in a Google Calendar that you specify.
+
+|link:{LinkFuseOnlineConnectorGuide}#connecting-to-google-sheets_connectors[Google Sheets]
+|Obtain data from Google Sheets spreadsheet that you specify, add/update
+data, create charts or create pivot tables in a Google Sheets spreadsheet that you specify.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-http_connectors[HTTP/HTTPS]
 |Connect to an HTTP or HTTPS endpoint and execute the
@@ -47,60 +51,60 @@ events in a Google Calendar that you specify.
 or publish streams of records to a Kafka topic that you specify.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-log_connectors[Log]
-|Send information about messages that an integration processes to the integration's log. 
+|Send information about messages that an integration processes to the integration's log.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-mqtt_connectors[MQTT]
 |Obtain messages from an MQ Telemetry Transport broker or publish messages
-to an MQTT broker. 
+to an MQTT broker.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-rest-apis_connectors[REST APIs]
 |Create a custom REST API client connector by uploading an OpenAPI
-schema. You can then create a connection to that REST API. 
+schema. You can then create a connection to that REST API.
 
-Create a REST API provider integration by uploading an OpenAPI schema 
+Create a REST API provider integration by uploading an OpenAPI schema
 that defines operations that trigger integration execution. See
-link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[triggering integration execution with API calls] 
+link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[triggering integration execution with API calls]
 in {NameOfFuseOnlineIntegrationGuide}.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-sf_connectors[Salesforce]
-|Create, update, fetch, or delete a Salesforce record. 
+|Create, update, fetch, or delete a Salesforce record.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-concur_connectors[SAP Concur]
-|Perform any one of a large variety of SAP Concur actions. 
+|Perform any one of a large variety of SAP Concur actions.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-servicenow_connectors[ServiceNow]
-|Obtain records from or copy records to your ServiceNow instance. 
+|Obtain records from or copy records to your ServiceNow instance.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-slack_connectors[Slack]
-|Obtain messages from a channel or send a message to a 
-Slack channel or user. 
+|Obtain messages from a channel or send a message to a
+Slack channel or user.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-databases_connectors[SQL databases]
-|Invoke a SQL statement or a SQL stored procedure on an Apache Derby, 
+|Invoke a SQL statement or a SQL stored procedure on an Apache Derby,
 MySQL, or PostgreSQL database. To connect to other types of SQL databases,
-you upload a {prodname} library extension that contains a 
-JDBC driver for that database. 
+you upload a {prodname} library extension that contains a
+JDBC driver for that database.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting_to_telegram_connectors[Telegram]
-|Obtain messages from a chat or send messages to a chat by using 
-a Telegram chat bot. 
+|Obtain messages from a chat or send messages to a chat by using
+a Telegram chat bot.
 
 |link:{LinkFuseOnlineConnectorGuide}#triggering-integrations-with-timers_connectors[Timer]
 | Set a simple timer or a `cron` timer to trigger integration execution.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-twitter_connectors[Twitter]
-|Trigger execution of an integration upon tweets that mention you or that 
-contain data you specify. 
+|Trigger execution of an integration upon tweets that mention you or that
+contain data you specify.
 
 |link:{LinkFuseOnlineConnectorGuide}#triggering-integrations-with-http-requests_connectors[Webhook]
 |Trigger integrations with HTTP `GET` or `POST` requests.
 
 |===
 
-If {prodname} does not provide a connector that you need, an 
+If {prodname} does not provide a connector that you need, an
 experienced developer can create an extension that defines a custom
-connector. For information about coding the 
-extension and creating its `.jar` file, which you upload to 
+connector. For information about coding the
+extension and creating its `.jar` file, which you upload to
 {prodname}, see:
 
 * link:{LinkToolingUserGuide}#fuseonlineextension[{NameOfToolingUserGuide}, how to use Fuse tooling to develop extensions]


### PR DESCRIPTION
Added some initial draft of user docs for Google Sheets connector. Basically following those files of Google Calendar connector.

You can access some basic field descriptions on Google Sheets objects on
https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets

Not sure if we should also link to those descriptions in the user docs (e.g. for brief description of the enum values used)

Fixes #4302