### PR TITLE
user doc: Consistently refer to OpenAPI documents, not specifications.

### DIFF
--- a/doc/connecting/topics/as_connecting-to-rest-apis.adoc
+++ b/doc/connecting/topics/as_connecting-to-rest-apis.adoc
@@ -7,7 +7,7 @@
 :context: rest
 
 In an integration, to connect to a REST API, you must have created a
-connector for that API by uploading an OpenAPI schema that
+connector for that API by uploading an OpenAPI document that
 describes the API. See 
 link:{LinkFuseOnlineIntegrationGuide}#adding-api-connectors_add-client-connector[{NameOfFuseOnlineIntegrationGuide}, Adding  REST API client connectors].
 

--- a/doc/connecting/topics/r_supported-connectors.adoc
+++ b/doc/connecting/topics/r_supported-connectors.adoc
@@ -59,9 +59,9 @@ to an MQTT broker.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-rest-apis_connectors[REST APIs]
 |Create a custom REST API client connector by uploading an OpenAPI
-schema. You can then create a connection to that REST API.
+document. You can then create a connection to that REST API.
 
-Create a REST API provider integration by uploading an OpenAPI schema
+Create a REST API provider integration by uploading an OpenAPI document
 that defines operations that trigger integration execution. See
 link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[triggering integration execution with API calls]
 in {NameOfFuseOnlineIntegrationGuide}.

--- a/doc/integrating-applications/topics/as_adding-api-connectors.adoc
+++ b/doc/integrating-applications/topics/as_adding-api-connectors.adoc
@@ -7,7 +7,7 @@
 :context: add-client-connector
 
 {prodname} can create a REST API client connector from an OpenAPI
-schema. For information about the content of the OpenAPI schema, 
+document. For information about the content of the OpenAPI document, 
 see 
 link:{LinkFuseOnlineIntegrationGuide}#developing-rest-api-client-connectors_dev-client-connector[Develop REST API client connectors]. 
 

--- a/doc/integrating-applications/topics/as_customizing.adoc
+++ b/doc/integrating-applications/topics/as_customizing.adoc
@@ -14,7 +14,7 @@ not provide a feature that you need, talk with a developer about
 your requirements. An experienced developer can help you customize
 integrations by providing any of the following:
 
-* An OpenAPI schema that {prodname} can
+* An OpenAPI document that {prodname} can
 use to create a connector for a REST API client. 
 +
 You upload this schema to
@@ -22,9 +22,9 @@ You upload this schema to
 You then use the connector to create a connection that you
 can add to an integration. For example, many retail web sites provide
 a REST API client interface that a developer can capture in an 
-OpenAPI schema.  
+OpenAPI document.  
 
-* An OpenAPI schema for a REST API service. 
+* An OpenAPI document that defines a REST API service. 
 +
 You upload this schema to {prodname}. {prodname} makes the
 API service available and provides the URL for API calls. This lets you 

--- a/doc/integrating-applications/topics/as_developing-rest-api-client-connectors.adoc
+++ b/doc/integrating-applications/topics/as_developing-rest-api-client-connectors.adoc
@@ -11,15 +11,15 @@ Representational State Transfer Application Programming Interfaces
 (REST APIs)
 that support Hypertext Transfer Protocol (HTTP).
 To do this, {prodname} requires a valid
-OpenAPI 2.0 schema that describes a REST API that you want to connect to.
-If the API service provider does not make an OpenAPI schema available
-then an experienced developer must create the OpenAPI schema.
+OpenAPI 2.0 document that describes a REST API that you want to connect to.
+If the API service provider does not make an OpenAPI document available
+then an experienced developer must create the OpenAPI document.
 
 The following topics provide information and instructions for developing
 REST API connectors:
 
 * <<about-api-client-connectors_{context}>>
-* <<guidelines-for-openapi-specifications_{context}>>
+* <<guidelines-for-openapi-documents_{context}>>
 // The following file contains content for a feature that was not actually added. 
 // So it is not linked in anywhere. But maybe some day, it will be. 
 // * <<access-token-strategy>>
@@ -28,7 +28,7 @@ REST API connectors:
 
 include::c_about-api-connectors.adoc[leveloffset=+1]
 
-include::c_guidelines-for-openapi-specifications.adoc[leveloffset=+1]
+include::c_guidelines-for-openapi-documents.adoc[leveloffset=+1]
 
 // include::access-token-strategy.adoc[leveloffset=+1]
 

--- a/doc/integrating-applications/topics/c_about-api-provider-flows.adoc
+++ b/doc/integrating-applications/topics/c_about-api-provider-flows.adoc
@@ -11,7 +11,7 @@ and finishes integration execution in the same way. In other words,
 the integration has one execution path.
  
 An API provider integration has multiple flows. Each operation that the 
-OpenAPI schema defines has its own flow, which {prodname} automatically 
+OpenAPI document defines has its own flow, which {prodname} automatically 
 creates. For each operation, you can edit its flow by:
    
 * Adding connections to the applications that need to process the data.

--- a/doc/integrating-applications/topics/c_about-api-provider-urls.adoc
+++ b/doc/integrating-applications/topics/c_about-api-provider-urls.adoc
@@ -14,13 +14,13 @@ Examples of REST clients are the `curl` utility, a web browser, the Postman app,
 and other applications that make REST calls. 
 
 
-In an integration, each operation that the OpenAPI schema defines has its own 
+In an integration, each operation that the OpenAPI document defines has its own 
 integration flow. Consequently, each operation can also have its own 
 REST API service URL. Each URL is defined by the base URL 
 and optionally by a subpath. REST API calls that trigger execution of a particular 
 integration flow specify that operation's URL. 
 
-Your OpenAPI schema determines which HTTP verbs (such as 
+Your OpenAPI document determines which HTTP verbs (such as 
 `GET`, `POST`, `DELETE` and so on) you can specify
 in calls to your REST API service URLs. Examples of calls to 
 API provider URLs are in the 

--- a/doc/integrating-applications/topics/c_description-kinds-extensions.adoc
+++ b/doc/integrating-applications/topics/c_description-kinds-extensions.adoc
@@ -16,7 +16,7 @@ SQL database, such as Oracle.
 * A single custom connector for creating connections to a particular application
 or service that you want to integrate. This is a connector extension. 
 +
-NOTE: {prodname} can use an OpenAPI schema to create a connector 
+NOTE: {prodname} can use an OpenAPI document to create a connector 
 for a REST API client. See 
 link:{LinkFuseOnlineIntegrationGuide}#developing-rest-api-client-connectors_custom[Develop a REST API client connector].
 

--- a/doc/integrating-applications/topics/c_guidelines-for-openapi-documents.adoc
+++ b/doc/integrating-applications/topics/c_guidelines-for-openapi-documents.adoc
@@ -1,14 +1,14 @@
 // This module is included in the following assemblies:
 // as_developing-rest-api-client-connectors.adoc
 
-[id='guidelines-for-openapi-specifications_{context}']
-= Guidelines for OpenAPI schemas
+[id='guidelines-for-openapi-documents_{context}']
+= Guidelines for OpenAPI documents
 
 When {prodname} creates a REST API client connector, it maps each resource
-operation in the OpenAPI schema to a connection action. The action name
-and action description come from documentation in the OpenAPI schema.
+operation in the OpenAPI document to a connection action. The action name
+and action description come from documentation in the OpenAPI document.
 
-The more detail that the OpenAPI schema provides, the more support
+The more detail that the OpenAPI document provides, the more support
 {prodname} can offer when connecting to the API. For example,
 the API definition is not required to declare data types for requests
 and responses. Without type declarations, {prodname}
@@ -16,21 +16,21 @@ defines the corresponding connection action as typeless. However, in an
 integration, you cannot add a data mapping step immediately before or
 immediately after an API connection that performs a typeless action.
 
-One remedy for this is to add more information to the OpenAPI schema.
+One remedy for this is to add more information to the OpenAPI document.
 Identify the OpenAPI resource operations that
 will map to the actions you want the API connection to perform. In the
-OpenAPI schema, ensure that there is a JSON schema that specifies
+OpenAPI document, ensure that there is a JSON schema that specifies
 each operation's request and response types.
 
 After you upload the schema, {prodname} gives you an opportunity 
 to review and edit it in Apicurio Studio, which is a visual editor for 
-designing APIs based on the OpenAPI schema. You can add more detail, 
+designing APIs based on the OpenAPI document. You can add more detail, 
 save  your updates, and {prodname} creates an API client connector hat 
 incorporates your updates. 
 
-If the OpenAPI schema for the API declares support for
+If the OpenAPI document for the API declares support for
 `application/json` content type and also `application/xml` content type
-then the connector uses the JSON format. If the OpenAPI schema
+then the connector uses the JSON format. If the OpenAPI document
 specifies `consumes` or `produces` parameters that define both
 `application/json` and `application/xml`, 
 then the connector uses the JSON format.

--- a/doc/integrating-applications/topics/c_overview-benefit-api-provider-integrations.adoc
+++ b/doc/integrating-applications/topics/c_overview-benefit-api-provider-integrations.adoc
@@ -6,7 +6,7 @@
 
 API provider integrations start with a REST API service that {prodname} 
 makes available. This REST API service is defined by an OpenAPI 2.0
-schema that you provide. 
+document that you provide. 
 
 The benefit of API provider integrations
 is that calls from REST API clients trigger execution of the integration. 
@@ -20,9 +20,9 @@ executes the integration only when the connection to Twitter finds such tweets.
 An API provider integration makes it possible to call a REST API when a 
 particular event occurs. This call
 triggers execution of the integration. To set this up, you upload an OpenAPI 2.0
-schema to {prodname}. {prodname} publishes the API and provides the URL 
+document to {prodname}. {prodname} publishes the API and provides the URL 
 where the service is available. In {prodname}, for each operation that the OpenAPI 
-schema defines, you add connections and steps that process data
+document defines, you add connections and steps that process data
 as required for the particular operation. For example, consider a human 
 resources application that calls a REST API service that {prodname} has 
 made available. Suppose the call invokes the operation that adds a new

--- a/doc/integrating-applications/topics/c_workflow-api-providers.adoc
+++ b/doc/integrating-applications/topics/c_workflow-api-providers.adoc
@@ -8,9 +8,9 @@ In {prodname}, after you click *Create Integration*, the workflow for
 creating an API provider integration is as follows.
 
 . On the *Choose a Start Connection* page, click the *API Provider* card.
-. On the *Start integration with an API call* page, upload a file that
+. On the *Start integration with an API call* page, upload a document that
 contains an OpenAPI 2.0 schema or indicate that you want to 
-create the schema now. If you upload a file, you can review and
+create the schema now. If you upload a document, you can review and
 edit it. If you select *Create from scratch*, {prodname} opens an editor
 that supports creation of OpenAPI schemas. 
 +

--- a/doc/integrating-applications/topics/p_configure-publish-api-provider-quickstart.adoc
+++ b/doc/integrating-applications/topics/p_configure-publish-api-provider-quickstart.adoc
@@ -6,7 +6,7 @@
 
 {prodname} provides an API provider quickstart integration that you can 
 import into your {prodname} environment. This quickstart includes 
-an OpenAPI schema for a task management API. After importing
+an OpenAPI document for a task management API. After importing
 the quickstart integration, you configure return codes, and then publish
 the integration. After you complete the procedure described below,
 the Task API integration is running and ready
@@ -17,7 +17,7 @@ test an API provider integration. But it is not a real-world example of
 how useful an API provider integration can be. For a real-world
 example, suppose that you already
 used {prodname} to publish several integrations. You could define an OpenAPI
-schema for triggering execution of those integrations. To do this, you
+document for triggering execution of those integrations. To do this, you
 would edit the integration flow for each OpenAPI operation to be almost the
 same as the integrations you already published. 
 

--- a/doc/integrating-applications/topics/p_create-api-provider-integration.adoc
+++ b/doc/integrating-applications/topics/p_create-api-provider-integration.adoc
@@ -5,20 +5,20 @@
 = Create an integration that is triggered by an API call
 
 To be able to invoke a call that triggers execution of an integration, you provide
-an OpenAPI schema that defines the operations that the integration
+an OpenAPI document that defines the operations that the integration
 can perform. For each operation, you specify an integration flow that
 connects to the applications and processes the integration data according to the
 requirements for that operation. 
 
 .Prerequisites
-* You can provide an OpenAPI schema for the REST API
+* You can provide an OpenAPI document for the REST API
 operations that you want the integration to perform. 
 +
 To experiment,
 https://github.com/syndesisio/syndesis-quickstarts/blob/master/api-provider/task-api.json[download the `task-api.json` file], 
-which is an OpenAPI schema for an API provider quickstart. You can
+which is an OpenAPI document for an API provider quickstart. You can
 then drag this file in when {prodname} prompts you to provide an OpenAPI
-schema. 
+document. 
 * You have a plan for the integration flow for each OpenAPI operation. 
 * You created a connection for each application or service that you want
 to add to an integration flow. 
@@ -29,20 +29,20 @@ to add to an integration flow.
 . In the upper right, click *Create Integration*. 
 . On the *Choose a Start Connection* page, click the *API Provider* card. 
 . On the *Start integration with an API call* page, if you have an OpenAPI 2.0
-schema that defines the REST API operations then upload it in one of the 
+document that defines the REST API operations then upload it in one of the 
 following ways:
 +
-* Drag and drop the file that contains the schema. 
+* Drag and drop the document that contains the schema. 
 * Click *Choose File* to navigate to and select the file that contains the
 schema. 
-* Click *Use a URL* and enter the URL for the schema. 
+* Click *Use a URL* and enter the URL for a document that contains the schema. 
 
 +
 Or, if you need to define the schema, select *Create from scratch*. 
 
 . Click *Next*. 
 +
-* If you uploaded a schema, remember that this is your only opportunity
+* If you uploaded a document, remember that this is your only opportunity
 to change it. To review or edit the schema: 
 +
 .. Click *Review/Edit* to open the Apicurio editor.
@@ -50,7 +50,7 @@ to change it. To review or edit the schema:
 .. In the upper right, click *Save* or *Cancel* to close the editor.
 .. Click *Next* and go to step 6 in this procedure. 
 
-* If you are creating a schema from scratch then in the Apicurio editor 
+* If you are creating a schema then in the Apicurio editor 
 that Syndesis opens:
 +
 .. Define the OpenAPI schema.

--- a/doc/integrating-applications/topics/p_create-integration-operation-flows.adoc
+++ b/doc/integrating-applications/topics/p_create-integration-operation-flows.adoc
@@ -4,7 +4,7 @@
 [id='create-integration-operation-flows_{context}']
 = Create the integration's operation flows
 
-The OpenAPI schema that defines your REST API service defines
+The OpenAPI document that defines your REST API service defines
 the operations that the service can perform. After you create an API
 provider integration, you can edit the
 integration flow for each operation. 

--- a/doc/integrating-applications/topics/p_creating-api-connectors.adoc
+++ b/doc/integrating-applications/topics/p_creating-api-connectors.adoc
@@ -4,11 +4,11 @@
 [id='creating-api-connectors_{context}']
 = Create REST API client connectors
 
-Upload an OpenAPI schema to enable {prodname} to create a REST API
+Upload an OpenAPI document to enable {prodname} to create a REST API
 client connector. 
 
 .Prerequisite
-You have an OpenAPI schema for the connector that you want
+You have an OpenAPI document for the connector that you want
 {prodname} to create.
 
 .Procedure
@@ -20,7 +20,7 @@ already available are listed here.
 . On the *Create API Client Connector* page, do one of the following:
 +
 * Click *Browse* and select the OpenAPI file that you want to upload.
-* Select *Use a URL* and paste the URL for your OpenAPI schema
+* Select *Use a URL* and paste the URL for your OpenAPI document
 in the input field. 
 
 . Click *Next*. If there is invalid or missing content, {prodname}
@@ -34,14 +34,14 @@ warnings about the action definitions.
 
 . If you are satisfied with the action summary, click *Next*.
 +
-Or, to revise the OpenAPI schema, in the lower right, click *Review/Edit* 
+Or, to revise the OpenAPI document, in the lower right, click *Review/Edit* 
 to open Apicurio Studio. Update the schema as needed. 
 In the upper right, click *Save* to incorporate your updates into the 
 new API client connector. Then click *Next* to continue creating the 
 API client connector. 
 +
 For details about using Apicurio Studio, see https://www.apicur.io/. 
-Sometimes, if you provide a URL for the OpenAPI schema, {prodname} 
+Sometimes, if you provide a URL for the OpenAPI document, {prodname} 
 can upload it but  cannot open it for editing. Typically, this is caused by 
 settings on the file’s host. To open the schema for editing, 
 {prodname} requires that the file host has:
@@ -58,14 +58,14 @@ want to use to access the API.
 ... *Authorization URL* is the location for registering {prodname} as
 a client of the API. Registration authorizes {prodname} to access the API.
 See link:{LinkFuseOnlineConnectorGuide}#register-with-rest-api_rest[{NameOfFuseOnlineConnectorGuide}, Register {prodname} as a REST API client]. 
-The OpenAPI schema or other
+The OpenAPI document or other
 documentation for the API should specify this URL. If it does not then
 you must contact the service provider to obtain this URL.
 ... *Access Token URL* is required for OAuth authorization. Again, the
-OpenAPI schema or other documentation for the API should provide
+OpenAPI document or other documentation for the API should provide
 this URL. If it does not then you must contact the service provider.
 . Click *Next*. {prodname} displays the connector's name,
-description, host, and base URL as indicated by the OpenAPI schema.
+description, host, and base URL as indicated by the OpenAPI document.
 For connections that you create from this connector,
 +
 ** {prodname}
@@ -73,8 +73,8 @@ concatenates the host and base URL values to define the endpoint for
 the connection. For example, if the host is `\https://example.com` and
 the base URL is `/api/v1` then the connection endpoint is
 `\https://example.com/api/v1`.
-** {prodname} applies the OpenAPI schema to data
-mapping steps. If the OpenAPI schema supports more than one schema then {prodname}
+** {prodname} applies the OpenAPI document to data
+mapping steps. If the OpenAPI document supports more than one schema then {prodname}
 uses the TLS (HTTPS) schema.
 . Review the connector details and optionally upload an icon for the connector.
 If you do not upload an icon, {prodname} generates one.
@@ -86,7 +86,7 @@ To override a value obtained from
 the OpenAPI file, edit the field value that you want to change.
 After {prodname} creates a connector,
 you cannot change it. To effect a change, you need to upload an updated
-OpenAPI schema so that {prodname} can create a new connector
+OpenAPI document so that {prodname} can create a new connector
 or you can upload the same schema and then edit it in Apicurio Studio. 
 You then continue the process for creating a new API client connector. 
 . When you are satisfied with the connector details, click *Create API Connector*.

--- a/doc/integrating-applications/topics/p_updating-api-connectors.adoc
+++ b/doc/integrating-applications/topics/p_updating-api-connectors.adoc
@@ -4,7 +4,7 @@
 [id='updating-api-connectors_{context}']
 = Update API client connectors by creating new ones
 
-When there is an update to an OpenAPI schema from which you created an
+When there is an update to an OpenAPI document from which you created an
 API client connector, and you want your API client connector to use those
 updates, you must create a new API client connector.
 You cannot directly update an API client connector. After you create
@@ -16,12 +16,12 @@ from the out-of-date connector.
 
 Be prepared to do one of the following:
 
-* Upload the updated OpenAPI schema.
+* Upload the updated OpenAPI document.
 * Upload the out-of-date schema again and update it in Apicurio Studio.
 
 .Procedure
 
-. Create a new API client connector based on the updated OpenAPI schema.
+. Create a new API client connector based on the updated OpenAPI document.
 To easily distinguish between the old connector and the new connector, 
 you  might want to specify a version number in the connector name or 
 the connector description. 

--- a/doc/integrating-applications/topics/r_providing-client-credentials.adoc
+++ b/doc/integrating-applications/topics/r_providing-client-credentials.adoc
@@ -24,7 +24,7 @@ https://access.redhat.com/support/offerings/techpreview/[Technology Preview feat
 endif::[]
 
 To specify that {prodname} should pass client credentials as parameters, 
-in the `securityDefinitions` section of the OpenAPI schema, 
+in the `securityDefinitions` section of the OpenAPI document, 
 add the `x-authorize-using-parameters` vendor extension with a setting of
 `true`. In the example
 below, the last line specifies `x-authorize-using-parameters`:

--- a/doc/integrating-applications/topics/r_refreshing-access-tokens.adoc
+++ b/doc/integrating-applications/topics/r_refreshing-access-tokens.adoc
@@ -28,7 +28,7 @@ endif::[]
 
 To specify that {prodname} should automatically try to obtain a new 
 access token in the situations described, 
-in the `securityDefinitions` section of the OpenAPI schema, 
+in the `securityDefinitions` section of the OpenAPI document, 
 add the `x-refresh-token-retry-statuses` vendor extension. The setting 
 of this extension is a comma separated list that
 specifies HTTP response status codes. When an access token's 

--- a/doc/tutorials/topics/as_amq2api-intro.adoc
+++ b/doc/tutorials/topics/as_amq2api-intro.adoc
@@ -20,9 +20,9 @@ it provides instructions for customizing
 and extending {prodname} by leading you through the procedures for:
 
 * Adding a custom data operation by uploading an extension.
-* Adding a custom REST API client connector by uploading an OpenAPI (Swagger) file.
+* Adding a custom REST API client connector by uploading an OpenAPI (Swagger) document.
 
-{prodname} provides the extension file and the OpenAPI file.
+{prodname} provides the extension file and the OpenAPI document.
 
 ifeval::["{location}" == "downstream"]
 .Prerequisite

--- a/doc/tutorials/topics/p_sf2db-confirm-works.adoc
+++ b/doc/tutorials/topics/p_sf2db-confirm-works.adoc
@@ -32,7 +32,7 @@ for your {prodname} environment. For example:
 Your {prodname} environment provides the To Do app, which has a 
 REST API for accessing a database that contains tasks. In the AMQ to REST 
 API sample integration tutorial, there are instructions for uploading an
-OpenAPI (Swagger) file for the To Do app to create an API client connector. 
+OpenAPI (Swagger) document for the To Do app to create an API client connector. 
 
 . In the *To Do App* display, you should see a notification that a new 
 lead was created in the database. 


### PR DESCRIPTION
The user doc now consistently refers to OpenAPI documents. 
Sometimes, references are to OpenAPI schemas or OpenAPI files. 