### PR TITLE
#4586 Fix step id for split and aggregate in integration runtime

### DIFF
--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/capture/OutMessageCaptureProcessorTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/capture/OutMessageCaptureProcessorTest.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.integration.runtime.sb.capture;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.syndesis.common.model.action.ConnectorAction;
@@ -160,6 +161,7 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id("s-split")
                     .stepKind(StepKind.split)
                     .build(),
                 new Step.Builder()
@@ -193,6 +195,7 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id("s-aggregate")
                     .stepKind(StepKind.aggregate)
                     .build()
             );
@@ -213,11 +216,12 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
 
             Exchange exchange1 = result.getExchanges().get(0);
             Map<String, Message> messages = OutMessageCaptureProcessor.getCapturedMessageMap(exchange1);
-            assertThat(messages).hasSize(4);
-            assertThat(messages.get("s1").getBody()).isEqualTo("World");
+            assertThat(messages).hasSize(5);
+            assertThat(messages.get("s-split").getBody()).isEqualTo("World");
             assertThat(messages.get("s2").getBody()).isEqualTo("Hello World");
             assertThat(messages.get("s3").getBody()).isEqualTo(-862545276);
             assertThat(messages.get("s4").getBody()).isEqualTo(-862545276);
+            assertThat(messages.get("s-aggregate").getBody()).isEqualTo(Collections.singletonList(-862545276));
         } finally {
             context.stop();
         }
@@ -240,6 +244,7 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id("s-split")
                     .stepKind(StepKind.split)
                     .build(),
                 new Step.Builder()
@@ -263,6 +268,7 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id("s-aggregate")
                     .stepKind(StepKind.aggregate)
                     .build()
             );
@@ -296,12 +302,12 @@ public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
 
             Exchange exchange1 = result.getExchanges().get(0);
             Map<String, Message> messages = OutMessageCaptureProcessor.getCapturedMessageMap(exchange1);
-            assertThat(messages.get("s1").getBody()).isEqualTo("Hiram");
+            assertThat(messages.get("s-split").getBody()).isEqualTo("Hiram");
             assertThat(messages.get("s2").getBody()).isEqualTo("Hello Hiram");
 
             Exchange exchange2 = result.getExchanges().get(1);
             Map<String, Message> messages2 = OutMessageCaptureProcessor.getCapturedMessageMap(exchange2);
-            assertThat(messages2.get("s1").getBody()).isEqualTo("World");
+            assertThat(messages2.get("s-split").getBody()).isEqualTo("World");
             assertThat(messages2.get("s2").getBody()).isEqualTo("Hello World");
         } finally {
             context.stop();

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
@@ -50,7 +50,7 @@ public class IntegrationRouteBuilderTest extends IntegrationTestSupport {
 
         assertThat(route.getInputs()).hasSize(1);
         assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "direct:expression");
-        assertThat(route.getOutputs()).hasSize(2);
+        assertThat(route.getOutputs()).hasSize(4);
         assertThat(getOutput(route, 0)).isInstanceOf(SetHeaderDefinition.class);
         assertThat(getOutput(route, 1)).isInstanceOf(SplitDefinition.class);
         assertThat(getOutput(route, 1).getOutputs()).hasSize(3);
@@ -62,5 +62,7 @@ public class IntegrationRouteBuilderTest extends IntegrationTestSupport {
         assertThat(getOutput(route, 1, 2, 1)).isInstanceOf(ToDefinition.class);
         assertThat(getOutput(route, 1, 2, 1)).hasFieldOrPropertyWithValue("uri", "mock:expression");
         assertThat(getOutput(route, 1, 2, 2)).isInstanceOf(ProcessDefinition.class);
+        assertThat(getOutput(route, 2)).isInstanceOf(SetHeaderDefinition.class);
+        assertThat(getOutput(route, 3)).isInstanceOf(ProcessDefinition.class);
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteTest.java
@@ -164,7 +164,7 @@ public class IntegrationRouteTest extends IntegrationTestSupport {
 
         assertThat(route.getInputs()).hasSize(1);
         assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "direct:start");
-        assertThat(route.getOutputs()).hasSize(2);
+        assertThat(route.getOutputs()).hasSize(4);
         assertThat(getOutput(route, 0)).isInstanceOf(SetHeaderDefinition.class);
         assertThat(getOutput(route, 1)).isInstanceOf(SplitDefinition.class);
         assertThat(getOutput(route, 1).getOutputs()).hasSize(4);
@@ -172,6 +172,8 @@ public class IntegrationRouteTest extends IntegrationTestSupport {
         assertThat(getOutput(route, 1, 1)).isInstanceOf(ProcessDefinition.class);
         assertThat(getOutput(route, 1, 2)).isInstanceOf(PipelineDefinition.class);
         assertThat(getOutput(route, 1, 3)).isInstanceOf(PipelineDefinition.class);
+        assertThat(getOutput(route, 2)).isInstanceOf(SetHeaderDefinition.class);
+        assertThat(getOutput(route, 3)).isInstanceOf(ProcessDefinition.class);
     }
 
     @Test
@@ -234,7 +236,7 @@ public class IntegrationRouteTest extends IntegrationTestSupport {
 
         assertThat(route.getInputs()).hasSize(1);
         assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "timer:integration?period=1s");
-        assertThat(route.getOutputs()).hasSize(3);
+        assertThat(route.getOutputs()).hasSize(5);
         assertThat(getOutput(route, 0)).isInstanceOf(SetHeaderDefinition.class);
         assertThat(getOutput(route, 1)).isInstanceOf(ToDefinition.class);
         assertThat(getOutput(route, 2)).isInstanceOf(SplitDefinition.class);
@@ -247,5 +249,7 @@ public class IntegrationRouteTest extends IntegrationTestSupport {
         assertThat(getOutput(route, 2, 2, 1)).isInstanceOf(ToDefinition.class);
         assertThat(getOutput(route, 2, 2, 1)).hasFieldOrPropertyWithValue("uri", "mock:timer");
         assertThat(getOutput(route, 2, 2, 2)).isInstanceOf(ProcessDefinition.class);
+        assertThat(getOutput(route, 3)).isInstanceOf(SetHeaderDefinition.class);
+        assertThat(getOutput(route, 4)).isInstanceOf(ProcessDefinition.class);
     }
 }


### PR DESCRIPTION
Split step was using the wrong (previous step) step id when adding messages to the out message capture processor in integration route builder. Also aggregate step did not add its message to the processor at all.

This lead to failing mappings that map from/to split or aggregate data shapes.

Fixes #4568 and relates to #4405