### PR TITLE
Project generator to report error when missing the data mapper mapping

### DIFF
--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -343,8 +343,9 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
 
                     if (mapping != null) {
                         final String resource = "mapping-flow-" + f + "-step-"  + s + ".json";
-
                         addTarEntry(tos, "src/main/resources/" + resource, mapping.getBytes(StandardCharsets.UTF_8));
+                    } else {
+                        throw new IllegalStateException("Missing configured property for data mapper mapping definition");
                     }
                 }
             }


### PR DESCRIPTION
Throw illegal state exception in case mapper is missing the mandatory mapping definition in configured properties