### PR TITLE
[3856] SQL connector should return all results as collection

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
@@ -15,8 +15,6 @@
  */
 package io.syndesis.connector.sql.customizer;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -42,29 +40,7 @@ public final class SqlStartConnectorCustomizer implements ComponentProxyCustomiz
     }
 
     private void doAfterProducer(Exchange exchange) {
-        final List<String> answer = new ArrayList<>();
-
         final Message in = exchange.getIn();
-        if (in.getBody(List.class) != null) {
-            @SuppressWarnings("unchecked")
-            final List<Map<String, Object>> maps = in.getBody(List.class);
-
-            if (maps != null) {
-                for (Map<String, Object> map: maps) {
-                    final String bean = JSONBeanUtil.toJSONBean(map);
-                    answer.add(bean);
-                }
-            }
-        } else {
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> singleMap = in.getBody(Map.class);
-
-            if (singleMap != null) {
-                final String bean = JSONBeanUtil.toJSONBean(singleMap);
-                answer.add(bean);
-            }
-        }
-
-        in.setBody(answer);
+        in.setBody(JSONBeanUtil.toJSONBeans(in));
     }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
@@ -40,8 +40,8 @@ public final class SqlStoredConnectorCustomizer implements ComponentProxyCustomi
 
     private void doAfterProducer(Exchange exchange) {
         @SuppressWarnings("unchecked")
-        final Map<String, Object> map = exchange.getIn().getBody(Map.class);
-        final String jsonBean = JSONBeanUtil.toJSONBean(map);
+        final Map<String, Object> body = exchange.getIn().getBody(Map.class);
+        final String jsonBean = JSONBeanUtil.toJSONBean(body);
 
         exchange.getIn().setBody(jsonBean);
     }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.connector.sql.common.JSONBeanUtil;
+import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+
+@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
+public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
+
+    // **************************
+    // Set up
+    // **************************
+
+    @Override
+    protected void doPreSetup() throws Exception {
+        try (Statement stmt = db.connection.createStatement()) {
+            //stmt.executeUpdate("DROP TABLE ADDRESS");
+            stmt.executeUpdate("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)");
+            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('East Davie Street', 100)");
+            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('Am Treptower Park', 75)");
+            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('Werner-von-Siemens-Ring', 14)");
+        }
+    }
+
+    @After
+    public void after() throws SQLException {
+        try (Statement stmt = db.connection.createStatement()) {
+            stmt.executeUpdate("DROP TABLE ADDRESS");
+        }
+    }
+
+    @Override
+    protected List<Step> createSteps() {
+        return Arrays.asList(
+            newSimpleEndpointStep(
+                "direct",
+                builder -> builder.putConfiguredProperty("name", "start")),
+            newSqlEndpointStep(
+                "sql-connector",
+                builder -> builder.putConfiguredProperty("query", "SELECT * FROM ADDRESS")),
+            newSimpleEndpointStep(
+                "log",
+                builder -> builder.putConfiguredProperty("loggerName", "test"))
+        );
+    }
+
+    // **************************
+    // Tests
+    // **************************
+
+    @Test
+    public void sqlConnectorQueryTest() {
+        List<?> results = template.requestBody("direct:start", null, List.class);
+
+        Assertions.assertThat(results).hasSize(3);
+        Properties rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(0).toString());
+        Assertions.assertThat(rowEntry).hasSize(2);
+        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("100");
+        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("East Davie Street");
+
+        rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(1).toString());
+        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("75");
+        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("Am Treptower Park");
+
+        rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(2).toString());
+        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("14");
+        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("Werner-von-Siemens-Ring");
+    }
+}


### PR DESCRIPTION
Sql connector now returning all rows of DB result set as a list of json beans. This is a base for implementing collection support on connectors introduced with https://github.com/syndesisio/syndesis/issues/3896