### PR TITLE
#4618 Data mapper select target doc when step.id is undefined

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -279,7 +279,8 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
     // The first step could be this datamapper step itself if it's not the first visit,
     // as DataShape is added by the following event
     let targetPair = subsequents[0];
-    if (targetPair.step.id === step.id) {
+    if (targetPair.step.id === step.id &&
+        targetPair.step.stepKind === step.stepKind) {
       targetPair = subsequents[1];
     }
     if (!targetPair) {


### PR DESCRIPTION
You can reproduce this when adding a data mapper at a position right before an aggregate step. The data mapper did not select the input of the aggregate but the input of the step subsequent to the aggregate.

This was because both data mapper step and aggregate step did have an `step.id === undefined` at that time. Following from that the logic in data mapper host component by mistake thought that the 1st subsequent step is the data mapper itself and used the step subsequent to that for populating the target doc.

So I have added another check on the `step.stepKind` to check wether the 1st step in line is the data mapper itself.

I do not know though why the aggregate step has a `step.id === undefined` maybe that is the root cause that should be fix in first place. 