### PR TITLE
SQL connector returns collection data shape

### DIFF
--- a/app/connector/sql/src/test/resources/sql/demo_add_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/demo_add_metadata.json
@@ -11,6 +11,9 @@
     "type" : "DEMO_ADD_OUT",
     "name" : "DEMO_ADD Return",
     "description" : "Return value of Stored Procedure 'DEMO_ADD'",
+    "metadata": {
+      "variant": "element"
+    },
     "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"DEMO_ADD_OUT\",\"properties\":{\"C\":{\"type\":\"integer\",\"required\":true}}}"
   },
   "properties" : {

--- a/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
@@ -10,8 +10,11 @@
     "kind" : "json-schema",
     "type" : "SQL_PARAM_OUT",
     "name" : "SQL Result",
+    "metadata": {
+      "variant": "collection"
+    },
     "description" : "Result of SQL [SELECT * FROM NAME WHERE ID=:#id]",
-    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true},\"FIRSTNAME\":{\"type\":\"string\",\"required\":true},\"LASTNAME\":{\"type\":\"string\",\"required\":true}}}"
+    "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true},\"FIRSTNAME\":{\"type\":\"string\",\"required\":true},\"LASTNAME\":{\"type\":\"string\",\"required\":true}}}}"
   },
   "properties" : {
     "query" : [ {

--- a/app/connector/sql/src/test/resources/sql/name_sql_no_param_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_no_param_metadata.json
@@ -8,7 +8,10 @@
     "type" : "SQL_PARAM_OUT",
     "name" : "SQL Result",
     "description" : "Result of SQL [SELECT * FROM NAME]",
-    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true},\"FIRSTNAME\":{\"type\":\"string\",\"required\":true},\"LASTNAME\":{\"type\":\"string\",\"required\":true}}}"
+    "metadata": {
+      "variant": "collection"
+    },
+    "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true},\"FIRSTNAME\":{\"type\":\"string\",\"required\":true},\"LASTNAME\":{\"type\":\"string\",\"required\":true}}}}"
   },
   "properties" : {
     "query" : [ {


### PR DESCRIPTION
SQL connector now using json-schema array collection type as output data shape for sql query actions.

Store procedure actions stay as is as the underlying Camel component is not able to provide a list of results but only a single entry as result set.