### PR TITLE
fix(server): make sure that ResourceUpdateController is ready to process events

### DIFF
--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateController.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/ResourceUpdateController.java
@@ -19,88 +19,162 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import io.syndesis.common.model.ChangeEvent;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.util.EventBus;
+import io.syndesis.common.util.EventBus.Subscription;
 import io.syndesis.common.util.Json;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 
 public class ResourceUpdateController {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUpdateController.class);
 
-    private final ResourceUpdateConfiguration configuration;
-    private final EventBus eventBus;
-    private final List<ResourceUpdateHandler> handlers;
-    private final AtomicBoolean running;
+    final Subscription handler = this::onEvent;
+
+    final AtomicBoolean running;
+
+    ScheduledExecutorService scheduler;
+
     private final List<ChangeEvent> allEvents;
 
-    @SuppressWarnings("PMD.AvoidUsingVolatile")
-    private volatile ScheduledExecutorService scheduler;
+    private final EventBus eventBus;
+
+    private final List<ResourceUpdateHandler> handlers;
+
+    private final Supplier<ScheduledExecutorService> schedulerCreator;
 
     @Autowired
-    public ResourceUpdateController(ResourceUpdateConfiguration configuration, EventBus eventBus, List<ResourceUpdateHandler> handlers) {
-        this.configuration = configuration;
+    public ResourceUpdateController(final ResourceUpdateConfiguration configuration, final EventBus eventBus, final List<ResourceUpdateHandler> handlers) {
         this.eventBus = eventBus;
         this.handlers = new ArrayList<>(handlers);
-        this.running = new AtomicBoolean(false);
+        running = new AtomicBoolean(false);
 
-        this.allEvents = new ArrayList<>();
-        for (Kind kind : Kind.values()) {
+        allEvents = new ArrayList<>();
+        for (final Kind kind : Kind.values()) {
             allEvents.add(new ChangeEvent.Builder().kind(kind.getModelName()).build());
         }
+
+        schedulerCreator = schedulerConfiguredFrom(configuration);
+        scheduler = schedulerCreator.get();
     }
 
     public void start() {
-        if (configuration.isEnabled()) {
-            running.set(true);
-
-            LOGGER.debug("Subscribing to EventBus");
-            eventBus.subscribe(getClass().getName(), this::onEvent);
-        }
-    }
-
-    public void stop() {
-        running.set(false);
-
-        eventBus.unsubscribe(getClass().getName());
-
-        if (scheduler != null) {
-            scheduler.shutdownNow();
-        }
-    }
-
-    private void onEvent(String event, String data) {
-        if (!running.get()) {
+        if (!running.compareAndSet(false, true)) {
             return;
         }
 
-        // Never do anything that could block in this callback!
-        if (Objects.equals(event, EventBus.Type.CHANGE_EVENT)) {
-            try {
-                ChangeEvent changeEvent = Json.reader().forType(ChangeEvent.class).readValue(data);
-                if (changeEvent != null) {
-                    scheduler.execute(() -> run(changeEvent));
-                }
-            } catch (IOException e) {
-                LOGGER.error("Error while processing change-event {}", data, e);
-            }
+        if (scheduler.isShutdown()) {
+            scheduler = schedulerCreator.get();
         }
+
+        LOGGER.debug("Subscribing to EventBus");
+        eventBus.subscribe(getClass().getName(), handler);
+    }
+
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+
+        eventBus.unsubscribe(getClass().getName());
+
+        scheduler.shutdownNow();
+    }
+
+    // FutureReturnValueIgnored: there should not be any exceptions from logging
+    // PMD.InvalidSlf4jMessageFormat: https://github.com/pmd/pmd/issues/939
+    @SuppressWarnings({"FutureReturnValueIgnored", "PMD.InvalidSlf4jMessageFormat"})
+    void onEvent(final String event, final String data) {
+        onEventInternal(event, data)
+            .whenComplete((x, t) -> {
+                if (t == null) {
+                    LOGGER.debug("Processed event: {} with data {}", event, data);
+                } else {
+                    LOGGER.warn("Failed to process event: {} with data {}", event, data, t);
+                }
+            });
+    }
+
+    CompletableFuture<Void> onEventInternal(final String event, final String data) {
+        if (!running.get()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        // Never do anything that could block in this callback!
+        if (!Objects.equals(event, EventBus.Type.CHANGE_EVENT)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        final ChangeEvent changeEvent;
+        try {
+            changeEvent = Json.reader().forType(ChangeEvent.class).readValue(data);
+        } catch (final IOException e) {
+            LOGGER.error("Error while processing change-event {}", data, e);
+            final CompletableFuture<Void> errored = new CompletableFuture<>();
+            errored.completeExceptionally(e);
+
+            return errored;
+        }
+
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+        if (changeEvent != null) {
+            scheduler.execute(() -> run(changeEvent, done));
+        }
+
+        return done;
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    final Supplier<ScheduledExecutorService> schedulerConfiguredFrom(final ResourceUpdateConfiguration configuration) {
+        return () -> {
+            final ScheduledExecutorService configuredScheduler = Executors.newScheduledThreadPool(1,
+                r -> new Thread(null, r, "ResourceUpdateController (scheduler)"));
+
+            if (configuration.getScheduler().isEnabled()) {
+                LOGGER.debug("Register background resource update check task (interval={}, interval-unit={})",
+                    configuration.getScheduler().getInterval(),
+                    configuration.getScheduler().getIntervalUnit());
+
+                final ScheduledFuture<?> task = configuredScheduler.scheduleWithFixedDelay(this::run, 0, configuration.getScheduler().getInterval(),
+                    configuration.getScheduler().getIntervalUnit());
+
+                CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return task.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new IllegalStateException(e);
+                    }
+                }).whenComplete((x, t) -> {
+                    if (t != null) {
+                        LOGGER.warn("Failure in scheduled event processing", t);
+                    }
+                });
+            } else {
+                LOGGER.debug("Execute one-time resource update check");
+                configuredScheduler.execute(this::run);
+            }
+
+            return configuredScheduler;
+        };
     }
 
     private void run() {
         for (int h = 0; h < handlers.size(); h++) {
-            ResourceUpdateHandler handler = handlers.get(h);
+            final ResourceUpdateHandler handler = handlers.get(h);
 
             for (int i = 0; i < allEvents.size(); i++) {
-                ChangeEvent event = allEvents.get(i);
+                final ChangeEvent event = allEvents.get(i);
 
                 if (handler.canHandle(event)) {
                     LOGGER.debug("Trigger handler {}", handler);
@@ -115,38 +189,21 @@ public class ResourceUpdateController {
         }
     }
 
-    private void run(ChangeEvent event) {
+    private void run(final ChangeEvent event, final CompletableFuture<Void> done) {
         if (!running.get()) {
+            done.complete(null);
             return;
         }
 
         for (int i = 0; i < handlers.size(); i++) {
-            ResourceUpdateHandler handler = handlers.get(i);
+            final ResourceUpdateHandler handler = handlers.get(i);
 
             if (handler.canHandle(event)) {
                 LOGGER.debug("Trigger handler {} for event {}", handler, event);
                 handler.process(event);
             }
         }
-    }
 
-    @SuppressWarnings({"FutureReturnValueIgnored", "PMD.DoNotUseThreads"})
-    @EventListener
-    public void onApplicationEvent(final ApplicationReadyEvent event) {
-        if (configuration.isEnabled()) {
-            scheduler = Executors.newScheduledThreadPool(1, r -> new Thread(null, r, "ResourceUpdateController (scheduler)"));
-
-            if (configuration.getScheduler().isEnabled()) {
-                LOGGER.debug("Register background resource update check task (interval={}, interval-unit={})",
-                    configuration.getScheduler().getInterval(),
-                    configuration.getScheduler().getIntervalUnit()
-                );
-
-                scheduler.scheduleWithFixedDelay(this::run, 0, configuration.getScheduler().getInterval(), configuration.getScheduler().getIntervalUnit());
-            } else {
-                LOGGER.debug("Execute one-time resource update check");
-                scheduler.execute(this::run);
-            }
-        }
+        done.complete(null);
     }
 }

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/ResourceUpdateControllerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/ResourceUpdateControllerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.update.controller;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.syndesis.common.model.ChangeEvent;
+import io.syndesis.common.util.EventBus;
+import io.syndesis.common.util.Json;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ResourceUpdateControllerTest {
+
+    ResourceUpdateController controller;
+
+    final ChangeEvent event = ChangeEvent.of("action", "kind", "id");
+
+    EventBus eventBus = mock(EventBus.class);
+
+    ResourceUpdateHandler[] handlers = {mock(ResourceUpdateHandler.class), mock(ResourceUpdateHandler.class)};
+
+    public ResourceUpdateControllerTest() {
+        final ResourceUpdateConfiguration configuration = new ResourceUpdateConfiguration();
+
+        controller = new ResourceUpdateController(configuration, eventBus, Arrays.asList(handlers));
+    }
+
+    @Test
+    public void shouldProcessEvents() throws InterruptedException, ExecutionException, TimeoutException {
+        reset(handlers); // ResourceUpdateController constructor invokes methods
+                         // on handlers, this makes the mocks forget about that
+
+        for (final ResourceUpdateHandler handler : handlers) {
+            when(handler.canHandle(event)).thenReturn(true);
+        }
+
+        final CompletableFuture<Void> processed = controller.onEventInternal(EventBus.Type.CHANGE_EVENT, Json.toString(event));
+
+        processed.get(1, TimeUnit.SECONDS);
+
+        for (final ResourceUpdateHandler handler : handlers) {
+            verify(handler).process(event);
+        }
+    }
+
+    @Before
+    public void startController() {
+        controller.start();
+
+        verify(eventBus).subscribe(eq(ResourceUpdateController.class.getName()), same(controller.handler));
+        assertThat(controller.scheduler.isShutdown()).isFalse();
+        assertThat(controller.running).isTrue();
+    }
+
+    @After
+    public void stopController() {
+        controller.stop();
+
+        verify(eventBus).unsubscribe(eq(ResourceUpdateController.class.getName()));
+        assertThat(controller.scheduler.isShutdown()).isTrue();
+        assertThat(controller.running).isFalse();
+    }
+}


### PR DESCRIPTION
The reported NullPointerException seems to have been caused by the `scheduler` being `null`, this initializes the scheduler from the constructor and makes sure that it cannot be set to `null`.

Fixes #4523