### PR TITLE
fix: make sure to perform the database reset

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/backend/BackendController.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/backend/BackendController.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.util.backend;
+
+public interface BackendController {
+
+    void start();
+
+    void stop();
+
+}

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/KubernetesSupport.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/KubernetesSupport.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -74,7 +75,7 @@ public class KubernetesSupport {
             String podLogUrl = url.toString();
 
             Thread.currentThread().setName("Logs Controller [running], request: " + podLogUrl);
-            Request request = new Request.Builder().url(new URL(podLogUrl)).get().build();
+            Request request = new Request.Builder().url(new URL(podLogUrl)).get().tag("log-watcher").build();
             OkHttpClient clone = okHttpClient.newBuilder()
                 .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
                 .build();
@@ -116,5 +117,10 @@ public class KubernetesSupport {
 
     public void setReadTimeout(final Duration readTimeout) {
         this.readTimeout = readTimeout;
+    }
+
+    void cancelAllRequests() {
+        final Dispatcher dispatcher = okHttpClient.dispatcher();
+        dispatcher.cancelAll();
     }
 }

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -107,11 +107,16 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         // May not be exposed (resources not present)
         removeExposure(sName);
 
+        final boolean removedImageStreams = removeImageStreams(sName);
+        final boolean removedDeploymentConfig = removeDeploymentConfig(sName);
+        final boolean removedSecret = removeSecret(sName);
+        final boolean removeBuildConfig = removeBuildConfig(sName);
+
         return
-            removeImageStreams(sName) &&
-            removeDeploymentConfig(sName) &&
-            removeSecret(sName) &&
-            removeBuildConfig(sName);
+            removedImageStreams &&
+            removedDeploymentConfig &&
+            removedSecret &&
+            removeBuildConfig;
     }
 
     @Override


### PR DESCRIPTION
This ensures that the controllers running on separate threads are stopped before database reset and restarted after database reset. Any database connections that might be opened at the point of a database reset are forcefully reset to make sure they're not preventing the `TRUNCATE`.

Fixes #4308