### PR TITLE
fix(#4848): Odata Connector to handle more complex predicates

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -18,6 +18,8 @@ package io.syndesis.connector.odata.component;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.camel.Component;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.olingo4.Olingo4AppEndpointConfiguration;
@@ -31,6 +33,10 @@ import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 final class ODataComponent extends ComponentProxyComponent implements ODataConstants {
+
+    private static final Pattern NUMBER_ONLY_PATTERN = Pattern.compile("-?\\d+");
+
+    private static final Pattern KEY_PREDICATE_PATTERN = Pattern.compile("\\(?'?(.+?)\\'?\\)?\\/(.+)");
 
     /**
      * These fields are populated using reflection by the HandlerCustomizer class.
@@ -262,18 +268,62 @@ final class ODataComponent extends ComponentProxyComponent implements ODataConst
         // this when component dependencies are upgraded.
         //
         String resourcePath = getResourcePath();
-        if (! resourcePath.contains(OPEN_BRACKET) && getKeyPredicate() != null) {
-            String keyPredicate = getKeyPredicate();
-            if (! keyPredicate.startsWith(OPEN_BRACKET)) {
-                keyPredicate = OPEN_BRACKET + keyPredicate;
-            }
-            if (! keyPredicate.endsWith(CLOSE_BRACKET)) {
-                keyPredicate = keyPredicate + CLOSE_BRACKET;
-            }
-
+        if (getKeyPredicate() != null) {
+            String keyPredicate = formatKeyPredicate();
             resourcePath = resourcePath + keyPredicate;
         }
+
+
         configuration.setResourcePath(resourcePath);
+    }
+
+    private String formatKeyPredicate() {
+        String keyPredicate = getKeyPredicate();
+        String subPredicate = null;
+
+        Matcher kp1Matcher = KEY_PREDICATE_PATTERN.matcher(keyPredicate);
+        if (kp1Matcher.matches()) {
+            keyPredicate = kp1Matcher.group(1);
+            subPredicate = kp1Matcher.group(2);
+        }
+
+        if (keyPredicate.startsWith(OPEN_BRACKET)) {
+            keyPredicate = keyPredicate.substring(1);
+        }
+
+        if (keyPredicate.startsWith(QUOTE_MARK)) {
+            keyPredicate = keyPredicate.substring(1);
+        }
+
+        if (keyPredicate.endsWith(CLOSE_BRACKET)) {
+            keyPredicate = keyPredicate.substring(0, keyPredicate.length() - 1);
+        }
+
+        if (keyPredicate.endsWith(QUOTE_MARK)) {
+            keyPredicate = keyPredicate.substring(0, keyPredicate.length() - 1);
+        }
+
+        //
+        // if keyPredicate is a number only, it doesn't need quotes
+        //
+        Matcher numberOnlyMatcher = NUMBER_ONLY_PATTERN.matcher(keyPredicate);
+        boolean noQuotes = numberOnlyMatcher.matches();
+
+        StringBuffer buf = new StringBuffer(OPEN_BRACKET);
+        if (! noQuotes) {
+            buf.append(QUOTE_MARK);
+        }
+        buf.append(keyPredicate);
+        if (! noQuotes) {
+            buf.append(QUOTE_MARK);
+        }
+        buf.append(CLOSE_BRACKET);
+
+        if (subPredicate != null) {
+            buf.append(FORWARD_SLASH).append(subPredicate);
+        }
+
+        return buf.toString();
     }
 
     @Override

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/AbstractODataCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/AbstractODataCustomizer.java
@@ -70,13 +70,13 @@ public abstract class AbstractODataCustomizer implements ComponentProxyCustomize
     }
 
     protected void convertMessageToJson(Message in) throws JsonProcessingException {
-        if (in.getBody(ClientItem.class) == null) {
+        if (in.getBody(Object.class) == null) {
             in.setBody(Collections.emptyList());
             return;
         }
 
         List<String> resultList = new ArrayList<>();
-        ClientItem item = in.getBody(ClientItem.class);
+        Object item = in.getBody(Object.class);
         if (item instanceof ClientEntitySet) {
             //
             // If the results have not been split and returned as a

--- a/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
+++ b/app/connector/odata/src/main/java/org/apache/camel/component/olingo4/Olingo4Consumer.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.olingo4.internal.Olingo4ApiName;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.component.AbstractApiConsumer;
 import org.apache.camel.util.component.ApiConsumerHelper;
+import org.apache.olingo.client.api.domain.ClientCollectionValue;
 import org.apache.olingo.client.api.domain.ClientEntity;
 import org.apache.olingo.client.api.domain.ClientEntitySet;
 import org.apache.olingo.client.api.domain.ClientValue;
@@ -156,7 +157,13 @@ public class Olingo4Consumer extends AbstractApiConsumer<Olingo4ApiName, Olingo4
                 }
                 splitResult.add(entity);
             }
-        } else if (result instanceof ClientEntity) {
+        } else if (result instanceof ClientValue && ((ClientValue) result).isCollection()) {
+            ClientValue value = (ClientValue) result;
+            ClientCollectionValue<ClientValue> collection = value.asCollection();
+            collection.forEach(v -> {
+                splitResult.add(v);
+            });
+        } else {
             splitResult.add(result);
         }
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
@@ -37,6 +37,8 @@ public abstract class AbstractODataReadRouteTest extends AbstractODataRouteTest 
     protected static final String REF_SERVER_PEOPLE_DATA_1 = "ref-server-people-data-1.json";
     protected static final String REF_SERVER_PEOPLE_DATA_2 = "ref-server-people-data-2.json";
     protected static final String REF_SERVER_PEOPLE_DATA_3 = "ref-server-people-data-3.json";
+    protected static final String REF_SERVER_PEOPLE_DATA_KLAX = "ref-server-data-klax.json";
+    protected static final String REF_SERVER_PEOPLE_DATA_KLAX_LOC = "ref-server-data-klax-location.json";
     protected static final String TEST_SERVER_DATA_EMPTY = "test-server-data-empty.json";
 
     private final boolean splitResult;

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -202,6 +202,57 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
     }
 
     @Test
+    public void testReferenceODataRouteIssue4791_1() throws Exception {
+        String resourcePath = "Airports";
+        String keyPredicate = "KLAX";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(KEY_PREDICATE, keyPredicate));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+        result.setResultWaitTime(360000);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
+    }
+
+    @Test
+    public void testReferenceODataRouteIssue4791_2() throws Exception {
+        String resourcePath = "Airports";
+        String keyPredicate = "('KLAX')/Location";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(KEY_PREDICATE, keyPredicate));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
+    }
+
+    @Test
     public void testODataRouteWithSimpleQuery() throws Exception {
         String queryParams = "$filter=ID eq 1";
         Connector odataConnector = createODataConnector(new PropertyBuilder<String>()

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -231,6 +231,57 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     }
 
     @Test
+    public void testReferenceODataRouteIssue4791_1() throws Exception {
+        String resourcePath = "Airports";
+        String keyPredicate = "KLAX";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(KEY_PREDICATE, keyPredicate));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+        result.setResultWaitTime(360000);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
+    }
+
+    @Test
+    public void testReferenceODataRouteIssue4791_2() throws Exception {
+        String resourcePath = "Airports";
+        String keyPredicate = "('KLAX')/Location";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(KEY_PREDICATE, keyPredicate));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
+    }
+
+    @Test
     public void testODataRouteWithSimpleQuery() throws Exception {
         String queryParams = "$filter=ID eq 1";
 

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax-location.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax-location.json
@@ -1,0 +1,5 @@
+[
+    "{Address:\"1 World Way, Los Angeles, CA, 90045\"}",
+    "{Loc:\"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'\"}",
+    "{City:[\"{Name:\\\"Los Angeles\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"California\\\"}\"]}"
+]

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax.json
@@ -1,0 +1,10 @@
+{
+    "Name":"Los Angeles International Airport",
+    "IcaoCode":"KLAX",
+    "IataCode":"LAX",
+    "Location":[
+        "{Address:\"1 World Way, Los Angeles, CA, 90045\"}",
+        "{Loc:\"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'\"}",
+        "{City:[\"{Name:\\\"Los Angeles\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"California\\\"}\"]}"
+    ]
+}


### PR DESCRIPTION
Backport for #4848.

* The connector should be able to handle more complex key predicates that
  have subections but also return values rather than entities as their
  query results.

* ODataComponent
 * Checks the format and validity of the key predicate, including
   * sub predicate, eg. (1)/Location
   * ensures quote marks, if required, and brackets

* AbstractODataCustomizer
 * Remove assumption of an entity being returned in the result since it can
   be a value

* Olingo4Consumer
 * Split should handle both entities and values

* Tests for more complex predicates and return of values.