### PR TITLE
fix: Missing Json instance inspection for basic filter options

### DIFF
--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonInstanceInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonInstanceInspector.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.inspector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.syndesis.common.util.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Component
+public class JsonInstanceInspector implements Inspector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonInstanceInspector.class);
+
+    private static final String ARRAY_CONTEXT = "[]";
+    static final List<String> COLLECTION_PATHS = Collections.singletonList("size()");
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<String> getPaths(String kind, String type, String specification, Optional<byte[]> exemplar) {
+        if (specification == null) {
+            return Collections.emptyList();
+        }
+
+        String context = null;
+        final List<String> paths = new ArrayList<>();
+        try {
+            Map<String, Object> json;
+            if (isArray(specification)) {
+                List<Object> items = Json.reader().forType(List.class).readValue(specification);
+                // add collection specific paths
+                paths.addAll(COLLECTION_PATHS);
+                context = ARRAY_CONTEXT;
+
+                if (items.isEmpty()) {
+                    return paths;
+                }
+
+                json = (Map<String, Object>) items.get(0);
+            } else {
+                json = Json.reader().forType(Map.class).readValue(specification);
+            }
+
+            fetchPaths(context, paths, json);
+        } catch (final IOException e) {
+            LOG.warn("Unable to parse the given JSON instance, increase log level to DEBUG to see the instance being parsed");
+            LOG.debug(specification);
+            LOG.trace("Unable to parse the given JSON instance", e);
+        }
+
+        return paths;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void fetchPaths(final String context, final List<String> paths, final Object json) {
+        if (json instanceof Map) {
+            Map<String, Object> properties = (Map<String, Object>) json;
+
+            if (properties.isEmpty() && context != null) {
+                paths.add(context);
+            }
+
+            for (final Map.Entry<String, Object> entry : properties.entrySet()) {
+                final String key = entry.getKey();
+                if (context == null) {
+                    fetchPaths(key, paths, entry.getValue());
+                } else {
+                    fetchPaths(context + "." + key, paths, entry.getValue());
+                }
+            }
+        } else if (json instanceof List) {
+            List<Object> items = (List) json;
+            if (!items.isEmpty()) {
+                if (context == null) {
+                    fetchPaths(ARRAY_CONTEXT, paths, items.get(0));
+                } else {
+                    COLLECTION_PATHS.stream().map(path -> context + "." + path).forEach(paths::add);
+                    fetchPaths(context + ARRAY_CONTEXT, paths, ((List) json).get(0));
+                }
+            } else {
+                COLLECTION_PATHS.stream().map(path -> context + "." + path).forEach(paths::add);
+                paths.add(context + ARRAY_CONTEXT);
+            }
+        } else {
+            paths.add(context);
+        }
+    }
+
+    private static boolean isArray(String specification) {
+        return specification.trim().startsWith("[") && specification.trim().endsWith("]");
+    }
+
+    @Override
+    public boolean supports(String kind, String type, String specification, Optional<byte[]> optional) {
+        return "json-instance".equals(kind) && !StringUtils.isEmpty(specification);
+
+    }
+}

--- a/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
+++ b/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.inspector;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class JsonInstanceInspectorTest {
+
+    private final String JSON_INSTANCE_KIND = "json-instance";
+    private JsonInstanceInspector inspector = new JsonInstanceInspector();
+
+    @Test
+    public void shouldCollectPathsFromJsonObject() {
+        final List<String> paths = inspector.getPaths(JSON_INSTANCE_KIND, "", getJsonInstance(), Optional.empty());
+        assertProperties(paths);
+        assertThat(paths).doesNotContainAnyElementsOf(JsonInstanceInspector.COLLECTION_PATHS);
+    }
+
+    @Test
+    public void shouldCollectPathsFromEmptyJsonObject() {
+        final List<String> paths = inspector.getPaths(JSON_INSTANCE_KIND, "", "{}", Optional.empty());
+        assertThat(paths).isEmpty();
+    }
+
+    @Test
+    public void shouldCollectPathsFromJsonArray() {
+        final List<String> paths = inspector.getPaths(JSON_INSTANCE_KIND, "", getJsonArrayInstance(), Optional.empty());
+        assertArrayProperties(paths);
+        assertThat(paths).containsAll(JsonInstanceInspector.COLLECTION_PATHS);
+    }
+
+    @Test
+    public void shouldCollectPathsFromEmptyJsonArray() {
+        final List<String> paths = inspector.getPaths(JSON_INSTANCE_KIND, "", "[]", Optional.empty());
+        assertThat(paths).isEqualTo(JsonInstanceInspector.COLLECTION_PATHS);
+    }
+
+    private String getJsonInstance() {
+        return "{" +
+                    "\"id\": \"" + UUID.randomUUID().toString() + "\"," +
+                    "\"firstName\": \"Foo\"," +
+                    "\"lastName\": \"Bar\"," +
+                    "\"isAlive\": true," +
+                    "\"age\": 30," +
+                    "\"address\": {" +
+                        "\"streetAddress\": \"21 1st Fake Street\"," +
+                        "\"city\": \"Fake Town\"," +
+                        "\"state\": \"ZZ\"," +
+                        "\"postalCode\": \"10000-0000\"" +
+                    "}," +
+                    "\"phoneNumbers\": [" +
+                        "{" +
+                            "\"type\": \"home\"," +
+                            "\"number\": \"000 555-1234\"" +
+                        "}," +
+                        "{" +
+                            "\"type\": \"office\"," +
+                            "\"number\": \"000 555-4567\"" +
+                        "}," +
+                        "{" +
+                            "\"type\": \"mobile\"," +
+                            "\"number\": \"123 456-7890\"" +
+                        "}" +
+                    "]," +
+                    "\"children\": []," +
+                    "\"spouse\": null," +
+                    "\"image\": {}" +
+                "}";
+    }
+
+    private String getJsonArrayInstance() {
+        return "[" + getJsonInstance() + "]";
+    }
+
+    private void assertProperties(List<String> paths) {
+        assertProperties(paths, null);
+    }
+
+    private void assertArrayProperties(List<String> paths) {
+        assertProperties(paths, "[]");
+    }
+
+    private void assertProperties(List<String> paths, String context) {
+        List<String> expectedPaths = Arrays.asList("id", "isAlive",
+                "firstName", "lastName", "address.city", "address.state",
+                "phoneNumbers[].type", "phoneNumbers.size()", "phoneNumbers[].number",
+                "children.size()", "children[]", "spouse", "image");
+
+        assertThat(paths).containsAll(expectedPaths.stream()
+                .map(item -> Optional.ofNullable(context).map(path -> path + ".").orElse("") + item)
+                .collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
Fixes #4162

Also adds nested Json array support for options in both Json instance and schema inspector. 