### PR TITLE
fix(#4459): Add names to java data shapes

### DIFF
--- a/app/connector/fhir/src/main/resources/META-INF/syndesis/connector/fhir.json
+++ b/app/connector/fhir/src/main/resources/META-INF/syndesis/connector/fhir.json
@@ -9,6 +9,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "ResourceId",
           "type": "io.syndesis.connector.fhir.FhirResourceId"
         },
         "outputDataShape": {
@@ -84,6 +85,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "ResourceQuery",
           "type": "io.syndesis.connector.fhir.FhirResourceQuery"
         },
         "outputDataShape": {
@@ -136,10 +138,12 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "ResourceId",
           "type": "io.syndesis.connector.fhir.FhirResourceId"
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "Outcome",
           "type": "ca.uhn.fhir.rest.api.MethodOutcome"
         },
         "propertyDefinitionSteps": [
@@ -204,6 +208,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "Outcome",
           "type": "ca.uhn.fhir.rest.api.MethodOutcome"
         },
         "propertyDefinitionSteps": [
@@ -258,6 +263,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "Outcome",
           "type": "ca.uhn.fhir.rest.api.MethodOutcome"
         },
         "propertyDefinitionSteps": [
@@ -335,6 +341,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "Outcome",
           "type": "ca.uhn.fhir.rest.api.MethodOutcome"
         },
         "propertyDefinitionSteps": [

--- a/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
+++ b/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
@@ -171,6 +171,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "ODataEntityID",
           "type": "java.lang.String"
         },
         "outputDataShape": {

--- a/app/connector/salesforce/src/main/resources/META-INF/syndesis/connector/salesforce.json
+++ b/app/connector/salesforce/src/main/resources/META-INF/syndesis/connector/salesforce.json
@@ -17,6 +17,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "SalesforceRecord",
           "type": "org.apache.camel.component.salesforce.api.dto.CreateSObjectResult"
         },
         "propertyDefinitionSteps": [
@@ -62,6 +63,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "SalesforceID",
           "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
         },
         "outputDataShape": {
@@ -111,6 +113,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "SalesforceID",
           "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
         },
         "outputDataShape": {
@@ -180,6 +183,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "SalesforceID",
           "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
         },
         "outputDataShape": {
@@ -229,6 +233,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "SalesforceID",
           "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
         },
         "outputDataShape": {
@@ -349,6 +354,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "SalesforceRecord",
           "type": "org.apache.camel.component.salesforce.api.dto.CreateSObjectResult"
         },
         "propertyDefinitionSteps": [
@@ -520,6 +526,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "SalesforceID",
           "type": "io.syndesis.connector.salesforce.SalesforceIdentifier"
         },
         "propertyDefinitionSteps": [

--- a/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
+++ b/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
@@ -10,6 +10,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "Message",
           "type": "io.syndesis.connector.slack.SlackPlainMessage"
         },
         "outputDataShape": {
@@ -49,6 +50,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "Message",
           "type": "io.syndesis.connector.slack.SlackPlainMessage"
         },
         "outputDataShape": {
@@ -91,6 +93,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "Message",
           "type": "org.apache.camel.component.slack.helper.SlackMessage"
         },
         "propertyDefinitionSteps": [

--- a/app/connector/telegram/src/main/resources/META-INF/syndesis/connector/telegram.json
+++ b/app/connector/telegram/src/main/resources/META-INF/syndesis/connector/telegram.json
@@ -13,6 +13,7 @@
         },
         "outputDataShape": {
           "kind": "java",
+          "name": "IncomingMessage",
           "type": "org.apache.camel.component.telegram.model.IncomingMessage"
         },
         "propertyDefinitionSteps": []
@@ -34,6 +35,7 @@
         ],
         "inputDataShape": {
           "kind": "java",
+          "name": "OutgoingMessage",
           "type": "org.apache.camel.component.telegram.model.OutgoingTextMessage"
         },
         "outputDataShape": {


### PR DESCRIPTION
* To stop class names being used in the data mapper, provide names for all
  java data shapes.