### PR TITLE
chore(ui): upgrade bootstrap to ~3.4

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -54,7 +54,7 @@
     "angular2-text-mask": "9.0.0",
     "apicurio-design-studio": "^0.2.22",
     "better-npm-run": "0.0.15",
-    "bootstrap": "3.4.0",
+    "bootstrap": "~3.4",
     "brace": "0.11.1",
     "codemirror": "5.42.2",
     "core-js": "2.5.5",
@@ -136,7 +136,8 @@
     "webdriver-manager": "12.0.2"
   },
   "resolutions": {
-    "ngx-bootstrap": "3.1.4"
+    "ngx-bootstrap": "3.1.4",
+    "bootstrap": "~3.4"
   },
   "snyk": true
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -1321,13 +1321,10 @@ bootstrap-touchspin@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz#9779deac72aaf577e5e762b8512c747c871d9597"
 
-bootstrap@3.3.x, bootstrap@^3.0, bootstrap@^3.3, bootstrap@~3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-
-bootstrap@3.4.0, bootstrap@~3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.0.tgz#f8d77540dd3062283d2ae7687e21c1e691961640"
+bootstrap@3.3.x, bootstrap@^3.0, bootstrap@^3.3, bootstrap@~3.3.7, bootstrap@~3.4, bootstrap@~3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 boxen@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
We need to upgrade due to a security issue.

Ref https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/