### PR TITLE
Fixes #4544 pivot table not placed at the beginning of the sheet

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
@@ -117,13 +117,17 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
                                     .map(GooglePivotTable::getSheetId)
                                     .orElse(0);
 
+        Integer sourceSheetId = Optional.ofNullable(model)
+                                    .map(GooglePivotTable::getSourceSheetId)
+                                    .orElse(sheetId);
+
         if (model != null && model.getStart() != null) {
             CellCoordinate start = CellCoordinate.fromCellId(model.getStart());
             return new GridCoordinate()
                     .setSheetId(sheetId)
                     .setColumnIndex(start.getColumnIndex())
                     .setRowIndex(start.getRowIndex());
-        } else if (pivotTable.getSource() != null) {
+        } else if (pivotTable.getSource() != null && sheetId.equals(sourceSheetId)) {
             return new GridCoordinate()
                     .setSheetId(sheetId)
                     .setColumnIndex(pivotTable.getSource().getEndColumnIndex() + 1)


### PR DESCRIPTION
This PR fixes #4544 where with these changes pivot table should be placed to the beginning of the target sheet. This is when source data sheet and target sheet diverge. Otherwise the pivot table is places to the subsequent column of the source data range.