### PR TITLE
fix(monitoring): Fix FuseOnlineDatabaseInstanceDown alert rule

### DIFF
--- a/doc/managing_environments/topics/alerting_sop.adoc
+++ b/doc/managing_environments/topics/alerting_sop.adoc
@@ -7,11 +7,11 @@
 
 *Alert name*
 
-FuseOnlineDatabaseHighRollbackRate
+FuseOnlineDatabaseInstanceDown
 
 *Description*
 
-The syndesis-db pod is not running or is not serving requests.
+The postgresql container within the syndesis-db pod is not running or is not serving requests.
 
 **Process steps**
 
@@ -25,12 +25,37 @@ The syndesis-db pod is not running or is not serving requests.
 
 [source,bash,options="nowrap"]
 ----
-oc logs syndesis-db-1-7nwh9 > syndesis-db.log
+oc logs syndesis-db-1-7nwh9 -c postgresql > postgresql.log
 ----
 
 5) Capture a snapshot of the 'Fuse Online - Infrastructure - DB' Grafana dashboard. The metrics can be useful for identifying errors and performance bottlenecks.
 
 6) Start or restart syndesis-db.
+
+=== FuseOnlinePostgresExporterDown
+
+*Alert name*
+
+FuseOnlinePostgresExporterDown
+
+*Description*
+
+The syndesis-db-metrics container within the syndesis-db pod is not running or is not serving requests.
+
+**Process steps**
+
+1) Log in to the OpenShift cluster.
+
+2) Switch to project namespace where Fuse Online is installed.
+
+3) If the syndesis-db pod is still running, capture logs for analysis.
+
+[source,bash,options="nowrap"]
+----
+oc logs syndesis-db-1-7nwh9 -c syndesis-db-metrics > syndesis-db-metrics.log
+----
+
+4) Start or restart the syndesis-db pod.
 
 == Syndesis Infrastructure - REST API Alerts
 

--- a/install/addons/syndesis-db-prometheus-rule.yml
+++ b/install/addons/syndesis-db-prometheus-rule.yml
@@ -25,3 +25,14 @@ spec:
           for: 5m
           labels:
             severity: critical
+        # Alert for any syndesis-db Postgres Exporter that is down
+        - alert: FuseOnlinePostgresExporterDown
+          annotations:
+            message: >-
+              syndesis-db has disappeared from Prometheus target discovery.
+            sop_url: https://github.com/syndesisio/syndesis/blob/master/doc/managing_environments/topics/alerting_sop.adoc#fuseonlinepostgresexporterdown
+          expr: >
+            absent(up{job="syndesis-db"}) == 1
+          for: 5m
+          labels:
+            severity: critical


### PR DESCRIPTION
After #4674 was implemented, the FuseOnlineDatabaseInstanceDown Prometheus alert rule no longer works. So this PR fixes that issue, but with some caveats that I documented in #4762.