### PR TITLE
feat(ui): API Provider editor pane-based layout

### DIFF
--- a/app/ui/src/app/common/openapi/editor/editor.component.scss
+++ b/app/ui/src/app/common/openapi/editor/editor.component.scss
@@ -7,6 +7,9 @@
     display: flex;
     flex-flow: column;
 
+    border-top: 2px solid transparent;
+    box-shadow: 0 1px 1px rgba(3, 3, 3, 0.175);
+
     &__header {
       display: flex;
       justify-content: space-between;

--- a/app/ui/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.scss
+++ b/app/ui/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.scss
@@ -3,3 +3,8 @@
     border-right: 0 !important;
   }
 }
+
+:host-context(.card-pf-heading) /deep/ .toolbar-pf {
+  border-bottom: 0 !important;
+  box-shadow: none !important;
+}

--- a/app/ui/src/app/integration/api-provider/editor-page/index.ts
+++ b/app/ui/src/app/integration/api-provider/editor-page/index.ts
@@ -1,0 +1,2 @@
+export * from './integration-api-provider-editor-page.component';
+export * from './integration-api-provider-editor-toolbar.component';

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
@@ -3,52 +3,34 @@
   [content]="content"
 >
   <ng-template #content>
-    <div class="row">
-      <div class="col-md-12">
-        <ol class="breadcrumb">
+    <div class="integrations edit row">
+      <div class="header">
+        <ol class="syn-breadcrumb">
           <li>
-            &lt;&lt;<a [routerLink]="['/integrations']">All Integrations</a>
-          </li>
-          <li>
-            <a
-              [routerLink]="[
-                '/integrations',
-                currentFlowService.integration.id
-              ]"
-              >{{ currentFlowService.integration.name }}</a
-            >
+            <i class="fa fa-angle-double-left"></i>
+            <a [routerLink]="['/integrations']">All Integrations</a>
           </li>
         </ol>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-12">
         <syndesis-integration-flow-toolbar
           [isApiProvider]="true"
           [hideOperationsButton]="false"
         ></syndesis-integration-flow-toolbar>
       </div>
-    </div>
-    <div class="row">
-      <div class="col-md-2">
+      <div class="content">
         <syndesis-integration-api-provider-operations-list
           [flows$]="currentFlowService.flows$"
           [integrationId]="currentFlowService.integration.id"
           [showDescription]="false"
           [showToolbar]="false"
+          class="operations"
         ></syndesis-integration-api-provider-operations-list>
-      </div>
-      <div class="col-md-10">
-        <div class="row">
-          <div class="col-md-12">
-            <syndesis-integration-flow-page-header></syndesis-integration-flow-page-header>
+        <div class="main-panel">
+          <syndesis-integration-flow-view
+            class="flow"
+          ></syndesis-integration-flow-view>
+          <div class="form">
+            <router-outlet></router-outlet>
           </div>
-        </div>
-        <div class="row">
-          <div class="col-md-2">
-            <syndesis-integration-flow-view></syndesis-integration-flow-view>
-          </div>
-          <div class="col-md-10"><router-outlet></router-outlet></div>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
@@ -11,10 +11,7 @@
             <a [routerLink]="['/integrations']">All Integrations</a>
           </li>
         </ol>
-        <syndesis-integration-flow-toolbar
-          [isApiProvider]="true"
-          [hideOperationsButton]="false"
-        ></syndesis-integration-flow-toolbar>
+        <syndesis-integration-api-provider-operation-editor-toolbar></syndesis-integration-api-provider-operation-editor-toolbar>
       </div>
       <div class="content">
         <syndesis-integration-api-provider-operations-list
@@ -28,9 +25,7 @@
           <syndesis-integration-flow-view
             class="flow"
           ></syndesis-integration-flow-view>
-          <div class="form">
-            <router-outlet></router-outlet>
-          </div>
+          <div class="form"><router-outlet></router-outlet></div>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
@@ -18,11 +18,25 @@
         ></syndesis-integration-api-provider-operation-editor-toolbar>
       </div>
       <div class="content">
-        <div class="main-panel">
-          <syndesis-integration-flow-view
-            class="flow"
-          ></syndesis-integration-flow-view>
-          <div class="form"><router-outlet></router-outlet></div>
+        <div class="card-pf">
+          <div class="card-pf-heading">
+            <div class="card-pf-title">
+              <integration-api-provider-operation-description
+                [description]="currentFlowService.getCurrentFlowDescription()"
+              ></integration-api-provider-operation-description>
+              {{ currentFlowService.getCurrentFlowName() }}
+            </div>
+          </div>
+          <div class="card-pf-body">
+            <div class="main-panel">
+              <syndesis-integration-flow-view
+                class="flow"
+              ></syndesis-integration-flow-view>
+              <div class="form">
+                <router-outlet></router-outlet>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
@@ -24,7 +24,9 @@
               <integration-api-provider-operation-description
                 [description]="currentFlowService.getCurrentFlowDescription()"
               ></integration-api-provider-operation-description>
-              {{ currentFlowService.getCurrentFlowName() }}
+              <span>
+                {{ currentFlowService.getCurrentFlowName() }}
+              </span>
             </div>
           </div>
           <div class="card-pf-body">

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.html
@@ -11,16 +11,13 @@
             <a [routerLink]="['/integrations']">All Integrations</a>
           </li>
         </ol>
-        <syndesis-integration-api-provider-operation-editor-toolbar></syndesis-integration-api-provider-operation-editor-toolbar>
+        <syndesis-integration-api-provider-operation-editor-toolbar
+          [showOperationsButton]="true"
+          [currentFlow]="currentFlowService.currentFlow$ | async"
+          [flows]="currentFlowService.flows$ | async"
+        ></syndesis-integration-api-provider-operation-editor-toolbar>
       </div>
       <div class="content">
-        <syndesis-integration-api-provider-operations-list
-          [flows$]="currentFlowService.flows$"
-          [integrationId]="currentFlowService.integration.id"
-          [showDescription]="false"
-          [showToolbar]="false"
-          class="operations"
-        ></syndesis-integration-api-provider-operations-list>
         <div class="main-panel">
           <syndesis-integration-flow-view
             class="flow"

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
@@ -8,7 +8,6 @@
   .content {
     display: flex;
     flex: 1;
-    padding: 20px;
 
     .card-pf {
       flex: 1;
@@ -16,6 +15,8 @@
       flex-flow: column;
       margin: 0;
       background: transparent;
+      border: 0;
+      box-shadow: 0;
 
       .card-pf-heading {
         margin-bottom: 0;
@@ -24,6 +25,12 @@
 
       .card-pf-title {
         display: flex;
+
+        > span {
+          font-weight: bold;
+          flex: 1;
+          padding-left: 20px;
+        }
       }
 
       .card-pf-body {
@@ -46,6 +53,10 @@
 
       .form {
         flex: 1 1 100%;
+
+        /deep/ .blank-slate-pf {
+          border: 0 none;
+        }
       }
     }
   }

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
@@ -10,7 +10,20 @@
     flex: 1;
 
     .operations {
+      flex: 0 0 400px;
+    }
+
+    .main-panel {
       flex: 1 1 auto;
+      display: flex;
+
+      .flow {
+        flex: 1 0 auto;
+      }
+
+      .form {
+        flex: 1 1 auto;
+      }
     }
   }
 }

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.scss
@@ -8,21 +8,44 @@
   .content {
     display: flex;
     flex: 1;
+    padding: 20px;
 
-    .operations {
-      flex: 0 0 400px;
+    .card-pf {
+      flex: 1;
+      display: flex;
+      flex-flow: column;
+      margin: 0;
+      background: transparent;
+
+      .card-pf-heading {
+        margin-bottom: 0;
+        background: #fff;
+      }
+
+      .card-pf-title {
+        display: flex;
+      }
+
+      .card-pf-body {
+        flex: 1;
+        margin: 0 -20px;
+        padding: 0;
+        overflow: hidden;
+      }
     }
 
     .main-panel {
+      height: 100%;
       flex: 1 1 auto;
       display: flex;
 
       .flow {
-        flex: 1 0 auto;
+        flex: 1 1 0;
+        background: #fff;
       }
 
       .form {
-        flex: 1 1 auto;
+        flex: 1 1 100%;
       }
     }
   }

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.ts
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-page.component.ts
@@ -3,6 +3,7 @@ import { IntegrationEditPage } from '../../edit-page/edit-page.component';
 
 @Component({
   selector: 'syndesis-integration-api-provider-operation-editor-page',
-  templateUrl: './integration-api-provider-editor-page.component.html'
+  templateUrl: './integration-api-provider-editor-page.component.html',
+  styleUrls: ['integration-api-provider-editor-page.component.scss']
 })
 export class ApiProviderOperationsEditorComponent extends IntegrationEditPage {}

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
@@ -19,48 +19,54 @@
               >
               </syndesis-editable-text>
             </div>
-            <button
-              class="btn btn-default"
-              *ngIf="showOperationsButton && !flowPageService.showDone"
-              [disabled]="
-                flowPageService.saveInProgress ||
-                flowPageService.publishInProgress
-              "
-              (click)="
-                save([
-                  '/integrations',
-                  currentFlowService.integration?.id,
-                  'operations'
-                ])
-              "
-            >
-              Go to Operation List
-            </button>
-            <div
-              dropdown
-              class="dropdown"
-              placement="bottom"
-              *ngIf="currentFlow && flows.length > 0"
-            >
-              <span dropdownToggle class="dropdown-toggle" type="button">
-                {{ currentFlow.name }}
-              </span>
-              <ul *dropdownMenu class="dropdown-menu" role="menu">
-                <ng-container *ngFor="let flow of flows">
-                  <li *ngIf="flow.id !== currentFlow.id">
-                    <a
-                      [routerLink]="[
-                        '/integrations',
-                        currentFlowService.integration?.id,
-                        'operations',
-                        flow.id,
-                        'edit'
-                      ]"
-                      >{{ flow.name }}</a
-                    >
-                  </li>
-                </ng-container>
-              </ul>
+            <div class="form-group">
+              <div
+                dropdown
+                class="dropdown btn-group"
+                placement="bottom"
+                *ngIf="currentFlow && flows.length > 0"
+              >
+                <button
+                  dropdownToggle
+                  class="btn btn-default dropdown-toggle"
+                  type="button"
+                >
+                  {{ currentFlow.name }}<span class="caret"></span>
+                </button>
+                <ul *dropdownMenu class="dropdown-menu" role="menu">
+                  <ng-container *ngFor="let flow of flows">
+                    <li *ngIf="flow.id !== currentFlow.id">
+                      <a
+                        [routerLink]="[
+                          '/integrations',
+                          currentFlowService.integration?.id,
+                          'operations',
+                          flow.id,
+                          'edit'
+                        ]"
+                        >{{ flow.name }}</a
+                      >
+                    </li>
+                  </ng-container>
+                </ul>
+              </div>
+              <button
+                class="btn btn-default"
+                *ngIf="showOperationsButton && !flowPageService.showDone"
+                [disabled]="
+                  flowPageService.saveInProgress ||
+                  flowPageService.publishInProgress
+                "
+                (click)="
+                  save([
+                    '/integrations',
+                    currentFlowService.integration?.id,
+                    'operations'
+                  ])
+                "
+              >
+                Go to Operation List
+              </button>
             </div>
             <div class="toolbar-pf-action-right">
               <a

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
@@ -8,7 +8,7 @@
         <div class="col-sm-12">
           <div class="toolbar-pf-actions">
             <div class="form-group toolbar-pf-filter">
-              <strong> <span>Integration</span> </strong>
+              <strong> <span>API Provider Integration</span> </strong>
             </div>
             <div class="form-group" *ngIf="currentFlowService.isSaved()">
               <label for="integrationName">Name</label>&nbsp;
@@ -20,6 +20,13 @@
               </syndesis-editable-text>
             </div>
             <div class="toolbar-pf-action-right">
+              <a
+                *ngIf="currentFlowService.isSaved()"
+                [routerLink]="['../specification']"
+                class="btn btn-link"
+              >
+                View/Edit API Definition <i class="fa fa-external-link"></i>
+              </a>
               <button
                 class="btn btn-default"
                 (click)="flowPageService.cancel()"

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
@@ -33,7 +33,30 @@
                 >
                   {{ currentFlow.name }}<span class="caret"></span>
                 </button>
-                <ul *dropdownMenu class="dropdown-menu" role="menu">
+                <ul *dropdownMenu class="dropdown-menu operations-menu" role="menu">
+                  <ng-container *ngIf="showOperationsButton && !flowPageService.showDone">
+                    <li style="padding: 0 4px;">
+                      <button
+                        class="btn btn-default"
+                        style="width: 100%"
+
+                        [disabled]="
+                        flowPageService.saveInProgress ||
+                        flowPageService.publishInProgress
+                      "
+                        (click)="
+                        save([
+                          '/integrations',
+                          currentFlowService.integration?.id,
+                          'operations'
+                        ])
+                      "
+                      >
+                        Go to Operation List
+                      </button>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                  </ng-container>
                   <ng-container *ngFor="let flow of flows">
                     <li *ngIf="flow.id !== currentFlow.id">
                       <a
@@ -44,29 +67,18 @@
                           flow.id,
                           'edit'
                         ]"
-                        >{{ flow.name }}</a
+                      >
+                        <strong>{{flow.name}}</strong><br>
+                        <integration-api-provider-operation-description
+                          [description]="flow.description"
+                          style="display: inline-flex"
+                        ></integration-api-provider-operation-description>
+                      </a
                       >
                     </li>
                   </ng-container>
                 </ul>
               </div>
-              <button
-                class="btn btn-default"
-                *ngIf="showOperationsButton && !flowPageService.showDone"
-                [disabled]="
-                  flowPageService.saveInProgress ||
-                  flowPageService.publishInProgress
-                "
-                (click)="
-                  save([
-                    '/integrations',
-                    currentFlowService.integration?.id,
-                    'operations'
-                  ])
-                "
-              >
-                Go to Operation List
-              </button>
             </div>
             <div class="toolbar-pf-action-right">
               <a

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
@@ -19,6 +19,49 @@
               >
               </syndesis-editable-text>
             </div>
+            <button
+              class="btn btn-default"
+              *ngIf="showOperationsButton && !flowPageService.showDone"
+              [disabled]="
+                flowPageService.saveInProgress ||
+                flowPageService.publishInProgress
+              "
+              (click)="
+                save([
+                  '/integrations',
+                  currentFlowService.integration?.id,
+                  'operations'
+                ])
+              "
+            >
+              Go to Operation List
+            </button>
+            <div
+              dropdown
+              class="dropdown"
+              placement="bottom"
+              *ngIf="currentFlow && flows.length > 0"
+            >
+              <span dropdownToggle class="dropdown-toggle" type="button">
+                {{ currentFlow.name }}
+              </span>
+              <ul *dropdownMenu class="dropdown-menu" role="menu">
+                <ng-container *ngFor="let flow of flows">
+                  <li *ngIf="flow.id !== currentFlow.id">
+                    <a
+                      [routerLink]="[
+                        '/integrations',
+                        currentFlowService.integration?.id,
+                        'operations',
+                        flow.id,
+                        'edit'
+                      ]"
+                      >{{ flow.name }}</a
+                    >
+                  </li>
+                </ng-container>
+              </ul>
+            </div>
             <div class="toolbar-pf-action-right">
               <a
                 *ngIf="currentFlowService.isSaved()"

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.scss
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.scss
@@ -1,0 +1,4 @@
+.operations-menu {
+  max-height: 50vh;
+  overflow: auto;
+}

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+import { FlowToolbarComponent } from '../../edit-page';
+
+@Component({
+  selector: 'syndesis-integration-api-provider-operation-editor-toolbar',
+  templateUrl: 'integration-api-provider-editor-toolbar.component.html',
+  styleUrls: ['./integration-api-provider-editor-toolbar.component.scss'],
+})
+export class ApiProviderOperationsToolbarComponent extends FlowToolbarComponent {}

--- a/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
+++ b/app/ui/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
@@ -1,9 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { FlowToolbarComponent } from '../../edit-page';
+import { Flow } from '@syndesis/ui/platform';
 
 @Component({
   selector: 'syndesis-integration-api-provider-operation-editor-toolbar',
   templateUrl: 'integration-api-provider-editor-toolbar.component.html',
   styleUrls: ['./integration-api-provider-editor-toolbar.component.scss'],
 })
-export class ApiProviderOperationsToolbarComponent extends FlowToolbarComponent {}
+export class ApiProviderOperationsToolbarComponent extends FlowToolbarComponent {
+  @Input()
+  showOperationsButton = false;
+
+  @Input()
+  flows: Flow[] = [];
+
+  @Input()
+  currentFlow: Flow = undefined;
+}

--- a/app/ui/src/app/integration/api-provider/index.ts
+++ b/app/ui/src/app/integration/api-provider/index.ts
@@ -1,6 +1,6 @@
 export * from '@syndesis/ui/integration/api-provider/operations-page/integration-api-provider-operations-page.component';
 export * from './operations-page/integration-api-provider-operations-list.component';
-export * from './editor-page/integration-api-provider-editor-page.component';
+export * from './editor-page';
 export * from '@syndesis/ui/integration/api-provider/creation-page/integration-api-provider-creation-page.component';
 export * from '@syndesis/ui/integration/api-provider/creation-page/step-upload/step-upload.component';
 export * from '@syndesis/ui/integration/api-provider/creation-page/step-validate/step-validate.component';

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operation-description-component.ts
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operation-description-component.ts
@@ -1,0 +1,31 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'integration-api-provider-operation-description',
+  template: `
+    <span class="verb col-sm-3" [attr.data-verb]="description.split(' ')[0]">
+      {{ description.split(' ')[0] }}
+    </span>
+    <span class="url col-sm-9">{{ description.split(' ')[1] }}</span>
+  `,
+  styles: [`
+    .verb {
+      font-weight: bold;
+    }
+    .verb[data-verb=GET] {
+      color: #3C96D4;
+    }
+    .verb[data-verb=POST] {
+      color: #61AF5A;
+    }
+    .verb[data-verb=PUT] {
+      color: #ED811D;
+    }
+    .verb[data-verb=DELETE] {
+      color: #D01414;
+    }
+  `]
+})
+export class ApiProviderOperationDescriptionComponent {
+  @Input() description: string;
+}

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operation-description-component.ts
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operation-description-component.ts
@@ -3,14 +3,20 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'integration-api-provider-operation-description',
   template: `
-    <span class="verb col-sm-3" [attr.data-verb]="description.split(' ')[0]">
+    <span class="verb" [attr.data-verb]="description.split(' ')[0]">
       {{ description.split(' ')[0] }}
     </span>
-    <span class="url col-sm-9">{{ description.split(' ')[1] }}</span>
+    <span class="url">{{ description.split(' ')[1] }}</span>
   `,
   styles: [`
+    :host {
+      display: flex;
+    }
     .verb {
       font-weight: bold;
+      flex-grow: 0;
+      flex-shrink: 1;
+      flex-basis: 30%;
     }
     .verb[data-verb=GET] {
       color: #3C96D4;
@@ -23,6 +29,9 @@ import { Component, Input } from '@angular/core';
     }
     .verb[data-verb=DELETE] {
       color: #D01414;
+    }
+    .url {
+      padding-left: 5%;
     }
   `]
 })

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
@@ -1,51 +1,62 @@
 <div class="syn-scrollable">
   <div class="syn-scrollable--body">
     <div class="container-fluid">
-      <div class="title">Operations ({{ (flows$ | async).length }})</div>
-      <p>
-        An integration can have multiple flows. Select an operation to start
-        creating a flow.
-      </p>
+      <div class="row row-cards-pf">
+        <div class="card-pf">
+          <div class="card-pf-heading">
+            <h1 class="card-pf-title">Operations ({{ (flows$ | async).length }})</h1>
+            <p>
+              An integration can have multiple flows. Select an operation to start
+              creating a flow.
+            </p>
 
-      <!-- Toolbar -->
-      <syndesis-list-toolbar
-        [items]="enrichedFlows$"
-        [filterTags]="false"
-        [filteredItems]="filteredFlows$"
-        [toolbarConfig]="toolbarConfig"
-      >
-      </syndesis-list-toolbar>
-
-      <div class="list-view-pf-view operations-list">
-        <pfng-list
-          [items]="filteredFlows$ | async"
-          [itemTemplate]="itemTemplate"
-          [actionTemplate]="actionTemplate"
-          (onClick)="handleClick($event)"
-        >
-          <ng-template #itemTemplate let-flow="item" let-index="index">
-            <div class="list-pf-content-wrapper">
-              <div *ngIf="showDescription" class="list-pf-main-content">
-                <div class="list-pf-description text-overflow-pf">
-                  {{ flow.description }}
-                </div>
+            <!-- Toolbar -->
+            <syndesis-list-toolbar
+              [items]="enrichedFlows$"
+              [filterTags]="false"
+              [filteredItems]="filteredFlows$"
+              [toolbarConfig]="toolbarConfig"
+            >
+            </syndesis-list-toolbar>
+          </div>
+          <div class="card-pf-body">
+            <div class="container-fluid">
+              <div class="row">
+                <pfng-list
+                  [items]="filteredFlows$ | async"
+                  [itemTemplate]="itemTemplate"
+                  [actionTemplate]="actionTemplate"
+                  (onClick)="handleClick($event)"
+                >
+                  <ng-template #itemTemplate let-flow="item" let-index="index">
+                    <div class="list-pf-content-wrapper">
+                      <div class="list-pf-main-content">
+                        <div class="list-pf-description text-overflow-pf">
+                          <integration-api-provider-operation-description
+                            [description]="flow.description"
+                          ></integration-api-provider-operation-description>
+                        </div>
+                      </div>
+                      <div class="list-pf-title">{{ flow.name }}</div>
+                    </div>
+                  </ng-template>
+                  <ng-template #actionTemplate let-flow="item" let-index="index">
+                    <span *ngIf="flow.implemented === 1">
+                      <button class="btn btn-default" (click)="handleClick(flow)">
+                        Edit Flow
+                      </button>
+                    </span>
+                    <span *ngIf="flow.implemented === 0">
+                      <button class="btn btn-primary" (click)="handleClick(flow)">
+                        Create a Flow
+                      </button>
+                    </span>
+                  </ng-template>
+                </pfng-list>
               </div>
-              <div class="list-pf-title">{{ flow.name }}</div>
             </div>
-          </ng-template>
-          <ng-template #actionTemplate let-flow="item" let-index="index">
-            <span *ngIf="flow.implemented === 1">
-              <button class="btn btn-default" (click)="handleClick(flow)">
-                Edit Flow
-              </button>
-            </span>
-            <span *ngIf="flow.implemented === 0">
-              <button class="btn btn-primary" (click)="handleClick(flow)">
-                Create a Flow
-              </button>
-            </span>
-          </ng-template>
-        </pfng-list>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
@@ -1,49 +1,53 @@
-<div class="container-fluid">
-  <div class="title">Operations ({{ (flows$ | async).length }})</div>
-  <p *ngIf="showDescription">
-    An integration can have multiple flows. Select an operation to start
-    creating a flow.
-  </p>
+<div class="syn-scrollable">
+  <div class="syn-scrollable--body">
+    <div class="container-fluid">
+      <div class="title">Operations ({{ (flows$ | async).length }})</div>
+      <p *ngIf="showDescription">
+        An integration can have multiple flows. Select an operation to start
+        creating a flow.
+      </p>
 
-  <!-- Toolbar -->
-  <syndesis-list-toolbar
-    *ngIf="showToolbar"
-    [items]="enrichedFlows$"
-    [filterTags]="false"
-    [filteredItems]="filteredFlows$"
-    [toolbarConfig]="toolbarConfig"
-  >
-  </syndesis-list-toolbar>
+      <!-- Toolbar -->
+      <syndesis-list-toolbar
+        *ngIf="showToolbar"
+        [items]="enrichedFlows$"
+        [filterTags]="false"
+        [filteredItems]="filteredFlows$"
+        [toolbarConfig]="toolbarConfig"
+      >
+      </syndesis-list-toolbar>
 
-  <div class="list-view-pf-view operations-list">
-    <pfng-list
-      [items]="flowItems | async"
-      [itemTemplate]="itemTemplate"
-      [actionTemplate]="actionTemplate"
-      (onClick)="handleClick($event)"
-    >
-      <ng-template #itemTemplate let-flow="item" let-index="index">
-        <div class="list-pf-content-wrapper">
-          <div *ngIf="showDescription" class="list-pf-main-content">
-            <div class="list-pf-description text-overflow-pf">
-              {{ flow.description }}
+      <div class="list-view-pf-view operations-list">
+        <pfng-list
+          [items]="flowItems | async"
+          [itemTemplate]="itemTemplate"
+          [actionTemplate]="actionTemplate"
+          (onClick)="handleClick($event)"
+        >
+          <ng-template #itemTemplate let-flow="item" let-index="index">
+            <div class="list-pf-content-wrapper">
+              <div *ngIf="showDescription" class="list-pf-main-content">
+                <div class="list-pf-description text-overflow-pf">
+                  {{ flow.description }}
+                </div>
+              </div>
+              <div class="list-pf-title">{{ flow.name }}</div>
             </div>
-          </div>
-          <div class="list-pf-title">{{ flow.name }}</div>
-        </div>
-      </ng-template>
-      <ng-template #actionTemplate let-flow="item" let-index="index">
-        <span *ngIf="flow.implemented === 1">
-          <button class="btn btn-default" (click)="handleClick(flow)">
-            Edit Flow
-          </button>
-        </span>
-        <span *ngIf="flow.implemented === 0">
-          <button class="btn btn-primary" (click)="handleClick(flow)">
-            Create a Flow
-          </button>
-        </span>
-      </ng-template>
-    </pfng-list>
+          </ng-template>
+          <ng-template #actionTemplate let-flow="item" let-index="index">
+            <span *ngIf="flow.implemented === 1">
+              <button class="btn btn-default" (click)="handleClick(flow)">
+                Edit Flow
+              </button>
+            </span>
+            <span *ngIf="flow.implemented === 0">
+              <button class="btn btn-primary" (click)="handleClick(flow)">
+                Create a Flow
+              </button>
+            </span>
+          </ng-template>
+        </pfng-list>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.html
@@ -2,14 +2,13 @@
   <div class="syn-scrollable--body">
     <div class="container-fluid">
       <div class="title">Operations ({{ (flows$ | async).length }})</div>
-      <p *ngIf="showDescription">
+      <p>
         An integration can have multiple flows. Select an operation to start
         creating a flow.
       </p>
 
       <!-- Toolbar -->
       <syndesis-list-toolbar
-        *ngIf="showToolbar"
         [items]="enrichedFlows$"
         [filterTags]="false"
         [filteredItems]="filteredFlows$"
@@ -19,7 +18,7 @@
 
       <div class="list-view-pf-view operations-list">
         <pfng-list
-          [items]="flowItems | async"
+          [items]="filteredFlows$ | async"
           [itemTemplate]="itemTemplate"
           [actionTemplate]="actionTemplate"
           (onClick)="handleClick($event)"

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
@@ -2,13 +2,13 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { Flow } from '@syndesis/ui/platform';
 import {
   ObjectPropertyFilterConfig,
-  ObjectPropertySortConfig
+  ObjectPropertySortConfig,
 } from '@syndesis/ui/common';
 import {
   FilterConfig,
   SortConfig,
   ToolbarConfig,
-  ListEvent
+  ListEvent,
 } from 'patternfly-ng';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -16,27 +16,23 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'syndesis-integration-api-provider-operations-list',
-  templateUrl: './integration-api-provider-operations-list.component.html'
+  templateUrl: './integration-api-provider-operations-list.component.html',
 })
 export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
   @Input()
   integrationId: string;
   @Input()
   flows$: Observable<Flow[]>;
-  @Input()
-  showDescription = true;
-  @Input()
-  showToolbar = true;
 
   enrichedFlows$ = new BehaviorSubject<Flow[]>(undefined);
   filteredFlows$ = new BehaviorSubject<Flow[]>(undefined);
   filter: ObjectPropertyFilterConfig = {
     filter: '',
-    propertyName: 'name'
+    propertyName: 'name',
   };
   sort: ObjectPropertySortConfig = {
     sortField: 'implemented',
-    descending: true
+    descending: true,
   };
 
   toolbarConfig = {
@@ -46,44 +42,40 @@ export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
           id: 'name',
           title: 'Operation Name',
           placeholder: 'Filter by Operation Name...',
-          type: 'text'
+          type: 'text',
         },
         {
           id: 'description',
           title: 'Method & Name',
           placeholder: 'Filter by Method & Name...',
-          type: 'text'
-        }
-      ]
+          type: 'text',
+        },
+      ],
     } as FilterConfig,
     sortConfig: {
       fields: [
         {
           id: 'implemented',
           title: 'Implemented',
-          sortType: 'numeric'
+          sortType: 'numeric',
         },
         {
           id: 'name',
           title: 'Operation Name',
-          sortType: 'alpha'
+          sortType: 'alpha',
         },
         {
           id: 'description',
           title: 'Method & Path',
-          sortType: 'alpha'
-        }
+          sortType: 'alpha',
+        },
       ],
-      isAscending: false
-    } as SortConfig
+      isAscending: false,
+    } as SortConfig,
   } as ToolbarConfig;
   subscription: any;
 
   constructor(private router: Router) {}
-
-  get flowItems() {
-    return this.showToolbar ? this.filteredFlows$ : this.enrichedFlows$;
-  }
 
   ngOnInit() {
     this.subscription = this.flows$
@@ -93,7 +85,7 @@ export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
             .map(f => {
               return {
                 ...f,
-                implemented: f.metadata.excerpt.startsWith('501') ? 0 : 1
+                implemented: f.metadata.excerpt.startsWith('501') ? 0 : 1,
               };
             })
             .sort((a, b) => b.implemented - a.implemented);
@@ -115,7 +107,7 @@ export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
       this.integrationId,
       'operations',
       (item as Flow).id,
-      'edit'
+      'edit',
     ]);
   }
 }

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
@@ -16,7 +16,7 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'syndesis-integration-api-provider-operations-list',
-  templateUrl: './integration-api-provider-operations-list.component.html',
+  templateUrl: './integration-api-provider-operations-list.component.html'
 })
 export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
   @Input()

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
@@ -6,7 +6,9 @@
         <a [routerLink]="['/integrations']">All Integrations</a>
       </li>
     </ol>
-    <syndesis-integration-api-provider-operation-editor-toolbar></syndesis-integration-api-provider-operation-editor-toolbar>
+    <syndesis-integration-api-provider-operation-editor-toolbar
+      [showOperationsButton]="false"
+    ></syndesis-integration-api-provider-operation-editor-toolbar>
   </div>
   <div class="content">
     <div class="operations">

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
@@ -1,30 +1,17 @@
-<div class="integrations">
-  <div class="row">
-    <div class="col-md-12">
-      <ol class="breadcrumb">
-        <li>
-          &lt;&lt;&nbsp;<a [routerLink]="['/integrations']">All Integrations</a>
-        </li>
-        <li *ngIf="(currentFlowService.loaded$ | async)">
-          <a
-            [routerLink]="['/integrations', currentFlowService.integration.id]"
-            >{{ currentFlowService.integration.name }}</a
-          >
-        </li>
-      </ol>
-    </div>
+<div class="integrations edit row">
+  <div class="header">
+    <ol class="syn-breadcrumb">
+      <li>
+        <i class="fa fa-angle-double-left"></i>
+        <a [routerLink]="['/integrations']">All Integrations</a>
+      </li>
+    </ol>
+    <syndesis-integration-flow-toolbar
+      [isApiProvider]="true"
+    ></syndesis-integration-flow-toolbar>
   </div>
-
-  <div class="row">
-    <div class="col-md-12">
-      <syndesis-integration-flow-toolbar
-        [isApiProvider]="true"
-      ></syndesis-integration-flow-toolbar>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-md-12">
+  <div class="content">
+    <div class="operations">
       <syndesis-loading
         [loading]="!(currentFlowService.loaded$ | async)"
         [content]="content"
@@ -35,12 +22,8 @@
 </div>
 
 <ng-template #content>
-  <div class="syn-scrollable">
-    <div class="syn-scrollable--body">
-      <syndesis-integration-api-provider-operations-list
-        [flows$]="currentFlowService.flows$"
-        [integrationId]="currentFlowService.integration?.id"
-      ></syndesis-integration-api-provider-operations-list>
-    </div>
-  </div>
+  <syndesis-integration-api-provider-operations-list
+    [flows$]="currentFlowService.flows$"
+    [integrationId]="currentFlowService.integration?.id"
+  ></syndesis-integration-api-provider-operations-list>
 </ng-template>

--- a/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
+++ b/app/ui/src/app/integration/api-provider/operations-page/integration-api-provider-operations-page.component.html
@@ -6,9 +6,7 @@
         <a [routerLink]="['/integrations']">All Integrations</a>
       </li>
     </ol>
-    <syndesis-integration-flow-toolbar
-      [isApiProvider]="true"
-    ></syndesis-integration-flow-toolbar>
+    <syndesis-integration-api-provider-operation-editor-toolbar></syndesis-integration-api-provider-operation-editor-toolbar>
   </div>
   <div class="content">
     <div class="operations">

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.html
@@ -37,15 +37,16 @@
     <div class="syn-scrollable">
       <div class="syn-scrollable--body">
         <div class="container-fluid">
-          <div class="title">
-            <h1>{{ step?.connection?.name }}</h1>
-            <h3>{{ action?.name }}</h3>
-          </div>
           <syndesis-loading [loading]="loading" [content]="content">
             <ng-template #content>
-              <p *ngIf="hasConfiguration">{{ descriptor.description }}</p>
               <div class="row row-cards-pf">
                 <div class="card-pf">
+                  <div class="card-pf-heading">
+                    <h1 class="card-pf-title">
+                      {{ step?.connection?.name }} - {{ action?.name }}
+                    </h1>
+                    <p *ngIf="hasConfiguration">{{ descriptor.description }}</p>
+                  </div>
                   <div class="card-pf-body">
                     <ng-container *ngIf="error">
                       <div class="row">

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -9,14 +9,14 @@
                 <h1 class="card-pf-title">
                   {{ step?.connection.name }} - Choose an Action
                 </h1>
-              </div>
-              <div class="card-pf-body">
                 <p>Choose an action for the selected connection.</p>
                 <!-- Toolbar -->
                 <syndesis-list-toolbar
                   [items]="actions$"
                   [filteredItems]="filteredActions$"
                 ></syndesis-list-toolbar>
+              </div>
+              <div class="card-pf-body">
                 <!-- Action List -->
                 <syndesis-list-actions
                   [actions]="filteredActions$ | async"

--- a/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
+++ b/app/ui/src/app/integration/edit-page/action-select/action-select.component.html
@@ -3,23 +3,28 @@
     <div class="syn-scrollable">
       <div class="syn-scrollable--body">
         <div class="container-fluid">
-          <div class="title">
-            <h1>{{ step?.connection.name }} - Choose an Action</h1>
-          </div>
-          <!-- Actions -->
-          <div>
-            <p>Choose an action for the selected connection.</p>
-            <!-- Toolbar -->
-            <syndesis-list-toolbar
-              [items]="actions$"
-              [filteredItems]="filteredActions$"
-            ></syndesis-list-toolbar>
-            <!-- Action List -->
-            <syndesis-list-actions
-              [actions]="filteredActions$ | async"
-              [loading]="loading$ | async"
-              (onSelected)="onSelected($event)"
-            ></syndesis-list-actions>
+          <div class="row row-cards-pf cards">
+            <div class="card-pf">
+              <div class="card-pf-heading">
+                <h1 class="card-pf-title">
+                  {{ step?.connection.name }} - Choose an Action
+                </h1>
+              </div>
+              <div class="card-pf-body">
+                <p>Choose an action for the selected connection.</p>
+                <!-- Toolbar -->
+                <syndesis-list-toolbar
+                  [items]="actions$"
+                  [filteredItems]="filteredActions$"
+                ></syndesis-list-toolbar>
+                <!-- Action List -->
+                <syndesis-list-actions
+                  [actions]="filteredActions$ | async"
+                  [loading]="loading$ | async"
+                  (onSelected)="onSelected($event)"
+                ></syndesis-list-actions>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/ui/src/app/integration/edit-page/edit-page.component.html
+++ b/app/ui/src/app/integration/edit-page/edit-page.component.html
@@ -8,32 +8,24 @@
         <ol class="syn-breadcrumb">
           <li>
             <i class="fa fa-angle-double-left"></i>
-            <a [routerLink]="['/integrations']">
-              All Integrations
-            </a>
+            <a [routerLink]="['/integrations']"> All Integrations </a>
           </li>
           <li *ngIf="currentFlowService.integration.name">
             <a
               [routerLink]="[
-              '/integrations',
-              currentFlowService.integration.id
-            ]"
-            >{{ currentFlowService.integration.name }}</a
+                '/integrations',
+                currentFlowService.integration.id
+              ]"
+              >{{ currentFlowService.integration.name }}</a
             >
           </li>
         </ol>
 
-        <syndesis-integration-flow-toolbar
-          [isApiProvider]="currentFlowService.isApiProvider()"
-        >
-        </syndesis-integration-flow-toolbar>
+        <syndesis-integration-flow-toolbar></syndesis-integration-flow-toolbar>
       </div>
       <div class="content">
         <!-- Sidebar -->
-        <div
-          class="wizard-sidebar"
-          *ngIf="!currentFlowService.isApiProvider()"
-        >
+        <div class="wizard-sidebar" *ngIf="!currentFlowService.isApiProvider()">
           <syndesis-integration-flow-view></syndesis-integration-flow-view>
         </div>
         <!-- Add/Edit Integration -->

--- a/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
@@ -26,6 +26,7 @@
               <a
                 *ngIf="isApiProvider && currentFlowService.isSaved()"
                 [routerLink]="['../specification']"
+                class="btn btn-link"
               >
                 View/Edit API Definition <i class="fa fa-external-link"></i>
               </a>
@@ -34,27 +35,6 @@
                 (click)="flowPageService.cancel()"
               >
                 Cancel
-              </button>
-              <button
-                class="btn btn-default"
-                *ngIf="
-                  isApiProvider &&
-                  !hideOperationsButton &&
-                  !flowPageService.showDone
-                "
-                [disabled]="
-                  flowPageService.saveInProgress ||
-                  flowPageService.publishInProgress
-                "
-                (click)="
-                  save([
-                    '/integrations',
-                    currentFlowService.integration?.id,
-                    'operations'
-                  ])
-                "
-              >
-                Go to Operation List
               </button>
               <button
                 class="btn btn-primary"

--- a/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
@@ -1,20 +1,14 @@
-import { Component, Input, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { CurrentFlowService } from '../current-flow.service';
 import { FlowPageService } from '../flow-page.service';
-import { IntegrationType } from '@syndesis/ui/platform';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'syndesis-integration-flow-toolbar',
   templateUrl: './flow-toolbar.component.html',
-  styleUrls: ['../../integration-common.scss', './flow-toolbar.component.scss']
+  styleUrls: ['../../integration-common.scss', './flow-toolbar.component.scss'],
 })
 export class FlowToolbarComponent {
-  @Input()
-  isApiProvider = false;
-  @Input()
-  hideOperationsButton = true;
-  IntegrationType = IntegrationType;
   @ViewChild('nameInput') nameInput: ElementRef;
 
   constructor(
@@ -35,7 +29,7 @@ export class FlowToolbarComponent {
     this.currentFlowService.events.emit({
       kind: 'integration-set-property',
       property: 'name',
-      value: name
+      value: name,
     });
   }
 

--- a/app/ui/src/app/integration/edit-page/list-actions/list-actions.component.html
+++ b/app/ui/src/app/integration/edit-page/list-actions/list-actions.component.html
@@ -1,22 +1,23 @@
 <syndesis-loading [loading]="loading" [content]="content">
   <ng-template #content>
-    <div class="integrations list-actions">
-      <div
-        class="action col-xs-12"
-        title="{{ action.name }}"
-        *ngFor="let action of (actions | derp)"
-        (click)="onSelect(action)"
-        [class.active]="isSelected(action)"
-      >
-        <!-- Name -->
-        <div class="col-xs-4 name">{{ action.name }}</div>
-
-        <!-- Description -->
-        <div class="col-xs-8 description">
-          <div class="list-group-item-text">
-            {{ action.description | truncate: truncateLimit:truncateTrail }}
-          </div>
-        </div>
+    <div class="container-fluid">
+      <div class="row">
+        <pfng-list
+          [items]="actions | derp"
+          [itemTemplate]="itemTemplate"
+          (onClick)="onSelect($event)"
+        >
+          <ng-template #itemTemplate let-action="item" let-index="index">
+            <div class="list-pf-content-wrapper">
+              <div class="list-pf-main-content">
+                <div class="list-pf-description text-overflow-pf">
+                  {{ action.description | truncate: truncateLimit:truncateTrail }}
+                </div>
+              </div>
+              <div class="list-pf-title">{{ action.name }}</div>
+            </div>
+          </ng-template>
+        </pfng-list>
       </div>
     </div>
   </ng-template>

--- a/app/ui/src/app/integration/edit-page/list-actions/list-actions.component.spec.ts
+++ b/app/ui/src/app/integration/edit-page/list-actions/list-actions.component.spec.ts
@@ -3,8 +3,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { SyndesisCommonModule } from '@syndesis/ui/common/common.module';
-import { ListActionsComponent } from '@syndesis/ui/integration/edit-page/list-actions/list-actions.component';
+import {
+  ListActionsComponent
+} from '@syndesis/ui/integration/edit-page/list-actions/list-actions.component';
 import { SyndesisStoreModule } from '@syndesis/ui/store/store.module';
+import { VendorModule } from '@syndesis/ui/vendor';
 
 describe('ListActionsComponent', () => {
   let component: ListActionsComponent;
@@ -14,6 +17,7 @@ describe('ListActionsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SyndesisCommonModule,
+        VendorModule,
         RouterTestingModule.withRoutes([]),
         SyndesisStoreModule
       ],

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -3,46 +3,52 @@
     <div class="syn-scrollable">
       <div class="syn-scrollable--body">
         <div class="container-fluid">
-          <div class="title">
-            <h1>
-              {{ 'Choose a ' + positionText + ' ' + typeText | titleize }}
-            </h1>
+          <div class="row row-cards-pf cards">
+            <div class="card-pf">
+              <div class="card-pf-heading">
+                <h1 class="card-pf-title">
+                  {{ 'Choose a ' + positionText + ' ' + typeText | titleize }}
+                </h1>
+              </div>
+              <div class="card-pf-body">
+                <p *ngIf="atStart">
+                  Click the connection that starts the integration. If the connection
+                  you need is not available, click Create Connection.
+                </p>
+                <p *ngIf="atEnd">
+                  Click the connection that completes the integration. If the
+                  connection you need is not available, click Create Connection.
+                </p>
+                <p *ngIf="!atStart && !atEnd">
+                  A step specifies an operation on the data in the integration. Click
+                  one to add it.
+                </p>
+                <syndesis-list-toolbar
+                  [items]="allSteps$"
+                  [filteredItems]="filteredSteps$"
+                  [viewTemplate]="viewTemplate"
+                >
+                  <ng-template #viewTemplate>
+                    <button
+                      *ngIf="atStart || atEnd"
+                      type="button"
+                      class="btn btn-default toolbar-pf-action-right"
+                      [routerLink]="['/connections/create']"
+                    >
+                      Create Connection
+                    </button>
+                  </ng-template>
+                </syndesis-list-toolbar>
+                <syndesis-connections-list
+                  [connections]="filteredSteps$ | async"
+                  [loading]="loading$ | async"
+                  (onSelected)="onSelected($event)"
+                  [showKebab]="false"
+                  [showNewConnection]="atStart || atEnd"
+                ></syndesis-connections-list>
+              </div>
+            </div>
           </div>
-          <p *ngIf="atStart">
-            Click the connection that starts the integration. If the connection
-            you need is not available, click Create Connection.
-          </p>
-          <p *ngIf="atEnd">
-            Click the connection that completes the integration. If the
-            connection you need is not available, click Create Connection.
-          </p>
-          <p *ngIf="!atStart && !atEnd">
-            A step specifies an operation on the data in the integration. Click
-            one to add it.
-          </p>
-          <syndesis-list-toolbar
-            [items]="allSteps$"
-            [filteredItems]="filteredSteps$"
-            [viewTemplate]="viewTemplate"
-          >
-            <ng-template #viewTemplate>
-              <button
-                *ngIf="atStart || atEnd"
-                type="button"
-                class="btn btn-default toolbar-pf-action-right"
-                [routerLink]="['/connections/create']"
-              >
-                Create Connection
-              </button>
-            </ng-template>
-          </syndesis-list-toolbar>
-          <syndesis-connections-list
-            [connections]="filteredSteps$ | async"
-            [loading]="loading$ | async"
-            (onSelected)="onSelected($event)"
-            [showKebab]="false"
-            [showNewConnection]="atStart || atEnd"
-          ></syndesis-connections-list>
         </div>
       </div>
     </div>

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -4,7 +4,7 @@
       <div class="syn-scrollable--body">
         <div class="container-fluid">
           <div class="row row-cards-pf cards">
-            <div class="card-pf">
+            <div class="card-pf select-card">
               <div class="card-pf-heading">
                 <h1 class="card-pf-title">
                   {{ 'Choose a ' + positionText + ' ' + typeText | titleize }}

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.html
@@ -9,8 +9,6 @@
                 <h1 class="card-pf-title">
                   {{ 'Choose a ' + positionText + ' ' + typeText | titleize }}
                 </h1>
-              </div>
-              <div class="card-pf-body">
                 <p *ngIf="atStart">
                   Click the connection that starts the integration. If the connection
                   you need is not available, click Create Connection.
@@ -29,16 +27,18 @@
                   [viewTemplate]="viewTemplate"
                 >
                   <ng-template #viewTemplate>
-                    <button
-                      *ngIf="atStart || atEnd"
-                      type="button"
-                      class="btn btn-default toolbar-pf-action-right"
-                      [routerLink]="['/connections/create']"
-                    >
-                      Create Connection
-                    </button>
-                  </ng-template>
+                  <button
+                    *ngIf="atStart || atEnd"
+                    type="button"
+                    class="btn btn-default toolbar-pf-action-right"
+                    [routerLink]="['/connections/create']"
+                  >
+                    Create Connection
+                  </button>
+                </ng-template>
                 </syndesis-list-toolbar>
+              </div>
+              <div class="card-pf-body">
                 <syndesis-connections-list
                   [connections]="filteredSteps$ | async"
                   [loading]="loading$ | async"

--- a/app/ui/src/app/integration/edit-page/step-select/step-select.component.scss
+++ b/app/ui/src/app/integration/edit-page/step-select/step-select.component.scss
@@ -3,3 +3,19 @@
     cursor: pointer !important;
   }
 }
+
+.select-card {
+  padding: 0;
+  background: #ededed;
+  border-top-color: #fff;
+
+  .card-pf-heading {
+    background: #fff;
+    margin: 0;
+    padding: 20px 20px 0;
+
+    .card-pf-title {
+      margin-top: 0;
+    }
+  }
+}

--- a/app/ui/src/app/integration/integration-support.module.ts
+++ b/app/ui/src/app/integration/integration-support.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import * as SYNDESIS_ABSTRACT_PROVIDERS from '@syndesis/ui/platform';
 
-import { IntegrationActionsProviderService } from '@syndesis/ui/integration/integration-actions-provider.service';
+import {
+  IntegrationActionsProviderService
+} from '@syndesis/ui/integration/integration-actions-provider.service';
 
 // TODO: This module is imported several times through the app, so it needs to
 //       expose forRoot() and forChild() methods. Otherwise it will wind up

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -9,7 +9,7 @@ import { VendorModule } from '@syndesis/ui/vendor';
 import {
   OpenApiModule,
   PatternflyUIModule,
-  SyndesisCommonModule
+  SyndesisCommonModule,
 } from '@syndesis/ui/common';
 import { ConnectionsModule } from '@syndesis/ui/connections';
 
@@ -19,7 +19,7 @@ import { IntegrationListPage } from '@syndesis/ui/integration/list-page';
 import { IntegrationImportPageComponent } from '@syndesis/ui/integration/import-page';
 import {
   INTEGRATION_DETAIL_DIRECTIVES,
-  IntegrationDetailComponent
+  IntegrationDetailComponent,
 } from '@syndesis/ui/integration/integration_detail';
 import { IntegrationLogsComponent } from '@syndesis/ui/integration/integration_logs';
 import {
@@ -28,12 +28,13 @@ import {
   ApiProviderOperationsEditorComponent,
   ApiProviderOperationsComponent,
   ApiProviderOperationsListComponent,
+  ApiProviderOperationsToolbarComponent,
   apiProviderReducer,
   ApiProviderSpecComponent,
   StepEditorComponent,
   StepNameComponent,
   StepUploadComponent,
-  StepValidateComponent
+  StepValidateComponent,
 } from '@syndesis/ui/integration/api-provider';
 
 import {
@@ -55,7 +56,7 @@ import {
   IntegrationStepConfigureComponent,
   ListActionsComponent,
   StepVisiblePipe,
-  TemplaterComponent
+  TemplaterComponent,
 } from '@syndesis/ui/integration/edit-page';
 import { ApiModule } from '@syndesis/ui/api';
 import { StoreModule } from '@ngrx/store';
@@ -75,114 +76,114 @@ const integrationListModuleFwd = forwardRef(() => IntegrationListModule);
 const editIntegrationChildRoutes = [
   {
     path: 'save-or-add-step',
-    component: IntegrationSaveOrAddStepComponent
+    component: IntegrationSaveOrAddStepComponent,
   },
   {
     path: 'integration-basics',
-    component: IntegrationBasicsComponent
+    component: IntegrationBasicsComponent,
   },
   {
     path: 'step-select/:position',
     component: IntegrationSelectStepComponent,
     resolve: {
-      steps: StepsResolverService
-    }
+      steps: StepsResolverService,
+    },
   },
   {
     path: 'action-select/:position',
-    component: IntegrationSelectActionComponent
+    component: IntegrationSelectActionComponent,
   },
   {
     path: 'action-configure/:position/:page',
-    component: IntegrationConfigureActionComponent
+    component: IntegrationConfigureActionComponent,
   },
   {
     path: 'action-configure/:position',
-    component: IntegrationConfigureActionComponent
+    component: IntegrationConfigureActionComponent,
   },
   {
     path: 'describe-data/:position',
-    redirectTo: 'describe-data/:position/input'
+    redirectTo: 'describe-data/:position/input',
   },
   {
     path: 'describe-data/:position/:direction',
-    component: IntegrationDescribeDataComponent
+    component: IntegrationDescribeDataComponent,
   },
   {
     path: 'step-configure/:position',
-    component: IntegrationStepConfigureComponent
+    component: IntegrationStepConfigureComponent,
   },
   // OpenAPI loader page
   {
     path: 'api-provider/create',
     component: ApiProviderSpecComponent,
-    canActivate: [ApiConnectorGuard]
-  }
+    canActivate: [ApiConnectorGuard],
+  },
 ];
 
 const routes: Routes = [
   {
     path: '',
     component: IntegrationListPage,
-    pathMatch: 'full'
+    pathMatch: 'full',
   },
   {
     path: 'import',
-    component: IntegrationImportPageComponent
+    component: IntegrationImportPageComponent,
   },
   {
     path: 'create',
     component: IntegrationEditPage,
     children: editIntegrationChildRoutes,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId',
-    component: IntegrationDetailComponent
+    component: IntegrationDetailComponent,
   },
   {
     path: ':integrationId/edit',
     component: IntegrationEditPage,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId/operations',
     component: ApiProviderOperationsComponent,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId/operations/edit',
     component: ApiProviderOperationsEditorComponent,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId/operations/:flowId/edit',
     component: ApiProviderOperationsEditorComponent,
     children: editIntegrationChildRoutes,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId/:flowId/edit',
     component: IntegrationEditPage,
     children: editIntegrationChildRoutes,
     resolve: {
-      integration: IntegrationResolverService
-    }
+      integration: IntegrationResolverService,
+    },
   },
   {
     path: ':integrationId/specification',
-    component: ApiProviderSpecificationEditorPage
-  }
+    component: ApiProviderSpecificationEditorPage,
+  },
 ];
 
 @NgModule({
@@ -202,7 +203,7 @@ const routes: Routes = [
     DataMapperModule,
     integrationSupportModuleFwd,
     integrationListModuleFwd,
-    OpenApiModule
+    OpenApiModule,
   ],
   declarations: [
     ...INTEGRATION_DETAIL_DIRECTIVES,
@@ -232,12 +233,13 @@ const routes: Routes = [
     ApiProviderOperationsComponent,
     ApiProviderOperationsEditorComponent,
     ApiProviderOperationsListComponent,
+    ApiProviderOperationsToolbarComponent,
     ApiProviderSpecComponent,
     StepUploadComponent,
     StepValidateComponent,
     StepEditorComponent,
     StepNameComponent,
-    ApiProviderSpecificationEditorPage
+    ApiProviderSpecificationEditorPage,
   ],
   providers: [
     CurrentFlowService,
@@ -245,7 +247,7 @@ const routes: Routes = [
     WindowRef,
     ApiProviderService,
     ApiConnectorGuard,
-    StepVisiblePipe
-  ]
+    StepVisiblePipe,
+  ],
 })
 export class IntegrationModule {}

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -68,7 +68,9 @@ import { ApiConnectorGuard } from '@syndesis/ui/integration/api-provider/api-pro
 import { ApiProviderSpecificationEditorPage } from './api-provider/operations-page/specification/specification-editor-page.component';
 import { IntegrationResolverService } from './edit-page/integration-resolver.service';
 import { StepsResolverService } from './edit-page/connection-resolver.service';
-import { ApiProviderOperationDescriptionComponent } from '@syndesis/ui/integration/api-provider/operations-page/integration-api-provider-operation-description-component';
+import {
+  ApiProviderOperationDescriptionComponent
+} from '@syndesis/ui/integration/api-provider/operations-page/integration-api-provider-operation-description-component';
 
 const syndesisCommonModuleFwd = forwardRef(() => SyndesisCommonModule);
 const integrationSupportModuleFwd = forwardRef(() => IntegrationSupportModule);

--- a/app/ui/src/app/integration/integration.module.ts
+++ b/app/ui/src/app/integration/integration.module.ts
@@ -68,6 +68,7 @@ import { ApiConnectorGuard } from '@syndesis/ui/integration/api-provider/api-pro
 import { ApiProviderSpecificationEditorPage } from './api-provider/operations-page/specification/specification-editor-page.component';
 import { IntegrationResolverService } from './edit-page/integration-resolver.service';
 import { StepsResolverService } from './edit-page/connection-resolver.service';
+import { ApiProviderOperationDescriptionComponent } from '@syndesis/ui/integration/api-provider/operations-page/integration-api-provider-operation-description-component';
 
 const syndesisCommonModuleFwd = forwardRef(() => SyndesisCommonModule);
 const integrationSupportModuleFwd = forwardRef(() => IntegrationSupportModule);
@@ -234,6 +235,7 @@ const routes: Routes = [
     ApiProviderOperationsEditorComponent,
     ApiProviderOperationsListComponent,
     ApiProviderOperationsToolbarComponent,
+    ApiProviderOperationDescriptionComponent,
     ApiProviderSpecComponent,
     StepUploadComponent,
     StepValidateComponent,


### PR DESCRIPTION
## Changes

* redone the layout of the pages to support scrollable panes
* wrapped editor steps in cards

<img width="1278" alt="screenshot 2019-02-07 at 16 12 19" src="https://user-images.githubusercontent.com/966316/52420899-3ec49180-2af3-11e9-8c6b-d67e89f093c4.png">
<img width="1278" alt="screenshot 2019-02-07 at 16 12 11" src="https://user-images.githubusercontent.com/966316/52420900-3ec49180-2af3-11e9-8e25-27dd296478c9.png">
<img width="1278" alt="screenshot 2019-02-07 at 16 12 05" src="https://user-images.githubusercontent.com/966316/52420901-3ec49180-2af3-11e9-8d63-f6a58a9aaefb.png">
<img width="1278" alt="screenshot 2019-02-07 at 16 11 47" src="https://user-images.githubusercontent.com/966316/52420902-3f5d2800-2af3-11e9-8e11-7eeb344848cb.png">
<img width="1278" alt="screenshot 2019-02-07 at 16 11 43" src="https://user-images.githubusercontent.com/966316/52420903-3f5d2800-2af3-11e9-81a2-2d31a6459d72.png">
<img width="1278" alt="screenshot 2019-02-07 at 16 11 31" src="https://user-images.githubusercontent.com/966316/52420904-3f5d2800-2af3-11e9-8385-b1acdf263390.png">


## Issues

![width-issue](https://user-images.githubusercontent.com/966316/52408155-838c0080-2ad2-11e9-8823-f6467848c38b.gif)

In this screencap the browser started at ~1200px and got up to ~1300px, but the main content (the rightmost pane) doesn't work great with that little space that's left. 
@dongniwang any suggestion?

Also, the connections grid doesn't look great on a white BG.