### PR TITLE
fix(fonts): consolidate font styles/sizes

### DIFF
--- a/app/ui/angular.json
+++ b/app/ui/angular.json
@@ -47,7 +47,7 @@
               "node_modules/patternfly/dist/css/patternfly.css",
               "node_modules/patternfly/dist/css/patternfly-additions.css",
               "node_modules/patternfly-ng/dist/css/patternfly-ng.min.css",
-              "node_modules/@patternfly/patternfly/patternfly-base.css",
+              "src/scss/patternfly-base-alacarte.scss",
               "node_modules/@patternfly/patternfly/components/Page/page.css",
               "node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.css",
               "node_modules/@patternfly/patternfly/components/Dropdown/dropdown.css",

--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -34,7 +34,7 @@
           aria-label="Toggle primary navigation"
           aria-expanded="true"
           (click)="hamburgerToggle()">
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <i class="fa fa-bars" aria-hidden="true"></i>
         </button>
       </div>
       <!-- Logo -->
@@ -75,7 +75,7 @@
               (clickOutside)="expandHelpDropdown()"
               [attachOutsideOnClick]=true>
               <i class="pf-icon pf-icon-help pf-m-user pf-screen-reader" aria-hidden="true"></i>
-              <i class="fas fa-ellipsis-v pf-m-mobile" aria-hidden="true"></i>
+              <i class="pf-icon fa fa-ellipsis-v pf-m-mobile" aria-hidden="true"></i>
             </button>
             <ul
               class="pf-c-dropdown__menu pf-m-align-right"
@@ -136,7 +136,7 @@
         </div>
       </div>
 
-      <div class="pf-c-page__header-tools-group">
+      <div class="pf-c-page__header-tools-group user-menu-group">
           <div class="pf-m-user pf-screen-reader">
             <div class="pf-c-dropdown">
               <button

--- a/app/ui/src/app/app.component.scss
+++ b/app/ui/src/app/app.component.scss
@@ -7,11 +7,16 @@ main {
 }
 
 .pf-c-page {
-  .nav-pf-vertical .list-group-item > a,
-  .nav-pf-vertical .list-group-item.active > a,
-  .nav-pf-vertical .list-group-item:hover > a {
-    font-weight: inherit;
-    text-decoration: none;
+  .nav-pf-vertical .list-group-item {
+    a {
+      font-weight: 400;
+    }
+    &:hover,
+    &.active {
+      a {
+        font-weight: 600;
+      }
+    }
   }
 
   #appLogo {

--- a/app/ui/src/scss/patternfly-base-alacarte.scss
+++ b/app/ui/src/scss/patternfly-base-alacarte.scss
@@ -1,0 +1,13 @@
+// Fontpath
+$pf-global--font-path: "~@patternfly/patternfly/assets/fonts" !default;
+// Iconpath
+$fa-font-path: "~@patternfly/patternfly/assets/fonts/webfonts" !default;
+// FontIcon Path
+$pf-global--fonticon-path: "~@patternfly/patternfly/assets/pficon" !default;
+
+@import "~@patternfly/patternfly/sass-utilities/all";
+@import "~@patternfly/patternfly/variables";
+@import "~@patternfly/patternfly/shield-noninheritable";
+@import "~@patternfly/patternfly/common";
+@import "~@patternfly/patternfly/themes";
+@import "~@patternfly/patternfly/pf-icons";

--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -1,4 +1,4 @@
-@import '@patternfly/patternfly/sass-utilities/_all.scss';
+@import '@patternfly/patternfly/sass-utilities/all';
 /// Common CSS overrides for UI normalization and styles referred to generic (PF/component-agnostic) items
 html,
 body {
@@ -39,6 +39,7 @@ body.cards-pf {
     background-color: #ededed;
     margin-top: 76px;
     overflow: auto;
+    padding-top: 0;
   }
 }
 
@@ -78,6 +79,10 @@ body.cards-pf {
 }
 
 @media screen and (max-width: 767px) {
+  .pf-c-page__header-brand-link {
+    --pf-c-page__header-brand-link--md--MaxWidth: 130px;
+  }
+
   .nav-pf-vertical {
     display: none;
 
@@ -235,6 +240,28 @@ body.cards-pf {
   &.left {
     .arrow {
       margin: 0;
+    }
+  }
+}
+
+// PF4 overrides
+.pf-c-page {
+  --pf-global--FontSize--md: 12px;
+  --pf-c-page__header-sidebar-toggle__c-button--FontSize: 24px;
+  --pf-c-page__header-brand--md--FlexBasis: 290px;
+
+  ul {
+    list-style-type: none;
+  }
+
+  .pf-c-page__header-tools-group {
+    .pf-icon {
+      font-size: 16px;
+    }
+    &.user-menu-group {
+      .pf-c-dropdown__toggle {
+        line-height: 2;
+      }
     }
   }
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -212,8 +212,9 @@
     webpack-sources "1.3.0"
 
 "@patternfly/patternfly@^1.0.181":
-  version "1.0.196"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.196.tgz#5445ce7e359a53d98c05f5f53b66dc3940830c98"
+  version "1.0.213"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.213.tgz#45354790401a78fbf82139691819f119c2562716"
+  integrity sha512-tkd32A6DBccvTfmhlQTZKqRjRkm2OFMt+Z5WzXwzhPQXfh8seLcI1xKgXZDCpTYwGhYnLSd3d03+NmXlceP4BQ==
 
 "@phenomnomnominal/tsquery@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
This PR makes an adjustment to what all we're importing from patternfly4-core. Previously, patternfly-base.css came with extra baggage that we didn't want (namely fonts). With these changes, the entire application again uses only PF3 fonts, and many of the various spacing issues should also be resolved.

To keep things clean on our end, a change in patternfly core was required - https://github.com/patternfly/patternfly-next/pull/1467 - we need this merged in pf-core before we can merge this PR. To see it all in action, pair these two branches together.

Fixes https://github.com/syndesisio/syndesis/issues/4608
Fixes https://github.com/syndesisio/syndesis/issues/4612

<img width="1188" alt="screen shot 2019-02-22 at 8 28 22 am" src="https://user-images.githubusercontent.com/5942899/53270616-3905a900-36ba-11e9-9dce-7039214f84c6.png">

<img width="1189" alt="screen shot 2019-02-22 at 8 24 08 am" src="https://user-images.githubusercontent.com/5942899/53270653-4de23c80-36ba-11e9-818e-9a92161cd1a6.png">

<img width="1188" alt="screen shot 2019-02-22 at 8 28 34 am" src="https://user-images.githubusercontent.com/5942899/53270667-58043b00-36ba-11e9-8f24-340a6e33e6c7.png">


import only the pf4 css modules we need
clean up font styles