### PR TITLE
chore(version): Update camel to version 2.21.0.fuse-730054

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
-    <camel.version>2.21.0.fuse-730049</camel.version>
+    <camel.version>2.21.0.fuse-730054</camel.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
-    <camel.version>2.21.0.fuse-730049</camel.version>
+    <camel.version>2.21.0.fuse-730054</camel.version>
     <atlasmap.version>1.39.3</atlasmap.version>
   </properties>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -75,7 +75,7 @@
     <commons.compress.version>1.18</commons.compress.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.21.0.fuse-730049</camel.version>
+    <camel.version>2.21.0.fuse-730054</camel.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>
     <dep.plugin.pmd.version>3.10.0</dep.plugin.pmd.version>


### PR DESCRIPTION
This fix should contains all the required stuff for the odata connector, in this way we can remove the camel bits from the connector and use directly the component.

FYI @phantomjinx 