### PR TITLE
refactor(tool): no need to list pods

### DIFF
--- a/tools/misc/extract_integration.sh
+++ b/tools/misc/extract_integration.sh
@@ -27,8 +27,6 @@ if [ ! -d $dest ]; then
   exit 1
 fi
 
-pod=$(oc get pods -o name | grep -v -- "-build" | grep $pod | sed -e "s/^pods\///")
-
 oc cp ${pod}:/tmp/src $dest
 
 secret=$(oc get pod $pod -o json | jq -r ".spec.volumes[]|select(.name==\"secret-volume\")|.secret.secretName")


### PR DESCRIPTION
The user needs to specify the full name of the pod, no need for greping
the output and making the tool fragile.

Ref #2911