### PR TITLE
Bump version of jackson-databind to 2.8.11.3

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1557,7 +1557,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.8.11.2</version>
+        <version>2.8.11.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
See https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.8.11.3/release-notes/VERSION#L6 for security related fixes