### PR TITLE
fix: Make sure to keep original data shape variants on metadata lookup

### DIFF
--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -43,15 +43,16 @@ public class AggregateMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JAVA)
                         .specification(getSpecification("person-spec.json"))
+                        .description("person")
                         .type(Person.class.getName())
-                        .putMetadata("variant", "element")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JAVA)
                                 .specification(getSpecification("person-list-spec.json"))
                                 .collectionType("List")
                                 .type(Person.class.getName())
                                 .collectionClassName(List.class.getName())
-                                .putMetadata("variant", "collection")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
                         .build())
@@ -62,9 +63,12 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-list-spec.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -73,30 +77,32 @@ public class AggregateMetadataHandlerTest {
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JAVA)
                         .specification(getSpecification("person-list-spec.json"))
+                        .description("person-list")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
-                        .putMetadata("variant", "collection")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JAVA)
                                 .specification(getSpecification("person-spec.json"))
                                 .type(Person.class.getName())
-                                .putMetadata("variant", "element")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
                         .build())
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JAVA)
                         .specification(getSpecification("person-spec.json"))
+                        .description("person")
                         .type(Person.class.getName())
-                        .putMetadata("variant", "element")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JAVA)
                                 .specification(getSpecification("person-list-spec.json"))
                                 .collectionType("List")
                                 .type(Person.class.getName())
                                 .collectionClassName(List.class.getName())
-                                .putMetadata("variant", "collection")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
                         .build())
@@ -106,15 +112,21 @@ public class AggregateMetadataHandlerTest {
 
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.inputShape().getKind());
-        Assert.assertEquals("element", enrichedMetadata.inputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-spec.json"), enrichedMetadata.inputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-list-spec.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -124,15 +136,16 @@ public class AggregateMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-schema.json"))
+                        .description("person-schema")
                         .type(Person.class.getName())
-                        .putMetadata("variant", "element")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_SCHEMA)
                                 .specification(getSpecification("person-list-schema.json"))
                                 .collectionType("List")
                                 .type(Person.class.getName())
                                 .collectionClassName(List.class.getName())
-                                .putMetadata("variant", "collection")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -143,9 +156,12 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-list-schema.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -154,30 +170,32 @@ public class AggregateMetadataHandlerTest {
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-list-schema.json"))
+                        .description("person-list-schema")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
-                        .putMetadata("variant", "collection")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_SCHEMA)
                                 .specification(getSpecification("person-schema.json"))
                                 .type(Person.class.getName())
-                                .putMetadata("variant", "element")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-schema.json"))
+                        .description("person-schema")
                         .type(Person.class.getName())
-                        .putMetadata("variant", "element")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_SCHEMA)
                                 .specification(getSpecification("person-list-schema.json"))
                                 .collectionType("List")
                                 .type(Person.class.getName())
                                 .collectionClassName(List.class.getName())
-                                .putMetadata("variant", "collection")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -187,15 +205,21 @@ public class AggregateMetadataHandlerTest {
 
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
-        Assert.assertEquals("element", enrichedMetadata.inputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-schema.json"), enrichedMetadata.inputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-schema", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-list-schema.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -204,6 +228,7 @@ public class AggregateMetadataHandlerTest {
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-list-schema.json"))
+                        .description("person-list-schema")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -212,6 +237,7 @@ public class AggregateMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-schema.json"))
+                        .description("person-schema")
                         .type(Person.class.getName())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -222,12 +248,18 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-schema.json")), enrichedMetadata.inputShape().getSpecification());
-        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-schema", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-schema.json")), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -237,15 +269,16 @@ public class AggregateMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-instance.json"))
+                        .description("person-instance")
                         .type(Person.class.getName())
-                        .putMetadata("variant", "element")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_INSTANCE)
                                 .specification(getSpecification("person-list-instance.json"))
                                 .collectionType("List")
                                 .type(Person.class.getName())
                                 .collectionClassName(List.class.getName())
-                                .putMetadata("variant", "collection")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -256,9 +289,12 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("collection", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-list-instance.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -267,6 +303,7 @@ public class AggregateMetadataHandlerTest {
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-list-instance.json"))
+                        .description("person-list-instance")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -275,6 +312,7 @@ public class AggregateMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-instance.json"))
+                        .description("person-instance")
                         .type(Person.class.getName())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -285,19 +323,26 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.inputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.inputShape().getSpecification()));
-        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-instance", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.outputShape().getSpecification()));
-        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     private DataShape dummyShape(DataShapeKinds kind) {
         return new DataShape.Builder()
                 .kind(kind)
+                .description("dummyShape")
                 .specification("{}")
-                .putMetadata("something", "else")
+                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, "dummy")
                 .build();
     }
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
@@ -43,6 +43,7 @@ public class SplitMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JAVA)
                         .specification(getSpecification("person-list-spec.json"))
+                        .description("person-list")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -64,7 +65,10 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
         Assert.assertEquals(getSpecification("person-spec.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -74,6 +78,7 @@ public class SplitMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-list-schema.json"))
+                        .description("person-list-schema")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -95,7 +100,10 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
         Assert.assertEquals(getSpecification("person-schema.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -105,6 +113,7 @@ public class SplitMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
                         .specification(getSpecification("person-list-schema.json"))
+                        .description("person-list-schema")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -118,7 +127,10 @@ public class SplitMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-schema.json")), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -128,6 +140,7 @@ public class SplitMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-list-instance.json"))
+                        .description("person-list-instance")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -149,7 +162,10 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
         Assert.assertEquals(getSpecification("person-instance.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(0, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     @Test
@@ -159,6 +175,7 @@ public class SplitMetadataHandlerTest {
                 .outputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
                         .specification(getSpecification("person-list-instance.json"))
+                        .description("person-list-instance")
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
@@ -172,14 +189,18 @@ public class SplitMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-instance.json")), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
     }
 
     private DataShape dummyShape(DataShapeKinds kind) {
         return new DataShape.Builder()
                 .kind(kind)
                 .specification("{}")
-                .putMetadata("something", "else")
+                .description("dummyShape")
+                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, "dummy")
                 .build();
     }
 


### PR DESCRIPTION
Data shape meta data lookup for split/aggregate keeps all variants of original shapes and adds original shape as variant to the new shape in order to optimize subsequent lookups. 

In addition to that this ensures proper lookup round trip when transforming from collection to element and back again.