### PR TITLE
user doc: change titles from imperative to gerund, connector guide and tutorials

### DIFF
--- a/doc/connecting/topics/as_connecting-to-amazon-s3.adoc
+++ b/doc/connecting/topics/as_connecting-to-amazon-s3.adoc
@@ -2,7 +2,7 @@
 // connecting/master.adoc
 
 [id='connecting-to-s3_{context}']
-= Connect to Amazon S3
+= Connecting to Amazon S3
 :context: s3
 
 An integration can retrieve data from an Amazon S3 bucket or copy data into
@@ -10,11 +10,11 @@ an Amazon S3 bucket. To do this, you create an Amazon S3
 connection and then add that Amazon S3 connection to an integration.
 For details, see:
 
-* <<prerequisites-for-creating-s3-connection_{context}>>
-* <<create-s3-connection_{context}>>
-* <<adding-s3-connection-start_{context}>>
-* <<adding-s3-connection-finish_{context}>>
-* <<adding-s3-connection-middle_{context}>>
+* xref:prerequisites-for-creating-s3-connection_{context}[]
+* xref:create-s3-connection_{context}[]
+* xref:adding-s3-connection-start_{context}[]
+* xref:adding-s3-connection-finish_{context}[]
+* xref:adding-s3-connection-middle_{context}[]
 
 include::r_prerequisites-for-creating-s3-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-amq.adoc
+++ b/doc/connecting/topics/as_connecting-to-amq.adoc
@@ -2,7 +2,7 @@
 // connecting/master.adoc
 
 [id='connecting-to-amq_{context}']
-= Connect to AMQ
+= Connecting to AMQ
 :context: amq
 
 In an integration, you can obtain messages from a
@@ -26,10 +26,10 @@ to create a connection to the broker of interest:
 
 To use the Red Hat AMQ connector, see:
 
-* <<create-amq-connection_{context}>>
-* <<adding-amq-connection-start_{context}>>
-* <<adding-amq-connection-finish_{context}>>
-* <<adding-amq-connection-middle_{context}>>
+* xref:create-amq-connection_{context}[]
+* xref:adding-amq-connection-start_{context}[]
+* xref:adding-amq-connection-finish_{context}[]
+* xref:adding-amq-connection-middle_{context}[]
 
 include::p_create-amq-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-amqp.adoc
+++ b/doc/connecting/topics/as_connecting-to-amqp.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-amqp_{context}']
-= Connect to AMQP
+= Connecting to AMQP
 :context: amqp
 
 In an integration, you can obtain messages from or publish messages
@@ -35,10 +35,10 @@ https://access.redhat.com/documentation/en-us/red_hat_jboss_a-mq/6.3/html-single
 
 To use the AMQP connector, see:
 
-* <<create-amqp-connection_{context}>> 
-* <<adding-amqp-connection-start_{context}>>
-* <<adding-amqp-connection-finish_{context}>>
-* <<adding-amqp-connection-middle_{context}>>
+* xref:create-amqp-connection_{context}[] 
+* xref:adding-amqp-connection-start_{context}[]
+* xref:adding-amqp-connection-finish_{context}[]
+* xref:adding-amqp-connection-middle_{context}[]
 
 include::p_create-amqp-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-concur.adoc
+++ b/doc/connecting/topics/as_connecting-to-concur.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-concur_{context}']
-= Connect to SAP Concur
+= Connecting to SAP Concur
 :context: concur
 
 SAP Concur manages business expenses, travel, and invoices. 
@@ -18,13 +18,13 @@ upload the new project codes to the appropriate list.
 
 See the following topics: 
 
-* <<user-roles-for-connecting-to-concur_{context}>>
-* <<obtain-concur-oauth-credentials-implementation_{context}>>
-* <<obtain-concur-oauth-credentials-production_{context}>>
-* <<configure-concur-connector_{context}>>
-* <<create-concur-connection_{context}>>
-* <<add-concur-connection_{context}>>
-* <<identify-concur-fields-for-mapping_{context}>>
+* xref:user-roles-for-connecting-to-concur_{context}[]
+* xref:obtain-concur-oauth-credentials-implementation_{context}[]
+* xref:obtain-concur-oauth-credentials-production_{context}[]
+* xref:configure-concur-connector_{context}[]
+* xref:create-concur-connection_{context}[]
+* xref:add-concur-connection_{context}[]
+* xref:identify-concur-fields-for-mapping_{context}[]
 
 
 include::c_user-roles-for-connecting-to-concur.adoc[leveloffset=+1]

--- a/doc/connecting/topics/as_connecting-to-databases.adoc
+++ b/doc/connecting/topics/as_connecting-to-databases.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-databases_{context}']
-= Connect to SQL databases
+= Connecting to SQL databases
 :context: db
 
 In an integration, you can connect to any of the following types of SQL
@@ -21,10 +21,10 @@ that database.
 
 See the following topics for details:
 
-* <<create-database-connection_{context}>>
-* <<adding-db-connection-start_{context}>>
-* <<adding-db-connection-finish-middle_{context}>>
-* <<connecting-to-proprietary-databases_{context}>>
+* xref:create-database-connection_{context}[]
+* xref:adding-db-connection-start_{context}[]
+* xref:adding-db-connection-finish-middle_{context}[]
+* xref:connecting-to-proprietary-databases_{context}[]
 
 include::p_create-database-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-dropbox.adoc
+++ b/doc/connecting/topics/as_connecting-to-dropbox.adoc
@@ -3,17 +3,17 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-dropbox_{context}']
-= Connect to Dropbox
+= Connecting to Dropbox
 :context: dropbox
 
 In an integration, you can download files from Dropbox or upload files
 to Dropbox. The following topics provide the details:
 
-* <<register-with-dropbox_{context}>>
-* <<create-dropbox-connection_{context}>>
-* <<adding-dropbox-connection-start_{context}>>
-* <<adding-dropbox-connection-finish_{context}>>
-* <<adding-dropbox-connection-middle_{context}>>
+* xref:register-with-dropbox_{context}[]
+* xref:create-dropbox-connection_{context}[]
+* xref:adding-dropbox-connection-start_{context}[]
+* xref:adding-dropbox-connection-finish_{context}[]
+* xref:adding-dropbox-connection-middle_{context}[]
 
 include::p_register-with-dropbox.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-ftp.adoc
+++ b/doc/connecting/topics/as_connecting-to-ftp.adoc
@@ -3,16 +3,16 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-ftp_{context}']
-= Connect to an FTP or SFTP server
+= Connecting to an FTP or SFTP server
 :context: ftp
 
 In an integration, you can connect to an FTP or SFTP server to download or 
 upload files. To do this, create an FTP or SFTP connection. You can then add this 
 connection to any number of integrations. The following topics provide details:
 
-* <<creating-ftp-connections_{context}>>
-* <<adding-ftp-start-connection_{context}>>
-* <<adding-ftp-finish-middle-connection_{context}>>
+* xref:creating-ftp-connections_{context}[]
+* xref:adding-ftp-start-connection_{context}[]
+* xref:adding-ftp-finish-middle-connection_{context}[]
 
 include::p_creating-ftp-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-gmail.adoc
+++ b/doc/connecting/topics/as_connecting-to-gmail.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/as_connecting-to-google.adoc
 
 [id='connecting-to-gmail_{context}']
-= Connect to Gmail
+= Connecting to Gmail
 :context: gmail
 
 To trigger execution of an integration when a particular Gmail
@@ -14,21 +14,21 @@ finish connection, or as a middle connection.
 
 The general steps for connecting to Gmail in an integration are:
 
-. link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Register {prodname} as a Google client application].
-. Create a Gmail connection. When you do this you choose the Gmail account that
+. link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
+. Creating a Gmail connection. When you do this you choose the Gmail account that
 the connection is authorized to access.
 . If your integration sends an email from a Gmail account, 
 decide how to populate an email to send.
-. Add a Gmail connection to an integration.
-. For a Gmail connection that sends an email, optionally map integration
+. Adding a Gmail connection to an integration.
+. For a Gmail connection that sends an email, optionally mapping integration
 data to the email fields. 
 
 Information and instructions are in the following topics:
 
-* <<create-gmail-connection_{context}>>
-* <<alternatives-for-populating-email-to-send_{context}>>
-* <<add-gmail-connection-start_{context}>>
-* <<add-gmail-connection-finish-middle_{context}>>
+* xref:create-gmail-connection_{context}[]
+* xref:alternatives-for-populating-email-to-send_{context}[]
+* xref:add-gmail-connection-start_{context}[]
+* xref:add-gmail-connection-finish-middle_{context}[]
 
 include::p_create-gmail-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-google-calendar.adoc
+++ b/doc/connecting/topics/as_connecting-to-google-calendar.adoc
@@ -4,7 +4,7 @@
 
 :context: google
 [id='connecting-to-google-calendar_{context}']
-= Connect to Google Calendar
+= Connecting to Google Calendar
 :context: calendar
 
 To trigger integration execution when a poll returns an update to a
@@ -15,11 +15,11 @@ as the integration's middle or finish connection.
 
 Details for connecting to Google Calendar are in the following topics:
 
-* <<create-google-calendar-connection_{context}>>
-* <<add-google-calendar-connection-start_{context}>>
-* <<add-google-calendar-connection-to-get-one-event_{context}>>
-* <<add-google-calendar-connection-update-event_{context}>>
-* <<add-google-calendar-connection-add-event_{context}>>
+* xref:create-google-calendar-connection_{context}[]
+* xref:add-google-calendar-connection-start_{context}[]
+* xref:add-google-calendar-connection-to-get-one-event_{context}[]
+* xref:add-google-calendar-connection-update-event_{context}[]
+* xref:add-google-calendar-connection-add-event_{context}[]
 
 include::p_create-google-calendar-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-google-sheets.adoc
+++ b/doc/connecting/topics/as_connecting-to-google-sheets.adoc
@@ -4,7 +4,7 @@
 
 :context: google
 [id='connecting-to-google-sheets_{context}']
-= Connect to Google Sheets
+= Connecting to Google Sheets
 :context: sheets
 
 To trigger execution of an integration when a Google Sheets connection

--- a/doc/connecting/topics/as_connecting-to-google.adoc
+++ b/doc/connecting/topics/as_connecting-to-google.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-google_{context}']
-= Connect to Google applications
+= Connecting to Google applications
 :context: google
 
 An integration can connect to Gmail, Google Calendar, and Google Sheets. 
@@ -13,10 +13,10 @@ Google API for each application that you want integrations to connect to.
 
 Information and instructions are in the following topics:
 
-* <<register-with-google_{context}>>
-* <<connecting-to-gmail_{context}>>
-* <<connecting-to-google-calendar_{context}>>
-* <<connecting-to-google-sheets_{context}>>
+* xref:register-with-google_{context}[]
+* xref:connecting-to-gmail_{context}[]
+* xref:connecting-to-google-calendar_{context}[]
+* xref:connecting-to-google-sheets_{context}[]
 
 include::p_register-with-google.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-http.adoc
+++ b/doc/connecting/topics/as_connecting-to-http.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-http_{context}']
-= Connect to HTTP and HTTPS endpoints
+= Connecting to HTTP and HTTPS endpoints
 :context: http
 
 In an integration, you can connect to HTTP and HTTPS endpoints to execute
@@ -12,8 +12,8 @@ or `PATCH` method. To do this, create
 an HTTP or HTTPS connection and then add it to an integration. 
 The following topics provide details:
 
-* <<creating-http-connections_{context}>>
-* <<adding-http-connections_{context}>>
+* xref:creating-http-connections_{context}[]
+* xref:adding-http-connections_{context}[]
 
 include::p_creating-http-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-kafka.adoc
+++ b/doc/connecting/topics/as_connecting-to-kafka.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-kafka_{context}']
-= Connect to Kafka
+= Connecting to Kafka
 :context: kafka
 
 Apache Kafka is a distributed streaming platform that you can use to
@@ -13,9 +13,9 @@ that you specify or publish data to a Kafka topic that you specify.
 To do this, create a connection to Kafka and then add that connection to an 
 integration. Details are in the following topics:
 
-* <<creating-kafka-connections_{context}>>
-* <<adding-kafka-connection-start_{context}>>
-* <<adding-kafka-connection-finish-middle_{context}>>
+* xref:creating-kafka-connections_{context}[]
+* xref:adding-kafka-connection-start_{context}[]
+* xref:adding-kafka-connection-finish-middle_{context}[]
 
 include::p_creating-kafka-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-kudu.adoc
+++ b/doc/connecting/topics/as_connecting-to-kudu.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-kudu_{context}']
-= Connect to Apache Kudu
+= Connecting to Apache Kudu
 :context: kudu
 
 Apache Kudu is a columnar storage manager developed for the Apache Hadoop platform. 

--- a/doc/connecting/topics/as_connecting-to-log.adoc
+++ b/doc/connecting/topics/as_connecting-to-log.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-log_{context}']
-= Connect to an integration's log
+= Connecting to an integration's log
 
 :context: connect-to-log
 
@@ -23,9 +23,9 @@ To obtain further details about integration execution, you can
 log information about the messages that an integration processes by 
 adding a log step and/or a log connection to an integration. 
 
-* <<comparison-log-step-connection_{context}>>
-* <<add-log-connection_{context}>>
-* <<create-replacement-log-connection_{context}>>
+* xref:comparison-log-step-connection_{context}[]
+* xref:add-log-connection_{context}[]
+* xref:create-replacement-log-connection_{context}[]
 
 include::r_comparison-log-step-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-mqtt.adoc
+++ b/doc/connecting/topics/as_connecting-to-mqtt.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-mqtt_{context}']
-= Connect to MQTT
+= Connecting to MQTT
 :context: mqtt
 
 MQ Telemetry Transport (MQTT) is a lightweight,
@@ -13,9 +13,9 @@ an MQTT broker. To do this, create a connection to the MQTT broker
 of interest and then add that connection to an integration.
 Details are in the following topics:
 
-* <<creating-mqtt-connections_{context}>>
-* <<adding-mqtt-connection-start_{context}>>
-* <<adding-mqtt-connection-finish-middle_{context}>>
+* xref:creating-mqtt-connections_{context}[]
+* xref:adding-mqtt-connection-start_{context}[]
+* xref:adding-mqtt-connection-finish-middle_{context}[]
 
 include::p_creating-mqtt-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-rest-apis.adoc
+++ b/doc/connecting/topics/as_connecting-to-rest-apis.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-rest-apis_{context}']
-= Connect to REST APIs
+= Connecting to REST APIs
 :context: rest
 
 In an integration, to connect to a REST API, you must have created a
@@ -15,9 +15,9 @@ When a connector for the REST API you want to connect to
 is available in {prodname},
 the steps for connecting to that REST API are:
 
-* <<register-with-rest-api_{context}>> if required
-* <<create-rest-api-connection_{context}>>
-* <<add-api-client-connection_{context}>>
+* xref:register-with-rest-api_{context}[] if required
+* xref:create-rest-api-connection_{context}[]
+* xref:add-api-client-connection_{context}[]
 
 include::p_registering-with-rest-api.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-servicenow.adoc
+++ b/doc/connecting/topics/as_connecting-to-servicenow.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-servicenow_{context}']
-= Connect to ServiceNow
+= Connecting to ServiceNow
 :context: servicenow
 
 An integration can retrieve records from a ServiceNow table or add records to 
@@ -12,11 +12,11 @@ In an integration, to connect to ServiceNow,
 create a ServiceNow connection and then add that connection to an integration.
 For details, see:
 
-* <<create-servicenow-connection_{context}>>
-* <<add-servicenow-connection-start_{context}>>
-* <<create-servicenow-import-set_{context}>>
-* <<add-servicenow-connection-finish_{context}>>
-* <<example-sf-servicenow-integration_{context}>>
+* xref:create-servicenow-connection_{context}[]
+* xref:add-servicenow-connection-start_{context}[]
+* xref:create-servicenow-import-set_{context}[]
+* xref:add-servicenow-connection-finish_{context}[]
+* xref:example-sf-servicenow-integration_{context}[]
 
 include::p_create-servicenow-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-sf.adoc
+++ b/doc/connecting/topics/as_connecting-to-sf.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-sf_{context}']
-= Connect to Salesforce
+= Connecting to Salesforce
 
 :context: salesforce
 
@@ -13,9 +13,9 @@ In an integration, to connect to Salesforce, you must register your
 a Salesforce connection, which you can then add to any number of 
 integrations. For details, see the following topics:
 
-* <<register-with-salesforce_{context}>>
-* <<create-salesforce-connection_{context}>>
-* <<adding-sf-connections_{context}>>
+* xref:register-with-salesforce_{context}[]
+* xref:create-salesforce-connection_{context}[]
+* xref:adding-sf-connections_{context}[]
 
 include::shared/p_register-with-sf.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-slack.adoc
+++ b/doc/connecting/topics/as_connecting-to-slack.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-slack_{context}']
-= Connect to Slack
+= Connecting to Slack
 :context: slack
 
 As a business user, you can create an integration that connects to Slack. A 
@@ -16,7 +16,6 @@ for keyword instances such as product names. Upon finding messages that
 contain those product names, the integration can notify the appropriate contact 
 in a Gmail connection. 
 
-
 * Deliver a message to a particular user or to a channel. For example, this 
 behavior is useful when an integration downloads a file from an FTP server and 
 processes it in some way. You can finish an integration by 
@@ -26,9 +25,9 @@ To connect to Slack in an integration, create a Slack
 connection and then add the connection to an integration. 
 Details are in the following topics:
 
-* <<creating-slack-connections_{context}>>
-* <<add-slack-connection-start_{context}>>
-* <<add-slack-connection-middle-finish_{context}>>
+* xref:creating-slack-connections_{context}[]
+* xref:add-slack-connection-start_{context}[]
+* xref:add-slack-connection-middle-finish_{context}[]
 
 include::p_creating-slack-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-telegram.adoc
+++ b/doc/connecting/topics/as_connecting-to-telegram.adoc
@@ -3,7 +3,7 @@
 :context: connectors
 
 [id='connecting-to-telegram_{context}']
-= Connect to Telegram
+= Connecting to Telegram
 
 As a business user, you can create an integration that connects to Telegram. A 
 connection to Telegram can do either one of the following:
@@ -25,9 +25,9 @@ To connect to Telegram in an integration, create a Telegram
 connection and then add the connection to an integration. 
 Details are in the following topics:
 
-* <<creating-telegram-connections_{context}>>
-* <<add-telegram-connection-start_{context}>>
-* <<add-telegram-connection-middle-finish_{context}>>
+* xref:creating-telegram-connections_{context}[]
+* xref:add-telegram-connection-start_{context}[]
+* xref:add-telegram-connection-middle-finish_{context}[]
 
 include::p_creating-telegram-connections.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_connecting-to-twitter.adoc
+++ b/doc/connecting/topics/as_connecting-to-twitter.adoc
@@ -3,14 +3,14 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='connecting-to-twitter_{context}']
-= Connect to Twitter
+= Connecting to Twitter
 :context: twitter
 
 To connect to Twitter in an integration, the main steps are: 
 
-* <<register-with-twitter_{context}>>
-* <<create-twitter-connection_{context}>>
-* <<adding-twitter-connections_{context}>>
+* xref:register-with-twitter_{context}[]
+* xref:create-twitter-connection_{context}[]
+* xref:adding-twitter-connections_{context}[]
 
 You need a Twitter developer account to authorize access from your
 {prodname} environment to Twitter. If you do not already have a Twitter

--- a/doc/connecting/topics/as_trigger-integration-with-timer.adoc
+++ b/doc/connecting/topics/as_trigger-integration-with-timer.adoc
@@ -3,7 +3,7 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='triggering-integrations-with-timers_{context}']
-= Trigger integration execution with a timer
+= Triggering integration execution with a timer
 :context: timer
 
 To trigger execution of an integration according to a schedule that
@@ -13,8 +13,8 @@ to start as many integrations as you like. You do not need to create
 a timer connection unless you inadvertently delete the provided
 timer connection. Details are in the following topics:
 
-* <<add-timer-connection_{context}>>
-* <<create-timer-connection_{context}>>
+* xref:add-timer-connection_{context}[]
+* xref:create-timer-connection_{context}[]
 
 include::p_add-timer-connection.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/as_triggering-integrations-with-http-requests.adoc
+++ b/doc/connecting/topics/as_triggering-integrations-with-http-requests.adoc
@@ -3,20 +3,20 @@
 // Downstream: connecting-fuse-online-to-applications-and-services/master.adoc
 
 [id='triggering-integrations-with-http-requests_{context}']
-= Trigger integration execution with an HTTP request (Webhook)
+= Triggering integration execution with an HTTP request (Webhook)
 :context: webhook
 
 You can trigger execution of an integration by sending an HTTP `GET` or `POST`
 request to an HTTP endpoint that {prodname} exposes. The following topics
 provide details: 
 
-* <<how-to-use-webhook_{context}>>
-* <<create-webhook-connection_{context}>>
-* <<start-with-webhook-connection_{context}>>
-* <<how-requests-are-handled_{context}>>
-* <<guidelines-for-service-sending-requests_{context}>>
-* <<about-json-schema-for-http-requests_{context}>>
-* <<how-to-specify-request_{context}>>
+* xref:how-to-use-webhook_{context}[]
+* xref:create-webhook-connection_{context}[]
+* xref:start-with-webhook-connection_{context}[]
+* xref:how-requests-are-handled_{context}[]
+* xref:guidelines-for-service-sending-requests_{context}[]
+* xref:about-json-schema-for-http-requests_{context}[]
+* xref:how-to-specify-request_{context}[]
 
 include::p_how-to-use-webhook.adoc[leveloffset=+1]
 

--- a/doc/connecting/topics/p_add-api-client-connection.adoc
+++ b/doc/connecting/topics/p_add-api-client-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-rest-apis.adoc
 
 [id='add-api-client-connection_{context}']
-= Add an API client connection to an integration
+= Adding an API client connection to an integration
 
 In an integration, to connect to a REST API, add a connection to that
 REST API to the integration. 

--- a/doc/connecting/topics/p_add-concur-connection.adoc
+++ b/doc/connecting/topics/p_add-concur-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-concur.adoc
 
 [id='add-concur-connection_{context}']
-= Add a SAP Concur connection to an integration
+= Adding a SAP Concur connection to an integration
 
 In an integration, a connection to SAP Concur is a middle or finish
 connection and not a start connection. A connection to SAP Concur can perform

--- a/doc/connecting/topics/p_add-gmail-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_add-gmail-connection-finish-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-gmail.adoc
 
 [id='add-gmail-connection-finish-middle_{context}']
-= Send an email from a Gmail account
+= Sending an email from a Gmail account
 
 In an integration, you can send an email from a Gmail account either
 in the middle of the integration or to finish the integration.  

--- a/doc/connecting/topics/p_add-gmail-connection-start.adoc
+++ b/doc/connecting/topics/p_add-gmail-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-gmail.adoc
 
 [id='add-gmail-connection-start_{context}']
-= Trigger an integration when polling returns a Gmail message
+= Triggering an integration when polling returns a Gmail message
 
 To trigger execution of an integration based on email received by 
 a particular Gmail account, add a Gmail connection as the start connection of

--- a/doc/connecting/topics/p_add-google-calendar-connection-add-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-add-event.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-calendar.adoc
 
 [id='add-google-calendar-connection-add-event_{context}']
-= Add an event to a Google calendar 
+= Adding an event to a Google calendar 
 
 In an integration, you can add an event to a Google calendar 
 in the middle of the integration or to finish the integration.  

--- a/doc/connecting/topics/p_add-google-calendar-connection-start.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-calendar.adoc
 
 [id='add-google-calendar-connection-start_{context}']
-= Trigger an integration when polling returns an event from a Google calendar
+= Triggering an integration when polling returns an event from a Google calendar
 
 To trigger execution of an integration upon obtaining events from 
 a Google Calendar that you specify, add a Google Calendar connection to an integration as 

--- a/doc/connecting/topics/p_add-google-calendar-connection-to-get-one-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-to-get-one-event.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-calendar.adoc
 
 [id='add-google-calendar-connection-to-get-one-event_{context}']
-= Obtain a particular event from a Google calendar
+= Obtaining a particular event from a Google calendar
 
 In an integration, you can obtain a particular Google calendar event
 in the middle of an integration. Obtaining a particular event is 

--- a/doc/connecting/topics/p_add-google-calendar-connection-update-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-update-event.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-calendar.adoc
 
 [id='add-google-calendar-connection-update-event_{context}']
-= Update an event in a Google calendar 
+= Updating an event in a Google calendar 
 
 In an integration, you can update an event in a Google calendar
 in the middle of the integration or to finish the integration.  

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-add-chart_{context}']
-= Add a chart to a sheet 
+= Adding a chart to a sheet 
 
 In the middle of an integration, or to finish an integration, 
 you can add a basic chart or a pie chart to a Google Sheets spreadsheet.

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-add-pivot-table_{context}']
-= Add a pivot table to a sheet
+= Adding a pivot table to a sheet
 
 In the middle of an integration, or to finish an integration, 
 you can add a pivot table to a Google Sheets spreadsheet.

--- a/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-append-sheet-values_{context}']
-= Append data to a sheet
+= Appending data to a sheet
 
 You can append data to a sheet 
 in the middle of the integration or to finish the integration.

--- a/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-create-spreadsheet_{context}']
-= Create a spreadsheet
+= Creating a spreadsheet
 
 To create a new spreadsheet in the middle of an integration, 
 add a Google Sheets connection between the start and finish connections. 

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-properties.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-properties.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-get-properties_{context}']
-= Trigger an integration when polling returns spreadsheet properties
+= Triggering an integration when polling returns spreadsheet properties
 
 To trigger execution of an integration upon obtaining properties from
 a Google Sheets spreadsheet, add a Google Sheets connection to an integration as

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-get-sheet-values_{context}']
-= Trigger an integration when polling returns spreadsheet data
+= Triggering an integration when polling returns spreadsheet data
 
 To trigger execution of an integration upon obtaining data from a
 Google Sheets spreadsheet, add a Google Sheets connection to an integration 

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-properties.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-properties.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-update-properties_{context}']
-= Update spreadsheet properties
+= Updating spreadsheet properties
 
 In an integration, you can update the properties of a spreadsheet 
 in the middle of the integration or to finish the integration.

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='add-google-sheets-connection-update-sheet-values_{context}']
-= Update data in a sheet
+= Updating data in a sheet
 
 In an integration, you can update data in a spreadsheet
 in the middle of the integration or to finish the integration.

--- a/doc/connecting/topics/p_add-kudu-connection-add-records.adoc
+++ b/doc/connecting/topics/p_add-kudu-connection-add-records.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kudu.adoc
 
 [id='add-kudu-connection-add-records_{context}']
-= Insert records into a Kudu table
+= Inserting records into a Kudu table
 
 In an integration, you can add records to a Kudu table to finish
 an integration. To do this, add a Kudu connection as the integration's 

--- a/doc/connecting/topics/p_add-kudu-connection-get-records.adoc
+++ b/doc/connecting/topics/p_add-kudu-connection-get-records.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kudu.adoc
 
 [id='add-kudu-connection-get-records_{context}']
-= Trigger an integration when scanning returns records from a Kudu table
+= Triggering an integration when scanning returns records from a Kudu table
 
 To trigger execution of an integration upon obtaining data from a 
 Kudu table, add a Kudu connection to an integration as its start 

--- a/doc/connecting/topics/p_add-log-connection.adoc
+++ b/doc/connecting/topics/p_add-log-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-log.adoc
 
 [id='add-log-connection_{context}']
-= Add a log connection to an integration
+= Adding a log connection to an integration
 
 To log information about the messages that an integration processes, 
 add one or more log connections to the integration. A log connection takes

--- a/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-servicenow.adoc
 
 [id='add-servicenow-connection-finish_{context}']
-= Copy records to ServiceNow during or to finish an integration
+= Copying records to ServiceNow during or to finish an integration
 
 In the middle of an integration, or to finish an integration, 
 you can copy records to 
@@ -17,7 +17,7 @@ as the finish connection or as a middle connection.
 add records to. Your ServiceNow administrator can
 help you identify the appropriate import set. If the import set 
 does not exist, see 
-link:{LinkFuseOnlineConnectorGuide}#create-servicenow-import-set_servicenow[Create an import set in ServiceNow].
+link:{LinkFuseOnlineConnectorGuide}#create-servicenow-import-set_servicenow[Creating an import set in ServiceNow].
 * The ServiceNow import set is configured to handle the addition 
 of records.
 

--- a/doc/connecting/topics/p_add-servicenow-connection-start.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-servicenow.adoc
 
 [id='add-servicenow-connection-start_{context}']
-= Start an integration by obtaining records from ServiceNow
+= Starting an integration by obtaining records from ServiceNow
 
 To start an integration by obtaining records from ServiceNow,
 add a ServiceNow connection to an integration as the start connection.

--- a/doc/connecting/topics/p_add-slack-connection-middle-finish.adoc
+++ b/doc/connecting/topics/p_add-slack-connection-middle-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-slack.adoc
 
 [id='add-slack-connection-middle-finish_{context}']
-= Add a Slack connection to send a message to a Slack channel or user
+= Adding a Slack connection to send a message to a Slack channel or user
 
 In an integration, you can send a message to a Slack channel or Slack user to
 finish an integration or in the middle of an integration. 

--- a/doc/connecting/topics/p_add-slack-connection-start.adoc
+++ b/doc/connecting/topics/p_add-slack-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-slack.adoc
 
 [id='add-slack-connection-start_{context}']
-= Add a Slack connection to trigger execution upon receiving messages
+= Adding a Slack connection to trigger execution upon receiving messages
 
 A Slack connection that starts an integration triggers execution of the 
 integration when the connection finds messages on a Slack channel that 

--- a/doc/connecting/topics/p_add-telegram-connection-middle-finish.adoc
+++ b/doc/connecting/topics/p_add-telegram-connection-middle-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-telegram.adoc
 
 [id='add-telegram-connection-middle-finish_{context}']
-= Add a Telegram connection to send a message to a Telegram chat
+= Adding a Telegram connection to send a message to a Telegram chat
 
 In an integration, you can send a message to a Telegram chat to
 finish an integration or in the middle of an integration. 

--- a/doc/connecting/topics/p_add-telegram-connection-start.adoc
+++ b/doc/connecting/topics/p_add-telegram-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-telegram.adoc
 
 [id='add-telegram-connection-start_{context}']
-= Add a Telegram connection to trigger integration execution upon receiving messages
+= Adding a Telegram connection to trigger integration execution upon receiving messages
 
 A Telegram connection that starts an integration triggers execution of the 
 integration each time that the connection receives a message from a Telegram 
@@ -10,7 +10,7 @@ chat bot that you specify.
 
 .Prerequisites
 
-* You created a <<creating-telegram-connections_{context},Telegram connection>>. 
+* You created a xref:creating-telegram-connections_{context}[Telegram connection]. 
 * You are creating an integration and {prodname} is prompting you to 
 choose how you want to start the integration. 
 

--- a/doc/connecting/topics/p_add-timer-connection.adoc
+++ b/doc/connecting/topics/p_add-timer-connection.adoc
@@ -2,7 +2,7 @@
 // as_trigger-integration-with-timer.adoc
 
 [id='add-timer-connection_{context}']
-= Add a timer connection to trigger integration execution
+= Adding a timer connection to trigger integration execution
 
 To trigger execution of an integration according to a schedule that
 you specify, add a timer connection as an integration's start

--- a/doc/connecting/topics/p_adding-amq-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amq.adoc
 
 [id='adding-amq-connection-finish_{context}']
-= Finish an integration by publishing AMQ messages
+= Finishing an integration by publishing AMQ messages
 
 To finish an integration by publishing messages to a Red Hat AMQ broker, 
 add a Red Hat AMQ connection as the finish connection.

--- a/doc/connecting/topics/p_adding-amq-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amq.adoc
 
 [id='adding-amq-connection-middle_{context}']
-= Publish AMQ messages in the middle of an integration
+= Publishing AMQ messages in the middle of an integration
 
 In the middle of an integration, to publish messages to a Red Hat AMQ broker, 
 add a Red Hat AMQ connection between the start and

--- a/doc/connecting/topics/p_adding-amq-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amq.adoc
 
 [id='adding-amq-connection-start_{context}']
-= Start an integration based on receiving AMQ messages
+= Starting an integration based on receiving AMQ messages
 
 To trigger execution of an integration based on receiving a message
 from a Red Hat AMQ broker, add a Red Hat AMQ connection as the start connection.

--- a/doc/connecting/topics/p_adding-amqp-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-finish_{context}']
-= Finish an integration by publishing AMQP messages
+= Finishing an integration by publishing AMQP messages
 
 To finish an integration by publishing messages to an AMQP broker,
 add an AMQP connection as the finish connection. 

--- a/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-middle_{context}']
-= Publish messages to AMQP in the middle of an integration
+= Publishing messages to AMQP in the middle of an integration
 
 In the middle of an integration, to publish messages to an AMQP broker,
 add an AMQP connection between the start and 

--- a/doc/connecting/topics/p_adding-amqp-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-start_{context}']
-= Start an integration based on receiving AMQP messages
+= Starting an integration based on receiving AMQP messages
 
 To trigger execution of an integration based on receiving messages from
 an AMQP broker, add an AMQP connection as the start connection. 

--- a/doc/connecting/topics/p_adding-db-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-db-connection-finish-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-databases.adoc
 
 [id='adding-db-connection-finish-middle_{context}']
-= Access a database in the middle or to complete an integration
+= Accessing a database in the middle or to complete an integration
 
 To finish an integration by accessing a database, add a database
 connection as the finish connection. To access 

--- a/doc/connecting/topics/p_adding-db-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-db-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-databases.adoc
 
 [id='adding-db-connection-start_{context}']
-= Start an integration by accessing a database
+= Starting an integration by accessing a database
 
 To trigger execution of an integration based on the result of invoking a SQL
 query or a SQL stored procedures, choose a database connection as the 

--- a/doc/connecting/topics/p_adding-dropbox-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-dropbox.adoc
 
 [id='adding-dropbox-connection-finish_{context}']
-= Finish an integration by adding files to Dropbox
+= Finishing an integration by adding files to Dropbox
 
 To finish an integration by uploading files to Dropbox,
 add a Dropbox connection as the finish connection.

--- a/doc/connecting/topics/p_adding-dropbox-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-dropbox.adoc
 
 [id='adding-dropbox-connection-middle_{context}']
-= Access Dropbox in the middle of an integration
+= Accessing Dropbox in the middle of an integration
 
 To upload a file to Dropbox in the middle of an integration,
 add a Dropbox connection between the start and 

--- a/doc/connecting/topics/p_adding-dropbox-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-dropbox.adoc
 
 [id='adding-dropbox-connection-start_{context}']
-= Start an integration by obtaining files from Dropbox
+= Starting an integration by obtaining files from Dropbox
 
 To start an integration by downloading files from Dropbox, 
 add a Dropbox connection as the start connection.

--- a/doc/connecting/topics/p_adding-ftp-finish-middle-connection.adoc
+++ b/doc/connecting/topics/p_adding-ftp-finish-middle-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-ftp.adoc
 
 [id='adding-ftp-finish-middle-connection_{context}']
-= Upload files to an FTP or SFTP server
+= Uploading files to an FTP or SFTP server
 
 To finish an integration by uploading files to an FTP or SFTP server, 
 add an FTP or SFTP connection as the integration's finish connection. You can also

--- a/doc/connecting/topics/p_adding-ftp-start-connection.adoc
+++ b/doc/connecting/topics/p_adding-ftp-start-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-ftp.adoc
 
 [id='adding-ftp-start-connection_{context}']
-= Obtain files from an FTP or SFTP server
+= Obtaining files from an FTP or SFTP server
 
 To trigger integration execution when
 an FTP or SFTP connection finds the file(s) you are interested in,

--- a/doc/connecting/topics/p_adding-http-connections.adoc
+++ b/doc/connecting/topics/p_adding-http-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-http.adoc
 
 [id='adding-http-connections_{context}']
-= Add an HTTP or HTTPS connection to an integration
+= Adding an HTTP or HTTPS connection to an integration
 
 You can add an HTTP or HTTPS connection to 
 any number of integrations.

--- a/doc/connecting/topics/p_adding-kafka-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-kafka-connection-finish-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kafka.adoc
 
 [id='adding-kafka-connection-finish-middle_{context}']
-= Publish data to a Kafka broker
+= Publishing data to a Kafka broker
 
 In an integration, you can publish data to a Kafka broker to finish
 an integration. To do this, add a Kafka connection as the integration's 

--- a/doc/connecting/topics/p_adding-kafka-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-kafka-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kafka.adoc
 
 [id='adding-kafka-connection-start_{context}']
-= Obtain data from a Kafka broker
+= Obtaining data from a Kafka broker
 
 To trigger execution of an integration based on receiving data
 from a Kafka broker, add a Kafka connection as the start connection. When 

--- a/doc/connecting/topics/p_adding-mqtt-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-mqtt-connection-finish-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-mqtt.adoc
 
 [id='adding-mqtt-connection-finish-middle_{context}']
-= Publish a message to an MQTT broker
+= Publishing a message to an MQTT broker
 
 In an integration, you can publish a message to an MQTT broker to finish
 an integration. To do this, add an MQTT connection as the integration's 

--- a/doc/connecting/topics/p_adding-mqtt-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-mqtt-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-mqtt.adoc
 
 [id='adding-mqtt-connection-start_{context}']
-= Obtain a message from an MQTT broker
+= Obtaining a message from an MQTT broker
 
 To trigger execution of an integration based on receiving a message
 from an MQTT broker, add an MQTT connection as the start connection. When 

--- a/doc/connecting/topics/p_adding-s3-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-finish.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='adding-s3-connection-finish_{context}']
-= Finish an integration by adding data to Amazon S3
+= Finishing an integration by adding data to Amazon S3
 
 To finish an integration by copying data to Amazon S3, 
 add an Amazon S3 connection as the finish connection in an integration. 

--- a/doc/connecting/topics/p_adding-s3-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-middle.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='adding-s3-connection-middle_{context}']
-= Add data to Amazon S3 in the middle of an integration
+= Adding data to Amazon S3 in the middle of an integration
 
 In the middle of an integration, to add data to Amazon S3, 
 add an Amazon S3 connection between the start and

--- a/doc/connecting/topics/p_adding-s3-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='adding-s3-connection-start_{context}']
-= Start an integration by obtaining data from Amazon S3
+= Starting an integration by obtaining data from Amazon S3
 
 To start an integration by obtaining data from an Amazon S3 bucket, 
 add an Amazon S3 connection as the start connection in an integration.

--- a/doc/connecting/topics/p_adding-sf-connections.adoc
+++ b/doc/connecting/topics/p_adding-sf-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-sf.adoc
 
 [id='adding-sf-connections_{context}']
-= Add a Salesforce connection to an integration
+= Adding a Salesforce connection to an integration
 
 In an integration, you can connect to Salesforce to start or finish the
 integration, or in the middle of an integration. To connect to Salesforce,

--- a/doc/connecting/topics/p_adding-twitter-connections.adoc
+++ b/doc/connecting/topics/p_adding-twitter-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-twitter.adoc
 
 [id='adding-twitter-connections_{context}']
-= Add a Twitter connection to an integration
+= Adding a Twitter connection to an integration
 
 In an integration, a connection to Twitter can trigger execution of
 an integration when a tweet contains your Twitter handle or when 

--- a/doc/connecting/topics/p_configure-concur-connector.adoc
+++ b/doc/connecting/topics/p_configure-concur-connector.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-concur.adoc
 
 [id='configure-concur-connector_{context}']
-= Configure the SAP Concur connector
+= Configuring the SAP Concur connector
 
 To connect to SAP Concur in an integration, you must configure the
 {prodname} SAP Concur connector. You can then use the connector

--- a/doc/connecting/topics/p_connecting-to-proprietary-databases.adoc
+++ b/doc/connecting/topics/p_connecting-to-proprietary-databases.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-databases.adoc
 
 [id='connecting-to-proprietary-databases_{context}']
-= Connect to proprietary databases
+= Connecting to proprietary databases
 
 To connect to a proprietary SQL database, the main tasks that must be
 accomplished are as follows:

--- a/doc/connecting/topics/p_create-amq-connection.adoc
+++ b/doc/connecting/topics/p_create-amq-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amq.adoc
 
 [id='create-amq-connection_{context}']
-= Create an AMQ connection
+= Creating an AMQ connection
 
 In an integration, to obtain messages from or to publish messages to: 
 

--- a/doc/connecting/topics/p_create-amqp-connection.adoc
+++ b/doc/connecting/topics/p_create-amqp-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amqp.adoc
 
 [id='create-amqp-connection_{context}']
-= Create an AMQP connection
+= Creating an AMQP connection
 
 In an integration, to obtain messages from or publish messages to an AMQP
 broker, create an AMQP connection, which you can add to an integration.

--- a/doc/connecting/topics/p_create-concur-connection.adoc
+++ b/doc/connecting/topics/p_create-concur-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-concur.adoc
 
 [id='create-concur-connection_{context}']
-= Create a SAP Concur connection
+= Creating a SAP Concur connection
 
 To connect to SAP Concur in an integration, you must first create a SAP
 Concur connection, which you can then add to any number of integrations. 

--- a/doc/connecting/topics/p_create-database-connection.adoc
+++ b/doc/connecting/topics/p_create-database-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-databases.adoc
 
 [id='create-database-connection_{context}']
-= Create a database connection
+= Creating a database connection
 
 You create a separate connection for each database that you want to 
 connect to in an integration. You can use the same connection in 

--- a/doc/connecting/topics/p_create-dropbox-connection.adoc
+++ b/doc/connecting/topics/p_create-dropbox-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-dropbox.adoc
 
 [id='create-dropbox-connection_{context}']
-= Create a Dropbox connection
+= Creating a Dropbox connection
 
 In an integration, to download or upload Dropbox files, create a 
 Dropbox connection, which you can add

--- a/doc/connecting/topics/p_create-gmail-connection.adoc
+++ b/doc/connecting/topics/p_create-gmail-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-gmail.adoc
 
 [id='create-gmail-connection_{context}']
-= Create a Gmail connection 
+= Creating a Gmail connection 
 
 When you create a Gmail connection, you authorize the connection to access one
 particular Gmail account. After you create a Gmail connection, you can 

--- a/doc/connecting/topics/p_create-google-calendar-connection.adoc
+++ b/doc/connecting/topics/p_create-google-calendar-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-calendar.adoc
 
 [id='create-google-calendar-connection_{context}']
-= Create a Google Calendar connection 
+= Creating a Google Calendar connection 
 
 When you create a Google Calendar connection, you authorize the connection to access 
 the Google calendars that are associated with one

--- a/doc/connecting/topics/p_create-google-sheets-connection.adoc
+++ b/doc/connecting/topics/p_create-google-sheets-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google-sheets.adoc
 
 [id='create-google-sheets-connection_{context}']
-= Create a Google Sheets connection
+= Creating a Google Sheets connection
 
 When you create a Google Sheets connection, you authorize the connection to access
 the Google Sheets spreadsheets that are associated with one

--- a/doc/connecting/topics/p_create-kudu-connections.adoc
+++ b/doc/connecting/topics/p_create-kudu-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kudu.adoc
 
 [id='create-kudu-connections_{context}']
-= Create a connection to an Apache Kudu data store
+= Creating a connection to an Apache Kudu data store
 
 In an integration, to obtain records from or insert records into
 a Kudu table, create a connection to a Kudu master host

--- a/doc/connecting/topics/p_create-replacement-log-connection.adoc
+++ b/doc/connecting/topics/p_create-replacement-log-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-log.adoc
 
 [id='create-replacement-log-connection_{context}']
-= Create a replacement log connection
+= Creating a replacement log connection
 
 {prodname} provides a log connection that you can add to an integration to
 log information about each message that an integration processes. If you 

--- a/doc/connecting/topics/p_create-s3-connection.adoc
+++ b/doc/connecting/topics/p_create-s3-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='create-s3-connection_{context}']
-= Create Amazon S3 connections
+= Creating Amazon S3 connections
 
 You must create an Amazon S3 connection before you can add an
 Amazon S3 connection to an integration.

--- a/doc/connecting/topics/p_create-servicenow-connection.adoc
+++ b/doc/connecting/topics/p_create-servicenow-connection.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-servicenow.adoc
 
 [id='create-servicenow-connection_{context}']
-= Create a ServiceNow connection
+= Creating a ServiceNow connection
 
 In an integration, to connect to your company's ServiceNow instance,
 you must create a ServiceNow connection.

--- a/doc/connecting/topics/p_create-servicenow-import-set.adoc
+++ b/doc/connecting/topics/p_create-servicenow-import-set.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-servicenow.adoc
 
 [id='create-servicenow-import-set_{context}']
-= Create an import set in ServiceNow
+= Creating an import set in ServiceNow
 
 In a {prodname} integration, a ServiceNow connection cannot directly 
 update a ServiceNow table. To update ServiceNow data in an integration, 

--- a/doc/connecting/topics/p_create-timer-connection.adoc
+++ b/doc/connecting/topics/p_create-timer-connection.adoc
@@ -2,7 +2,7 @@
 // as_trigger-integration-with-timer.adoc
 
 [id='create-timer-connection_{context}']
-= Create a replacement timer connection
+= Creating a replacement timer connection
 
 {prodname} provides a timer connection; you do not need to create one.
 However, if you inadvertently delete the provided timer connection

--- a/doc/connecting/topics/p_create-webhook-connection.adoc
+++ b/doc/connecting/topics/p_create-webhook-connection.adoc
@@ -2,7 +2,7 @@
 // as_triggering-integrations-with-http-requests.adoc
 
 [id='create-webhook-connection_{context}']
-= Use the Webhook connection 
+= Using the Webhook connection 
 
 {prodname} provides a Webhook connection that you can use in 
 any number of integrations as the start connection. Each time you 

--- a/doc/connecting/topics/p_creating-ftp-connections.adoc
+++ b/doc/connecting/topics/p_creating-ftp-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-ftp.adoc
 
 [id='creating-ftp-connections_{context}']
-= Create an FTP or SFTP connection
+= Creating an FTP or SFTP connection
 
 In an integration, to download or upload files from/to an FTP or SFTP server, 
 create a connection to that FTP or SFTP server. You can add the same 

--- a/doc/connecting/topics/p_creating-http-connections.adoc
+++ b/doc/connecting/topics/p_creating-http-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-http.adoc
 
 [id='creating-http-connections_{context}']
-= Create a connection to an HTTP or HTTPS endpoint
+= Creating a connection to an HTTP or HTTPS endpoint
 
 In an integration, to execute the HTTP `GET`, `PUT`, `POST`, `DELETE`, 
 `HEAD`, `OPTIONS`, `TRACE`, or `PATCH` method, create a connection to

--- a/doc/connecting/topics/p_creating-kafka-connections.adoc
+++ b/doc/connecting/topics/p_creating-kafka-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-kafka.adoc
 
 [id='creating-kafka-connections_{context}']
-= Create a connection to a Kafka broker
+= Creating a connection to a Kafka broker
 
 In an integration, to subscribe for data from a Kafka topic 
 or publish data to a Kafka topic, 

--- a/doc/connecting/topics/p_creating-mqtt-connections.adoc
+++ b/doc/connecting/topics/p_creating-mqtt-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-mqtt.adoc
 
 [id='creating-mqtt-connections_{context}']
-= Create a connection to an MQTT broker
+= Creating a connection to an MQTT broker
 
 In an integration, to obtain messages from or publish messages to
 an MQTT broker, create a connection to the MQTT broker

--- a/doc/connecting/topics/p_creating-rest-api-connections.adoc
+++ b/doc/connecting/topics/p_creating-rest-api-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-rest-apis.adoc
 
 [id='create-rest-api-connection_{context}']
-= Create a An API client connection
+= Creating a REST API client connection
 
 In an integration, to connect to a REST API, create a connection to 
 that REST API, which you can then add to any number of integrations. 

--- a/doc/connecting/topics/p_creating-slack-connections.adoc
+++ b/doc/connecting/topics/p_creating-slack-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-slack.adoc
 
 [id='creating-slack-connections_{context}']
-= Create a Slack connection
+= Creating a Slack connection
 
 In an integration, a Slack connection can retrieve messages from a 
 channel that you specify or send a message to a channel or user. 

--- a/doc/connecting/topics/p_creating-telegram-connections.adoc
+++ b/doc/connecting/topics/p_creating-telegram-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-telegram.adoc
 
 [id='creating-telegram-connections_{context}']
-= Create a Telegram connection
+= Creating a Telegram connection
 
 In an integration, a Telegram connection can receive messages that have been 
 sent to a particular chat. A chat bot that you create forwards the messages 

--- a/doc/connecting/topics/p_register-with-dropbox.adoc
+++ b/doc/connecting/topics/p_register-with-dropbox.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to_dropbox.adoc
 
 [id='register-with-dropbox_{context}']
-= Register {prodname} as a Dropbox client
+= Registering {prodname} as a Dropbox client
 
 You must register your {prodname} environment as a client application
 that can access Dropbox.

--- a/doc/connecting/topics/p_register-with-google.adoc
+++ b/doc/connecting/topics/p_register-with-google.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-google.adoc
 
 [id='register-with-google_{context}']
-= Register {prodname} as a Google client application
+= Registering {prodname} as a Google client application
 
 In an integration, to be able to connect to Gmail, Google Calendar, or
 Google Sheets, 

--- a/doc/connecting/topics/p_registering-with-rest-api.adoc
+++ b/doc/connecting/topics/p_registering-with-rest-api.adoc
@@ -2,9 +2,9 @@
 // as_connecting-to-rest-apis.adoc
 
 [id='register-with-rest-api_{context}']
-= Register {prodname} as an API client
+= Registering {prodname} as a REST API client
 
-Before {prodname} creates an API client
+Before {prodname} creates a REST API client
 connector, it prompts you to indicate the API's security requirements.
 For APIs that use the OAuth protocol, when {prodname} creates the connector it also
 adds an entry for the API to the {prodname} *Settings* page. This is
@@ -13,7 +13,7 @@ authorize {prodname} to access the API.
 
 If the API you want to connect to does not use OAuth, skip this
 section and see 
-link:{LinkFuseOnlineConnectorGuide}#create-rest-api-connection_rest[Create a REST API connection].
+link:{LinkFuseOnlineConnectorGuide}#create-rest-api-connection_rest[Creating a REST API connection].
 
 .Prerequisite
 You must know the URL for the OAuth custom application setting page for the

--- a/doc/connecting/topics/p_start-with-webhook-connection.adoc
+++ b/doc/connecting/topics/p_start-with-webhook-connection.adoc
@@ -2,7 +2,7 @@
 // as_triggering-integrations-with-http-requests.adoc
 
 [id='start-with-webhook-connection_{context}']
-= Create an integration that an HTTP request can trigger
+= Creating an integration that an HTTP request can trigger
 
 To trigger execution of an integration with an HTTP `GET` or `POST` request,
 add a Webhook connection as the integration's start connection. 

--- a/doc/shared/p_create-sf-connection.adoc
+++ b/doc/shared/p_create-sf-connection.adoc
@@ -10,7 +10,7 @@
 
 
 [id='create-salesforce-connection_{context}']
-= Create a Salesforce connection
+= Creating a Salesforce connection
 
 To create an integration that accesses data in Salesforce, you 
 must first create a Salesforce connection.  
@@ -26,11 +26,11 @@ application that can access Salesforce.
 +
 ifeval::["{context}" == "t2sf"]
 If you did not already register {prodname}, see 
-link:{LinkFuseOnlineTutorials}#register-with-salesforce_t2sf[Register with Salesforce].
+link:{LinkFuseOnlineTutorials}#register-with-salesforce_t2sf[Registering with Salesforce].
 endif::[]
 ifeval::["{context}" == "sf2db"]
 If you did not already register {prodname}, see 
-link:{LinkFuseOnlineTutorials}#register-with-salesforce_sf2db[Register with Salesforce].
+link:{LinkFuseOnlineTutorials}#register-with-salesforce_sf2db[Registering with Salesforce].
 endif::[]
 
 +
@@ -57,7 +57,7 @@ correct {prodname} callback URL:
 
 If you get this error message, then in Salesforce, ensure that the {prodname}
 callback URL is specified according to the instructions in
-link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Register with Salesforce].
+link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Registering with Salesforce].
 ====
 . Click *Allow* to return to {prodname}.
 . In the *Connection Name* field, enter your choice of a name that

--- a/doc/shared/p_create-twitter-connection.adoc
+++ b/doc/shared/p_create-twitter-connection.adoc
@@ -8,7 +8,7 @@
 
 
 [id='create-twitter-connection_{context}']
-= Create a Twitter connection
+= Creating a Twitter connection
 
 To create an integration that obtains data from Twitter, you 
 must first create a Twitter connection.  

--- a/doc/shared/p_register-with-sf.adoc
+++ b/doc/shared/p_register-with-sf.adoc
@@ -1,4 +1,4 @@
-/ Module included in the following assemblies:
+// Module included in the following assemblies:
 // Upstream:
 // tutorials/topics/as_t2sf-intro.adoc
 // tutorials/topics/as_sf2db-intro.adoc
@@ -9,7 +9,7 @@
 // fuse-online-sample-integration-tutorials/upstream/as_sf2db-intro.adoc
 
 [id='register-with-salesforce_{context}']
-= Register {prodname} as a Salesforce client application
+= Registering {prodname} as a Salesforce client application
 
 In an integration, to connect to Salesforce, the first thing you must do is
 register your {prodname} environment as a client application
@@ -26,13 +26,13 @@ credentials.
 ifeval::["{context}" == "t2sf"]
 If you already registered {prodname} as a Salesforce
 client and created a Salesforce connection, skip to 
-link:{LinkFuseOnlineTutorials}#create-twitter-sf-integration_t2sf[Create Twitter to Salesforce integration].
+link:{LinkFuseOnlineTutorials}#create-twitter-sf-integration_t2sf[Creating Twitter to Salesforce integration].
 endif::[]
 
 ifeval::["{context}" == "sf2db"]
 If you already registered {prodname} as a Salesforce
 client and created a Salesforce connection, skip to 
-link:{LinkFuseOnlineTutorials}#create-sf-db-integration_sf2db[Create Salesforce to database integration]. 
+link:{LinkFuseOnlineTutorials}#create-sf-db-integration_sf2db[Creating Salesforce to database integration]. 
 endif::[]
 
  

--- a/doc/shared/p_register-with-twitter.adoc
+++ b/doc/shared/p_register-with-twitter.adoc
@@ -7,7 +7,7 @@
 // connecting-fuse-online-to-applications-and-services/upstream/as_connecting-to-twitter.adoc
 
 [id='register-with-twitter_{context}']
-= Register {prodname} as a Twitter client application
+= Registering {prodname} as a Twitter client application
 
 In an integration, to connect to Twitter, the first thing you must do is
 register your {prodname} environment as a client application

--- a/doc/tutorials/topics/as_amq2api-create-integration.adoc
+++ b/doc/tutorials/topics/as_amq2api-create-integration.adoc
@@ -3,16 +3,16 @@
 
 :parent-context: {context}
 [id='amq2api-create-integration_{context}']
-= Create and deploy AMQ to REST API sample integration
+= Creating and deploying the AMQ to REST API sample integration
 :context: create-amq
 
 To create and deploy the AMQ to REST API sample integration, the main steps are:
 
-. <<amq2api-choose-start-connection_{context}>>
-. <<amq2api-choose-finish-connection_{context}>>
-. <<amq2api-add-damage-reporter-step_{context}>>
-. <<amq2api-add-mapping-step_{context}>>
-. <<amq2api-name-and-publish_{context}>>
+. xref:amq2api-choose-start-connection_{context}[]
+. xref:amq2api-choose-finish-connection_{context}[]
+. xref:amq2api-add-damage-reporter-step_{context}[]
+. xref:amq2api-add-mapping-step_{context}[]
+. xref:amq2api-name-and-publish_{context}[]
 
 .Prerequisites
 * You created a connection to the provided Red Hat AMQ broker. 

--- a/doc/tutorials/topics/as_amq2api-intro.adoc
+++ b/doc/tutorials/topics/as_amq2api-intro.adoc
@@ -3,7 +3,7 @@
 
 :parent-context: {context}
 [id='amq-to-rest-api_{context}']
-= Implement an AMQ to REST API sample integration
+= Implementing an AMQ to REST API sample integration
 
 :context: amq2api
 This sample integration connects to a Red Hat AMQ broker to obtain item
@@ -34,14 +34,14 @@ endif::[]
 
 To implement the AMQ to REST API sample integration, the main steps are:
 
-. <<amq2api-create-amq-connection_{context}>>
-. <<amq2api-create-custom-step_{context}>>
-. <<amq2api-create-rest-api-connector_{context}>>
-. <<amq2api-upload-todo-app-icon_{context}>>
-. <<amq2api-create-rest-api-connection_{context}>>
-. <<amq2api-create-integration_{context}>>
-. <<amq2api-confirm-works_{context}>>
-. <<cleanup_{context}>>
+. xref:amq2api-create-amq-connection_{context}[]
+. xref:amq2api-create-custom-step_{context}[]
+. xref:amq2api-create-rest-api-connector_{context}[]
+. xref:amq2api-upload-todo-app-icon_{context}[]
+. xref:amq2api-create-rest-api-connection_{context}[]
+. xref:amq2api-create-integration_{context}[]
+. xref:amq2api-confirm-works_{context}[]
+. xref:cleanup_{context}[]
 
 
 include::p_amq2api-create-amq-connection.adoc[leveloffset=+1]

--- a/doc/tutorials/topics/as_sf2db-create-integration.adoc
+++ b/doc/tutorials/topics/as_sf2db-create-integration.adoc
@@ -3,16 +3,16 @@
 
 :parent-context: {context}
 [id='create-sf-db-integration_{context}']
-= Create and deploy Salesforce to database sample integration
+= Creating and deploying the Salesforce to database sample integration
 
 :context: sf2db-create
 To create and deploy an integration that uses the Salesforce
 connection and the database connection, the main steps are:
 
-* <<sf2db-choose-start-connection_{context}>>
-* <<sf2db-choose-finish-connection_{context}>>
-* <<sf2db-add-data-mapping-step_{context}>>
-* <<sf2db-name-and-publish_{context}>>
+* xref:sf2db-choose-start-connection_{context}[]
+* xref:sf2db-choose-finish-connection_{context}[]
+* xref:sf2db-add-data-mapping-step_{context}[]
+* xref:sf2db-name-and-publish_{context}[]
 
 .Prerequisites
 * You registered your {prodname} environment as a Salesforce client.

--- a/doc/tutorials/topics/as_sf2db-intro.adoc
+++ b/doc/tutorials/topics/as_sf2db-intro.adoc
@@ -3,7 +3,7 @@
 
 :parent-context: {context}
 [id='salesforce-to-db_{context}']
-= Implement a Salesforce to database sample integration
+= Implementing the Salesforce to database sample integration
 :context: sf2db
 
 This sample integration captures updates in Salesforce and then
@@ -39,11 +39,11 @@ endif::[]
 
 To implement, deploy, and test this sample integration, the main steps are:
 
-. <<register-with-salesforce_{context}>>
-. <<create-salesforce-connection_{context}>>
-. <<create-sf-db-integration_{context}>>
-. <<sf2db-confirm-working_{context}>>
-. <<cleanup_{context}>>
+. xref:register-with-salesforce_{context}[]
+. xref:create-salesforce-connection_{context}[]
+. xref:create-sf-db-integration_{context}[]
+. xref:sf2db-confirm-working_{context}[]
+. xref:cleanup_{context}[]
 
 include::shared/p_register-with-sf.adoc[leveloffset=+1]
 

--- a/doc/tutorials/topics/as_t2sf-create-integration.adoc
+++ b/doc/tutorials/topics/as_t2sf-create-integration.adoc
@@ -3,18 +3,18 @@
 ifdef::context[:parent-context: {context}]
 
 [id='create-twitter-sf-integration_{context}']
-= Create and deploy Twitter to Salesforce sample integration
+= Creating and deploying the Twitter to Salesforce sample integration
 
 :context: t2sf-create
 To create and deploy an integration that uses the
 Twitter and Salesforce connections that 
 you created, the main steps are:
 
-* <<t2sf-choose-start-connection_{context}>>
-* <<t2sf-choose-finish-connection_{context}>>
-* <<t2sf-add-basic-filter-step_{context}>>
-* <<t2sf-add-data-mapping-step_{context}>>
-* <<t2sf-name-and-publish_{context}>>
+* xref:t2sf-choose-start-connection_{context}[]
+* xref:t2sf-choose-finish-connection_{context}[]
+* xref:t2sf-add-basic-filter-step_{context}[]
+* xref:t2sf-add-data-mapping-step_{context}[]
+* xref:t2sf-name-and-publish_{context}[]
 
 .Prerequisites
 * You registered your {prodname} environment as a Twitter client and

--- a/doc/tutorials/topics/as_t2sf-intro.adoc
+++ b/doc/tutorials/topics/as_t2sf-intro.adoc
@@ -2,7 +2,7 @@
 // master.adoc
 
 [id='twitter-to-salesforce_{context}']
-= Implement a Twitter to Salesforce sample integration
+= Implementing the Twitter to Salesforce sample integration
 :context: t2sf
 
 This sample integration watches Twitter for tweets that mention
@@ -36,13 +36,13 @@ endif::[]
 
 To implement, deploy, and test this sample integration, the main steps are:
 
-. <<register-with-twitter_{context}>>
-. <<create-twitter-connection_{context}>>
-. <<register-with-salesforce_{context}>>
-. <<create-salesforce-connection_{context}>>
-. <<create-twitter-sf-integration_{context}>>
-. <<t2sf-confirm-working_{context}>>
-. <<cleanup_{context}>>
+. xref:register-with-twitter_{context}[]
+. xref:create-twitter-connection_{context}[]
+. xref:register-with-salesforce_{context}[]
+. xref:create-salesforce-connection_{context}[]
+. xref:create-twitter-sf-integration_{context}[]
+. xref:t2sf-confirm-working_{context}[]
+. xref:cleanup_{context}[]
 
 include::shared/p_register-with-twitter.adoc[leveloffset=+1]
 

--- a/doc/tutorials/topics/p_amq2api-add-damage-reporter-step.adoc
+++ b/doc/tutorials/topics/p_amq2api-add-damage-reporter-step.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-create-integration.adoc
 
 [id='amq2api-add-damage-reporter-step_{context}']
-= Add a damage reporter step
+= Adding a damage reporter step
 
 With the start and finish connections in place, you are ready to
 add the custom step that receives the messages from the Red Hat AMQ broker

--- a/doc/tutorials/topics/p_amq2api-add-mapping-step.adoc
+++ b/doc/tutorials/topics/p_amq2api-add-mapping-step.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-create-integration.adoc
 
 [id='amq2api-add-mapping-step_{context}']
-= Add a data mapping step
+= Adding a data mapping step
 
 To continue creating the AMQ to REST API sample integration, you need to add a 
 data mapping step. This step correlates the `task` field in the

--- a/doc/tutorials/topics/p_amq2api-choose-finish.adoc
+++ b/doc/tutorials/topics/p_amq2api-choose-finish.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-create-integration.adoc
 
 [id='amq2api-choose-finish-connection_{context}']
-= Choose the finish connection
+= Choosing the finish connection
 
 In {prodname}, to continue creating the AMQ to REST API sample
 integration, after you add the start connection, you add the finish connection

--- a/doc/tutorials/topics/p_amq2api-choose-start.adoc
+++ b/doc/tutorials/topics/p_amq2api-choose-start.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-create-integration.adoc
 
 [id='amq2api-choose-start-connection_{context}']
-= Choose the start connection
+= Choosing the start connection
 
 In {prodname}, to create the sample AMQ to REST API sample integration,
 the first task is to choose the start connection. 

--- a/doc/tutorials/topics/p_amq2api-confirm-works.adoc
+++ b/doc/tutorials/topics/p_amq2api-confirm-works.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-confirm-works_{context}']
-= Confirm that the AMQ to REST API integration works
+= Confirming that the AMQ to REST API integration works
 
 After you create and publish the AMQ to REST API sample integration, 
 you can confirm that it works as defined. 

--- a/doc/tutorials/topics/p_amq2api-create-amq-connection.adoc
+++ b/doc/tutorials/topics/p_amq2api-create-amq-connection.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-create-amq-connection_{context}']
-= Create an AMQ connection
+= Creating an AMQ connection
 
 The AMQ to REST API sample integration starts by connecting to an
 AMQ broker (Red Hat AMQ) that is provided in your OpenShift Online  

--- a/doc/tutorials/topics/p_amq2api-create-custom-step.adoc
+++ b/doc/tutorials/topics/p_amq2api-create-custom-step.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-create-custom-step_{context}']
-= Make a custom step available
+= Making a custom step available
 
 {prodname} provides a number of steps that operate on 
 integration data between connections. If {prodname} does not provide a

--- a/doc/tutorials/topics/p_amq2api-create-rest-api-connection.adoc
+++ b/doc/tutorials/topics/p_amq2api-create-rest-api-connection.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-create-rest-api-connection_{context}']
-= Create a REST API connection
+= Creating a REST API connection
 
 In an integration, before you can connect to a REST API, you create a REST API 
 client connector and then use that connector to create a connection. 

--- a/doc/tutorials/topics/p_amq2api-create-rest-api-connector.adoc
+++ b/doc/tutorials/topics/p_amq2api-create-rest-api-connector.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-create-rest-api-connector_{context}']
-= Create a REST API connector
+= Creating a REST API connector
 
 {prodname} can create connectors for REST APIs
 that support Hypertext Transfer Protocol (HTTP)/1.0 or HTTP/1.1.

--- a/doc/tutorials/topics/p_amq2api-name-and-publish.adoc
+++ b/doc/tutorials/topics/p_amq2api-name-and-publish.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-create-integration.adoc
 
 [id='amq2api-name-and-publish_{context}']
-= Give the integration a name and deploy it
+= Giving the integration a name and deploying it
 
 The AMQ to REST API sample integration is complete when it has a Red Hat AMQ start
 connection, a Damage Reporter step, a data mapper step, and it finishes

--- a/doc/tutorials/topics/p_amq2api-upload-todo-app-icon.adoc
+++ b/doc/tutorials/topics/p_amq2api-upload-todo-app-icon.adoc
@@ -2,7 +2,7 @@
 // as_amq2api-intro.adoc
 
 [id='amq2api-upload-todo-app-icon_{context}']
-= Upload the To Do app icon
+= Uploading the To Do app icon
 
 To show the flow of an integration, {prodname} displays icons that identify
 the applications that the integration is connecting to. Your {prodname}

--- a/doc/tutorials/topics/p_clean-up.adoc
+++ b/doc/tutorials/topics/p_clean-up.adoc
@@ -4,7 +4,7 @@
 // as_amq2api-intro.adoc
 
 [id='cleanup_{context}']
-= Clean up your integration
+= Cleaning up your integration
 
 When you are done working with a sample integration, you should stop it and
 delete it so that you can use the resources for another integration. 

--- a/doc/tutorials/topics/p_sf2db-add-mapping-step.adoc
+++ b/doc/tutorials/topics/p_sf2db-add-mapping-step.adoc
@@ -2,7 +2,7 @@
 // as_sf2db-create-integration.adoc
 
 [id='sf2db-add-data-mapping-step_{context}']
-= Add a data mapping step
+= Adding a data mapping step
 
 To continue creating the Salesforce to database sample integration,
 add a data mapping step that correlates Salesforce lead fields to

--- a/doc/tutorials/topics/p_sf2db-choose-finish.adoc
+++ b/doc/tutorials/topics/p_sf2db-choose-finish.adoc
@@ -2,7 +2,7 @@
 // as_sf2db-create-integration.adoc
 
 [id='sf2db-choose-finish-connection_{context}']
-= Choose the finish connection
+= Choosing the finish connection
 
 In {prodname}, to continue creating the Salesforce to database sample
 integration, after you add the start connection, you add the finish connection

--- a/doc/tutorials/topics/p_sf2db-choose-start.adoc
+++ b/doc/tutorials/topics/p_sf2db-choose-start.adoc
@@ -2,7 +2,7 @@
 // as_sf2db-create-integration.adoc
 
 [id='sf2db-choose-start-connection_{context}']
-= Choose the start connection
+= Choosing the start connection
 
 In {prodname}, to create the sample Salesforce to database integration, 
 the first task is to choose the start connection. 

--- a/doc/tutorials/topics/p_sf2db-confirm-works.adoc
+++ b/doc/tutorials/topics/p_sf2db-confirm-works.adoc
@@ -2,7 +2,7 @@
 // as_sf2db-intro.adoc
 
 [id='sf2db-confirm-working_{context}']
-= Confirm that the Salesforce to database integration works
+= Confirming that the Salesforce to database integration works
 
 To confirm that the Salesforce to database integration is working, 
 create a new lead in Salesforce and then open the web app that 

--- a/doc/tutorials/topics/p_sf2db-name-and-publish.adoc
+++ b/doc/tutorials/topics/p_sf2db-name-and-publish.adoc
@@ -2,7 +2,7 @@
 // as_sf2db-create-integration.adoc
 
 [id='sf2db-name-and-publish_{context}']
-= Give the integration a name and deploy it
+= Giving the integration a name and deploying it
 
 When the Salesforce to database sample integration is complete then you
 can deploy it and see how it works. 

--- a/doc/tutorials/topics/p_t2sf-add-filter-step.adoc
+++ b/doc/tutorials/topics/p_t2sf-add-filter-step.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-create-integration.adoc
 
 [id='t2sf-add-basic-filter-step_{context}']
-= Add a basic filter step
+= Adding a basic filter step
 
 In {prodname}, to continue creating the Twitter to Salesforce sample
 integration, add a basic filter step that checks tweets that mention you

--- a/doc/tutorials/topics/p_t2sf-add-mapping-step.adoc
+++ b/doc/tutorials/topics/p_t2sf-add-mapping-step.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-create-integration.adoc
 
 [id='t2sf-add-data-mapping-step_{context}']
-= Add a data mapping step
+= Adding a data mapping step
 
 To continue creating the Twitter to Salesforce sample integration,
 add a data mapping step that correlates Twitter mention fields to

--- a/doc/tutorials/topics/p_t2sf-choose-finish.adoc
+++ b/doc/tutorials/topics/p_t2sf-choose-finish.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-create-integration.adoc
 
 [id='t2sf-choose-finish-connection_{context}']
-= Choose the finish connection
+= Choosing the finish connection
 
 In {prodname}, to continue creating the Twitter to Salesforce sample
 integration, after you add the start connection, you add the finish connection

--- a/doc/tutorials/topics/p_t2sf-choose-start.adoc
+++ b/doc/tutorials/topics/p_t2sf-choose-start.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-create-integration.adoc
 
 [id='t2sf-choose-start-connection_{context}']
-= Choose the start connection
+= Choosing the start connection
 
 In {prodname}, to create the sample Twitter to Salesforce integration, 
 the first task is to choose the start connection. 

--- a/doc/tutorials/topics/p_t2sf-confirm-working.adoc
+++ b/doc/tutorials/topics/p_t2sf-confirm-working.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-intro.adoc
 
 [id='t2sf-confirm-working_{context}']
-= Confirm that the Twitter to Salesforce integration works
+= Confirming that the Twitter to Salesforce integration works
 
 To confirm that the Twitter to Salesforce sample integration is working,
 tweet some messages and check for results in Salesforce. 

--- a/doc/tutorials/topics/p_t2sf-name-and-publish.adoc
+++ b/doc/tutorials/topics/p_t2sf-name-and-publish.adoc
@@ -2,7 +2,7 @@
 // as_t2sf-create-integration.adoc
 
 [id='t2sf-name-and-publish_{context}']
-= Give the integration a name and deploy it
+= Giving the integration a name and deploying it
 
 When the Twitter to Salesforce sample integration is complete then you
 can deploy it and see how it works. 

--- a/doc/tutorials/topics/r_comparison-of-sample-integrations.adoc
+++ b/doc/tutorials/topics/r_comparison-of-sample-integrations.adoc
@@ -2,7 +2,7 @@
 // master.adoc
 
 [id='comparison-of-sample-integrations_{context}']
-= Choose the sample integration to create first
+= Choosing the sample integration to create first
 
 You can create the sample integrations in any order. To help you decide
 which one to try first, the following table compares them.


### PR DESCRIPTION
To be consistent with doc for other products, I had to change heading from imperatives to gerunds. So titles that were something like "Add a Twitter connection" are now "Adding a Twitter connection". This merge covers the connector guide and the tutorials. I did the integration user guide as part the updates for api provider integrations. 