### PR TITLE
fix(dropdowns): fix the user/help dropdown toggles

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -71,8 +71,8 @@
               id="helpDropdownButton"
               class="pf-c-dropdown__toggle pf-m-plain"
               aria-expanded="false"
-              (click)="expandHelpDropdown()"
-              (clickOutside)="expandHelpDropdown()"
+              (click)="toggleHelpDropdown()"
+              (clickOutside)="closeHelpDropdown()"
               [attachOutsideOnClick]=true>
               <i class="pf-icon pf-icon-help pf-m-user pf-screen-reader" aria-hidden="true"></i>
               <i class="pf-icon fa fa-ellipsis-v pf-m-mobile" aria-hidden="true"></i>
@@ -143,8 +143,8 @@
                 id="userMenuDropdownButton"
                 class="pf-c-dropdown__toggle pf-m-plain"
                 aria-expanded="false"
-                (click)="userMenuDropdown()"
-                (clickOutside)="userMenuDropdown()"
+                (click)="toggleUserMenuDropdown()"
+                (clickOutside)="closeUserMenuDropdown()"
                 [attachOutsideOnClick]=true>
                 {{ ( user$ | async)?.username }}
               </button>

--- a/app/ui/src/app/app.component.ts
+++ b/app/ui/src/app/app.component.ts
@@ -200,17 +200,31 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   /**
-   * Expands the help dropdown menu within the masthead.
+   * Toggles the help dropdown menu within the masthead
    */
-  expandHelpDropdown(): void {
+  toggleHelpDropdown(): void {
     this.helpExpanded = this.helpExpanded ? false : true;
   }
 
   /**
-   * Expands the logout dropdown menu within the masthead.
+   * Closes the help dropdown menu when clicking outside
    */
-  userMenuDropdown(): void {
+  closeHelpDropdown(): void {
+    this.helpExpanded = false;
+  }
+
+  /**
+   * Toggles the logout dropdown menu within the masthead
+   */
+  toggleUserMenuDropdown(): void {
     this.userMenuExpanded = this.userMenuExpanded ? false : true;
+  }
+
+  /**
+   * Closes the logout dropdown when clicking outside
+   */
+  closeUserMenuDropdown(): void {
+    this.userMenuExpanded = false;
   }
 
   /**

--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -260,3 +260,13 @@ body.cards-pf {
     }
   }
 }
+
+.integrations {
+  .operations {
+    .list-pf {
+      .list-pf-actions {
+        min-width: 92px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR applies some minor bug fixes, namely the dropdown toggles in the masthead and the misalignment of the operation names in the operation editor.

Should help close https://github.com/syndesisio/syndesis/issues/4609

<img width="390" alt="Screen Shot 2019-03-12 at 4 18 41 PM" src="https://user-images.githubusercontent.com/5942899/54233088-8f5c4f80-44e2-11e9-8678-5948cdcb794d.png">
