### PR TITLE
user doc: Add prereq that client ID and secret are in Settings page entry

### DIFF
--- a/doc/connecting/topics/p_create-gmail-connection.adoc
+++ b/doc/connecting/topics/p_create-gmail-connection.adoc
@@ -8,10 +8,12 @@ When you create a Gmail connection, you authorize the connection to access one
 particular Gmail account. After you create a Gmail connection, you can 
 add it to multiple integrations.
 
-.Prerequisite
-You 
+.Prerequisites
+* You 
 link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Gmail API. 
+* The {prodname} *Settings* page entry for Gmail has values for the client ID and client secret, which
+you obtained by registering {prodname} as a Google client application. 
 
 .Procedure
 

--- a/doc/connecting/topics/p_create-google-calendar-connection.adoc
+++ b/doc/connecting/topics/p_create-google-calendar-connection.adoc
@@ -9,10 +9,12 @@ the Google calendars that are associated with one
 particular Google account. After you create a Google Calendar connection, you can 
 add it to multiple integrations.
 
-.Prerequisite
-You 
+.Prerequisites
+* You 
 link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Google Calendar API. 
+* The {prodname} *Settings* page entry for Google Calendar has values for the client ID and client secret, which
+you obtained by registering {prodname} as a Google client application. 
 
 .Procedure
 

--- a/doc/connecting/topics/p_create-google-sheets-connection.adoc
+++ b/doc/connecting/topics/p_create-google-sheets-connection.adoc
@@ -10,9 +10,12 @@ particular Google account, which you choose. After you create a Google Sheets co
 add it to multiple integrations.
 
 .Prerequisite
-You 
+* You 
 link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Google Sheets API. 
+* The {prodname} *Settings* page entry for Google Sheets has values for the client ID and client secret, which
+you obtained by registering {prodname} as a Google client application. 
+
 
 .Procedure
 


### PR DESCRIPTION
This new prerequisite is in the topics about creating  a Gmail connection, creating a Google Calendar connection, and creating a Google Sheets connection. 
This is related to https://github.com/syndesisio/syndesis/issues/4431