### PR TITLE
Fix #4717: constrain permissions needed by the operator

### DIFF
--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -262,8 +262,7 @@
     - camel.apache.org
     resources:
     - "*"
-    verbs:
-    - "*"
+    verbs: [ get, list, create, update, delete, deletecollection, watch]
 - kind: RoleBinding
   apiVersion: rbac.authorization.k8s.io/v1beta1
   metadata:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1376,8 +1376,7 @@ objects:
     - camel.apache.org
     resources:
     - "*"
-    verbs:
-    - "*"
+    verbs: [ get, list, create, update, delete, deletecollection, watch]
 - kind: RoleBinding
   apiVersion: rbac.authorization.k8s.io/v1beta1
   metadata:


### PR DESCRIPTION
Fix #4717.
Tested on local minishift. No more restarts.