### PR TITLE
User doc for ServiceNow example description

### DIFF
--- a/doc/connecting/topics/as_connecting-to-servicenow.adoc
+++ b/doc/connecting/topics/as_connecting-to-servicenow.adoc
@@ -7,14 +7,16 @@
 :context: servicenow
 
 An integration can retrieve records from a ServiceNow table or add records to 
-a ServiceNow import set. To do this, you create a ServiceNow
+a ServiceNow import set, which ServiceNow uses to update a table. 
+To do this, you create a ServiceNow
 connection and then add that connection to an integration.
 For details, see:
 
 * <<create-servicenow-connection_{context}>>
 * <<add-servicenow-connection-start_{context}>>
 * <<add-servicenow-connection-finish_{context}>>
-
+* <<create-servicenow-web-service_{context}>>
+* <<example-sf-servicenow-integration_{context}>>
 
 include::p_create-servicenow-connection.adoc[leveloffset=+1]
 
@@ -22,5 +24,8 @@ include::p_add-servicenow-connection-start.adoc[leveloffset=+1]
 
 include::p_add-servicenow-connection-finish.adoc[leveloffset=+1]
 
+include::p_create-servicenow-web-service.adoc[leveloffset=+1]
+
+include::r_example-sf-servicenow-integration.adoc[leveloffset=+1]
 
 :context: connectors

--- a/doc/connecting/topics/as_connecting-to-servicenow.adoc
+++ b/doc/connecting/topics/as_connecting-to-servicenow.adoc
@@ -7,15 +7,14 @@
 :context: servicenow
 
 An integration can retrieve records from a ServiceNow table or add records to 
-a ServiceNow import set, which ServiceNow uses to update a table. To add 
-records, a prerequisite is for a ServiceNow administrator to create an 
-inbound ServiceNow web service. In an integration, to connect to ServiceNow,
+a ServiceNow import set, which ServiceNow uses to update a table. 
+In an integration, to connect to ServiceNow,
 create a ServiceNow connection and then add that connection to an integration.
 For details, see:
 
 * <<create-servicenow-connection_{context}>>
 * <<add-servicenow-connection-start_{context}>>
-* <<create-servicenow-web-service_{context}>>
+* <<create-servicenow-import-set_{context}>>
 * <<add-servicenow-connection-finish_{context}>>
 * <<example-sf-servicenow-integration_{context}>>
 
@@ -23,7 +22,7 @@ include::p_create-servicenow-connection.adoc[leveloffset=+1]
 
 include::p_add-servicenow-connection-start.adoc[leveloffset=+1]
 
-include::p_create-servicenow-web-service.adoc[leveloffset=+1]
+include::p_create-servicenow-import-set.adoc[leveloffset=+1]
 
 include::p_add-servicenow-connection-finish.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-servicenow.adoc
+++ b/doc/connecting/topics/as_connecting-to-servicenow.adoc
@@ -7,24 +7,25 @@
 :context: servicenow
 
 An integration can retrieve records from a ServiceNow table or add records to 
-a ServiceNow import set, which ServiceNow uses to update a table. 
-To do this, you create a ServiceNow
-connection and then add that connection to an integration.
+a ServiceNow import set, which ServiceNow uses to update a table. To add 
+records, a prerequisite is for a ServiceNow administrator to create an 
+inbound ServiceNow web service. In an integration, to connect to ServiceNow,
+create a ServiceNow connection and then add that connection to an integration.
 For details, see:
 
 * <<create-servicenow-connection_{context}>>
 * <<add-servicenow-connection-start_{context}>>
-* <<add-servicenow-connection-finish_{context}>>
 * <<create-servicenow-web-service_{context}>>
+* <<add-servicenow-connection-finish_{context}>>
 * <<example-sf-servicenow-integration_{context}>>
 
 include::p_create-servicenow-connection.adoc[leveloffset=+1]
 
 include::p_add-servicenow-connection-start.adoc[leveloffset=+1]
 
-include::p_add-servicenow-connection-finish.adoc[leveloffset=+1]
-
 include::p_create-servicenow-web-service.adoc[leveloffset=+1]
+
+include::p_add-servicenow-connection-finish.adoc[leveloffset=+1]
 
 include::r_example-sf-servicenow-integration.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
@@ -15,8 +15,11 @@ as the finish connection or as a middle connection.
 * The integration has a start connection.
 * You know the name of the ServiceNow import set that you want to 
 add records to. Your ServiceNow administrator can
-help you identify the appropriate import set. 
-* The ServiceNow import set must have been configured to handle the addition 
+help you identify the appropriate import set. If the import set 
+does not exist, see 
+link:{LinkFuseOnlineConnectorGuide}#create-servicenow-web-service_servicenow[Create ServiceNow web service],
+which implicitly creates an import set. 
+* The ServiceNow import set must be configured to handle the addition 
 of records.
 
 .Procedure
@@ -40,8 +43,10 @@ you want to add records to.
 
 .Results
 * {prodname} adds the connection to the integration. 
-* If a data mapper step is needed before this connection, then 
-in the integration visualization panel, 
+* Typically, a data mapper step is needed before this connection.
+In the integration visualization panel, 
 {prodname} displays 
 image:shared/images/WarningIcon.png[Data Type Mismatch] on the
-connection.
+connection. In most integrations, you need to map a source field 
+to the target field that is used as the correlation field in the 
+ServiceNow table. 

--- a/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
@@ -17,8 +17,8 @@ as the finish connection or as a middle connection.
 add records to. Your ServiceNow administrator can
 help you identify the appropriate import set. If the import set 
 does not exist, see 
-link:{LinkFuseOnlineConnectorGuide}#create-servicenow-web-service_servicenow[Create ServiceNow web service],
-which implicitly creates an import set. 
+link:{LinkFuseOnlineConnectorGuide}#create-servicenow-web-service_servicenow[Create an inbound web service in ServiceNow].
+Creation of an inbound web service implicitly creates an import set. 
 * The ServiceNow import set must be configured to handle the addition 
 of records.
 

--- a/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
@@ -17,9 +17,8 @@ as the finish connection or as a middle connection.
 add records to. Your ServiceNow administrator can
 help you identify the appropriate import set. If the import set 
 does not exist, see 
-link:{LinkFuseOnlineConnectorGuide}#create-servicenow-web-service_servicenow[Create an inbound web service in ServiceNow].
-Creation of an inbound web service implicitly creates an import set. 
-* The ServiceNow import set must be configured to handle the addition 
+link:{LinkFuseOnlineConnectorGuide}#create-servicenow-import-set_servicenow[Create an import set in ServiceNow].
+* The ServiceNow import set is configured to handle the addition 
 of records.
 
 .Procedure
@@ -36,8 +35,8 @@ that is in the location where you want to copy records to ServiceNow.
 Click *Add a connection*, and click the ServiceNow connection that you
 want to add to the integration. 
 
-. Click the *Create Record* action. 
-. Click in *The Import Set name* field and select the import set that
+. Click the *Add Record* action. 
+. Click in the *Import Set* field and select the import set that
 you want to add records to. 
 . Click *Next*. 
 

--- a/doc/connecting/topics/p_add-servicenow-connection-start.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-start.adoc
@@ -27,9 +27,9 @@ you want to use to start the integration.
 obtain records from a ServiceNow table that you select. 
 . Configure the *Retrieve Record* action: 
 
-.. Click in *The table name* field and select the table that you want
+.. Click in the *Table name* field and select the table that you want
 to obtain records from. 
-.. In *The query used to filter the result set* field, enter a ServiceNow
+.. In the *Query to filter the result set* field, enter a ServiceNow
 query. For example, consider the `state=1^impact=2` query on a table
 that keeps records about incidents. This query returns records for  new
 incidents (`state=1`) that have a medium impact (`impact=2`). 

--- a/doc/connecting/topics/p_create-servicenow-import-set.adoc
+++ b/doc/connecting/topics/p_create-servicenow-import-set.adoc
@@ -1,14 +1,15 @@
 // This module is included in the following assemblies:
 // as_connecting-to-servicenow.adoc
 
-[id='create-servicenow-web-service_{context}']
-= Create an inbound web service in ServiceNow
+[id='create-servicenow-import-set_{context}']
+= Create an import set in ServiceNow
 
 In a {prodname} integration, a ServiceNow connection cannot directly 
 update a ServiceNow table. To update ServiceNow data in an integration, 
-a prerequisite is for a ServiceNow administrator to create a ServiceNow 
-inbound web service. This implicitly creates a ServiceNow import set, 
-which is required for an integration to add data to ServiceNow. The 
+a prerequisite is an import set that stages updates for a ServiceNow table. 
+Often, the easiest way to create an import set is for
+a ServiceNow administrator to create a ServiceNow 
+inbound web service. This implicitly creates a ServiceNow import set. The 
 import set is based on the ServiceNow target table that the administrator 
 selects when creating the web service. A ServiceNow connection updates 
 this import set, and ServiceNow uses the import set to update the 

--- a/doc/connecting/topics/p_create-servicenow-web-service.adoc
+++ b/doc/connecting/topics/p_create-servicenow-web-service.adoc
@@ -23,7 +23,7 @@ You must have ServiceNow administrative privileges.
 .. In the *Target table* field, select the ServiceNow table that this service updates. 
 .. Select *Copy fields from target table*. This creates an import set that has 
 the same schema as the target table. The import set is a staging area for updating the target table.
-.. Select *Create transform map*. This enables ServiceNow to copy and transform data from the import set to the target table. 
+.. Select *Create transform map*. This map enables ServiceNow to copy and transform data from the import set to the target table. 
 
 . Click *Create* to create the web service. 
 . In the next display, under *Related Links*, click *Auto Map Matching Fields* to 
@@ -37,7 +37,7 @@ ServiceNow updates that record in the target table rather than creating a new re
 . Select the *Coalesce* checkbox to identify the field that you just selected
 as the correlation field. Without a correlation field, ServiceNow adds each 
 record in the import set to the target table.
-. Update the web service.
+. Click *Update*.
 . Confirm that the transform map was created:
 .. In ServiceNow, search for `transform map`. 
 .. Under *System Import Sets*, click *Transform Maps* to display a list of transform maps. 

--- a/doc/connecting/topics/p_create-servicenow-web-service.adoc
+++ b/doc/connecting/topics/p_create-servicenow-web-service.adoc
@@ -2,35 +2,41 @@
 // as_connecting-to-servicenow.adoc
 
 [id='create-servicenow-web-service_{context}']
-= Create a ServiceNow inbound web service
+= Create an inbound web service in ServiceNow
 
 In a {prodname} integration, a ServiceNow connection cannot directly 
-update a ServiceNow table. To update a ServiceNow table in an integration, 
-you must create a ServiceNow inbound web service, which creates a ServiceNow 
-import set that is based on the ServiceNow table that you select. A ServiceNow 
-connection updates this import set, and ServiceNow uses the import set to 
-update the corresponding ServiceNow table. 
+update a ServiceNow table. To update ServiceNow data in an integration, 
+a prerequisite is for a ServiceNow administrator to create a ServiceNow 
+inbound web service. This implicitly creates a ServiceNow import set, 
+which is required for an integration to add data to ServiceNow. The 
+import set is based on the ServiceNow target table that the administrator 
+selects when creating the web service. A ServiceNow connection updates 
+this import set, and ServiceNow uses the import set to update the 
+corresponding ServiceNow table.
 
 .Prerequisites
 You must have ServiceNow administrative privileges. 
 
-.Procedure
+.Procedure in ServiceNow
 
 . In ServiceNow, search for `web services`. 
 . In the results, under *System Web Services* > *Inbound*, click *Create New*. 
 . In the *Create Web Service* page, enter the required information, including:
-.. In the *Label* field, specify the display name for the web service. The web service's import set will also have this name. 
+.. In the *Label* field, specify the display name for the web service. 
+The web service's import set will also have this name. 
 .. In the *Target table* field, select the ServiceNow table that this service updates. 
 .. Select *Copy fields from target table*. This creates an import set that has 
-the same schema as the target table. The import set is a staging area for updating the target table.
-.. Select *Create transform map*. This map enables ServiceNow to copy and transform data from the import set to the target table. 
+the same schema as the target table. The import set is a staging area for 
+updating the target table.
+.. Select *Create transform map*. This map enables ServiceNow to copy and 
+transform data from the import set to the target table. 
 
 . Click *Create* to create the web service. 
 . In the next display, under *Related Links*, click *Auto Map Matching Fields* to 
 display a list of fields in the target table that you selected. 
 . Select one target table field to be the correlation (or coalesce) field. 
 +
-When the value of the correlation field of a record in the import set 
+When the value of the correlation field in a record in the import set 
 matches the value of a correlation field in the target table, 
 ServiceNow updates that record in the target table rather than creating a new record. 
 
@@ -43,3 +49,6 @@ record in the import set to the target table.
 .. Under *System Import Sets*, click *Transform Maps* to display a list of transform maps. 
 .. In this list, confirm that there is a transform map whose name is 
 the value that you specified for the label of the web service that you created. 
+
+.Additional resource
+link:https://docs.servicenow.com/bundle/london-platform-administration/page/administer/import-sets/reference/import-sets-landing-page.html[ServiceNow documentation for import sets]

--- a/doc/connecting/topics/p_create-servicenow-web-service.adoc
+++ b/doc/connecting/topics/p_create-servicenow-web-service.adoc
@@ -7,8 +7,8 @@
 In a {prodname} integration, a ServiceNow connection cannot directly 
 update a ServiceNow table. To update a ServiceNow table in an integration, 
 you must create a ServiceNow inbound web service, which creates a ServiceNow 
-info set that is based on the ServiceNow table that you select. A ServiceNow 
-connection updates this info set, and ServiceNow uses the info set to 
+import set that is based on the ServiceNow table that you select. A ServiceNow 
+connection updates this import set, and ServiceNow uses the import set to 
 update the corresponding ServiceNow table. 
 
 .Prerequisites
@@ -19,22 +19,24 @@ You must have ServiceNow administrative privileges.
 . In ServiceNow, search for `web services`. 
 . In the results, under *System Web Services* > *Inbound*, click *Create New*. 
 . In the *Create Web Service* page, enter the required information, including:
-.. In the *Label* field, specify the display name for the web service. The web service's info set will also have this name. 
+.. In the *Label* field, specify the display name for the web service. The web service's import set will also have this name. 
 .. In the *Target table* field, select the ServiceNow table that this service updates. 
-.. Select *Copy fields from target table*. This creates an import set that is a clone of the target table. 
-.. Select *Create transform map*. This enables ServiceNow to copy and transform data from the info set to the target table. 
+.. Select *Copy fields from target table*. This creates an import set that has 
+the same schema as the target table. The import set is a staging area for updating the target table.
+.. Select *Create transform map*. This enables ServiceNow to copy and transform data from the import set to the target table. 
 
 . Click *Create* to create the web service. 
 . In the next display, under *Related Links*, click *Auto Map Matching Fields* to 
 display a list of fields in the target table that you selected. 
-. Select one target table field to be the correlation field. 
+. Select one target table field to be the correlation (or coalesce) field. 
 +
-When the value of the correlation field of a record in the info set 
+When the value of the correlation field of a record in the import set 
 matches the value of a correlation field in the target table, 
 ServiceNow updates that record in the target table rather than creating a new record. 
 
 . Select the *Coalesce* checkbox to identify the field that you just selected
-as the correlation field. 
+as the correlation field. Without a correlation field, ServiceNow adds each 
+record in the import set to the target table.
 . Update the web service.
 . Confirm that the transform map was created:
 .. In ServiceNow, search for `transform map`. 

--- a/doc/connecting/topics/p_create-servicenow-web-service.adoc
+++ b/doc/connecting/topics/p_create-servicenow-web-service.adoc
@@ -1,0 +1,43 @@
+// This module is included in the following assemblies:
+// as_connecting-to-servicenow.adoc
+
+[id='create-servicenow-web-service_{context}']
+= Create a ServiceNow inbound web service
+
+In a {prodname} integration, a ServiceNow connection cannot directly 
+update a ServiceNow table. To update a ServiceNow table in an integration, 
+you must create a ServiceNow inbound web service, which creates a ServiceNow 
+info set that is based on the ServiceNow table that you select. A ServiceNow 
+connection updates this info set, and ServiceNow uses the info set to 
+update the corresponding ServiceNow table. 
+
+.Prerequisites
+You must have ServiceNow administrative privileges. 
+
+.Procedure
+
+. In ServiceNow, search for `web services`. 
+. In the results, under *System Web Services* > *Inbound*, click *Create New*. 
+. In the *Create Web Service* page, enter the required information, including:
+.. In the *Label* field, specify the display name for the web service. The web service's info set will also have this name. 
+.. In the *Target table* field, select the ServiceNow table that this service updates. 
+.. Select *Copy fields from target table*. This creates an import set that is a clone of the target table. 
+.. Select *Create transform map*. This enables ServiceNow to copy and transform data from the info set to the target table. 
+
+. Click *Create* to create the web service. 
+. In the next display, under *Related Links*, click *Auto Map Matching Fields* to 
+display a list of fields in the target table that you selected. 
+. Select one target table field to be the correlation field. 
++
+When the value of the correlation field of a record in the info set 
+matches the value of a correlation field in the target table, 
+ServiceNow updates that record in the target table rather than creating a new record. 
+
+. Select the *Coalesce* checkbox to identify the field that you just selected
+as the correlation field. 
+. Update the web service.
+. Confirm that the transform map was created:
+.. In ServiceNow, search for `transform map`. 
+.. Under *System Import Sets*, click *Transform Maps* to display a list of transform maps. 
+.. In this list, confirm that there is a transform map whose name is 
+the value that you specified for the label of the web service that you created. 

--- a/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
+++ b/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
@@ -22,15 +22,16 @@ an integration to add data to ServiceNow. For this example:
 * The name of the web service is *Cases from Salesforce*.
 * The service's target table is *Incidents*. This is the table that
 contains the data to be updated.
-* Selection of *Copy fields from target table* creates an import 
-set that has the same schema as the *Incidents* table. The name of the
+* The import set has the same schema as the *Incidents* table
+because of the selection of *Copy fields from target table*. The name of the
 import set is also *Cases from Salesforce*. 
-* Selection of *Create transform map* enables ServiceNow to copy and 
-transform data from the *Cases from Salesforce* import set to the
-*Incidents* target table. 
-* In the import set, the `correlation_Id` field is selected and then the
-*Coalesce* checkbox is selected. This sets the `correlation_Id` field
-as the correlation field in the import set. 
+* ServiceNow can copy and transform data from the *Cases from Salesforce*
+import set to the *Incidents* target table because of the selection of
+*Create transform map*.
+
+* In the import set, the correlation field is `correlation_Id` because 
+of the selection of the `correlation_Id` field followed by selection of the
+*Coalesce* checkbox.
 
 .Procedure overview (in {prodname})
 In {prodname}, you create the Salesforce and ServiceNow connections.
@@ -65,9 +66,12 @@ This ServiceNow connection adds new or updated Salesforce cases to the
 * Salesforce `subject` to the ServiceNow `short_description`
 * Salesforce `description` to the ServiceNow `description`
 
-Give the integration a name and then publish it. For this example, 
-the integration names are *On SF Create Case* and *On SF Update Case*. 
+. Give the integration a name and then publish it. 
 
+* For the integration that obtains new cases, use *On SF Create Case*.
+* For the integration that obtains updated cases, *On SF Update Case*. 
+
+.Confirm that the integrations work
 When both integrations are
 running, you can confirm that the integrations work:
 
@@ -76,7 +80,7 @@ running, you can confirm that the integrations work:
 Click its *Activity* tab to see that {prodname} executed the integration once. 
 . In ServiceNow, view the *Incidents* table. You should see a new incident that
 has the subject and description that you specified in Salesforce. 
-. Back in Salesforce, update the case you just created by changing 
+. Back in Salesforce, update the case that you just created by changing 
 its subject. 
 . In {prodname}, view the summary for the *On SF Update Case* integration. 
 Click its *Activity* tab to see that {prodname} executed the integration once. 

--- a/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
+++ b/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
@@ -1,0 +1,87 @@
+// This module is included in the following assemblies:
+// as_connecting-to-servicenow.adoc
+
+[id='example-sf-servicenow-integration_{context}']
+= Example Salesforce to ServiceNow integrations
+
+This example describes two integrations:
+
+* One integration obtains new
+cases from Salesforce and adds them as incidents to ServiceNow. 
+
+* The other integration obtains updated
+cases from Salesforce and then updates a corresponding
+incident in ServiceNow. 
+
+For both integrations, a prerequisite is for a ServiceNow
+administrator to create an inbound web service. 
+This implicitly creates a ServiceNow info set, which is required for 
+an integration to add data to ServiceNow. For this example:
+
+* The name of the web service is *Cases from Salesforce*.
+* The service's target table is *Incidents*. This is the table that
+contains the data to be updated.
+* Selection of *Copy fields from target table* creates an import 
+set that is a clone of the target table. The name of the
+info set is also *Cases from Salesforce*. 
+* Selection of *Create transform map* enables ServiceNow to copy and 
+transform data from the *Cases from Salesforce* info set to the
+*Incidents* target table. 
+* In the info set, the `correlation_Id` field was selected and then the
+*Coalesce* checkbox was selected. This sets the `correlation_Id` field
+as the correlation field in the info set. 
+
+In {prodname}, you create the Salesforce and ServiceNow connections.
+
+The two integrations are the same except for the action performed
+by the Salesforce connection. This is noted in the following steps.
+To create the integrations, you would perform these steps twice, 
+that is, once to create each integration: 
+
+. Add the Salesforce connection as the start connection. 
++
+* To create the integration that obtains new cases, select the
+*On create* action. 
+* To create the integration that obtains updated cases, select the 
+*On update* action. 
++
+Select the *Case* object for the action to operate on. 
+This Salesforce connection returns new *Case* objects or 
+updated *Case* objects according to the chosen action.
+
+. Add the ServiceNow connection as the finish connection,
+select the *Create Record* action, and select *Cases from Salesforce* 
+as the import set that the integration updates. 
+This ServiceNow connection adds new or updated Salesforce cases to the
+*Cases from Salesforce* info set. 
+
+. Add a data mapper step that maps:
++
+* Salesforce case `id` to the ServiceNow info set's `correlation_Id`
+* Salesforce `subject` to the ServiceNow `short_description`
+* Salesforce `description` to the ServiceNow `description`
+
+Give the integration a name and publish it. For this example, 
+the integration names are *On SF Create Case* and *On SF Update Case*. 
+
+When both integrations are
+running, you can confirm that the integrations work:
+
+. In Salesforce, create a case.
+. In {prodname}, view the summary for the *On SF Create Case* integration.
+Click its *Activity* tab to see that {prodname} executed the integration once. 
+. In ServiceNow, view the *Incidents* table. You should see a new incident that
+has the subject and description that you specified in Salesforce. 
+. Back in Salesforce, update the case you just created by changing 
+its subject. 
+. In {prodname}, view the summary for the *On SF Update Case* integration. 
+Click its *Activity* tab to see that {prodname} executed the integration once. 
+. In ServiceNow, view the *Incidents* table and expand the entry for the
+incident that was previously new. You should
+see that this incident, has an updated `short_description` value. 
+ServiceNow checks the info set entry for the value of its `correlation_Id`. If
+this value already exists in the *Incidents* table, then ServiceNow updates 
+the incident that has that value. 
+
+
+. 

--- a/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
+++ b/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
@@ -13,6 +13,7 @@ cases from Salesforce and adds them as incidents to ServiceNow.
 cases from Salesforce and then updates a corresponding
 incident in ServiceNow. 
 
+.Prerequisite (in ServiceNow)
 For both integrations, a prerequisite is for a ServiceNow
 administrator to create an inbound web service. 
 This implicitly creates a ServiceNow import set, which is required for 
@@ -27,14 +28,15 @@ import set is also *Cases from Salesforce*.
 * Selection of *Create transform map* enables ServiceNow to copy and 
 transform data from the *Cases from Salesforce* import set to the
 *Incidents* target table. 
-* In the import set, the `correlation_Id` field was selected and then the
-*Coalesce* checkbox was selected. This sets the `correlation_Id` field
+* In the import set, the `correlation_Id` field is selected and then the
+*Coalesce* checkbox is selected. This sets the `correlation_Id` field
 as the correlation field in the import set. 
 
+.Procedure overview (in {prodname})
 In {prodname}, you create the Salesforce and ServiceNow connections.
 
 The two integrations are the same except for the action performed
-by the Salesforce connection. This is noted in the following steps.
+by the Salesforce connection, as noted in the following steps.
 To create the integrations, you would perform these steps twice, 
 that is, once to create each integration: 
 
@@ -44,14 +46,16 @@ that is, once to create each integration:
 *On create* action. 
 * To create the integration that obtains updated cases, select the 
 *On update* action. 
-+
-Select the *Case* object for the action to operate on. 
+
+. Select the *Case* object for the action to operate on. 
 This Salesforce connection returns new *Case* objects or 
 updated *Case* objects according to the chosen action.
 
-. Add the ServiceNow connection as the finish connection,
-select the *Create Record* action, and select *Cases from Salesforce* 
+. Add the ServiceNow connection as the finish connection.
+
+. Select the *Create Record* action, and then select *Cases from Salesforce* 
 as the import set that the integration updates. 
++
 This ServiceNow connection adds new or updated Salesforce cases to the
 *Cases from Salesforce* import set. 
 
@@ -61,7 +65,7 @@ This ServiceNow connection adds new or updated Salesforce cases to the
 * Salesforce `subject` to the ServiceNow `short_description`
 * Salesforce `description` to the ServiceNow `description`
 
-Give the integration a name and publish it. For this example, 
+Give the integration a name and then publish it. For this example, 
 the integration names are *On SF Create Case* and *On SF Update Case*. 
 
 When both integrations are

--- a/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
+++ b/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
@@ -15,21 +15,21 @@ incident in ServiceNow.
 
 For both integrations, a prerequisite is for a ServiceNow
 administrator to create an inbound web service. 
-This implicitly creates a ServiceNow info set, which is required for 
+This implicitly creates a ServiceNow import set, which is required for 
 an integration to add data to ServiceNow. For this example:
 
 * The name of the web service is *Cases from Salesforce*.
 * The service's target table is *Incidents*. This is the table that
 contains the data to be updated.
 * Selection of *Copy fields from target table* creates an import 
-set that is a clone of the target table. The name of the
-info set is also *Cases from Salesforce*. 
+set that has the same schema as the *Incidents* table. The name of the
+import set is also *Cases from Salesforce*. 
 * Selection of *Create transform map* enables ServiceNow to copy and 
-transform data from the *Cases from Salesforce* info set to the
+transform data from the *Cases from Salesforce* import set to the
 *Incidents* target table. 
-* In the info set, the `correlation_Id` field was selected and then the
+* In the import set, the `correlation_Id` field was selected and then the
 *Coalesce* checkbox was selected. This sets the `correlation_Id` field
-as the correlation field in the info set. 
+as the correlation field in the import set. 
 
 In {prodname}, you create the Salesforce and ServiceNow connections.
 
@@ -53,11 +53,11 @@ updated *Case* objects according to the chosen action.
 select the *Create Record* action, and select *Cases from Salesforce* 
 as the import set that the integration updates. 
 This ServiceNow connection adds new or updated Salesforce cases to the
-*Cases from Salesforce* info set. 
+*Cases from Salesforce* import set. 
 
 . Add a data mapper step that maps:
 +
-* Salesforce case `id` to the ServiceNow info set's `correlation_Id`
+* Salesforce case `id` to the ServiceNow import set's `correlation_Id`
 * Salesforce `subject` to the ServiceNow `short_description`
 * Salesforce `description` to the ServiceNow `description`
 
@@ -79,7 +79,7 @@ Click its *Activity* tab to see that {prodname} executed the integration once.
 . In ServiceNow, view the *Incidents* table and expand the entry for the
 incident that was previously new. You should
 see that this incident, has an updated `short_description` value. 
-ServiceNow checks the info set entry for the value of its `correlation_Id`. If
+ServiceNow checks the import set entry for the value of its `correlation_Id`. If
 this value already exists in the *Incidents* table, then ServiceNow updates 
 the incident that has that value. 
 


### PR DESCRIPTION
Ready to merge.
This adds a description of a SF to ServiceNow example integration. It also adds instructions for how to create an import set in ServiceNow, which is required for a connection to update a ServiceNow table. 
Reviewed and approved by Luca and by QE - Matej. 