### PR TITLE
fix(#4756): Make UI honour default values for checkboxes

### DIFF
--- a/app/ui/src/app/core/providers/form-factory-provider.service.ts
+++ b/app/ui/src/app/core/providers/form-factory-provider.service.ts
@@ -66,7 +66,7 @@ export class FormFactoryProviderService extends FormFactoryService {
         case 'checkbox':
           type = 'checkbox';
           // massage string values as the form builder doesn't do this
-          if (typeof value !== 'boolean') {
+          if (typeof value === 'string') {
             value = value === 'true';
           }
           break;
@@ -318,7 +318,7 @@ export class FormFactoryProviderService extends FormFactoryService {
     let initialValue = false;
     if (value !== undefined && value !== null) {
       initialValue = !!value;
-    } else if (field.value !== undefined || field.value !== null) {
+    } else if (field.value !== undefined && field.value !== null) {
       initialValue = !!field.value;
     } else {
       initialValue = !!field.defaultValue;


### PR DESCRIPTION
* Avoids assigning 'value' as it disrupts the evaluation and selection of
  either value, field.value or field.defaultValue

* Fixes if logic.