### PR TITLE
fix: ensure that the openapi.json is not reinterpreted

### DIFF
--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
@@ -23,7 +23,7 @@ public class RestRouteConfiguration {
                     .description("Returns the OpenAPI specification for this service")
                     .route()
                     .setHeader(Exchange.CONTENT_TYPE, constant("application/vnd.oai.openapi+json"))
-                    .setBody(simple("resource:classpath:openapi.json"));
+                    .setBody(constant("resource:classpath:openapi.json"));
             }
         };
     }

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
@@ -23,7 +23,7 @@ public class RestRouteConfiguration {
                     .description("Returns the OpenAPI specification for this service")
                     .route()
                     .setHeader(Exchange.CONTENT_TYPE, constant("application/vnd.oai.openapi+json"))
-                    .setBody(simple("resource:classpath:openapi.json"));
+                    .setBody(constant("resource:classpath:openapi.json"));
             }
         };
     }


### PR DESCRIPTION
The use of `simple` expression made the content of the `src/main/resources/openapi.json` was reinterpreted and any quoted and escaped newline characters (`\n` within a quoted string) were expanded to newlines making the string span multiple lines and breaking the JSON syntax.

Fixes #4468