### PR TITLE
fix: #4811 SQL DELETE as start connection not working

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -176,7 +176,7 @@ public final class JSONBeanUtil {
     public static List<String> toJSONBeans(Message in) {
         final List<String> jsonBeans = new ArrayList<>();
 
-        if (in.getBody(List.class) != null) {
+        if (in.getBody() instanceof List) {
             @SuppressWarnings("unchecked")
             final List<Map<String, Object>> maps = in.getBody(List.class);
 
@@ -186,7 +186,7 @@ public final class JSONBeanUtil {
                     jsonBeans.add(bean);
                 }
             }
-        } else {
+        } else if (in.getBody() instanceof Map) {
             @SuppressWarnings("unchecked")
             final Map<String, Object> singleMap = in.getBody(Map.class);
 


### PR DESCRIPTION
When SQL DELETE or INSERT statement is used as a start connection for an integration the connector fails with some class cast exception. 

This was caused by the Camel exchange `in.getBody(List.class)` auto converting the (empty) body to a list as demanded. But the resulting list then causes a class cast exception as the list is not of required type `List<Map<String, Object>>`

This PR makes sure that exchange body is not auto converted to a list.