### PR TITLE
fix: handle all sheets and its properties in a spreadsheet

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizer.java
@@ -15,7 +15,11 @@
  */
 package io.syndesis.connector.sheets;
 
-import com.google.api.services.sheets.v4.model.SheetProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import io.syndesis.connector.sheets.model.GoogleSheet;
@@ -27,8 +31,6 @@ import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
 import org.apache.camel.util.ObjectHelper;
-
-import java.util.Map;
 
 public class GoogleSheetsGetSpreadsheetCustomizer implements ComponentProxyCustomizer {
 
@@ -61,14 +63,20 @@ public class GoogleSheetsGetSpreadsheetCustomizer implements ComponentProxyCusto
                 model.setLocale(spreadsheetProperties.getLocale());
             }
 
+            List<GoogleSheet> sheets = new ArrayList<>();
             if (ObjectHelper.isNotEmpty(spreadsheet.getSheets())) {
-                SheetProperties sheetProperties = spreadsheet.getSheets().get(0).getProperties();
-                GoogleSheet sheet = new GoogleSheet();
-                sheet.setSheetId(sheetProperties.getSheetId());
-                sheet.setIndex(sheetProperties.getIndex());
-                sheet.setTitle(sheetProperties.getTitle());
-                model.setSheet(sheet);
+                spreadsheet.getSheets().stream()
+                        .map(Sheet::getProperties)
+                        .forEach(props -> {
+                            GoogleSheet sheet = new GoogleSheet();
+                            sheet.setSheetId(props.getSheetId());
+                            sheet.setIndex(props.getIndex());
+                            sheet.setTitle(props.getTitle());
+                            sheets.add(sheet);
+                        });
+
             }
+            model.setSheets(sheets);
         }
 
         in.setBody(model);

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSheet.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSheet.java
@@ -18,11 +18,11 @@ package io.syndesis.connector.sheets.model;
 
 public class GoogleSheet {
 
-    private int index;
-    private int sheetId;
+    private Integer index;
+    private Integer sheetId;
     private String title;
 
-    public int getIndex() {
+    public Integer getIndex() {
         return index;
     }
 
@@ -31,11 +31,11 @@ public class GoogleSheet {
      *
      * @param index
      */
-    public void setIndex(int index) {
+    public void setIndex(Integer index) {
         this.index = index;
     }
 
-    public int getSheetId() {
+    public Integer getSheetId() {
         return sheetId;
     }
 
@@ -44,7 +44,7 @@ public class GoogleSheet {
      *
      * @param sheetId
      */
-    public void setSheetId(int sheetId) {
+    public void setSheetId(Integer sheetId) {
         this.sheetId = sheetId;
     }
 
@@ -63,6 +63,6 @@ public class GoogleSheet {
 
     @Override
     public String toString() {
-        return String.format("%s [sheet=%s, index=%s, title=%s]", GoogleSheet.class.getSimpleName(), sheetId, index, title);
+        return String.format("%s [sheetId=%s, index=%s, title=%s]", GoogleSheet.class.getSimpleName(), sheetId, index, title);
     }
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSpreadsheet.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSpreadsheet.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.connector.sheets.model;
 
+import java.util.List;
+
 public class GoogleSpreadsheet {
 
     private String spreadsheetId;
@@ -24,7 +26,7 @@ public class GoogleSpreadsheet {
 
     private String url;
 
-    private GoogleSheet sheet;
+    private List<GoogleSheet> sheets;
 
     public String getSpreadsheetId() {
         return spreadsheetId;
@@ -91,22 +93,22 @@ public class GoogleSpreadsheet {
         this.locale = locale;
     }
 
-    public GoogleSheet getSheet() {
-        return sheet;
+    public List<GoogleSheet> getSheets() {
+        return sheets;
     }
 
     /**
-     * Specifies the sheet.
+     * Specifies the sheets.
      *
-     * @param sheet
+     * @param sheets
      */
-    public void setSheet(GoogleSheet sheet) {
-        this.sheet = sheet;
+    public void setSheets(List<GoogleSheet> sheets) {
+        this.sheets = sheets;
     }
 
     @Override
     public String toString() {
-        return String.format("%s [spreadsheetId=%s, title=%s, url=%s, sheet=%s]", GoogleSpreadsheet.class.getSimpleName(), spreadsheetId, title, url, sheet);
+        return String.format("%s [spreadsheetId=%s, title=%s, url=%s, sheets=%s]", GoogleSpreadsheet.class.getSimpleName(), spreadsheetId, title, url, sheets);
     }
 
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
@@ -87,7 +87,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleS
         sheetModel.setSheetId(1);
         sheetModel.setIndex(1);
 
-        model.setSheet(sheetModel);
+        model.setSheets(Collections.singletonList(sheetModel));
 
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
@@ -135,9 +135,10 @@ public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleS
         Assert.assertEquals("America/New_York", model.getTimeZone());
         Assert.assertEquals("en", model.getLocale());
 
-        Assert.assertEquals("Sheet1", model.getSheet().getTitle());
-        Assert.assertEquals(1, model.getSheet().getSheetId());
-        Assert.assertEquals(1, model.getSheet().getIndex());
+        Assert.assertEquals(1, model.getSheets().size());
+        Assert.assertEquals("Sheet1", model.getSheets().get(0).getTitle());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getSheetId());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getIndex());
     }
 
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizerTest.java
@@ -16,6 +16,10 @@
 
 package io.syndesis.connector.sheets;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
@@ -28,10 +32,6 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class GoogleSheetsGetSpreadsheetCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -80,9 +80,10 @@ public class GoogleSheetsGetSpreadsheetCustomizerTest extends AbstractGoogleShee
         Assert.assertEquals("America/New_York", model.getTimeZone());
         Assert.assertEquals("en", model.getLocale());
 
-        Assert.assertEquals("Sheet1", model.getSheet().getTitle());
-        Assert.assertEquals(1, model.getSheet().getSheetId());
-        Assert.assertEquals(1, model.getSheet().getIndex());
+        Assert.assertEquals(1, model.getSheets().size());
+        Assert.assertEquals("Sheet1", model.getSheets().get(0).getTitle());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getSheetId());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getIndex());
     }
 
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
@@ -16,6 +16,7 @@
 
 package io.syndesis.connector.sheets;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -93,12 +94,16 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         model.setTimeZone("America/New_York");
         model.setLocale("en");
 
-        GoogleSheet sheetModel = new GoogleSheet();
-        sheetModel.setTitle("Sheet1");
-        sheetModel.setSheetId(1);
-        sheetModel.setIndex(1);
+        GoogleSheet sheet1 = new GoogleSheet();
+        sheet1.setTitle("Sheet1");
+        sheet1.setSheetId(1);
+        sheet1.setIndex(1);
 
-        model.setSheet(sheetModel);
+        GoogleSheet sheet2 = new GoogleSheet();
+        sheet2.setTitle("Sheet2");
+        sheet2.setSheetId(2);
+
+        model.setSheets(Arrays.asList(sheet1, sheet2));
 
         inbound.getIn().setBody(model);
         getComponent().getBeforeProducer().process(inbound);
@@ -107,7 +112,7 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         Assert.assertEquals(model.getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
 
         BatchUpdateSpreadsheetRequest batchUpdateRequest = (BatchUpdateSpreadsheetRequest) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest");
-        Assert.assertEquals(2, batchUpdateRequest.getRequests().size());
+        Assert.assertEquals(3, batchUpdateRequest.getRequests().size());
 
         UpdateSpreadsheetPropertiesRequest updateSpreadsheetPropertiesRequest = batchUpdateRequest.getRequests().get(0).getUpdateSpreadsheetProperties();
         Assert.assertEquals("title,timeZone,locale", updateSpreadsheetPropertiesRequest.getFields());
@@ -117,7 +122,15 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
 
         UpdateSheetPropertiesRequest updateSheetPropertiesRequest = batchUpdateRequest.getRequests().get(1).getUpdateSheetProperties();
         Assert.assertEquals("title", updateSheetPropertiesRequest.getFields());
+        Assert.assertEquals(Integer.valueOf(1), updateSheetPropertiesRequest.getProperties().getIndex());
+        Assert.assertEquals(Integer.valueOf(1), updateSheetPropertiesRequest.getProperties().getSheetId());
         Assert.assertEquals("Sheet1", updateSheetPropertiesRequest.getProperties().getTitle());
+
+        updateSheetPropertiesRequest = batchUpdateRequest.getRequests().get(2).getUpdateSheetProperties();
+        Assert.assertEquals("title", updateSheetPropertiesRequest.getFields());
+        Assert.assertNull(updateSheetPropertiesRequest.getProperties().getIndex());
+        Assert.assertEquals(Integer.valueOf(2), updateSheetPropertiesRequest.getProperties().getSheetId());
+        Assert.assertEquals("Sheet2", updateSheetPropertiesRequest.getProperties().getTitle());
     }
 
     @Test
@@ -157,8 +170,9 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         Assert.assertEquals("America/New_York", model.getTimeZone());
         Assert.assertEquals("en", model.getLocale());
 
-        Assert.assertEquals("Sheet1", model.getSheet().getTitle());
-        Assert.assertEquals(1, model.getSheet().getSheetId());
-        Assert.assertEquals(1, model.getSheet().getIndex());
+        Assert.assertEquals(1, model.getSheets().size());
+        Assert.assertEquals("Sheet1", model.getSheets().get(0).getTitle());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getSheetId());
+        Assert.assertEquals(Integer.valueOf(1), model.getSheets().get(0).getIndex());
     }
 }


### PR DESCRIPTION
Google Sheets connector handing all sheets and its properties when getting and updating spreadsheet properties.

Fixes #4672 