### PR TITLE
backport #4802

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -137,7 +137,8 @@
   },
   "resolutions": {
     "ngx-bootstrap": "3.1.4",
-    "bootstrap": "~3.4"
+    "bootstrap": "~3.4",
+    "codemirror": "5.42.2"
   },
   "snyk": true
 }

--- a/app/ui/yarn.lock
+++ b/app/ui/yarn.lock
@@ -1856,13 +1856,9 @@ codelyzer@4.0.2:
     source-map "^0.5.6"
     sprintf-js "^1.0.3"
 
-codemirror@5.42.2:
+codemirror@5.42.2, codemirror@^5.22.2:
   version "5.42.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.42.2.tgz#801ab715a7a7e1c7ed4162b78e9d8138b98de8f0"
-
-codemirror@^5.22.2:
-  version "5.40.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.40.0.tgz#2f5ed47366e514f41349ba0fe34daaa39be4e257"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* Aligns the ng2-codemirror dependency codemirror dependency with the main
  dependency versioning in package.json. Without this, a node_modules
  sub-directory is created in node_modules/ng2-codemirror and causes a
  codemirror version conflict. The codemirror/lint.js addon fails to get
  imported correctly and the performLint() function is never initialised.
  This results in the templater step not linting or highlighting text.

(cherry picked from commit 147bc834a930995fac7d3cd419ff5b5328e64cc9)

```
# Conflicts:
#	app/ui/package.json
```

Fixes #4802