### PR TITLE
fix: Filter step inside split/aggregate

### DIFF
--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
@@ -50,7 +50,7 @@ public class IntegrationRouteBuilderTest extends IntegrationTestSupport {
 
         assertThat(route.getInputs()).hasSize(1);
         assertThat(route.getInputs().get(0)).hasFieldOrPropertyWithValue("uri", "direct:expression");
-        assertThat(route.getOutputs()).hasSize(4);
+        assertThat(route.getOutputs()).hasSize(2);
         assertThat(getOutput(route, 0)).isInstanceOf(SetHeaderDefinition.class);
         assertThat(getOutput(route, 1)).isInstanceOf(SplitDefinition.class);
         assertThat(getOutput(route, 1).getOutputs()).hasSize(3);
@@ -62,7 +62,5 @@ public class IntegrationRouteBuilderTest extends IntegrationTestSupport {
         assertThat(getOutput(route, 1, 2, 1)).isInstanceOf(ToDefinition.class);
         assertThat(getOutput(route, 1, 2, 1)).hasFieldOrPropertyWithValue("uri", "mock:expression");
         assertThat(getOutput(route, 1, 2, 2)).isInstanceOf(ProcessDefinition.class);
-        assertThat(getOutput(route, 2)).isInstanceOf(SetHeaderDefinition.class);
-        assertThat(getOutput(route, 3)).isInstanceOf(ProcessDefinition.class);
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerJsonTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerJsonTest.java
@@ -16,30 +16,40 @@
 package io.syndesis.integration.runtime.handlers;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import io.syndesis.common.util.Resources;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 import io.syndesis.integration.runtime.IntegrationStepHandler;
 import io.syndesis.integration.runtime.IntegrationTestSupport;
+import io.syndesis.integration.runtime.logging.BodyLogger;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SplitStepHandlerJsonTest extends IntegrationTestSupport {
 
+    /**
+     * Test split to the very end of the integration - no aggregate
+     * direct -> split -> mock
+     */
     @Test
-    public void testTokenizeBodyStep() throws Exception {
+    public void testSplitToEnd() throws Exception {
         final CamelContext context = new DefaultCamelContext();
 
         try {
             final RouteBuilder routes = new IntegrationRouteBuilder(
-                "classpath:/syndesis/integration/SplitStepHandlerJsonTest.json",
-                Resources.loadServices(IntegrationStepHandler.class)
+                    "classpath:/syndesis/integration/split-to-end.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
             );
 
             // Set up the camel context
@@ -63,5 +73,258 @@ public class SplitStepHandlerJsonTest extends IntegrationTestSupport {
         } finally {
             context.stop();
         }
+    }
+
+    /**
+     * Test chains of split/aggregate where a 2nd split directly follows on the 1st aggregate.
+     * direct -> split -> log -> aggregate -> split -> log -> aggregate -> mock
+     */
+    @Test
+    public void testSplitAggregateChain() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                    "classpath:/syndesis/integration/split-chain.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+            addBodyLogger(context);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("a,b,c", "de", "f,g");
+
+            result.expectedBodiesReceived(body);
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+        } finally {
+            context.stop();
+        }
+    }
+
+    /**
+     * Test subsequent split/aggregate where a 1st split operates on a initial collection of elements and a
+     * 2nd split operates on a completely new collection provided by some mock endpoint.
+     * direct -> split -> log -> aggregate -> bean:myMock -> split -> log -> aggregate -> mock
+     */
+    @Test
+    public void testSubsequentSplitAggregate() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                    "classpath:/syndesis/integration/subsequent-split.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+
+            SimpleRegistry beanRegistry = new SimpleRegistry();
+            beanRegistry.put("bodyLogger", new BodyLogger.Default());
+            beanRegistry.put("myMock", (Processor) exchange -> exchange.getIn().setBody(Arrays.asList("d", "e", "f")));
+            context.setRegistry(beanRegistry);
+
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("a", "b", "c");
+
+            result.expectedMessageCount(1);
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+            List<?> bodyReceived = result.getExchanges().get(0).getIn().getBody(List.class);
+            assertThat(bodyReceived).hasSize(3);
+            assertThat(bodyReceived.get(0)).isEqualTo("d");
+            assertThat(bodyReceived.get(1)).isEqualTo("e");
+            assertThat(bodyReceived.get(2)).isEqualTo("f");
+        } finally {
+            context.stop();
+        }
+    }
+
+    /**
+     * Test multiple split steps in an integration, both split operating to the very end of an integration - no aggregate
+     * direct -> split -> log -> split -> mock
+     */
+    @Test
+    public void testMultipleSplit() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                    "classpath:/syndesis/integration/multiple-split.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+            addBodyLogger(context);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("a,b,c", "de", "f,g");
+
+            result.expectedBodiesReceived("a", "b", "c", "de", "f", "g");
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+        } finally {
+            context.stop();
+        }
+    }
+
+    /**
+     * Test nested split/aggregate where a 2nd split lives inside the 1st split/aggregate
+     * direct -> split -> log -> split -> log -> mock -> aggregate -> log -> aggregate -> mock
+     */
+    @Test
+    public void testNestedSplitAggregate() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                    "classpath:/syndesis/integration/nested-split.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+            addBodyLogger(context);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final MockEndpoint nestedResult = context.getEndpoint("mock:nested-mock", MockEndpoint.class);
+            final List<String> body = Arrays.asList("a,b,c", "de", "f,g");
+
+            result.expectedMessageCount(1);
+            nestedResult.expectedBodiesReceived("a", "b", "c", "de", "f", "g");
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+            nestedResult.assertIsSatisfied();
+
+            List<?> bodyReceived = result.getExchanges().get(0).getIn().getBody(List.class);
+            assertThat(bodyReceived).hasSize(3);
+            assertThat(bodyReceived.get(0)).isEqualTo(Arrays.asList("a","b","c"));
+            assertThat(bodyReceived.get(1)).isEqualTo(Collections.singletonList("de"));
+            assertThat(bodyReceived.get(2)).isEqualTo(Arrays.asList("f","g"));
+        } finally {
+            context.stop();
+        }
+    }
+
+    /**
+     * Test filter step that lives after a split - no aggregate
+     * direct -> split -> filter -> log -> mock
+     */
+    @Test
+    public void testFilterAfterSplit() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                    "classpath:/syndesis/integration/filter-after-split.json",
+                    Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+            addBodyLogger(context);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("{\"task\": \"Play with the dog\"}",
+                                                    "{\"task\": \"Wash the dog\"}",
+                                                    "{\"task\": \"Feed the dog\"}",
+                                                    "{\"task\": \"Walk the dog\"}");
+
+            result.expectedMessageCount(1);
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+            assertThat(result.getExchanges().get(0).getIn().getBody(String.class)).isEqualTo("{\"task\": \"Feed the dog\"}");
+        } finally {
+            context.stop();
+        }
+    }
+
+    /**
+     * Test filter step that lives inside of a split/aggregate. Only the filtered matches should be aggregated.
+     * direct -> split -> filter -> log -> aggregate -> mock
+     */
+    @Test
+    public void testFilterInSplitAggregate() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = new IntegrationRouteBuilder(
+                "classpath:/syndesis/integration/filter-in-split.json",
+                Resources.loadServices(IntegrationStepHandler.class)
+            );
+
+            // Set up the camel context
+            context.addRoutes(routes);
+            addBodyLogger(context);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("{\"task\": \"Play with the dog\"}",
+                                                    "{\"task\": \"Wash the dog\"}",
+                                                    "{\"task\": \"Feed the dog\"}",
+                                                    "{\"task\": \"Walk the dog\"}");
+
+
+            result.expectedMessageCount(1);
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+            List<?> bodyReceived = result.getExchanges().get(0).getIn().getBody(List.class);
+            assertThat(bodyReceived).hasSize(1);
+            assertThat(bodyReceived.get(0)).isEqualTo("{\"task\": \"Wash the dog\"}");
+        } finally {
+            context.stop();
+        }
+    }
+
+    private void addBodyLogger(DefaultCamelContext context) {
+        SimpleRegistry beanRegistry = new SimpleRegistry();
+        beanRegistry.put("bodyLogger", new BodyLogger.Default());
+        context.setRegistry(beanRegistry);
     }
 }

--- a/app/integration/runtime/src/test/resources/syndesis/integration/filter-after-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/filter-after-split.json
@@ -1,0 +1,113 @@
+{
+  "id": "i-LZtXPGIgIW9s3VxFK7lz",
+  "connections": [],
+  "name": "FilterAfterSplit",
+  "flows": [
+    {
+      "id": "-LZtWw6144Xrj9YO3G0E",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZtYaHbOyXAeCAPBjh1",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZtXKme44Xrj9YO3G0E",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split",
+          "configuredProperties": {}
+        },
+        {
+          "id": "-LZtXKme44Xrj9YO3G0F",
+          "configuredProperties": {
+            "predicate": "AND",
+            "rules": "[{\"path\":\"task\",\"op\":\"contains\",\"value\":\"Feed\"}]",
+            "type": "rule"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "ruleFilter",
+          "name": "Basic Filter"
+        },
+        {
+          "id": "-LZtXKme44Xrj9YO3G0G",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/filter-in-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/filter-in-split.json
@@ -1,0 +1,141 @@
+{
+  "id": "i-LZta0CygIW9s3VxFK7qz",
+  "connections": [],
+  "name": "FilterInSplit",
+  "flows": [
+    {
+      "id": "-LZt_X4TOyXAeCAPBjh9",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjh9",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false",
+            "customText": "Before split"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjhA",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split",
+          "configuredProperties": {}
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjhB",
+          "configuredProperties": {
+            "predicate": "AND",
+            "rules": "[{\"path\":\"task\",\"op\":\"contains\",\"value\":\"Wash\"}]",
+            "type": "rule"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "ruleFilter",
+          "name": "Basic Filter"
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjhC",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false",
+            "customText": "After filter"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjhD",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "descriptor": {},
+            "actionType": "step"
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate",
+          "configuredProperties": {}
+        },
+        {
+          "id": "-LZt_wf-OyXAeCAPBjhE",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false",
+            "customText": "End result"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/inconsistent-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/inconsistent-split.json
@@ -1,0 +1,171 @@
+{
+  "id": "i-LZspTNggL5xULfktGzqz",
+  "connections": [],
+  "name": "InconsistentSplit",
+  "flows": [
+    {
+      "id": "-LZspDCP-UwxzsO_9ImW",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImW",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImX",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImY",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_6HmD",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImZ",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Im_",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Ima",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_1Amg",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Imb",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/integration.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/integration.json
@@ -59,15 +59,6 @@
           "metadata": {
             "step.index": "3"
           }
-        },
-        {
-          "stepKind": "aggregate",
-          "configuredProperties": {
-          },
-          "dependencies": [],
-          "metadata": {
-            "step.index": "4"
-          }
         }
       ]
     }

--- a/app/integration/runtime/src/test/resources/syndesis/integration/multiple-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/multiple-split.json
@@ -1,0 +1,111 @@
+{
+  "id": "i-LZta0CygIW9s3VxFK7qz",
+  "connections": [],
+  "name": "MultipleSplit",
+  "flows": [
+    {
+      "id": "-LZsxEPuAOp2wiOtQrHp",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZsxS-XAOp2wiOtQrHs",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZsxS-XAOp2wiOtQrHt",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZsxS-YAOp2wiOtQrHt",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "descriptor": {},
+            "actionType": "step"
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZsxS-YAOp2wiOtQrHu",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/nested-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/nested-split.json
@@ -1,0 +1,183 @@
+{
+  "id": "i-LZsVWTOgL5xULfktGzgz",
+  "connections": [],
+  "name": "NestedSplit",
+  "flows": [
+    {
+      "id": "-LZsV14Z-UwxzsO_9Ilv",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZsZehE-UwxzsO_9Ily",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZsZehE-UwxzsO_9Ilz",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZsaL6n-UwxzsO_9Im1",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split",
+          "configuredProperties": {}
+        },
+        {
+          "id": "-LZsaL6n-UwxzsO_9Im2",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "nested-mock"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZsZehE-UwxzsO_9Im-",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZs_O8g-UwxzsO_9Im0",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZs_O8g-UwxzsO_9Im1",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZsZehE-UwxzsO_9Im0",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/split-aggregate.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/split-aggregate.json
@@ -1,0 +1,111 @@
+{
+  "id": "i-LZspTNggL5xULfktGzqz",
+  "connections": [],
+  "name": "SplitAggregate",
+  "flows": [
+    {
+      "id": "-LZspDCP-UwxzsO_9ImW",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImW",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImX",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImY",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Imb",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/split-chain.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/split-chain.json
@@ -1,0 +1,147 @@
+{
+  "id": "i-LZspTNggL5xULfktGzqz",
+  "connections": [],
+  "name": "SplitChain",
+  "flows": [
+    {
+      "id": "-LZspDCP-UwxzsO_9ImW",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImW",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImX",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImY",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9ImZ",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Im_",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Ima",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspR7T-UwxzsO_9Imb",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}

--- a/app/integration/runtime/src/test/resources/syndesis/integration/split-to-end.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/split-to-end.json
@@ -1,6 +1,7 @@
 {
   "description": "This is a test integration!",
   "connections": [],
+  "name": "SplitToEnd",
   "flows": [
     {
       "steps": [
@@ -24,7 +25,7 @@
           },
           "dependencies": [],
           "metadata": {
-            "step.index": "1"
+            "configured": "true"
           }
         },
         {
@@ -34,7 +35,7 @@
           },
           "dependencies": [],
           "metadata": {
-            "step.index": "2"
+            "configured": "true"
           }
         },
         {
@@ -57,16 +58,7 @@
           },
           "dependencies": [],
           "metadata": {
-            "step.index": "3"
-          }
-        },
-        {
-          "stepKind": "aggregate",
-          "configuredProperties": {
-          },
-          "dependencies": [],
-          "metadata": {
-            "step.index": "4"
+            "configured": "true"
           }
         }
       ]

--- a/app/integration/runtime/src/test/resources/syndesis/integration/subsequent-split.json
+++ b/app/integration/runtime/src/test/resources/syndesis/integration/subsequent-split.json
@@ -1,0 +1,169 @@
+{
+  "id": "i-LZspEgPgL5xULfktGzoz",
+  "connections": [],
+  "name": "SubsequentSplit",
+  "flows": [
+    {
+      "id": "-LZsomBS-UwxzsO_9ImO",
+      "steps": [
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "direct",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImO",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImP",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImQ",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "bean",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "beanName": "myMock"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImR",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "split",
+          "name": "Split"
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImS",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImT",
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "actionType": "step",
+            "descriptor": {}
+          },
+          "stepKind": "aggregate",
+          "name": "Aggregate"
+        },
+        {
+          "id": "-LZspCRm-UwxzsO_9ImU",
+          "configuredProperties": {
+            "bodyLoggingEnabled": "true",
+            "contextLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        },
+        {
+          "action": {
+            "descriptor": {
+              "componentScheme": "mock",
+              "connectorCustomizers": [],
+              "propertyDefinitionSteps": [],
+              "configuredProperties": {
+                "name": "expression"
+              }
+            },
+            "tags": [],
+            "actionType": "connector",
+            "dependencies": []
+          },
+          "stepKind": "endpoint",
+          "configuredProperties": {
+
+          },
+          "dependencies": [],
+          "metadata": {
+            "configured": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "currentState": "Unpublished",
+  "targetState": "Unpublished",
+  "isDraft": true,
+  "type": "SingleFlow",
+  "statusDetail": null
+}


### PR DESCRIPTION
Make sure that aggregate step closes corresponding split and all other expression nodes (e.g. filter) that live inside split/aggregate.

With that you can use filter step inside a split/aggregate block.

Fixes #4752 

Also added some more unit tests on split/aggregate scenarios