### PR TITLE
fix: disable `Next` when the given OpenAPI document has errors

### DIFF
--- a/app/ui/src/app/common/button.component.ts
+++ b/app/ui/src/app/common/button.component.ts
@@ -3,30 +3,53 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'syndesis-button',
   template: `
-    <button [attr.type]="type" class="submit syndesis-button syn-form__submit btn"
+    <button
+      [attr.type]="type"
+      class="submit syndesis-button syn-form__submit btn"
       [class.btn-primary]="theme == 'primary'"
       [class.btn-default]="theme == 'default'"
-      [ngClass]="{ 'syndesis-button--loading': loading, 'syndesis-button--disabled': disabled }"
-      [attr.disabled]="(disabled || loading) ? 'disabled' : null">
-      <i class="spinner spinner-sm syndesis-button__spinner" *ngIf="loading"></i>
-      <span class="syndesis-button__label">
-        <ng-content></ng-content>
-      </span>
+      (click)="(click)"
+      [ngClass]="{
+        'syndesis-button--loading': loading,
+        'syndesis-button--disabled': disabled
+      }"
+      [disabled]="disabled || loading ? true : false"
+    >
+      <i
+        class="spinner spinner-sm syndesis-button__spinner"
+        *ngIf="loading"
+      ></i>
+      <span class="syndesis-button__label"> <ng-content></ng-content> </span>
     </button>
   `,
   styles: [
     `
-    :host-context(.is-margin-reset) .submit { margin: 0; }
-    ::ng-deep syndesis-button + syndesis-button { margin-left: 5px; }
-    .syndesis-button { display: inline-flex; justify-content: center; }
-    .syndesis-button__spinner { display: block; margin: 0; }
-    .syndesis-button__spinner + .syndesis-button__label { padding-left: 1em; }
-  `
-  ]
+      :host-context(.is-margin-reset) .submit {
+        margin: 0;
+      }
+      ::ng-deep syndesis-button + syndesis-button {
+        margin-left: 5px;
+      }
+      .syndesis-button {
+        display: inline-flex;
+        justify-content: center;
+      }
+      .syndesis-button__spinner {
+        display: block;
+        margin: 0;
+      }
+      .syndesis-button__spinner + .syndesis-button__label {
+        padding-left: 1em;
+      }
+    `,
+  ],
 })
 export class ButtonComponent {
   @Input() type: 'button' | 'submit' = 'button';
   @Input() theme: 'primary' | 'default' = 'primary';
   @Input() disabled: boolean;
   @Input() loading: boolean;
+  @Input() click = () => {
+    // Default click hander, noop
+  }
 }

--- a/app/ui/src/app/integration/api-provider/creation-page/step-validate/step-validate.component.html
+++ b/app/ui/src/app/integration/api-provider/creation-page/step-validate/step-validate.component.html
@@ -24,7 +24,7 @@
                 </syndesis-button>
               </fieldset>
               <fieldset>
-                <syndesis-button (click)="onDone.emit()" type="button" theme="primary">
+                <syndesis-button (click)="onDone.emit()" [disabled]="hasErrors()" type="button" theme="primary">
                   {{ 'shared.next' | synI18n }}
                 </syndesis-button>
 

--- a/app/ui/src/app/integration/api-provider/creation-page/step-validate/step-validate.component.ts
+++ b/app/ui/src/app/integration/api-provider/creation-page/step-validate/step-validate.component.ts
@@ -11,4 +11,10 @@ export class StepValidateComponent {
   @Output() onDone = new EventEmitter<boolean>();
   @Output() onEdit = new EventEmitter<boolean>();
   @Output() onCancel = new EventEmitter<boolean>();
+
+  hasErrors() {
+    const errors = this.validationResponse.errors;
+
+    return typeof(errors) !== 'undefined' && errors.length > 0;
+  }
 }


### PR DESCRIPTION
Kinda; there's a weird issue with `<button disabled="disabled">` that isn't really disabled. Not sure what's going on here. Can someone from @syndesisio/ui-api take a look at this?

![Peek 2019-03-11 18-04](https://user-images.githubusercontent.com/1306050/54142615-68d9de00-4428-11e9-9c7b-396744afa2c7.gif)


Fixes #4437