### PR TITLE
[collection support] Fix to preserve original data shapes on meta lookup

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
@@ -72,7 +72,11 @@ public class StepActionHandler extends BaseHandler {
         final Meta<StepDescriptor> metaResult;
         if (metadataHandler.isPresent()) {
             final DynamicActionMetadata enrichedMetadata = metadataHandler.get().handle(metadata);
-            metaResult = Meta.verbatim(applyMetadata(enrichedMetadata));
+            if (enrichedMetadata.equals(DynamicActionMetadata.NOTHING)) {
+                metaResult = Meta.verbatim(applyMetadata(metadata));
+            } else {
+                metaResult = Meta.verbatim(applyMetadata(enrichedMetadata));
+            }
         } else {
             metaResult = Meta.verbatim(applyMetadata(metadata));
         }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
@@ -155,6 +155,29 @@ public class StepActionHandlerTest {
     }
 
     @Test
+    public void shouldPreserveShapesForUnsupportedShapeKind() {
+        DataShape xmlSchape = new DataShape.Builder()
+                .kind(DataShapeKinds.XML_SCHEMA_INSPECTED)
+                .specification("</>")
+                .putMetadata("something", "else")
+                .build();
+
+        final DynamicActionMetadata givenMetadata = new DynamicActionMetadata.Builder()
+                .inputShape(xmlSchape)
+                .outputShape(xmlSchape)
+                .build();
+
+        final Response response = handler.enrichStepMetadata(StepKind.split.name(), givenMetadata);
+
+        @SuppressWarnings("unchecked")
+        final Meta<StepDescriptor> meta = (Meta<StepDescriptor>) response.getEntity();
+
+        final StepDescriptor descriptor = meta.getValue();
+        assertThat(descriptor.getInputDataShape()).contains(xmlSchape);
+        assertThat(descriptor.getOutputDataShape()).contains(xmlSchape);
+    }
+
+    @Test
     public void shouldPreserveShapesForUnsupportedStepKind() {
         final DynamicActionMetadata givenMetadata = new DynamicActionMetadata.Builder()
                 .inputShape(dummyShape())


### PR DESCRIPTION
When step data shape meta data lookup resolves to nothing preserve original shapes