### PR TITLE
fix: SQL connector failsafe query parameter read from body

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -76,8 +76,8 @@ public final class JSONBeanUtil {
         return ret;
     }
 
-    public static Map<String,SqlParameterValue> parseSqlParametersFromJSONBean(final String json, final Map<String, Integer> jdbcTypeMap) {
-        if (json == null || json.isEmpty()) {
+    public static Map<String, SqlParameterValue> parseSqlParametersFromJSONBean(final String json, final Map<String, Integer> jdbcTypeMap) {
+        if (!isValidJSONBean(json)) {
             return Collections.emptyMap(); // json is empty so no need to parse
         }
 
@@ -106,6 +106,15 @@ public final class JSONBeanUtil {
             ret.put(key, sqlParam);
         }
         return ret;
+    }
+
+    /**
+     * Validate JSON bean for being a proper parameter information object.
+     * @param json
+     * @return
+     */
+    private static boolean isValidJSONBean(String json) {
+        return json != null && !json.isEmpty() && json.trim().startsWith("{") && json.trim().endsWith("}");
     }
 
     /**

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
@@ -15,17 +15,20 @@
  */
 package io.syndesis.connector.sql.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.jdbc.core.SqlParameterValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JSONBeanUtilTest {
 
@@ -101,9 +104,10 @@ public class JSONBeanUtilTest {
     @Test
     public void parseSqlParametersFromJSONBeanWhenNoParameters() throws JsonProcessingException {
         try {
-            String[] jsonParamValues = { null, "" };
+            String[] jsonParamValues = { null, "", "{}", "[]", "something else" };
             for (int i = 0; i < jsonParamValues.length; ++i) {
-                JSONBeanUtil.parseSqlParametersFromJSONBean(jsonParamValues[i], new HashMap<>());
+                Map<String, SqlParameterValue> retMap = JSONBeanUtil.parseSqlParametersFromJSONBean(jsonParamValues[i], new HashMap<>());
+                assertThat(retMap).isEmpty();
             }
         } catch (Exception ex) {
             throw new AssertionError("Should not throw exception when json parameter is empty", ex);


### PR DESCRIPTION
SQL connector needs to read query parameter information from exchange body. With this PR connector only reads that information when SQL query actually uses parameters and when body is of proper Json object type.

This ensures failsafe processing in (rare) cases where SQL connection step is not provided with proper Json parameter exchange body (e.g. static SQL queries without any parameters and consecutive SQL steps)

Fixes #4728 