### PR TITLE
[collection support] Update database migration for schema 28

### DIFF
--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion28Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion28Test.java
@@ -21,8 +21,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.Action;
 import io.syndesis.common.model.action.StepAction;
+import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.Json;
@@ -36,7 +39,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.DefaultResourceLoader;
 
 /**
- * Test db schema migration to version 28. This migration will auto add split steps to integrations with implicit split
+ * Test db schema migration to version 28. This migration will auto add split step to integrations with implicit split
  * configured.
  *
  * @author Christoph Deppisch
@@ -49,6 +52,7 @@ public class UpgradeVersion28Test {
     private Migrator migrator = new DefaultMigrator(new DefaultResourceLoader());
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
     public void testSchemaUpgrade() throws IOException {
         JsonDB jsondb = MemorySqlJsonDB.create(Collections.emptyList());
         jsondb.push(INTEGRATIONS_PATH, new ClassPathResource("migrations/sql-integration.json").getInputStream());
@@ -65,36 +69,56 @@ public class UpgradeVersion28Test {
 
         Assert.assertEquals(4, integrationIds.size());
         Integration integration = Json.reader().forType(Integration.class).readValue(jsondb.getAsString(INTEGRATIONS_PATH + "/" + integrationIds.get(0)));
-        Assert.assertEquals(6, integration.getFlows().get(0).getSteps().size());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(0).getStepKind());
-        Assert.assertEquals(StepKind.split, integration.getFlows().get(0).getSteps().get(1).getStepKind());
-        Assert.assertEquals(StepKind.log, integration.getFlows().get(0).getSteps().get(2).getStepKind());
-        Assert.assertEquals(StepKind.mapper, integration.getFlows().get(0).getSteps().get(3).getStepKind());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(4).getStepKind());
-        Assert.assertEquals(StepKind.aggregate, integration.getFlows().get(0).getSteps().get(5).getStepKind());
+        Flow flow = integration.getFlows().get(0);
+        assertStepsOnFlow(flow, StepKind.endpoint, StepKind.split, StepKind.log, StepKind.mapper, StepKind.endpoint);
+        Assert.assertTrue(flow.getSteps().get(0).getId().isPresent());
+        Assert.assertNotEquals("step-sql-start", flow.getSteps().get(0).getId().get());
+        Assert.assertEquals("step-sql-start", flow.getSteps().get(1).getId().orElseThrow(AssertionError::new));
+
+        DataShape splitInputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getInputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.NONE, splitInputShape.getKind());
+        Assert.assertEquals("SQL_PARAM_IN", splitInputShape.getType());
+        Assert.assertNull(splitInputShape.getSpecification());
+
+        DataShape splitOutputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getOutputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, splitOutputShape.getKind());
+        Assert.assertEquals("SQL_PARAM_OUT", splitOutputShape.getType());
+        Assert.assertNotNull(splitOutputShape.getSpecification());
 
         integration = Json.reader().forType(Integration.class).readValue(jsondb.getAsString(INTEGRATIONS_PATH + "/" + integrationIds.get(1)));
-        Assert.assertEquals(2, integration.getFlows().get(0).getSteps().size());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(0).getStepKind());
-        Assert.assertEquals("Simple Timer", integration.getFlows().get(0).getSteps().get(0).getAction().orElseGet(UpgradeVersion28Test::dummyAction).getName());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(1).getStepKind());
-        Assert.assertEquals("Simple Logger", integration.getFlows().get(0).getSteps().get(1).getAction().orElseGet(UpgradeVersion28Test::dummyAction).getName());
+        flow = integration.getFlows().get(0);
+        assertStepsOnFlow(flow, StepKind.endpoint, StepKind.endpoint);
+        Assert.assertEquals("Simple Timer", flow.getSteps().get(0).getAction().orElseGet(UpgradeVersion28Test::dummyAction).getName());
+        Assert.assertEquals("Simple Logger", flow.getSteps().get(1).getAction().orElseGet(UpgradeVersion28Test::dummyAction).getName());
 
         integration = Json.reader().forType(Integration.class).readValue(jsondb.getAsString(INTEGRATIONS_PATH + "/" + integrationIds.get(2)));
-        Assert.assertEquals(5, integration.getFlows().get(0).getSteps().size());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(0).getStepKind());
-        Assert.assertEquals(StepKind.split, integration.getFlows().get(0).getSteps().get(1).getStepKind());
-        Assert.assertEquals(StepKind.mapper, integration.getFlows().get(0).getSteps().get(2).getStepKind());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(3).getStepKind());
-        Assert.assertEquals(StepKind.aggregate, integration.getFlows().get(0).getSteps().get(4).getStepKind());
+        flow = integration.getFlows().get(0);
+        assertStepsOnFlow(flow, StepKind.endpoint, StepKind.split, StepKind.mapper, StepKind.endpoint);
+        Assert.assertNotEquals("step-service-now-start", flow.getSteps().get(0).getId().get());
+        Assert.assertEquals("step-service-now-start", flow.getSteps().get(1).getId().orElseThrow(AssertionError::new));
+
+        splitInputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getInputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.NONE, splitInputShape.getKind());
+        Assert.assertNull(splitInputShape.getSpecification());
+
+        splitOutputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getOutputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, splitOutputShape.getKind());
+        Assert.assertEquals("{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true}}}", splitOutputShape.getSpecification());
 
         integration = Json.reader().forType(Integration.class).readValue(jsondb.getAsString(INTEGRATIONS_PATH + "/" + integrationIds.get(3)));
-        Assert.assertEquals(5, integration.getFlows().get(0).getSteps().size());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(0).getStepKind());
-        Assert.assertEquals(StepKind.split, integration.getFlows().get(0).getSteps().get(1).getStepKind());
-        Assert.assertEquals(StepKind.log, integration.getFlows().get(0).getSteps().get(2).getStepKind());
-        Assert.assertEquals(StepKind.endpoint, integration.getFlows().get(0).getSteps().get(3).getStepKind());
-        Assert.assertEquals(StepKind.aggregate, integration.getFlows().get(0).getSteps().get(4).getStepKind());
+        flow = integration.getFlows().get(0);
+        assertStepsOnFlow(flow, StepKind.endpoint, StepKind.split, StepKind.log, StepKind.endpoint);
+        Assert.assertNotEquals("step-aws-s3-start", flow.getSteps().get(0).getId().get());
+        Assert.assertEquals("step-aws-s3-start", flow.getSteps().get(1).getId().orElseThrow(AssertionError::new));
+
+        splitInputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getInputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.NONE, splitInputShape.getKind());
+        Assert.assertNull(splitInputShape.getSpecification());
+
+        splitOutputShape = flow.getSteps().get(1).getActionAs(StepAction.class).orElseThrow(AssertionError::new).getDescriptor().getOutputDataShape().orElseThrow(AssertionError::new);
+        Assert.assertEquals(DataShapeKinds.JAVA, splitOutputShape.getKind());
+        Assert.assertEquals("S3Object", splitOutputShape.getName());
+        Assert.assertEquals("java.io.InputStream", splitOutputShape.getType());
     }
 
     @Test
@@ -112,10 +136,20 @@ public class UpgradeVersion28Test {
 
         Assert.assertEquals(1, integrationIds.size());
         Integration integration = Json.reader().forType(Integration.class).readValue(jsondb.getAsString(INTEGRATIONS_PATH + "/" + integrationIds.get(0)));
-        Assert.assertEquals(6, integration.getFlows().get(0).getSteps().size());
+        Assert.assertEquals(5, integration.getFlows().get(0).getSteps().size());
+        Assert.assertEquals(StepKind.split, integration.getFlows().get(0).getSteps().get(1).getStepKind());
+        Assert.assertEquals("step-sql-start", integration.getFlows().get(0).getSteps().get(1).getId().orElseThrow(AssertionError::new));
     }
 
     private static Action dummyAction() {
         return new StepAction.Builder().build();
+    }
+
+    private void assertStepsOnFlow(Flow flow, StepKind ... steps) {
+        Assert.assertEquals(steps.length, flow.getSteps().size());
+
+        for (int i = 0; i < steps.length; i++) {
+            Assert.assertEquals(steps[i], flow.getSteps().get(i).getStepKind());
+        }
     }
 }

--- a/app/server/runtime/src/test/resources/migrations/aws-s3-integration.json
+++ b/app/server/runtime/src/test/resources/migrations/aws-s3-integration.json
@@ -3,10 +3,21 @@
     {
       "steps": [
         {
+          "id": "step-aws-s3-start",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",
-            "descriptor": {},
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "description": "Represent one Amazon S3 Object",
+                "kind": "java",
+                "name": "S3Object",
+                "type": "java.io.InputStream"
+              }
+            },
             "id": "io.syndesis:aws-s3-polling-bucket-connector",
             "name": "Poll an Amazon S3 Bucket",
             "pattern": "From",
@@ -23,6 +34,7 @@
           }
         },
         {
+          "id": "step-2",
           "stepKind": "log",
           "name": "Log",
           "configuredProperties": {
@@ -34,6 +46,7 @@
           }
         },
         {
+          "id": "step-3",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",

--- a/app/server/runtime/src/test/resources/migrations/servicenow-integration.json
+++ b/app/server/runtime/src/test/resources/migrations/servicenow-integration.json
@@ -3,10 +3,19 @@
     {
       "steps": [
         {
+          "id": "step-service-now-start",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",
-            "descriptor": {},
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape" : {
+                "kind" : "json-schema",
+                "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true}}}"
+              }
+            },
             "id": "io.syndesis:servicenow-action-retrieve-record",
             "name": "Retrieve Record",
             "pattern": "From",
@@ -25,6 +34,7 @@
           }
         },
         {
+          "id": "step-2",
           "stepKind": "mapper",
           "name": "Data Mapper",
           "action": {
@@ -39,6 +49,7 @@
           }
         },
         {
+          "id": "step-3",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",

--- a/app/server/runtime/src/test/resources/migrations/simple-timer-integration.json
+++ b/app/server/runtime/src/test/resources/migrations/simple-timer-integration.json
@@ -3,6 +3,7 @@
     {
       "steps": [
         {
+          "id": "step-1",
           "stepKind": "endpoint",
           "action": {
             "id": "io.syndesis:timer-action",
@@ -26,6 +27,7 @@
           }
         },
         {
+          "id": "step-2",
           "stepKind": "endpoint",
           "action": {
             "id": "io.syndesis:log-action",

--- a/app/server/runtime/src/test/resources/migrations/sql-integration.json
+++ b/app/server/runtime/src/test/resources/migrations/sql-integration.json
@@ -3,10 +3,23 @@
     {
       "steps": [
         {
+          "id": "step-sql-start",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",
-            "descriptor": {},
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none",
+                "type": "SQL_PARAM_IN"
+              },
+              "outputDataShape" : {
+                "kind" : "json-schema",
+                "type" : "SQL_PARAM_OUT",
+                "name" : "SQL Result",
+                "description" : "Result of SQL [SELECT * FROM NAME WHERE ID=:#id]",
+                "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"ID\":{\"type\":\"integer\",\"required\":true},\"FIRSTNAME\":{\"type\":\"string\",\"required\":true},\"LASTNAME\":{\"type\":\"string\",\"required\":true}}}}"
+              }
+            },
             "id": "sql-start-connector",
             "name": "Periodic SQL invocation",
             "pattern": "From",
@@ -23,6 +36,7 @@
           }
         },
         {
+          "id": "step-2",
           "stepKind": "log",
           "name": "Log",
           "configuredProperties": {
@@ -34,6 +48,7 @@
           }
         },
         {
+          "id": "step-3",
           "stepKind": "mapper",
           "name": "Data Mapper",
           "action": {
@@ -48,6 +63,7 @@
           }
         },
         {
+          "id": "step-4",
           "stepKind": "endpoint",
           "action": {
             "actionType": "connector",


### PR DESCRIPTION
- DB schema migration now sets proper step id for added split step (fixes #4515)
- migration now also sets proper split step input and output data shapes from previous step
- aggregate step is not added automatically as it causes some confusion to the user (see #4516)

New split step needs to use the step id of the previous step so that data mappers still work as expected. Previous step is provided with a newly generated id.

We can just copy the input and output shapes as in schema 27 and below no collection typed shapes did exist.

Fixes #4560
Fixes #4515