### PR TITLE
fix(monitoring): Add missing labels to alert rules

### DIFF
--- a/install/addons/syndesis-db-prometheus-rule.yml
+++ b/install/addons/syndesis-db-prometheus-rule.yml
@@ -7,6 +7,8 @@ metadata:
     syndesis.io/type: infrastructure
     prometheus: application-monitoring
     role: alert-rules
+    monitoring-key: middleware
+    application-monitoring: "true"
   name: syndesis-db-rules
 spec:
   groups:

--- a/install/addons/syndesis-jvm-prometheus-rule.yml
+++ b/install/addons/syndesis-jvm-prometheus-rule.yml
@@ -7,6 +7,8 @@ metadata:
     syndesis.io/type: infrastructure
     prometheus: application-monitoring
     role: alert-rules
+    monitoring-key: middleware
+    application-monitoring: "true"
   name: syndesis-jvm-rules
 spec:
   groups:

--- a/install/addons/syndesis-rest-api-prometheus-rule.yml
+++ b/install/addons/syndesis-rest-api-prometheus-rule.yml
@@ -7,6 +7,8 @@ metadata:
     syndesis.io/type: infrastructure
     prometheus: application-monitoring
     role: alert-rules
+    monitoring-key: middleware
+    application-monitoring: "true"
   name: syndesis-rest-api-rules
 spec:
   groups:


### PR DESCRIPTION
Follow up to #4514. I missed some labels for the alert rules that are expected by the integr8ly operator.