### PR TITLE
fix(IVP): create common class for IVP step badge icons

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.html
@@ -52,7 +52,7 @@
       />
     </div>
     <span
-      class="pficon pficon-warning-triangle-o data-mismatch"
+      class="pficon pficon-warning-triangle-o step-badge data-mismatch"
       *ngIf="shouldAddDatamapper || previousStepShouldDefineDataShape"
       [popover]="dataWarningPopover"
       [popoverTitle]="[
@@ -70,7 +70,7 @@
     </span>
 
     <span
-      class="pficon pficon-info step-suggestion"
+      class="pficon pficon-info step-badge step-suggestion"
       *ngIf="isUnclosedSplit"
       [popover]="splitWarningPopover"
       popoverTitle="Step suggestion"

--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view-step.component.scss
@@ -88,10 +88,6 @@
     justify-content: center;
     position: relative;
 
-    &:not(.not-connection) + .data-mismatch {
-      transform: translate(25%, -25%);
-    }
-
     .connection-icon {
       height: 24px;
       margin-top: 1px;
@@ -128,31 +124,25 @@
     }
   }
 
-  .data-mismatch {
+  .step-badge {
     position: absolute;
-    background: #ec7a08;
     border-radius: 50%;
     padding: 5px;
     cursor: pointer;
     top: 0;
     right: 0;
+    transform: translate(25%, -25%);
 
     &::before {
       color: $color-pf-white;
     }
-  }
 
-  .step-suggestion {
-    position: absolute;
-    background: #0088ce;
-    border-radius: 50%;
-    padding: 5px;
-    cursor: pointer;
-    top: 0;
-    right: 0;
+    &.step-suggestion {
+      background: #0088ce;
+    }
 
-    &::before {
-      color: $color-pf-white;
+    &.data-mismatch {
+      background: #ec7a08;
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/4591

If you look in the original issue (https://github.com/syndesisio/syndesis/issues/4591), you'll see a data-mismatch icon by the aggregate step. I don't see an aggregate step on master. Is that new functionality, or am I missing something?