### PR TITLE
fix: Ensure consistent split/aggregate steps in UI

### DIFF
--- a/app/ui/src/app/store/step/step.store.ts
+++ b/app/ui/src/app/store/step/step.store.ts
@@ -141,7 +141,7 @@ $\{in.body.title\} // Evaluates true when body contains title.
       properties: {},
       configuredProperties: undefined
     }),
-    StepStore.requiresSplit({
+    StepStore.requiresConsistentSplitAggregate({
       id: undefined,
       connection: undefined,
       action: undefined,
@@ -373,13 +373,29 @@ $\{in.body.title\} // Evaluates true when body contains title.
     return obj;
   }
 
-  static requiresSplit(obj: StepKind): StepKind {
+  static requiresConsistentSplitAggregate(obj: StepKind): StepKind {
     obj.visible = (
       position: number,
       previousSteps: Array<Step>,
       subsequentSteps: Array<Step>
     ) => {
-      return previousSteps.filter(s => s.stepKind == SPLIT).length > 0;
+      const countPreviousSplit = previousSteps.filter(s => s.stepKind == SPLIT).length;
+      const countPreviousAggregate = previousSteps.filter(s => s.stepKind == AGGREGATE).length;
+
+      if (countPreviousSplit <= countPreviousAggregate) {
+        return false;
+      }
+
+      const positionNextSplit = subsequentSteps.findIndex(s => s.stepKind == SPLIT);
+      const positionNextAggregate = subsequentSteps.findIndex(s => s.stepKind == AGGREGATE);
+
+      if (positionNextSplit === -1) {
+        return positionNextAggregate === -1;
+      }
+
+      return positionNextAggregate === -1 || positionNextSplit < positionNextAggregate;
+
+
     };
     return obj;
   }

--- a/app/ui/src/app/store/step/step.store.ts
+++ b/app/ui/src/app/store/step/step.store.ts
@@ -394,8 +394,6 @@ $\{in.body.title\} // Evaluates true when body contains title.
       }
 
       return positionNextAggregate === -1 || positionNextSplit < positionNextAggregate;
-
-
     };
     return obj;
   }


### PR DESCRIPTION
Added some checks when adding steps of kind aggregate. Aggregate step should only get displayed when applicable according to the current position in the integration.

This is when a previous split step is present that has not yet a corresponding aggregate. This makes sure that each split has only one corresponding aggregate step. Logic supports nested split/aggregate as well as multiple subsequent split steps.

Fixes #4710 