### PR TITLE
fix(#4590): Fix dependency on integration-runtime-tests in odata

### DIFF
--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -44,12 +44,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.syndesis.integration</groupId>
-        <artifactId>integration-runtime</artifactId>
-        <version>${project.version}</version>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.3</version>
@@ -230,12 +224,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.syndesis.integration</groupId>
-      <artifactId>integration-runtime</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>test</scope>
@@ -377,7 +365,7 @@
           </execution>
         </executions>
       </plugin>
-       <plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationTestSupport.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationTestSupport.java
@@ -170,23 +170,6 @@ public class IntegrationTestSupport implements StringConstants {
         return json;
     }
 
-    /**
-     * @param inStream
-     * @return a string representation of the content of the given stream
-     * @throws IOException
-     */
-    public static String streamToString(InputStream inStream) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, "UTF-8"));
-        StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = reader.readLine()) != null) {
-            builder.append(line);
-            builder.append(NEW_LINE);
-        }
-
-        return builder.toString().trim();
-    }
-
     public static final class MyBean {
         @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
         public String myProcessor(@Body String body) {


### PR DESCRIPTION
* Make all test dependencies in odata active if basepom.check.skip-all
  is not defined or false, ie. if flash profile active.