### PR TITLE
fix: Set proper data shape variant metadata for split/aggregate

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
@@ -56,19 +56,12 @@ public class AggregateStepHandler implements IntegrationStepHandler {
             public Object getValue(Exchange exchange) {
                 // Account for filter match indicator and only aggregate those values that actually matched the filter.
                 // When filter match indicator is not present aggregate all.
-                Optional<Boolean> filterMatchIndicator = Optional.ofNullable(exchange.getProperty(Exchange.FILTER_MATCHED))
-                                                .map(value -> {
-                                                    if (value instanceof Boolean) {
-                                                        return (Boolean) value;
-                                                    }
-                                                    return Boolean.FALSE;
-                                                });
-
-                if (filterMatchIndicator.isPresent() && Boolean.FALSE.equals(filterMatchIndicator.get())) {
+                if (exchange.getProperty(Exchange.FILTER_MATCHED, true, Boolean.class)) {
+                    return super.getValue(exchange);
+                } else {
                     return null;
                 }
 
-                return super.getValue(exchange);
             }
         }),
         latest(UseLatestAggregationStrategy::new),

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -78,13 +78,13 @@ class AggregateMetadataHandler implements StepMetadataHandler {
     }
 
     DataShape adaptInputShape(DataShape dataShape) throws IOException {
-        Optional<DataShape> singleElementShape = dataShape.findVariantByMeta("variant", "element");
+        Optional<DataShape> singleElementShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_ELEMENT);
 
         if (singleElementShape.isPresent()) {
             return singleElementShape.get();
         }
 
-        DataShape collectionShape = dataShape.findVariantByMeta("variant", "collection").orElse(dataShape);
+        DataShape collectionShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_COLLECTION).orElse(dataShape);
 
         if (collectionShape.getKind().equals(DataShapeKinds.JSON_SCHEMA)) {
             String specification = dataShape.getSpecification();
@@ -96,6 +96,7 @@ class AggregateMetadataHandler implements StepMetadataHandler {
                 itemSchema.set$schema(schema.get$schema());
                 if (items.isSingleItems()) {
                     return new DataShape.Builder().createFrom(collectionShape)
+                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
                                                         .specification(Json.writer().writeValueAsString(itemSchema))
                                                         .build();
                 }
@@ -105,6 +106,7 @@ class AggregateMetadataHandler implements StepMetadataHandler {
             List<Object> items = Json.reader().forType(List.class).readValue(specification);
             if (!items.isEmpty()) {
                 return new DataShape.Builder().createFrom(collectionShape)
+                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
                                                         .specification(Json.writer().writeValueAsString(items.get(0)))
                                                         .build();
             }
@@ -114,13 +116,13 @@ class AggregateMetadataHandler implements StepMetadataHandler {
     }
 
     DataShape adaptOutputShape(DataShape dataShape) throws IOException {
-        Optional<DataShape> collectionShape = dataShape.findVariantByMeta("variant", "collection");
+        Optional<DataShape> collectionShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_COLLECTION);
 
         if (collectionShape.isPresent()) {
             return collectionShape.get();
         }
 
-        DataShape singleElementShape = dataShape.findVariantByMeta("variant", "element").orElse(dataShape);
+        DataShape singleElementShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_ELEMENT).orElse(dataShape);
 
         if (singleElementShape.getKind().equals(DataShapeKinds.JSON_SCHEMA)) {
             String specification = dataShape.getSpecification();
@@ -132,11 +134,13 @@ class AggregateMetadataHandler implements StepMetadataHandler {
             schema.set$schema(null);
 
             return new DataShape.Builder().createFrom(singleElementShape)
+                                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
                                             .specification(Json.writer().writeValueAsString(collectionSchema))
                                             .build();
         } else if (singleElementShape.getKind().equals(DataShapeKinds.JSON_INSTANCE)) {
             String specification = dataShape.getSpecification();
             return new DataShape.Builder().createFrom(singleElementShape)
+                                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
                                             .specification("[" + specification + "]")
                                             .build();
         }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -52,7 +52,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
                                             .decompress()
                                             .build();
 
-                Optional<DataShape> singleElementShape = dataShape.findVariantByMeta("variant", "element");
+                Optional<DataShape> singleElementShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_ELEMENT);
 
                 if (singleElementShape.isPresent()) {
                     return new DynamicActionMetadata.Builder()
@@ -61,7 +61,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
                             .build();
                 }
 
-                DataShape collectionShape = dataShape.findVariantByMeta("variant", "collection").orElse(dataShape);
+                DataShape collectionShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_COLLECTION).orElse(dataShape);
 
                 if (collectionShape.getKind().equals(DataShapeKinds.JSON_SCHEMA)) {
                     String specification = dataShape.getSpecification();
@@ -75,6 +75,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
                             return new DynamicActionMetadata.Builder()
                                     .createFrom(metadata)
                                     .outputShape(new DataShape.Builder().createFrom(collectionShape)
+                                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
                                                                         .specification(Json.writer().writeValueAsString(itemSchema))
                                                                         .build())
                                     .build();
@@ -87,6 +88,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
                         return new DynamicActionMetadata.Builder()
                                 .createFrom(metadata)
                                 .outputShape(new DataShape.Builder().createFrom(collectionShape)
+                                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
                                                                         .specification(Json.writer().writeValueAsString(items.get(0)))
                                                                         .build())
                                 .build();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
@@ -24,6 +24,10 @@ import io.syndesis.common.model.integration.StepKind;
  */
 interface StepMetadataHandler {
 
+    String VARIANT_METADATA_KEY = "variant";
+    String VARIANT_ELEMENT = "element";
+    String VARIANT_COLLECTION = "collection";
+
     /**
      * Adapt dynamic meta data for given step descriptor;
      * @param metadata


### PR DESCRIPTION
Make sure to set proper variant metadata on data shapes for split and aggregate during meta lookup. This ensures that subsequent lookup calls get the correct variant.