### PR TITLE
fix(overrides): remove glyphicon from overrides

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -221,11 +221,6 @@ body.cards-pf {
   }
 }
 
-// Tooltip styling override
-.glyphicon-info-sign {
-  display: block;
-}
-
 // Override PF3's popover/tooltip arrow margin, use ngx-bootstrap's positioning
 .popover,
 .tooltip {


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/4520

fixes https://github.com/syndesisio/syndesis/issues/4594

I believe this was just added to help align tooltips, but it's not necessary since those items are already `inline-block`, and it would have only addressed the info icon, not any other icons. `display: block` was causing problems on pages where there is a `&nbsp;` followed by the glyphicon, pushing the glyphicon onto a second line. 