### PR TITLE
fix(card-tech-preview): change container to body to prevent popover from being cut off

### DIFF
--- a/app/ui/src/app/common/card-tech-preview.component.ts
+++ b/app/ui/src/app/common/card-tech-preview.component.ts
@@ -16,6 +16,7 @@ import { Connection, Connector } from '@syndesis/ui/platform';
             <span class="pficon pficon-info"
                   outsideClick="true"
                   placement="left"
+                  container="body"
                   [popover]="synTechPreviewInfo"></span>
     </div>
   `,


### PR DESCRIPTION
I don't see any tech previews in my list of connections, but this should address it. Could someone verify it, or let me know how I can get a connection with the tech preview icon/popover?

fixes https://github.com/syndesisio/syndesis/issues/4385