### PR TITLE
chore: Enable debug logging for Google Sheets

### DIFF
--- a/app/connector/google-sheets/src/test/resources/logback-test.xml
+++ b/app/connector/google-sheets/src/test/resources/logback-test.xml
@@ -32,13 +32,13 @@
   <logger name="org.apache.camel.util.IntrospectionSupport" level="INFO"/>
   <logger name="org.apache.camel" level="INFO"/>
   <logger name="io.syndesis" level="DEBUG"/>
-  <logger name="com.consol.citrus" level="INFO"/>
+  <logger name="com.consol.citrus" level="DEBUG"/>
   <logger name="org.springframework" level="INFO"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="com.google.api" level="INFO"/>
 
   <root level="INFO">
-    <!--<appender-ref ref="STDOUT"/>-->
+    <appender-ref ref="STDOUT"/>
     <appender-ref ref="FILE"/>
   </root>
 


### PR DESCRIPTION
Enable debug logging for Google Sheets integration tests to analyze flaky CI builds