### PR TITLE
refactor(server): additional fixes for #4477

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/app/common/util/pom.xml
+++ b/app/common/util/pom.xml
@@ -54,6 +54,29 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-parser</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-models</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -73,6 +96,18 @@
     <dependency>
       <groupId>net.iharder</groupId>
       <artifactId>base64</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/app/common/util/src/main/java/io/syndesis/common/util/openapi/CapturingCodec.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/openapi/CapturingCodec.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.server.api.generator.swagger.util;
+package io.syndesis.common.util.openapi;
 
 import java.io.IOException;
 import java.util.Iterator;

--- a/app/common/util/src/main/java/io/syndesis/common/util/openapi/OpenApiHelper.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/openapi/OpenApiHelper.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.util.openapi;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.models.Swagger;
+import io.swagger.models.properties.Property;
+import io.swagger.parser.SwaggerParser;
+import io.swagger.util.PropertyDeserializer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.util.JsonParserDelegate;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * All interaction with SwaggerParser should be done through this class because
+ * it performs additional setup of the Jackson ObjectMapper used by the
+ * SwaggerParser in order to make sure that the parssing and serialization is
+ * done in accordance to the specification.
+ */
+public final class OpenApiHelper {
+
+    static final SwaggerParser SWAGGER_PARSER = new SwaggerParser();
+
+    static {
+        final ObjectMapper mapper = io.swagger.util.Json.mapper();
+
+        // make sure that Jackson is using our own BaseIntegerProperty which
+        // supports `enum` property
+        mapper.addMixIn(Property.class, BaseIntegerProperty.class);
+
+        // we don't need empty arrays
+        mapper.configOverride(List.class).setInclude(JsonInclude.Value.construct(Include.NON_EMPTY, null));
+    }
+
+    @JsonDeserialize(using = BaseIntegerProperty.Serializer.class)
+    public static class BaseIntegerProperty extends io.swagger.models.properties.BaseIntegerProperty {
+
+        protected List<Integer> enumValues;
+
+        public static final class Serializer extends JsonDeserializer<Property> {
+
+            private final JsonDeserializer<Property> defaultDeserializer = new PropertyDeserializer();
+
+            @Override
+            public Property deserialize(final JsonParser parser, final DeserializationContext context) throws IOException, JsonProcessingException {
+                final CapturingCodec capturingCodec = new CapturingCodec(parser.getCodec());
+
+                final Property property = defaultDeserializer.deserialize(new JsonParserDelegate(parser) {
+                    @Override
+                    public ObjectCodec getCodec() {
+                        return capturingCodec;
+                    }
+                }, context);
+
+                if (!(property instanceof io.swagger.models.properties.BaseIntegerProperty)) {
+                    return property;
+                }
+
+                final JsonNode captured = (JsonNode) capturingCodec.captured();
+
+                final JsonNode enumNode = captured.get("enum");
+                if (enumNode == null || enumNode.isMissingNode() || enumNode.isNull() || !enumNode.isArray()) {
+                    return property;
+                }
+
+                final BaseIntegerProperty integerProperty = new BaseIntegerProperty((io.swagger.models.properties.BaseIntegerProperty) property);
+                integerProperty.enumValues = new ArrayList<>();
+                ((ArrayNode) enumNode).elements().forEachRemaining(value -> {
+                    if (value.isNumber()) {
+                        integerProperty.enumValues.add(value.intValue());
+                    }
+                });
+
+                return integerProperty;
+            }
+
+        }
+
+        public BaseIntegerProperty(final io.swagger.models.properties.BaseIntegerProperty property) {
+            access = property.getAccess();
+            allowEmptyValue = property.getAllowEmptyValue();
+            description = property.getDescription();
+            example = property.getExample();
+            exclusiveMaximum = property.getExclusiveMaximum();
+            exclusiveMinimum = property.getExclusiveMinimum();
+            format = property.getFormat();
+            maximum = property.getMaximum();
+            minimum = property.getMinimum();
+            multipleOf = property.getMultipleOf();
+            name = property.getName();
+            position = property.getPosition();
+            readOnly = property.getReadOnly();
+            required = property.getRequired();
+            title = property.getTitle();
+            type = property.getType();
+            vendorExtensions = property.getVendorExtensions();
+            xml = property.getXml();
+        }
+
+        public List<Integer> getEnum() {
+            return enumValues;
+        }
+
+        public void setEnum(final List<Integer> enumValues) {
+            this.enumValues = enumValues;
+        }
+    }
+
+    private OpenApiHelper() {
+        // helper class
+    }
+
+    public static ObjectMapper mapper() {
+        return io.swagger.util.Json.mapper();
+    }
+
+    public static Swagger parse(final String specification) {
+        return SWAGGER_PARSER.parse(specification);
+    }
+
+    public static String serialize(final Swagger swagger) {
+        try {
+            return io.swagger.util.Json.mapper().writeValueAsString(swagger);
+        } catch (final JsonProcessingException e) {
+            throw new IllegalStateException("Unable to serialize OpenAPI document", e);
+        }
+    }
+}

--- a/app/common/util/src/test/java/io/syndesis/common/util/immutable/SkipNullsTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/immutable/SkipNullsTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SkipNullsTest {
 
     @Value.Immutable
+    @Value.Style(jdkOnly = true)
     public interface TestValue {
         @SkipNulls
         Set<String> noNulls();

--- a/app/common/util/src/test/java/io/syndesis/common/util/openapi/OpenApiHelperTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/openapi/OpenApiHelperTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.util.openapi;
+
+import java.util.List;
+
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.util.Json;
+import io.syndesis.common.util.openapi.OpenApiHelper.BaseIntegerProperty;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenApiHelperTest {
+
+    @Test
+    public void shouldDeserializeSerializeWithoutLoosingEnumValues() throws JSONException {
+        final String document = "{\"swagger\":\"2.0\",\"definitions\":{\"Test\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"integer\",\"enum\":[1,2,3]}}}}}}}}}";
+        final Swagger parsed = OpenApiHelper.parse(document);
+
+        final String serialized = OpenApiHelper.serialize(parsed);
+
+        JSONAssert.assertEquals(document,
+            serialized, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void shouldSerializeWithoutAddingResponseSchema() throws JSONException {
+        final Swagger document = new Swagger().path("/api", new Path()
+            .get(new Operation()
+                .response(200, new Response()
+                    .responseSchema(new ModelImpl()
+                        .type("object")
+                        .property("key", new IntegerProperty())))));
+
+        final String serialized = OpenApiHelper.serialize(document);
+
+        JSONAssert.assertEquals(
+            "{\"swagger\":\"2.0\",\"paths\":{\"/api\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"integer\",\"format\":\"int32\"}}}}}}}}}",
+            serialized, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void shouldSetupSwaggerJacksonPatches() {
+        OpenApiHelper.mapper(); // setup
+        final ObjectMapper mapper = Json.mapper();
+
+        assertThat(mapper.findMixInClassFor(Property.class)).isEqualTo(BaseIntegerProperty.class);
+        assertThat(mapper.configOverride(List.class).getInclude()).isEqualTo(JsonInclude.Value.construct(Include.NON_EMPTY, null));
+    }
+
+}

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -61,10 +61,6 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-models</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-parser</artifactId>
-    </dependency>
 
     <!-- spring -->
     <dependency>

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -41,7 +41,6 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import io.swagger.models.Swagger;
-import io.swagger.parser.SwaggerParser;
 import io.syndesis.common.model.Dependency;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.ResourceIdentifier;
@@ -62,6 +61,7 @@ import io.syndesis.common.util.MavenProperties;
 import io.syndesis.common.util.Names;
 import io.syndesis.common.util.Optionals;
 import io.syndesis.common.util.Predicates;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.integration.project.generator.mvn.MavenGav;
@@ -372,7 +372,7 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
 
         final StringBuilder code = new StringBuilder();
         final byte[] openApiBytes = res.get().getDocument();
-        final Swagger swagger = new SwaggerParser().parse(new String(openApiBytes, StandardCharsets.UTF_8));
+        final Swagger swagger = OpenApiHelper.parse(new String(openApiBytes, StandardCharsets.UTF_8));
 
         RestDslGenerator.toAppendable(ProjectGeneratorHelper.normalizePaths(swagger))
             .withClassName("RestRoute")

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -43,11 +43,6 @@
 
     <dependency>
       <groupId>io.swagger</groupId>
-      <artifactId>swagger-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.swagger</groupId>
       <artifactId>swagger-parser</artifactId>
     </dependency>
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
@@ -47,6 +47,7 @@ import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 import io.syndesis.server.api.generator.APIGenerator;
 import io.syndesis.server.api.generator.APIIntegration;
 import io.syndesis.server.api.generator.APIValidationContext;
@@ -230,7 +231,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
         }
 
         // TODO: evaluate what can be shrinked (e.g. SwaggerHelper#minimalSwaggerUsedByComponent)
-        byte[] updatedSwagger = SwaggerHelper.serialize(swagger).getBytes(StandardCharsets.UTF_8);
+        byte[] updatedSwagger = OpenApiHelper.serialize(swagger).getBytes(StandardCharsets.UTF_8);
 
         // same check SwaggerParser is performing
         final String specificationContentType;

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelper.java
@@ -35,16 +35,13 @@ import io.swagger.models.ModelImpl;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.RefModel;
-import io.swagger.models.Response;
 import io.swagger.models.Swagger;
-import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
-import io.swagger.parser.SwaggerParser;
 import io.swagger.parser.util.RemoteUrl;
-import io.swagger.util.PropertyDeserializer;
 import io.syndesis.common.model.Violation;
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.Resources;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 import io.syndesis.server.api.generator.APIValidationContext;
 import io.syndesis.server.api.generator.swagger.SwaggerModelInfo;
 import io.syndesis.server.api.generator.swagger.SyndesisSwaggerValidationRules;
@@ -54,18 +51,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.util.JsonParserDelegate;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -95,86 +82,6 @@ public final class SwaggerHelper {
 
     private static final Pattern JSONDB_DISALLOWED_KEY_CHARS = Pattern.compile("[^ -\"&-\\-0-Z\\^-\u007E\u0080-\u10FFFF]");
 
-    @JsonIgnoreProperties("responseSchema")
-    @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
-    public abstract static class IgnoreResponseSchemaMixin {
-        // mixin class
-    }
-
-    @JsonDeserialize(using = BaseIntegerProperty.Serializer.class)
-    public static class BaseIntegerProperty extends io.swagger.models.properties.BaseIntegerProperty {
-
-        protected List<Integer> enumValues;
-
-        public BaseIntegerProperty(final io.swagger.models.properties.BaseIntegerProperty property) {
-            access = property.getAccess();
-            allowEmptyValue = property.getAllowEmptyValue();
-            description = property.getDescription();
-            example = property.getExample();
-            exclusiveMaximum = property.getExclusiveMaximum();
-            exclusiveMinimum = property.getExclusiveMinimum();
-            format = property.getFormat();
-            maximum = property.getMaximum();
-            minimum = property.getMinimum();
-            multipleOf = property.getMultipleOf();
-            name = property.getName();
-            position = property.getPosition();
-            readOnly = property.getReadOnly();
-            required = property.getRequired();
-            title = property.getTitle();
-            type = property.getType();
-            vendorExtensions = property.getVendorExtensions();
-            xml = property.getXml();
-        }
-
-        public List<Integer> getEnum() {
-            return enumValues;
-        }
-
-        public void setEnum(final List<Integer> enumValues) {
-            this.enumValues = enumValues;
-        }
-
-        public static final class Serializer extends JsonDeserializer<Property> {
-
-            private final JsonDeserializer<Property> defaultDeserializer = new PropertyDeserializer();
-
-            @Override
-            public Property deserialize(final JsonParser parser, final DeserializationContext context) throws IOException, JsonProcessingException {
-                final CapturingCodec capturingCodec = new CapturingCodec(parser.getCodec());
-
-                final Property property = defaultDeserializer.deserialize(new JsonParserDelegate(parser) {
-                    @Override
-                    public ObjectCodec getCodec() {
-                        return capturingCodec;
-                    }
-                }, context);
-
-                if (!(property instanceof io.swagger.models.properties.BaseIntegerProperty)) {
-                    return property;
-                }
-
-                final JsonNode captured = (JsonNode) capturingCodec.captured();
-
-                final JsonNode enumNode = captured.get("enum");
-                if (enumNode == null || enumNode.isMissingNode() || enumNode.isNull() || !enumNode.isArray()) {
-                    return property;
-                }
-
-                final BaseIntegerProperty integerProperty = new BaseIntegerProperty((io.swagger.models.properties.BaseIntegerProperty) property);
-                integerProperty.enumValues = new ArrayList<>();
-                ((ArrayNode) enumNode).elements().forEachRemaining(value -> {
-                    if (value.isNumber()) {
-                        integerProperty.enumValues.add(value.intValue());
-                    }
-                });
-
-                return integerProperty;
-            }
-
-        }
-    }
-
     static {
         try {
             final JsonNode swagger20Schema = Json.reader().readTree(Resources.getResourceAsText(SWAGGER_2_0_SCHEMA_FILE));
@@ -182,15 +89,6 @@ public final class SwaggerHelper {
                 .preloadSchema(SWAGGER_IO_V2_SCHEMA_URI, swagger20Schema)
                 .freeze();
             SWAGGER_2_0_SCHEMA = JsonSchemaFactory.newBuilder().setLoadingConfiguration(loadingConfiguration).freeze().getJsonSchema(SWAGGER_IO_V2_SCHEMA_URI);
-
-            // make sure that we don't read or serialize superfluously added `responseSchema` property
-            io.swagger.util.Json.mapper().addMixIn(Response.class, IgnoreResponseSchemaMixin.class);
-
-            // make sure that Jackson is using our own BaseIntegerProperty which supports `enum` property
-            io.swagger.util.Json.mapper().addMixIn(Property.class, BaseIntegerProperty.class);
-
-            // we don't need empty arrays
-            io.swagger.util.Json.mapper().configOverride(List.class).setInclude(JsonInclude.Value.construct(Include.NON_EMPTY, null));
         } catch (final ProcessingException | IOException ex) {
             throw new IllegalStateException("Unable to load the schema file embedded in the artifact", ex);
         }
@@ -321,8 +219,7 @@ public final class SwaggerHelper {
                 .build();
         }
 
-        final SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.parse(resolvedSpecification);
+        final Swagger swagger = OpenApiHelper.parse(specification);
         if (swagger == null) {
             LOG.debug("Unable to read OpenAPI document\n{}\n", specification);
             return resultBuilder
@@ -336,14 +233,6 @@ public final class SwaggerHelper {
             return SyndesisSwaggerValidationRules.get(validationContext).apply(swaggerModelInfo);
         }
         return resultBuilder.model(swagger).build();
-    }
-
-    public static String serialize(final Swagger swagger) {
-        try {
-            return io.swagger.util.Json.mapper().writeValueAsString(swagger);
-        } catch (final JsonProcessingException e) {
-            throw new IllegalStateException("Unable to serialize OpenAPI document", e);
-        }
     }
 
     static JsonNode convertToJson(final String specification) throws IOException, JsonProcessingException {
@@ -426,10 +315,6 @@ public final class SwaggerHelper {
             return new SwaggerModelInfo.Builder().addError(new Violation.Builder().error("error").property("")
                 .message("Unable to load the OpenAPI schema file embedded in the artifact").build()).build();
         }
-    }
-
-    public static ObjectMapper mapper() {
-        return io.swagger.util.Json.mapper();
     }
 
 }

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -24,7 +24,6 @@ import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
-import io.swagger.parser.SwaggerParser;
 import io.syndesis.common.model.action.ActionsSummary;
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
@@ -32,7 +31,7 @@ import io.syndesis.common.model.api.APISummary;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSettings;
-import io.syndesis.server.api.generator.swagger.util.SwaggerHelper;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 
 import org.junit.Test;
 
@@ -55,7 +54,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     @Test
     public void shouldCreatePropertyParametersFromPetstoreSwagger() throws IOException {
         final String specification = resource("/swagger/petstore.swagger.json");
-        final Swagger swagger = new SwaggerParser().parse(specification);
+        final Swagger swagger = OpenApiHelper.parse(specification);
 
         final Parameter petIdPathParameter = swagger.getPath("/pet/{petId}").getGet().getParameters().get(0);
 
@@ -237,7 +236,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
 
     private static ConnectorSettings createSettingsFrom(final Swagger swagger) {
         return new ConnectorSettings.Builder()//
-            .putConfiguredProperty("specification", SwaggerHelper.serialize(swagger))//
+            .putConfiguredProperty("specification", OpenApiHelper.serialize(swagger))//
             .build();
     }
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorRequestShapeTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorRequestShapeTest.java
@@ -23,10 +23,10 @@ import java.util.Arrays;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
-import io.swagger.parser.SwaggerParser;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.SoftAssertions;
@@ -65,8 +65,7 @@ public class UnifiedXmlDataShapeGeneratorRequestShapeTest {
         }
 
         json = (ObjectNode) Json.reader().readTree(specification);
-        final SwaggerParser parser = new SwaggerParser();
-        swagger = parser.parse(specification);
+        swagger = OpenApiHelper.parse(specification);
     }
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorShapeValidityTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorShapeValidityTest.java
@@ -37,8 +37,7 @@ import io.swagger.models.parameters.BodyParameter;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
-import io.syndesis.server.api.generator.APIValidationContext;
-import io.syndesis.server.api.generator.swagger.util.SwaggerHelper;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -209,7 +208,7 @@ public class UnifiedXmlDataShapeGeneratorShapeValidityTest {
             } catch (final IOException e) {
                 throw new AssertionError("Unable to parse swagger specification in path as JSON: " + specification, e);
             }
-            final Swagger swagger = SwaggerHelper.parse(specificationContent, APIValidationContext.NONE).getModel();
+            final Swagger swagger = OpenApiHelper.parse(specificationContent);
 
             swagger.getPaths().forEach((path, operations) -> {
                 operations.getOperationMap().forEach((method, operation) -> {

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/UnifiedXmlDataShapeGeneratorTest.java
@@ -24,7 +24,7 @@ import java.util.Map.Entry;
 import io.swagger.models.Swagger;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
-import io.syndesis.server.api.generator.swagger.util.SwaggerHelper;
+import io.syndesis.common.util.openapi.OpenApiHelper;
 import io.syndesis.server.api.generator.swagger.util.XmlSchemaHelper;
 
 import org.dom4j.Document;
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class UnifiedXmlDataShapeGeneratorTest {
 
-    private static final ObjectMapper MAPPER = SwaggerHelper.mapper();
+    private static final ObjectMapper MAPPER = OpenApiHelper.mapper();
 
     private static final Map<String, UnifiedXmlDataShapeGenerator.SchemaPrefixAndElement> NO_MORE_SCHEMAS = null;
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
@@ -20,21 +20,12 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import io.swagger.models.ModelImpl;
-import io.swagger.models.Operation;
-import io.swagger.models.Path;
-import io.swagger.models.Response;
-import io.swagger.models.Swagger;
-import io.swagger.models.properties.IntegerProperty;
 import io.syndesis.server.api.generator.APIValidationContext;
 import io.syndesis.server.api.generator.swagger.AbstractSwaggerConnectorTest;
 import io.syndesis.server.api.generator.swagger.SwaggerModelInfo;
 import io.syndesis.server.jsondb.impl.JsonRecordSupport;
 
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static io.syndesis.server.api.generator.swagger.TestHelper.resource;
 
@@ -42,18 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
-
-    @Test
-    public void shouldDeserializeSerializeWithoutLoosingEnumValues() throws JSONException {
-        final String document = "{\"swagger\":\"2.0\",\"definitions\":{\"Test\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"integer\",\"enum\":[1,2,3]}}}}}}}}}";
-        final SwaggerModelInfo info = SwaggerHelper.parse(document, APIValidationContext.CONSUMED_API);
-        final Swagger parsed = info.getModel();
-
-        final String serialized = SwaggerHelper.serialize(parsed);
-
-        JSONAssert.assertEquals(document,
-            serialized, JSONCompareMode.STRICT);
-    }
 
     @Test
     public void shouldSanitizeListOfTags() {
@@ -74,21 +53,6 @@ public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
         assertThatCode(() -> JsonRecordSupport.validateKey(sanitized)).doesNotThrowAnyException();
     }
 
-    @Test
-    public void shouldSerializeWithoutAddingResponseSchema() throws JSONException {
-        final Swagger document = new Swagger().path("/api", new Path()
-            .get(new Operation()
-                .response(200, new Response()
-                    .responseSchema(new ModelImpl()
-                        .type("object")
-                        .property("key", new IntegerProperty())))));
-
-        final String serialized = SwaggerHelper.serialize(document);
-
-        JSONAssert.assertEquals(
-            "{\"swagger\":\"2.0\",\"paths\":{\"/api\":{\"get\":{\"responses\":{\"200\":{\"schema\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"integer\",\"format\":\"int32\"}}}}}}}}}",
-            serialized, JSONCompareMode.STRICT);
-    }
 
     @Test
     public void testThatAllSwaggerFilesAreValid() throws IOException {


### PR DESCRIPTION
We need to make sure that the configuration changes and mixins of Jackson ObjectMapper used by SwaggerParser's are applied. And the way to make sure that they are is to make sure that all usage of SwaggerParser is done through `OpenApiHelper` which was created by refactoring bits of `SwaggerHelper` from `server-api-generator` into `common-util` as it is used in `integration-project-generator` also.

This should make sure that the observed flakiness of the `SwaggerHelperTest`, which is due to the order of execution/initialization of ObjectMapper used by SwaggerParser is fixed. I'll run the CircleCI workflow multiple times to make sure this is the case.

Ref #4477