### PR TITLE
fix: use the right editor when there's only 1 operation

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="pf-c-background-image">
   <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-    <filter id="image_overlay" width="">
+    <filter id="image_overlay">
       <feColorMatrix type="matrix" values="1 0 0 0 0
               1 0 0 0 0
               1 0 0 0 0

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -214,7 +214,6 @@
 "@patternfly/patternfly@^1.0.181":
   version "1.0.196"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.196.tgz#5445ce7e359a53d98c05f5f53b66dc3940830c98"
-  integrity sha512-fHC+kxw2MPDtvDz+stJGvR+CEqa59fD/gTpavSkjGFVsp5h8kN0WeVPiQK7lx/Rf5IPL0d/szABWg38YDwQzGQ==
 
 "@phenomnomnominal/tsquery@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
fixes #4619

Also fixes an error message that pops up when the page renders due to an empty string being used in an SVG child element.