### PR TITLE
fix(#4802) remove ng2-codemirror/node_modules during build

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -138,7 +138,8 @@
   "resolutions": {
     "ngx-bootstrap": "3.1.4",
     "bootstrap": "~3.4",
-    "bootstrap-select": "1.13.6"
+    "bootstrap-select": "1.13.6",
+    "codemirror": "5.42.2"
   },
   "snyk": true
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -1849,13 +1849,9 @@ codelyzer@4.0.2:
     source-map "^0.5.6"
     sprintf-js "^1.0.3"
 
-codemirror@5.42.2:
+codemirror@5.42.2, codemirror@^5.22.2:
   version "5.42.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.42.2.tgz#801ab715a7a7e1c7ed4162b78e9d8138b98de8f0"
-
-codemirror@^5.22.2:
-  version "5.40.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.40.0.tgz#2f5ed47366e514f41349ba0fe34daaa39be4e257"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* package.json
* post-install.sh
 * Remove the older version of codemirror from ng2-codemirror to avoid a
   conflict

* index.ts
 * Suddenly codemirror linting and highlighting start to work correctly
   after reverting this change.