### PR TITLE
chore(#4693): sync up odata forked code with 2.x branch of upstream

### DIFF
--- a/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
+++ b/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
@@ -49,7 +49,7 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
     @Override
     protected int poll() throws Exception {
         // invoke the consumer method
-        final Map<String, Object> args = new HashMap<String, Object>();
+        final Map<String, Object> args = new HashMap<>();
         args.putAll(endpoint.getEndpointProperties());
 
         // let the endpoint and the Consumer intercept properties
@@ -99,10 +99,10 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
             //
             // Allow consumer idle properties to properly handle an empty polling response
             //
-            int processed = ApiConsumerHelper.getResultsProcessed(this, result[0], isSplitResult());
             if (result[0] instanceof ClientEntitySet && ((ClientEntitySet) result[0]).getEntities().isEmpty()) {
                 return 0;
             } else {
+                int processed = ApiConsumerHelper.getResultsProcessed(this, result[0], isSplitResult());
                 return processed;
             }
 

--- a/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
+++ b/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Endpoint.java
@@ -43,6 +43,7 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
 
     protected static final String RESOURCE_PATH_PROPERTY = "resourcePath";
     protected static final String RESPONSE_HANDLER_PROPERTY = "responseHandler";
+    protected static final String SERVICE_URI_PROPERTY = "serviceUri";
     protected static final String FILTER_ALREADY_SEEN = "filterAlreadySeen";
 
     private static final String KEY_PREDICATE_PROPERTY = "keyPredicate";
@@ -70,10 +71,11 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
         this.olingo4Configuration = endpointConfiguration;
 
         // get all endpoint property names
-        endpointPropertyNames = new HashSet<String>(getPropertiesHelper().getValidEndpointProperties(olingo4Configuration));
+        endpointPropertyNames = new HashSet<>(getPropertiesHelper().getValidEndpointProperties(olingo4Configuration));
         // avoid adding edm as queryParam
         endpointPropertyNames.add(EDM_PROPERTY);
         endpointPropertyNames.add(ENDPOINT_HTTP_HEADERS_PROPERTY);
+        endpointPropertyNames.add(SERVICE_URI_PROPERTY);
         endpointPropertyNames.add(FILTER_ALREADY_SEEN);
     }
 
@@ -169,10 +171,7 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
         properties.put(EDM_PROPERTY, apiProxy.getEdm());
 
         // handle filterAlreadySeen property
-        properties.put(FILTER_ALREADY_SEEN, configuration.getFilterAlreadySeen());
-
-        // handle filterAlreadySeen property
-        properties.put(FILTER_ALREADY_SEEN, configuration.getFilterAlreadySeen());
+        properties.put(FILTER_ALREADY_SEEN, olingo4Configuration.getFilterAlreadySeen());
 
         // handle keyPredicate
         final String keyPredicate = (String)properties.get(KEY_PREDICATE_PROPERTY);
@@ -199,7 +198,7 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
 
     private void parseQueryParams(Map<String, Object> options) {
         // extract non-endpoint properties as query params
-        final Map<String, String> queryParams = new HashMap<String, String>();
+        final Map<String, String> queryParams = new HashMap<>();
         for (Iterator<Map.Entry<String, Object>> it = options.entrySet().iterator(); it.hasNext();) {
 
             final Map.Entry<String, Object> entry = it.next();
@@ -208,6 +207,9 @@ public class Olingo4Endpoint extends AbstractApiEndpoint<Olingo4ApiName, Olingo4
             /**
              * Added in to fix
              * https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-13054
+             *
+             * Avoid swallowing consumer scheduler properties, which
+             * get processed in configureProperties()
              */
             if (paramName.startsWith("consumer.")) {
                 continue;

--- a/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Index.java
+++ b/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Index.java
@@ -23,9 +23,10 @@ import java.util.Set;
 import org.apache.olingo.client.api.domain.ClientEntity;
 import org.apache.olingo.client.api.domain.ClientEntitySet;
 
+@SuppressWarnings("PMD")
 public class Olingo4Index {
 
-    private final Set<Integer> resultIndex = new HashSet<>();
+    private Set<Integer> resultIndex = new HashSet<>();
 
     private Object filter(Object o) {
         if (resultIndex.contains(o.hashCode())) {
@@ -94,21 +95,23 @@ public class Olingo4Index {
         }
     }
 
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     public Object filterResponse(Object response) {
         if (response instanceof ClientEntitySet) {
-            return filter((ClientEntitySet) response);
+            response = filter((ClientEntitySet) response);
         } else if (response instanceof Iterable) {
-            return filter((Iterable<Object>) response);
+            response = filter((Iterable<Object>) response);
         } else if (response.getClass().isArray()) {
             List<Object> result = new ArrayList<>();
             final int size = Array.getLength(response);
             for (int i = 0; i < size; i++) {
                 result.add(Array.get(response, i));
             }
-            return filter(result);
+            response = filter(result);
         } else {
-            return filter(response);
+            response = filter(response);
         }
+
+        return response;
     }
 }

--- a/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Producer.java
+++ b/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Producer.java
@@ -48,7 +48,7 @@ public class Olingo4Producer extends AbstractApiProducer<Olingo4ApiName, Olingo4
     @SuppressWarnings("PMD")
     public boolean process(final Exchange exchange, final AsyncCallback callback) {
         // properties for method arguments
-        final Map<String, Object> properties = new HashMap<String, Object>();
+        final Map<String, Object> properties = new HashMap<>();
         properties.putAll(endpoint.getEndpointProperties());
         propertiesHelper.getExchangeProperties(exchange, properties);
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -359,35 +359,23 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
 
         RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
         context.addRoutes(routes);
-        int expectedMsgCount = defaultTestServer.getResultCount();
         MockEndpoint result = initMockEndpoint();
-        result.setMinimumExpectedMessageCount(expectedMsgCount);
+        result.setMinimumExpectedMessageCount(1);
 
         context.start();
 
         result.assertIsSatisfied();
 
-        for (int i = 0; i < expectedMsgCount; ++i) {
-            @SuppressWarnings( "unchecked" )
-            List<String> json = extractJsonFromExchgMsg(result, i, List.class);
+        @SuppressWarnings( "unchecked" )
+        List<String> json = extractJsonFromExchgMsg(result, 0, List.class);
 
-            String expected;
-            switch (i) {
-                case 0:
-                    expected = testData(TEST_SERVER_DATA_1);
-                    JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
-                    expected = testData(TEST_SERVER_DATA_2);
-                    JSONAssert.assertEquals(expected, json.get(1), JSONCompareMode.LENIENT);
-                    expected = testData(TEST_SERVER_DATA_3);
-                    JSONAssert.assertEquals(expected, json.get(2), JSONCompareMode.LENIENT);
-                    break;
-                default:
-                    //
-                    // Subsequent polling messages should be empty
-                    //
-                    assertTrue(json.isEmpty());
-            }
-        }
+        String expected;
+        expected = testData(TEST_SERVER_DATA_1);
+        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        expected = testData(TEST_SERVER_DATA_2);
+        JSONAssert.assertEquals(expected, json.get(1), JSONCompareMode.LENIENT);
+        expected = testData(TEST_SERVER_DATA_3);
+        JSONAssert.assertEquals(expected, json.get(2), JSONCompareMode.LENIENT);
 
         //
         // Check backup consumer options carried through to olingo4 component


### PR DESCRIPTION
* Syncs the forked olingo4 component code with the code in the upstream
  camel-olingo4 2.x branch

* Most of the changes are the licence header. However, one change does
  affect a test.

* ODataRead...ResultsTest
 * Due to the change in Olingo4Consumer, only 1 message is returned and
   empty messages are never created. Thus, the test should only expect 1
   message and not 3.