### PR TITLE
fix(#4758): Fix use of certificate option in odata connector

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataConstants.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataConstants.java
@@ -37,9 +37,7 @@ public interface ODataConstants extends StringConstants {
 
     String BASIC_USER_NAME = "basicUserName";
 
-    String SKIP_CERT_CHECK = "skipCertificateCheck";
-
-    String CLIENT_CERTIFICATE = "clientCertificate";
+    String SERVER_CERTIFICATE = "serverCertificate";
 
     String CONSUMER = "consumer";
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -50,7 +50,7 @@ final class ODataComponent extends ComponentProxyComponent implements ODataConst
     private String serviceUri;
     private String basicUserName;
     private String basicPassword;
-    private String clientCertificate;
+    private String serverCertificate;
     private String keyPredicate;
     private String queryParams;
     private boolean filterAlreadySeen;
@@ -106,12 +106,12 @@ final class ODataComponent extends ComponentProxyComponent implements ODataConst
     }
 
 
-    public String getClientCertificate() {
-        return clientCertificate;
+    public String getServerCertificate() {
+        return serverCertificate;
     }
 
-    public void setClientCertificate(String clientCertificate) {
-        this.clientCertificate = clientCertificate;
+    public void setServerCertificate(String serverCertificate) {
+        this.serverCertificate = serverCertificate;
     }
 
     public String getKeyPredicate() {
@@ -186,7 +186,7 @@ final class ODataComponent extends ComponentProxyComponent implements ODataConst
             .propertyIfNotNull(SERVICE_URI, getServiceUri())
             .propertyIfNotNull(BASIC_USER_NAME, getBasicUserName())
             .propertyIfNotNull(BASIC_PASSWORD, getBasicPassword())
-            .propertyIfNotNull(CLIENT_CERTIFICATE, getClientCertificate())
+            .propertyIfNotNull(SERVER_CERTIFICATE, getServerCertificate())
             .propertyIfNotNull(KEY_PREDICATE, getKeyPredicate())
             .propertyIfNotNull(QUERY_PARAMS, getQueryParams())
             .build();
@@ -217,7 +217,6 @@ final class ODataComponent extends ComponentProxyComponent implements ODataConst
 
         HttpAsyncClientBuilder httpAsyncClientBuilder = ODataUtil.createHttpAsyncClientBuilder(resolvedOptions);
         configuration.setHttpAsyncClientBuilder(httpAsyncClientBuilder);
-        configuration.setSslContextParameters(ODataUtil.createSSLContextParameters(resolvedOptions));
 
         if (getServiceUri() != null) {
             configuration.setServiceUri(getServiceUri());

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
@@ -61,13 +61,6 @@ public class ODataVerifierExtension extends DefaultComponentVerifierExtension im
                           parameterKey(BASIC_USER_NAME).parameterKey(BASIC_PASSWORD).build());
         }
 
-        final String serviceUrl = (String) parameters.get(SERVICE_URI);
-        if (ODataUtil.isServiceSSL(serviceUrl) && ObjectHelper.isEmpty(parameters.get(CLIENT_CERTIFICATE))) {
-            builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.GENERIC,
-            "An https / ssl OData connection requires an ssl client certificate.").
-                      parameterKey(CLIENT_CERTIFICATE).build());
-        }
-
         return builder.build();
     }
 
@@ -103,11 +96,11 @@ public class ODataVerifierExtension extends DefaultComponentVerifierExtension im
 
             } catch (CertificateException e) {
                 builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION, "Invalid certificate: " + e.getMessage()).
-                              parameterKey(CLIENT_CERTIFICATE).
+                              parameterKey(SERVER_CERTIFICATE).
                               build());
             } catch (Exception e) {
                 builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION, "Failure to communicate with serviceUrl: " + e.getMessage()).
-                              parameterKey(SERVICE_URI).parameterKey(CLIENT_CERTIFICATE).
+                              parameterKey(SERVICE_URI).parameterKey(SERVER_CERTIFICATE).
                               build());
             }
 

--- a/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
+++ b/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
@@ -337,27 +337,16 @@
       "secret": false,
       "type": "string"
     },
-    "clientCertificate": {
+    "serverCertificate": {
       "componentProperty": true,
       "deprecated": false,
-      "description": "Client certificate for SSL connections",
-      "displayName": "Client Certificate",
+      "description": "If the https/SSL server is internal and possesses a self-signed certificate then enable SSL by adding the certificate here.",
+      "displayName": "Server Certificate",
       "group": "security",
       "javaType": "java.lang.String",
       "kind": "parameter",
       "label": "common,security",
       "order": "5",
-      "relation": [
-        {
-          "action": "ENABLE",
-          "when": [
-            {
-              "id": "skipCertificateCheck",
-              "value": "false"
-            }
-          ]
-        }
-      ],
       "required": false,
       "secret": false,
       "type": "textarea"
@@ -371,31 +360,6 @@
       "labelHint": "The service root URL of your OData server",
       "order": "1",
       "required": true,
-      "secret": false,
-      "type": "string"
-    },
-    "skipCertificateCheck": {
-      "componentProperty": true,
-      "defaultValue": "false",
-      "deprecated": false,
-      "displayName": "Check Certificate",
-      "enum": [
-        {
-          "label": "Disable",
-          "value": "true"
-        },
-        {
-          "label": "Enable",
-          "value": "false"
-        }
-      ],
-      "group": "security",
-      "javaType": "java.lang.String",
-      "kind": "property",
-      "label": "common,security",
-      "labelHint": "Ensure certificate checks are enabled for secure production environments. Disable for convenience in only development environments.",
-      "order": "4",
-      "required": false,
       "secret": false,
       "type": "string"
     }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -73,6 +73,8 @@ public abstract class AbstractODataTest implements ODataConstants {
 
     protected static ODataTestServer sslAuthTestServer;
 
+    protected static final String REF_SERVICE_URI = "https://services.odata.org/TripPinRESTierService";
+
     protected CamelContext context;
 
     @Configuration

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/BaseOlingo4Test.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/BaseOlingo4Test.java
@@ -71,7 +71,7 @@ public class BaseOlingo4Test extends AbstractODataTest {
 
     @Test
     public void testExpectations() throws Exception {
-        URI httpURI = URI.create(defaultTestServer.serviceUrl() + FORWARD_SLASH + defaultTestServer.resourcePath());
+        URI httpURI = URI.create(defaultTestServer.servicePlainUri() + FORWARD_SLASH + defaultTestServer.resourcePath());
         String camelURI = "olingo4://read/" + defaultTestServer.resourcePath();
 
         //
@@ -94,7 +94,7 @@ public class BaseOlingo4Test extends AbstractODataTest {
         // workaround the no serviceUri problem.
         //
         Olingo4AppEndpointConfiguration configuration = new Olingo4AppEndpointConfiguration();
-        configuration.setServiceUri(defaultTestServer.serviceUrl());
+        configuration.setServiceUri(defaultTestServer.servicePlainUri());
 
         //
         // Apply empty values to these properties so they are

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -71,7 +71,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     @Test
     public void testSimpleODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -91,7 +91,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testAuthenticatedODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(
                                                         new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, authTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, authTestServer.servicePlainUri())
                                                             .property(BASIC_USER_NAME, ODataTestServer.USER),
                                                         new PropertyBuilder<ConfigurationProperty>()
                                                             .property(BASIC_PASSWORD, basicPasswordProperty())
@@ -111,11 +111,15 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         testListResult(result, 0, TEST_SERVER_DATA_1, TEST_SERVER_DATA_2, TEST_SERVER_DATA_3);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testSSLODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, sslTestServer.serviceUrl())
-                                                            .property(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate()));
+                                                            .property(SERVICE_URI, sslTestServer.serviceSSLUri())
+                                                            .property(SERVER_CERTIFICATE, ODataTestServer.serverCertificate()));
 
         Step odataStep = createODataStep(odataConnector, sslTestServer.resourcePath());
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -131,12 +135,16 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         testListResult(result, 0, TEST_SERVER_DATA_1, TEST_SERVER_DATA_2, TEST_SERVER_DATA_3);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testSSLAuthenticatedODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(
                                                             new PropertyBuilder<String>()
-                                                                .property(SERVICE_URI, sslAuthTestServer.serviceUrl())
-                                                                .property(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate())
+                                                                .property(SERVICE_URI, sslAuthTestServer.serviceSSLUri())
+                                                                .property(SERVER_CERTIFICATE, ODataTestServer.serverCertificate())
                                                                 .property(BASIC_USER_NAME, ODataTestServer.USER),
                                                             new PropertyBuilder<ConfigurationProperty>()
                                                                 .property(BASIC_PASSWORD, basicPasswordProperty())
@@ -159,16 +167,15 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     @Test
     @Ignore("Run manually as not strictly required")
     public void testReferenceODataRoute() throws Exception {
-        String serviceUri = "https://services.odata.org/TripPinRESTierService";
         String resourcePath = "People";
         String queryParam = "$count=true";
 
         context = new SpringCamelContext(applicationContext);
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, serviceUri)
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
                                                             .property(QUERY_PARAMS, queryParam)
-                                                            .property(CLIENT_CERTIFICATE, ODataTestServer.referenceServiceCertificate()));
+                                                            .property(SERVER_CERTIFICATE, ODataTestServer.referenceServiceCertificate()));
 
         Step odataStep = createODataStep(odataConnector, resourcePath);
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -198,7 +205,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testODataRouteWithSimpleQuery() throws Exception {
         String queryParams = "$filter=ID eq 1";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -219,7 +226,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testODataRouteWithCountQuery() throws Exception {
         String queryParams = "$count=true";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -249,7 +256,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testODataRouteWithMoreComplexQuery() throws Exception {
         String queryParams = "$filter=ID le 2&$orderby=ID desc";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -274,7 +281,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testODataRouteWithKeyPredicate() throws Exception {
         String keyPredicate = "1";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(KEY_PREDICATE, keyPredicate));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -295,7 +302,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     public void testODataRouteWithKeyPredicateWithBrackets() throws Exception {
         String keyPredicate = "(1)";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(KEY_PREDICATE, keyPredicate));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -318,7 +325,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         String delayValue = "1000";
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(INITIAL_DELAY, initialDelayValue)
                                                             .property(DELAY, delayValue));
 
@@ -349,7 +356,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         String backoffIdleThreshold = "1";
         String backoffMultiplier = "1";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(FILTER_ALREADY_SEEN, Boolean.TRUE.toString())
                                                             .property(BACKOFF_IDLE_THRESHOLD, backoffIdleThreshold)
                                                             .property(BACKOFF_MULTIPLIER, backoffMultiplier));

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.olingo4.Olingo4Endpoint;
 import org.apache.camel.spring.SpringCamelContext;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -71,7 +70,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     @Test
     public void testSimpleODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                                .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                                .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -94,7 +93,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     public void testAuthenticatedODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(
                                                     new PropertyBuilder<String>()
-                                                        .property(SERVICE_URI, authTestServer.serviceUrl())
+                                                        .property(SERVICE_URI, authTestServer.servicePlainUri())
                                                         .property(BASIC_USER_NAME, ODataTestServer.USER),
                                                     new PropertyBuilder<ConfigurationProperty>()
                                                         .property(BASIC_PASSWORD, basicPasswordProperty())
@@ -116,11 +115,15 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         testListResult(result, 2, TEST_SERVER_DATA_3);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testSSLODataRoute() throws Exception {
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, sslTestServer.serviceUrl())
-                                                            .property(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate()));
+                                                            .property(SERVICE_URI, sslTestServer.serviceSSLUri())
+                                                            .property(SERVER_CERTIFICATE, ODataTestServer.serverCertificate()));
 
         Step odataStep = createODataStep(odataConnector, sslTestServer.resourcePath());
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -128,6 +131,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
         context.addRoutes(routes);
         MockEndpoint result = initMockEndpoint();
+        result.setResultWaitTime(360000L);
         result.setMinimumExpectedMessageCount(sslTestServer.getResultCount());
 
         context.start();
@@ -138,13 +142,16 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         testListResult(result, 2, TEST_SERVER_DATA_3);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testSSLAuthenticatedODataRoute() throws Exception {
-
         Connector odataConnector = createODataConnector(
                                                         new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, sslAuthTestServer.serviceUrl())
-                                                            .property(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate())
+                                                            .property(SERVICE_URI, sslAuthTestServer.serviceSSLUri())
+                                                            .property(SERVER_CERTIFICATE, ODataTestServer.serverCertificate())
                                                             .property(BASIC_USER_NAME, ODataTestServer.USER),
                                                         new PropertyBuilder<ConfigurationProperty>()
                                                             .property(BASIC_PASSWORD, basicPasswordProperty())
@@ -168,18 +175,46 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     }
 
     @Test
-    @Ignore("Run manually as not strictly required")
-    public void testReferenceODataRoute() throws Exception {
-        String serviceUri = "https://services.odata.org/TripPinRESTierService";
+    public void testReferenceODataRouteWithCertificate() throws Exception {
         String resourcePath = "People";
         String queryParam = "$count=true";
 
         context = new SpringCamelContext(applicationContext);
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, serviceUri)
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
                                                             .property(QUERY_PARAMS, queryParam)
-                                                            .property(CLIENT_CERTIFICATE, ODataTestServer.referenceServiceCertificate()));
+                                                            .property(SERVER_CERTIFICATE, ODataTestServer.referenceServiceCertificate()));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_1);
+    }
+
+    /**
+     * The reference server has a certificate trusted by the root certificates already
+     * in the java cacerts keystore. Therefore, it should not be necessary to supply
+     * a server certifcate.
+     */
+    @Test
+    public void testReferenceODataRouteWithoutCertificate() throws Exception {
+        String resourcePath = "People";
+        String queryParam = "$count=true";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(QUERY_PARAMS, queryParam));
 
         Step odataStep = createODataStep(odataConnector, resourcePath);
         Integration odataIntegration = createIntegration(odataStep, mockStep);
@@ -200,7 +235,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String queryParams = "$filter=ID eq 1";
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -222,7 +257,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     public void testODataRouteWithCountQuery() throws Exception {
         String queryParams = "$count=true";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -248,7 +283,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String queryParams = "$filter=ID le 2&$orderby=ID desc";
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(QUERY_PARAMS, queryParams));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -277,7 +312,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     public void testODataRouteWithKeyPredicate() throws Exception {
         String keyPredicate = "1";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(KEY_PREDICATE, keyPredicate));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -298,7 +333,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     public void testODataRouteWithKeyPredicateWithBrackets() throws Exception {
         String keyPredicate = "(1)";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(KEY_PREDICATE, keyPredicate));
 
         Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
@@ -321,7 +356,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String delayValue = "1000";
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(INITIAL_DELAY, initialDelayValue)
                                                             .property(DELAY, delayValue));
 
@@ -356,7 +391,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String backoffMultiplier = "1";
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl())
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri())
                                                             .property(FILTER_ALREADY_SEEN, Boolean.TRUE.toString())
                                                             .property(BACKOFF_IDLE_THRESHOLD, backoffIdleThreshold)
                                                             .property(BACKOFF_MULTIPLIER, backoffMultiplier));

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
@@ -120,7 +120,7 @@ public class ODataCreateTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
 
         String resourcePath = defaultTestServer.resourcePath();

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
@@ -116,7 +116,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         String resourcePath = defaultTestServer.resourcePath();
         String keyPredicate = "1";
@@ -152,7 +152,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
 
         String resourcePath = defaultTestServer.resourcePath();
@@ -189,7 +189,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         String resourcePath = defaultTestServer.resourcePath();
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -165,7 +165,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
 
         String resourcePath = defaultTestServer.resourcePath();
@@ -217,7 +217,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         Step directStep = createDirectStep();
 
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
-                                                            .property(SERVICE_URI, defaultTestServer.serviceUrl()));
+                                                            .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         String resourcePath = defaultTestServer.resourcePath();
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
@@ -64,7 +64,7 @@ public class ODataVerifierTest extends AbstractODataTest {
     @Test
     public void testVerifyWithServer() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, defaultTestServer.serviceUrl());
+        parameters.put(SERVICE_URI, defaultTestServer.servicePlainUri());
 
         Verifier verifier = new ODataVerifierAutoConfiguration().odataVerifier();
         List<VerifierResponse> responses = verifier.verify(context, "odata", parameters);
@@ -78,7 +78,7 @@ public class ODataVerifierTest extends AbstractODataTest {
     @Test
     public void testVerifyWithBasicAuthenticatedServer() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, authTestServer.serviceUrl());
+        parameters.put(SERVICE_URI, authTestServer.servicePlainUri());
         parameters.put(BASIC_USER_NAME, ODataTestServer.USER);
         parameters.put(BASIC_PASSWORD, ODataTestServer.USER_PASSWORD);
 
@@ -94,7 +94,7 @@ public class ODataVerifierTest extends AbstractODataTest {
     @Test
     public void testVerifyWithBasicAuthenticatedServerWrongPassword() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, authTestServer.serviceUrl());
+        parameters.put(SERVICE_URI, authTestServer.servicePlainUri());
         parameters.put(BASIC_USER_NAME, ODataTestServer.USER);
         parameters.put(BASIC_PASSWORD, "WrongPassword");
 
@@ -113,33 +113,15 @@ public class ODataVerifierTest extends AbstractODataTest {
                         .allMatch(response -> response.getStatus() == Verifier.Status.ERROR);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testVerifyWithSSLServer() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, sslTestServer.serviceUrl());
-        parameters.put(SKIP_CERT_CHECK, false);
-        parameters.put(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate());
-
-        Verifier verifier = new ODataVerifierAutoConfiguration().odataVerifier();
-        List<VerifierResponse> responses = verifier.verify(context, "odata", parameters);
-
-        assertThat(responses).hasSize(2);
-        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.PARAMETERS);
-        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
-        assertThat(responses).allMatch(response -> response.getStatus() == Verifier.Status.OK);
-    }
-
-    /**
-     * Can use the different certificate and it will still be valid, ie. ignores certificate checking altogether
-     * @throws Exception
-     */
-    @Test
-    public void testVerifyWithSSLServerSkipCertificateCheck() throws Exception {
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, sslTestServer.serviceUrl());
-        // Turns off any certificate checking
-        parameters.put(SKIP_CERT_CHECK, true);
-        parameters.put(CLIENT_CERTIFICATE, ODataTestServer.differentCertificate());
+        parameters.put(SERVICE_URI, sslTestServer.serviceSSLUri());
+        parameters.put(SERVER_CERTIFICATE, ODataTestServer.serverCertificate());
 
         Verifier verifier = new ODataVerifierAutoConfiguration().odataVerifier();
         List<VerifierResponse> responses = verifier.verify(context, "odata", parameters);
@@ -153,9 +135,8 @@ public class ODataVerifierTest extends AbstractODataTest {
     @Test
     public void testVerifyWithSSLServerFailsDifferentCertificate() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, sslTestServer.serviceUrl());
-        parameters.put(SKIP_CERT_CHECK, false);
-        parameters.put(CLIENT_CERTIFICATE, ODataTestServer.differentCertificate());
+        parameters.put(SERVICE_URI, sslTestServer.serviceSSLUri());
+        parameters.put(SERVER_CERTIFICATE, ODataTestServer.differentCertificate());
 
         Verifier verifier = new ODataVerifierAutoConfiguration().odataVerifier();
         List<VerifierResponse> responses = verifier.verify(context, "odata", parameters);
@@ -173,12 +154,15 @@ public class ODataVerifierTest extends AbstractODataTest {
                         .allMatch(response -> response.getStatus() == Verifier.Status.ERROR);
     }
 
+    /**
+     * Needs to supply server certificate since the server is unknown to the default
+     * certificate authorities that is loaded into the keystore by default
+     */
     @Test
     public void testVerifyWithSSLServerAndBasicAuthentication() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(SERVICE_URI, sslTestServer.serviceUrl());
-        parameters.put(SKIP_CERT_CHECK, false);
-        parameters.put(CLIENT_CERTIFICATE, ODataTestServer.serverCertificate());
+        parameters.put(SERVICE_URI, sslTestServer.serviceSSLUri());
+        parameters.put(SERVER_CERTIFICATE, ODataTestServer.serverCertificate());
         parameters.put(BASIC_USER_NAME, ODataTestServer.USER);
         parameters.put(BASIC_PASSWORD, ODataTestServer.USER_PASSWORD);
 

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1.json
@@ -21,5 +21,5 @@
     ]
   ],
   "HomeAddress": "",
-  "ResultCount": "20"
+  "ResultCount": 20
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-2.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-2.json
@@ -17,5 +17,5 @@
     ]
   ],
   "HomeAddress": "",
-  "ResultCount": "20"
+  "ResultCount": 20
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-3.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-3.json
@@ -18,5 +18,5 @@
     ]
   ],
   "HomeAddress": "",
-  "ResultCount": "20"
+  "ResultCount": 20
 }


### PR DESCRIPTION
* Clarifies the odata connector certificate option as a SERVER certificate
  option rather than client. This option provides facility for adding a
  self-signed certificate from internal servers not registered with a known
  certificate authority.

* ODataUtil
 * Removes skipCertificateCheck and insecure certificate-trust code
 * Loads the default keystore from JAVA_HOME that contains mainstream root
   certificate authorities. These will allow most legitimate servers on the
   internet to be verified and trusted for SSL comms.
 * Use SERVER_CERTIFICATE option for any extra certificates to import into
   keystore to allow trusting of servers not registered with certificate
   authorities

* ODataVerifierExtension
 * Removes assumption that SSL server requires a certificate.

* odata.json
 * Removes skipCertificateCheck entirely
 * Updates certificate input to reflect change in use.

* Test updates
 * More tests against reference server (public server with registered SSL
   certificate)
 * More tests against internal test server that demonstrate requiring a
   server certificate in order to successfully test.
 * Allow both plain & SSL serviceUrls if running test server as java
   application