### PR TITLE
Fix Json type source and target conversion for topmost collection support

### DIFF
--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -96,6 +96,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-json-model</artifactId>
+      <version>${atlasmap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-twitter</artifactId>
       <scope>test</scope>

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
@@ -15,17 +15,40 @@
  */
 package io.syndesis.integration.runtime.handlers;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.Json;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 import io.syndesis.integration.runtime.IntegrationStepHandler;
 import io.syndesis.integration.runtime.capture.OutMessageCaptureProcessor;
-import io.syndesis.common.model.integration.Step;
-import io.syndesis.common.model.integration.StepKind;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("PMD.AvoidReassigningParameters")
 public class DataMapperStepHandler implements IntegrationStepHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataMapperStepHandler.class);
+
+    private static final String ATLASMAP_MODEL_VERSION = "v2";
+    static final String ATLASMAP_JSON_DATA_SOURCE = "io.atlasmap.json." + ATLASMAP_MODEL_VERSION + ".JsonDataSource";
+
     @Override
     public boolean canHandle(Step step) {
         return StepKind.mapper == step.getStepKind();
@@ -35,8 +58,126 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
     public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String flowIndex, String stepIndex) {
         ObjectHelper.notNull(route, "route");
 
-        return Optional.of(
-            route.toF("atlas:mapping-flow-%s-step-%s.json?encoding=UTF-8&sourceMapName=" + OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP, flowIndex, stepIndex)
-        );
+        List<Map<String, Object>> dataSources = getAtlasmapDataSources(step.getConfiguredProperties());
+
+        route = handleJsonTypeSourceProcessor(route, dataSources).orElse(route);
+        route = route.toF("atlas:mapping-flow-%s-step-%s.json?encoding=UTF-8&sourceMapName=" + OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP, flowIndex, stepIndex);
+        route = handleJsonTypeTargetProcessor(route, dataSources).orElse(route);
+
+        return Optional.of(route);
+    }
+
+    /**
+     * In case atlas mapping definition contains Json typed source documents we need to make sure to convert those from list to Json array Strings before passing those
+     * source documents to the mapper.
+     * @param route
+     * @param dataSources
+     * @return
+     */
+    private Optional<ProcessorDefinition<?>> handleJsonTypeSourceProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
+        List<String> jsonTypeSourceIds = dataSources.stream()
+                                                    .filter(s -> ATLASMAP_JSON_DATA_SOURCE.equals(s.get("jsonType")) && "SOURCE".equals(s.get("dataSourceType")))
+                                                    .map(s -> Optional.ofNullable(s.get("id")).map(Object::toString).orElse(""))
+                                                    .collect(Collectors.toList());
+
+        if (ObjectHelper.isNotEmpty(jsonTypeSourceIds)) {
+            return Optional.of(route.process(new JsonTypeSourceProcessor(jsonTypeSourceIds)));
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * In case mapping definition has Json typed target document we need to make sure to convert the output. This is because mapper provides Json target collection as Json array String representation.
+     * We prefer to use list objects where each element is a Json Object String.
+     * @param route
+     * @param dataSources
+     * @return
+     */
+    private Optional<ProcessorDefinition<?>> handleJsonTypeTargetProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
+        boolean isJsonTypeTarget = dataSources.stream()
+                .anyMatch(s -> ATLASMAP_JSON_DATA_SOURCE.equals(s.get("jsonType")) && "TARGET".equals(s.get("dataSourceType")));
+
+        if (isJsonTypeTarget) {
+            return Optional.of(route.process(new JsonTypeTargetProcessor()));
+        }
+
+        return Optional.empty();
+
+    }
+
+    /**
+     * Reads atlas mapping definition from configured step properties and extracts all data source elements.
+     * @param configuredProperties
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> getAtlasmapDataSources(Map<String, String> configuredProperties) {
+        List<Map<String, Object>> sources = new ArrayList<>();
+
+        try {
+            Map<String, Object> atlasMapping = Json.reader().forType(Map.class).readValue(configuredProperties.getOrDefault("atlasmapping", "{}"));
+            atlasMapping = (Map<String, Object>) atlasMapping.getOrDefault("AtlasMapping", new HashMap<>());
+            sources = (List<Map<String, Object>>) atlasMapping.getOrDefault("dataSource", Collections.emptyList());
+        } catch (IOException | ClassCastException e) {
+            LOG.warn("Failed to read atlas mapping definition from configured properties", e);
+        }
+
+        return sources;
+    }
+
+    /**
+     * Processor converts all Json collection typed entries in captured out messages to a
+     * Json array String representation. See {@link OutMessageCaptureProcessor}
+     */
+    static class JsonTypeSourceProcessor implements Processor {
+        final List<String> jsonTypeSourceIds;
+
+        JsonTypeSourceProcessor(List<String> jsonTypeSourceIds) {
+            this.jsonTypeSourceIds = jsonTypeSourceIds;
+        }
+
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            for (String sourceId : jsonTypeSourceIds) {
+                Message message = OutMessageCaptureProcessor.getCapturedMessageMap(exchange).get(sourceId);
+
+                if (message == null && jsonTypeSourceIds.size() == 1) {
+                    message = exchange.hasOut() ? exchange.getOut() : exchange.getIn();
+                }
+
+                if (message != null && message.getBody() instanceof List) {
+                    List<?> jsonBeans = message.getBody(List.class);
+                    message.setBody("[" + jsonBeans.stream().map(Object::toString).collect(Collectors.joining(",")) + "]");
+                }
+            }
+        }
+    }
+
+    /**
+     * Processor converts Atlasmap target Json array String representation to list of Json bean strings.
+     */
+    static class JsonTypeTargetProcessor implements Processor {
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            final Message message = exchange.hasOut() ? exchange.getOut() : exchange.getIn();
+
+            if (message != null && message.getBody(String.class) != null) {
+                try {
+                    JsonNode json = Json.reader().readTree(message.getBody(String.class));
+                    if (json.isArray()) {
+                        List<String> jsonBeans = new ArrayList<>();
+                        Iterator<JsonNode> it = json.elements();
+                        while (it.hasNext()) {
+                            jsonBeans.add(Json.writer().writeValueAsString(it.next()));
+                        }
+
+                        message.setBody(jsonBeans);
+                    }
+                } catch (JsonParseException e) {
+                    LOG.warn("Unable to convert json array type String to required format", e);
+                }
+            }
+        }
     }
 }

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
@@ -76,7 +76,8 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
     private void addJsonTypeSourceProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
         List<String> jsonTypeSourceIds = dataSources.stream()
                                                     .filter(s -> ATLASMAP_JSON_DATA_SOURCE.equals(s.get("jsonType")) && "SOURCE".equals(s.get("dataSourceType")))
-                                                    .map(s -> Optional.ofNullable(s.get("id")).map(Object::toString).orElse(""))
+                                                    .filter(s -> ObjectHelper.isNotEmpty(s.get("id")))
+                                                    .map(s -> s.get("id").toString())
                                                     .collect(Collectors.toList());
 
         if (ObjectHelper.isNotEmpty(jsonTypeSourceIds)) {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandlerTest.java
@@ -15,7 +15,11 @@
  */
 package io.syndesis.integration.runtime.handlers;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
@@ -24,8 +28,12 @@ import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.capture.OutMessageCaptureProcessor;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.camel.impl.DefaultMessage;
 import org.apache.camel.model.PipelineDefinition;
 import org.apache.camel.model.ProcessDefinition;
 import org.apache.camel.model.RouteDefinition;
@@ -38,38 +46,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
 public class DataMapperStepHandlerTest extends IntegrationTestSupport {
 
+    private CamelContext camelContext = new DefaultCamelContext();
+
     @Test
     public void testDataMapperStep() throws Exception {
         final CamelContext context = new DefaultCamelContext();
 
         try {
-            final RouteBuilder routeBuilder = newIntegrationRouteBuilder(
-                new Step.Builder()
-                    .id("step-1")
-                    .stepKind(StepKind.endpoint)
-                    .action(new ConnectorAction.Builder()
-                        .descriptor(new ConnectorDescriptor.Builder()
-                            .componentScheme("direct")
-                            .putConfiguredProperty("name", "start")
-                            .build())
-                        .build())
-                    .build(),
-                new Step.Builder()
-                    .id("step-2")
-                    .stepKind(StepKind.mapper)
-                    .putConfiguredProperty("atlasmapping", "{}")
-                    .build(),
-                new Step.Builder()
-                    .id("step-3")
-                    .stepKind(StepKind.endpoint)
-                    .action(new ConnectorAction.Builder()
-                        .descriptor(new ConnectorDescriptor.Builder()
-                            .componentScheme("mock")
-                            .putConfiguredProperty("name", "result")
-                            .build())
-                        .build())
-                    .build()
-            );
+            final RouteBuilder routeBuilder = newIntegrationRouteBuilder(getTestSteps());
 
             // Set up the camel context
             context.addRoutes(routeBuilder);
@@ -105,5 +89,250 @@ public class DataMapperStepHandlerTest extends IntegrationTestSupport {
         } finally {
             context.stop();
         }
+    }
+
+    @Test
+    public void testJsonTypeProcessors() throws Exception {
+        final CamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routeBuilder = newIntegrationRouteBuilder(getTestSteps("{" +
+                                    "\"AtlasMapping\":{" +
+                                        "\"dataSource\":[" +
+                                            "{\"jsonType\":\"" + DataMapperStepHandler.ATLASMAP_JSON_DATA_SOURCE + "\",\"id\":\"source\",\"uri\":\"atlas:json:source\",\"dataSourceType\":\"SOURCE\"}," +
+                                            "{\"jsonType\":\"" + DataMapperStepHandler.ATLASMAP_JSON_DATA_SOURCE + "\",\"id\":\"target\",\"uri\":\"atlas:json:target\",\"dataSourceType\":\"TARGET\",\"template\":null}" +
+                                        "]," +
+                                        "\"mappings\":{}" +
+                                        "}" +
+                                    "}"));
+
+            // Set up the camel context
+            context.addRoutes(routeBuilder);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            List<RouteDefinition> routes = context.getRouteDefinitions();
+            assertThat(routes).hasSize(1);
+
+            RouteDefinition route = context.getRouteDefinitions().get(0);
+            assertThat(route).isNotNull();
+            assertThat(route.getInputs()).hasSize(1);
+            assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "direct:start");
+            assertThat(route.getOutputs()).hasSize(5);
+            assertThat(route.getOutputs().get(0)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(1)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(2)).isInstanceOf(ProcessDefinition.class);
+
+            // Atlas
+            assertThat(route.getOutputs().get(3)).isInstanceOf(PipelineDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs()).hasSize(5);
+            assertThat(route.getOutputs().get(3).getOutputs().get(0)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(1)).isInstanceOf(ProcessDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(2)).isInstanceOf(ToDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(2)).hasFieldOrPropertyWithValue(
+                    "uri",
+                    "atlas:mapping-flow-0-step-1.json?encoding=UTF-8&sourceMapName=" + OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP
+            );
+            assertThat(route.getOutputs().get(3).getOutputs().get(3)).isInstanceOf(ProcessDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(4)).isInstanceOf(ProcessDefinition.class);
+            assertThat(route.getOutputs().get(4)).isInstanceOf(PipelineDefinition.class);
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testJsonTypeProcessorsSkip() throws Exception {
+        final CamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routeBuilder = newIntegrationRouteBuilder(getTestSteps("{" +
+                                    "\"AtlasMapping\":{" +
+                                        "\"dataSource\":[" +
+                                            "{\"jsonType\":\"io.atlasmap.v2.DataSource\",\"id\":\"source\",\"uri\":\"atlas:java?className=twitter4j.Status\",\"dataSourceType\":\"SOURCE\"}," +
+                                            "{\"jsonType\":\"io.atlasmap.v2.DataSource\",\"id\":\"target\",\"uri\":\"atlas:java?className=io.syndesis.connector.gmail.GmailMessageModel\",\"dataSourceType\":\"TARGET\",\"template\":null}" +
+                                        "]," +
+                                        "\"mappings\":{}" +
+                                        "}" +
+                                    "}"));
+
+            // Set up the camel context
+            context.addRoutes(routeBuilder);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            List<RouteDefinition> routes = context.getRouteDefinitions();
+            assertThat(routes).hasSize(1);
+
+            RouteDefinition route = context.getRouteDefinitions().get(0);
+            assertThat(route).isNotNull();
+            assertThat(route.getInputs()).hasSize(1);
+            assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "direct:start");
+            assertThat(route.getOutputs()).hasSize(5);
+            assertThat(route.getOutputs().get(0)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(1)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(2)).isInstanceOf(ProcessDefinition.class);
+
+            // Atlas
+            assertThat(route.getOutputs().get(3)).isInstanceOf(PipelineDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs()).hasSize(3);
+            assertThat(route.getOutputs().get(3).getOutputs().get(0)).isInstanceOf(SetHeaderDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(1)).isInstanceOf(ToDefinition.class);
+            assertThat(route.getOutputs().get(3).getOutputs().get(1)).hasFieldOrPropertyWithValue(
+                    "uri",
+                    "atlas:mapping-flow-0-step-1.json?encoding=UTF-8&sourceMapName=" + OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP
+            );
+            assertThat(route.getOutputs().get(3).getOutputs().get(2)).isInstanceOf(ProcessDefinition.class);
+            assertThat(route.getOutputs().get(4)).isInstanceOf(PipelineDefinition.class);
+        } finally {
+            context.stop();
+        }
+    }
+
+    private Step[] getTestSteps() {
+        return getTestSteps("{}");
+    }
+
+    private Step[] getTestSteps(String atlasMapping) {
+        return new Step[]{
+                new Step.Builder()
+                        .id("step-1")
+                        .stepKind(StepKind.endpoint)
+                        .action(new ConnectorAction.Builder()
+                                .descriptor(new ConnectorDescriptor.Builder()
+                                        .componentScheme("direct")
+                                        .putConfiguredProperty("name", "start")
+                                        .build())
+                                .build())
+                        .build(),
+                new Step.Builder()
+                        .id("step-2")
+                        .stepKind(StepKind.mapper)
+                        .putConfiguredProperty("atlasmapping", atlasMapping)
+                        .build(),
+                new Step.Builder()
+                        .id("step-3")
+                        .stepKind(StepKind.endpoint)
+                        .action(new ConnectorAction.Builder()
+                                .descriptor(new ConnectorDescriptor.Builder()
+                                        .componentScheme("mock")
+                                        .putConfiguredProperty("name", "result")
+                                        .build())
+                                .build())
+                        .build()
+        };
+    }
+
+    @Test
+    public void testJsonTypeSourceProcessingOnExchange() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody(Arrays.asList("{\"name\": \"Howard\", \"age\": 29}", "{\"name\": \"Sheldon\", \"age\": 30}"));
+
+        new DataMapperStepHandler.JsonTypeSourceProcessor(Collections.singletonList("m1")).process(exchange);
+
+        assertThat(exchange.getIn().getBody(String.class)).isEqualTo("[{\"name\": \"Howard\", \"age\": 29},{\"name\": \"Sheldon\", \"age\": 30}]");
+    }
+
+    @Test
+    public void testJsonTypeSourceProcessingSkipOnNonListBody() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody("{\"name\": \"Leonard\", \"age\": 30}");
+
+        new DataMapperStepHandler.JsonTypeSourceProcessor(Collections.singletonList("m1")).process(exchange);
+
+        assertThat(exchange.getIn().getBody(String.class)).isEqualTo("{\"name\": \"Leonard\", \"age\": 30}");
+    }
+
+    @Test
+    public void testJsonTypeSourceProcessing() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        Map<String, Message> captured = new HashMap<>();
+
+        Message m1 = new DefaultMessage(camelContext);
+        m1.setBody(Arrays.asList("{\"name\": \"Howard\", \"age\": 29}", "{\"name\": \"Sheldon\", \"age\": 30}"));
+        captured.put("m1", m1);
+
+        Message m2 = new DefaultMessage(camelContext);
+        m2.setBody("{\"something\": \"else\"}");
+        captured.put("m2", m2);
+
+        exchange.setProperty(OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP, captured);
+
+        new DataMapperStepHandler.JsonTypeSourceProcessor(Arrays.asList("m1", "m2")).process(exchange);
+
+        assertThat(captured.get("m1").getBody(String.class)).isEqualTo("[{\"name\": \"Howard\", \"age\": 29},{\"name\": \"Sheldon\", \"age\": 30}]");
+        assertThat(captured.get("m2").getBody(String.class)).isEqualTo("{\"something\": \"else\"}");
+    }
+
+    @Test
+    public void testJsonTypeSourceProcessingMissingSources() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        Map<String, Message> captured = new HashMap<>();
+
+        Message m1 = new DefaultMessage(camelContext);
+        m1.setBody(Collections.singletonList("{\"name\": \"Amy\", \"age\": 29}"));
+        captured.put("m1", m1);
+
+        exchange.setProperty(OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP, captured);
+
+        new DataMapperStepHandler.JsonTypeSourceProcessor(Arrays.asList("m1", "m2_missing", "m3_missing")).process(exchange);
+
+        assertThat(captured.get("m1").getBody(String.class)).isEqualTo("[{\"name\": \"Amy\", \"age\": 29}]");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testJsonTypeTargetProcessing() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody("[{\"name\": \"Bernadette\", \"age\": 27},{\"name\": \"Penny\", \"age\": 29}]");
+
+        new DataMapperStepHandler.JsonTypeTargetProcessor().process(exchange);
+
+        List<String> jsonBeans = exchange.getIn().getBody(List.class);
+        assertThat(jsonBeans).isEqualTo(Arrays.asList("{\"name\":\"Bernadette\",\"age\":27}", "{\"name\":\"Penny\",\"age\":29}"));
+    }
+
+    @Test
+    public void testJsonTypeTargetProcessingEmptyList() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody("[]");
+
+        new DataMapperStepHandler.JsonTypeTargetProcessor().process(exchange);
+
+        assertThat(0).isEqualTo(exchange.getIn().getBody(List.class).size());
+    }
+
+    @Test
+    public void testJsonTypeTargetProcessingNoArrayType() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody("{\"name\": \"Leonard\", \"age\": 30}");
+
+        new DataMapperStepHandler.JsonTypeTargetProcessor().process(exchange);
+
+        assertThat(exchange.getIn().getBody(String.class)).isEqualTo("{\"name\": \"Leonard\", \"age\": 30}");
+    }
+
+    @Test
+    public void testJsonTypeTargetProcessingNoJsonType() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody("something completely different");
+
+        new DataMapperStepHandler.JsonTypeTargetProcessor().process(exchange);
+
+        assertThat(exchange.getIn().getBody(String.class)).isEqualTo("something completely different");
+    }
+
+    @Test
+    public void testJsonTypeTargetProcessingNoStringBody() throws Exception {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody(100L);
+
+        new DataMapperStepHandler.JsonTypeTargetProcessor().process(exchange);
+
+        assertThat(exchange.getIn().getBody(Long.class)).isEqualTo(Long.valueOf(100L));
     }
 }


### PR DESCRIPTION
The problem was that Syndesis operates on List<String> bodies when dealing with topmost collections for Json schema based data shapes.

Atlasmap data mapper expects a Json array String representation of that topmost collection. So we need to convert the source documents marked as Json type documents that are passed to mapper in `OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP` or in the exchange itself.

Also we need to convert mapper output target document form Json array String representation back to List<String> where each element is a Json Object String.

I have added this conversion to the datamapper step handler. The handler is provided with the atlasmap mapping definition and reads all Json typed source and target document ids. Based on those and on the List<String> nature of the documents we do a conversion before and after mapper processing.

This is related to #4257 and fixes https://github.com/atlasmap/atlasmap/issues/759