### PR TITLE
#4405 Aggregate step should provide input shape of subsequent step

### DIFF
--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -37,7 +37,7 @@ public class AggregateMetadataHandlerTest {
     private AggregateMetadataHandler metadataHandler = new AggregateMetadataHandler();
 
     @Test
-    public void shouldExtractJavaCollectionVariant() throws IOException {
+    public void shouldExtractJavaOutputCollectionVariant() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(StepActionHandler.NO_SHAPE)
                 .outputShape(new DataShape.Builder()
@@ -60,6 +60,56 @@ public class AggregateMetadataHandlerTest {
         DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
 
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(getSpecification("person-list-spec.json"), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+    }
+
+    @Test
+    public void shouldExtractJavaInputElementVariant() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JAVA)
+                        .specification(getSpecification("person-list-spec.json"))
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .putMetadata("variant", "collection")
+                        .addVariant(new DataShape.Builder()
+                                .kind(DataShapeKinds.JAVA)
+                                .specification(getSpecification("person-spec.json"))
+                                .type(Person.class.getName())
+                                .putMetadata("variant", "element")
+                                .build())
+                        .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
+                        .build())
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JAVA)
+                        .specification(getSpecification("person-spec.json"))
+                        .type(Person.class.getName())
+                        .putMetadata("variant", "element")
+                        .addVariant(new DataShape.Builder()
+                                .kind(DataShapeKinds.JAVA)
+                                .specification(getSpecification("person-list-spec.json"))
+                                .collectionType("List")
+                                .type(Person.class.getName())
+                                .collectionClassName(List.class.getName())
+                                .putMetadata("variant", "collection")
+                                .build())
+                        .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals("element", enrichedMetadata.inputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(getSpecification("person-spec.json"), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(0, enrichedMetadata.inputShape().getVariants().size());
+
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
@@ -99,9 +149,66 @@ public class AggregateMetadataHandlerTest {
     }
 
     @Test
-    public void shouldAutoExtractJsonSchemaCollection() throws IOException {
+    public void shouldExtractJsonSchemaInputElementVariant() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
-                .inputShape(StepActionHandler.NO_SHAPE)
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-list-schema.json"))
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .putMetadata("variant", "collection")
+                        .addVariant(new DataShape.Builder()
+                                .kind(DataShapeKinds.JSON_SCHEMA)
+                                .specification(getSpecification("person-schema.json"))
+                                .type(Person.class.getName())
+                                .putMetadata("variant", "element")
+                                .build())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-schema.json"))
+                        .type(Person.class.getName())
+                        .putMetadata("variant", "element")
+                        .addVariant(new DataShape.Builder()
+                                .kind(DataShapeKinds.JSON_SCHEMA)
+                                .specification(getSpecification("person-list-schema.json"))
+                                .collectionType("List")
+                                .type(Person.class.getName())
+                                .collectionClassName(List.class.getName())
+                                .putMetadata("variant", "collection")
+                                .build())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals("element", enrichedMetadata.inputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(getSpecification("person-schema.json"), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(0, enrichedMetadata.inputShape().getVariants().size());
+
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(getSpecification("person-list-schema.json"), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+    }
+
+    @Test
+    public void shouldAutoExtractJsonSchemaVariants() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-list-schema.json"))
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-schema.json"))
@@ -112,7 +219,11 @@ public class AggregateMetadataHandlerTest {
 
         DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
 
-        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-schema.json")), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-schema.json")), enrichedMetadata.outputShape().getSpecification());
@@ -151,9 +262,16 @@ public class AggregateMetadataHandlerTest {
     }
 
     @Test
-    public void shouldAutoExtractJsonInstanceCollection() throws IOException {
+    public void shouldAutoExtractJsonInstanceVariants() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
-                .inputShape(StepActionHandler.NO_SHAPE)
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification(getSpecification("person-list-instance.json"))
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-instance.json"))
@@ -164,7 +282,11 @@ public class AggregateMetadataHandlerTest {
 
         DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
 
-        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.inputShape().getSpecification()));
+        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.outputShape().getSpecification()));

--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -598,9 +598,11 @@ export class CurrentFlowService {
       case AGGREGATE:
         // A split step needs the data shape of the previous thing with a data shape
         const prev = this.getPreviousStepWithDataShape(position);
+        const subsequent = this.getSubsequentStepWithDataShape(position);
+        const subsequentDataShape = subsequent !== undefined ? subsequent.action.descriptor.inputDataShape : undefined;
         this.integrationSupportService
           .getStepDescriptor(step.stepKind, {
-            inputShape: prev.action.descriptor.inputDataShape,
+            inputShape: step.stepKind === AGGREGATE ? subsequentDataShape : prev.action.descriptor.inputDataShape,
             outputShape: prev.action.descriptor.outputDataShape,
           })
           .subscribe(


### PR DESCRIPTION
Aggregate step should not only provide output shape of previous step but also the input shape of the subsequent step.

If subsequent step defines a collection shape the server step metadata lookup provides the single element variant of that shape.