### PR TITLE
[flaky test] Fighting flaky test behavior on CircleCi

### DIFF
--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/server/GoogleSheetsApiTestServer.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/server/GoogleSheetsApiTestServer.java
@@ -94,6 +94,7 @@ public class GoogleSheetsApiTestServer {
      */
     public void reset() {
         if (runner != null) {
+            runner.purgeEndpoints(action -> action.endpoint(httpServer));
             runner.stop();
         }
     }
@@ -108,14 +109,6 @@ public class GoogleSheetsApiTestServer {
 
     public void afterPropertiesSet() throws Exception {
         httpServer.afterPropertiesSet();
-    }
-
-    /**
-     * Specifies the test runner.
-     * @param runner
-     */
-    public void setRunner(TestRunner runner) {
-        this.runner = runner;
     }
 
     public TestRunner getRunner() {

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/server/GoogleSheetsApiTestServerRule.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/server/GoogleSheetsApiTestServerRule.java
@@ -26,6 +26,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.SocketUtils;
 
 import static org.apache.camel.component.google.sheets.server.GoogleSheetsApiTestServerAssert.assertThatGoogleApi;
@@ -48,7 +49,8 @@ public class GoogleSheetsApiTestServerRule implements TestRule {
             googleApiTestServer = new GoogleSheetsApiTestServer.Builder(CitrusEndpoints.http()
                     .server()
                     .port(serverPort)
-                    .timeout(5000)
+                    .timeout(15000)
+                    .defaultStatus(HttpStatus.REQUEST_TIMEOUT)
                     .autoStart(true))
                     .keyStorePath(new ClassPathResource(SERVER_KEYSTORE).getFile().toPath())
                     .keyStorePassword(SERVER_KEYSTORE_PASSWORD)


### PR DESCRIPTION
So more analyzing brought some light to the issue on CircleCi:

- Google test server ran into timeouts waiting for the client to send create spreadsheet requests (server reporting `ActionTimeoutException`)
- Failed server mocking due to timeouts influenced further tests running after that (tests reporting `NullPointerException`)
- Google test server sending `Http 200 Ok` with empty response as default when running into timeouts caused Google Sheets client to error with `No JSON input found` which is quite misleading

Now I have increased the server timeout to give the Google Sheets client more time to fire the requests (CirlceCi is very slow sometimes). Also avoid other tests to be influenced by that timeout by purging the server inbound message queue between tests. Last not least set default response code to `408 REQUEST_TIMEOUT` on test server to have more clear error messages when that timeout should happen.