### PR TITLE
fix: filter out all headers but Content-Type

### DIFF
--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderStartEndpointCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderStartEndpointCustomizer.java
@@ -27,6 +27,7 @@ import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.processor.Pipeline;
@@ -71,7 +72,7 @@ public class ApiProviderStartEndpointCustomizer implements ComponentProxyCustomi
         // influence HTTP components in the flow after this connector don't
         // interpret them, for instance the `Host` header is particularly
         // troublesome
-        beforeConsumers.add((e) -> e.getIn().removeHeaders("*", "Syndesis.*"));
+        beforeConsumers.add((e) -> e.getIn().removeHeaders("*", Exchange.CONTENT_TYPE, "Syndesis.*"));
 
         component.setBeforeConsumer(Pipeline.newInstance(context, beforeConsumers));
     }

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestWrapperProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpRequestWrapperProcessor.java
@@ -73,6 +73,12 @@ public class HttpRequestWrapperProcessor implements Processor {
         final Message replacement = new DefaultMessage(exchange.getContext());
         replacement.copyFromWithNewBody(message, newBody);
 
+        // we rely on having the Content-Type match the body when we're
+        // extracting parameters from the JSON body, otherwise we don't
+        // know if the content is JSON or XML (or any future supported
+        // content type)
+        replacement.setHeader(Exchange.CONTENT_TYPE, "application/json");
+
         ExchangeHelper.replaceMessage(exchange, replacement, false);
     }
 

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategy.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategy.java
@@ -23,7 +23,10 @@ public class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
     protected void initialize() {
         super.initialize();
 
-        setOutFilterPattern("(?i)(Syndesis|Camel|org\\.apache\\.camel).*");
-        setInFilterPattern("(?i)(Syndesis|Camel|org\\.apache\\.camel).*");
+        // just remove everything
+        setOutFilterPattern(".*");
+
+        // we need to preserve the Content-Type header
+        setInFilterPattern("^(?!Content-Type).*$");
     }
 }

--- a/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategyTest.java
+++ b/app/connector/support/processor/src/test/java/io/syndesis/connector/support/processor/SyndesisHeaderStrategyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.processor;
+
+import org.apache.camel.Exchange;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SyndesisHeaderStrategyTest {
+
+    private static final Exchange NOT_USED = null;
+
+    @Test
+    public void shouldFilterOutEverythingButInwardContentTypeHeader() {
+        final SyndesisHeaderStrategy headerStrategy = new SyndesisHeaderStrategy();
+
+        assertThat(headerStrategy.applyFilterToCamelHeaders("Content-Type", "", NOT_USED)).isTrue();
+        assertThat(headerStrategy.applyFilterToExternalHeaders("Content-Type", "", NOT_USED)).isFalse();
+
+        assertThat(headerStrategy.applyFilterToCamelHeaders("Host", "", NOT_USED)).isTrue();
+        assertThat(headerStrategy.applyFilterToExternalHeaders("Host", "", NOT_USED)).isTrue();
+
+        assertThat(headerStrategy.applyFilterToCamelHeaders("Forward", "", NOT_USED)).isTrue();
+        assertThat(headerStrategy.applyFilterToExternalHeaders("Forward", "", NOT_USED)).isTrue();
+    }
+}

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/RestRouteConfiguration.java.mustache
@@ -14,9 +14,9 @@ public class RestRouteConfiguration {
             @Override
             public void configure() throws Exception {
                 restConfiguration()
-                .contextPath("/")
-                .component("servlet")
-                .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
+                    .contextPath("/")
+                    .component("servlet")
+                    .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
 
                 rest()
                     .get("/openapi.json")

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateApplicationWithRestDSL/RestRouteConfiguration.java
@@ -14,9 +14,9 @@ public class RestRouteConfiguration {
             @Override
             public void configure() throws Exception {
                 restConfiguration()
-                .contextPath("/")
-                .component("servlet")
-                .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
+                    .contextPath("/")
+                    .component("servlet")
+                    .endpointProperty("headerFilterStrategy", "syndesisHeaderStrategy");
 
                 rest()
                     .get("/openapi.json")


### PR DESCRIPTION
Previously we only filtered out headers with names containing `Syndesis`, `Camel` or `org.apache.camel`. This allowed headers received from outside to be passed on to 3rd parties. To be on the safe side this filters out all headers except for the `Content-Type` header which we need internally when dealing with Syndesis HTTP message body containing both parameters and body (unified data shape).

Fixes #3727

Also one tiny formatting refactor for the generated sources.