### PR TITLE
fix(ui): switch logo width from percentage to rem

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -28,7 +28,7 @@ body.cards-pf {
     margin: 6px 0 0 25px;
     white-space: nowrap;
     #appLogo {
-      width: 39%;
+      width: 11.7rem;
       height: auto;
     }
     .navbar-brand-icon {


### PR DESCRIPTION
Using percentage seems to be causing Firefox to calculate the percentage
across the whole page width.

![screenshot_2019-02-06 syndesis](https://user-images.githubusercontent.com/1306050/52341787-d6eb4980-2a13-11e9-9a44-c8c247ac0f8d.png)
