### PR TITLE
feat: fetch updated datashapes and metadata from the backend when changes are done to the integration flow

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-view/flow-view.component.ts
@@ -133,11 +133,11 @@ export class FlowViewComponent implements OnInit, OnDestroy {
             break;
 
           case INTEGRATION_SIDEBAR_COLLAPSE:
-            this.isCollapsed = true;
+            setTimeout(() => (this.isCollapsed = true), 1);
             break;
 
           case INTEGRATION_SIDEBAR_EXPAND:
-            this.isCollapsed = false;
+            setTimeout(() => (this.isCollapsed = false), 1);
             break;
           default:
         }


### PR DESCRIPTION
fixes #4743

@christophd This works but we may want to consider a better bulk update API where I just send the whole integration flow perhaps to figure out data shapes.  This solution will start making the editor feel a bit sluggish I suspect when the flow gets longer.

I also wound up having to fetch metadata for connections as well when I found that I could remove the mismatch warning on the API provider flow by visiting the config page, as that's (before this PR) the only spot when the UI fetches updated data shapes for a connection.