### PR TITLE
Fusedoc 2921 connector guide updates

### DIFF
--- a/doc/connecting/master.adoc
+++ b/doc/connecting/master.adoc
@@ -2,11 +2,11 @@
 include::topics/shared/attributes.adoc[]
 
 :prodname: Syndesis
-:prodversion: 7.2
+:prodversion: 7.3
 :imagesdir: topics
 :prodnameinurl: fuse-ignite
 :productpkg: red_hat_fuse
-:version: 7.2
+:version: 7.3
 :location: upstream
 :context: connectors
 

--- a/doc/connecting/topics/as_connecting-to-amazon-s3.adoc
+++ b/doc/connecting/topics/as_connecting-to-amazon-s3.adoc
@@ -7,7 +7,7 @@
 
 An integration can retrieve data from an Amazon S3 bucket or copy data into
 an Amazon S3 bucket. To do this, you create an Amazon S3
-connection and then add that Amazon S3 connection to an integration.
+connection and then add that Amazon S3 connection to an integration flow.
 For details, see:
 
 * xref:prerequisites-for-creating-s3-connection_{context}[]

--- a/doc/connecting/topics/as_connecting-to-databases.adoc
+++ b/doc/connecting/topics/as_connecting-to-databases.adoc
@@ -14,7 +14,7 @@ databases:
 * PostgreSQL
 
 You create a connection to the database that you want to access in an integration
-and then you add that connection to an integration. 
+and then you add that connection to an integration following. 
 
 To connect to other types of databases, you must upload a JDBC driver for
 that database. 

--- a/doc/connecting/topics/as_connecting-to-ftp.adoc
+++ b/doc/connecting/topics/as_connecting-to-ftp.adoc
@@ -7,8 +7,8 @@
 :context: ftp
 
 In an integration, you can connect to an FTP or SFTP server to download or 
-upload files. To do this, create an FTP or SFTP connection. You can then add this 
-connection to any number of integrations. The following topics provide details:
+upload files. To do this, create an FTP or SFTP connection and then add  
+it to an integration flow. The following topics provide details:
 
 * xref:creating-ftp-connections_{context}[]
 * xref:adding-ftp-start-connection_{context}[]

--- a/doc/connecting/topics/as_connecting-to-gmail.adoc
+++ b/doc/connecting/topics/as_connecting-to-gmail.adoc
@@ -7,10 +7,12 @@
 :context: gmail
 
 To trigger execution of an integration when a particular Gmail
-account receives an email, add a Gmail connection to an integration as its
+account receives an email, add a Gmail connection to a simple integration as its
 start connection. In an integration, to send an email from a
-particular Gmail account, add a Gmail connection as the integration's
-finish connection, or as a middle connection. 
+particular Gmail account, you can do either of the following: 
+
+* Add a Gmail connection to the middle of a flow.
+* Add a Gmail connection to finish a simple integration.
 
 The general steps for connecting to Gmail in an integration are:
 
@@ -19,7 +21,7 @@ The general steps for connecting to Gmail in an integration are:
 the connection is authorized to access.
 . If your integration sends an email from a Gmail account, 
 decide how to populate an email to send.
-. Adding a Gmail connection to an integration.
+. Adding a Gmail connection to an integration flow.
 . For a Gmail connection that sends an email, optionally mapping integration
 data to the email fields. 
 

--- a/doc/connecting/topics/as_connecting-to-google-calendar.adoc
+++ b/doc/connecting/topics/as_connecting-to-google-calendar.adoc
@@ -8,10 +8,12 @@
 :context: calendar
 
 To trigger integration execution when a poll returns an update to a
-Google calendar, add a Google Calendar connection to an integration 
+Google calendar, add a Google Calendar connection to a simple integration 
 as its start connection. To add an event to a calendar or update an
-event in a calendar, add a Google Calendar connection to an integration 
-as the integration's middle or finish connection. 
+event in a calendar, you can do either of the following: 
+
+* Add a Google Calendar connection to the middle of a flow.
+* Add a Google Calendar connection to finish a simple integration.  
 
 Details for connecting to Google Calendar are in the following topics:
 

--- a/doc/connecting/topics/as_connecting-to-google-sheets.adoc
+++ b/doc/connecting/topics/as_connecting-to-google-sheets.adoc
@@ -9,11 +9,14 @@
 
 To trigger execution of an integration when a Google Sheets connection
 returns spreadsheet data or spreadsheet properties, add a Google Sheets 
-connection to an integration as its start connection. To finish an
-integration, you can add a Google Sheets connection that updates
-spreadsheet data or properties, or that inserts a chart or pivot table
-into a spreadsheet. In the middle of an integration, you can add a
-Google Sheets connection that obtains, creates or updates a spreadsheet, 
+connection to a simple integration as its start connection. To finish a
+simple integration by updating
+spreadsheet values or properties, or by inserting a chart or pivot table
+into a spreadsheet, add a Google Sheets connection to a simple 
+integration as its finish connection. 
+
+In the middle of a flow, you can add a
+Google Sheets connection that obtains, creates or updates values in a spreadsheet, 
 or that inserts a chart or pivot table into a spreadsheet. 
 
 Details for connecting to Google Sheets are in the following topics:

--- a/doc/connecting/topics/as_connecting-to-google.adoc
+++ b/doc/connecting/topics/as_connecting-to-google.adoc
@@ -9,7 +9,7 @@
 An integration can connect to these Google applications: Gmail, Calendar, Sheets.
 To create a connection to a Google application, you must register your
 {prodname} environment as a Google client application and enable the 
-Google API for each application that you want integrations to connect to. 
+Google API for each application that you want an integration to connect to. 
 
 Information and instructions are in the following topics:
 

--- a/doc/connecting/topics/as_connecting-to-http.adoc
+++ b/doc/connecting/topics/as_connecting-to-http.adoc
@@ -9,7 +9,7 @@
 In an integration, you can connect to HTTP and HTTPS endpoints to execute
 the `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`, 
 or `PATCH` method. To do this, create 
-an HTTP or HTTPS connection and then add it to an integration. 
+an HTTP or HTTPS connection and then add it to an integration flow. 
 The following topics provide details:
 
 * xref:creating-http-connections_{context}[]

--- a/doc/connecting/topics/as_connecting-to-kafka.adoc
+++ b/doc/connecting/topics/as_connecting-to-kafka.adoc
@@ -11,7 +11,7 @@ obtain and publish data.
 In an integration, you can subscribe for data from a Kafka topic 
 that you specify or publish data to a Kafka topic that you specify.  
 To do this, create a connection to Kafka and then add that connection to an 
-integration. Details are in the following topics:
+integration flow. Details are in the following topics:
 
 * xref:creating-kafka-connections_{context}[]
 * xref:adding-kafka-connection-start_{context}[]

--- a/doc/connecting/topics/as_connecting-to-log.adoc
+++ b/doc/connecting/topics/as_connecting-to-log.adoc
@@ -7,7 +7,8 @@
 
 :context: connect-to-log
 
-For each integration step, {prodname} provides the following activity 
+For each execution of an integration, 
+for each step in a flow, {prodname} provides the following activity 
 information:
 
 * The date and time that the step was executed
@@ -21,7 +22,7 @@ link:{LinkFuseOnlineIntegrationGuide}#viewing-integration-activity-information_m
 
 To obtain further details about integration execution, you can 
 log information about the messages that an integration processes by 
-adding a log step and/or a log connection to an integration. 
+adding a log step and/or a log connection to an integration flow. 
 
 * xref:comparison-log-step-connection_{context}[]
 * xref:add-log-connection_{context}[]

--- a/doc/connecting/topics/as_connecting-to-mqtt.adoc
+++ b/doc/connecting/topics/as_connecting-to-mqtt.adoc
@@ -10,7 +10,7 @@ MQ Telemetry Transport (MQTT) is a lightweight,
 machine-to-machine, internet of things, connectivity protocol. 
 In an integration, you can obtain messages from or publish messages to
 an MQTT broker. To do this, create a connection to the MQTT broker
-of interest and then add that connection to an integration.
+of interest and then add that connection to an integration flow.
 Details are in the following topics:
 
 * xref:creating-mqtt-connections_{context}[]

--- a/doc/connecting/topics/as_connecting-to-rest-apis.adoc
+++ b/doc/connecting/topics/as_connecting-to-rest-apis.adoc
@@ -9,7 +9,7 @@
 In an integration, to connect to a REST API, you must have created a
 connector for that API by uploading an OpenAPI document that
 describes the API. See 
-link:{LinkFuseOnlineIntegrationGuide}#adding-api-connectors_add-client-connector[{NameOfFuseOnlineIntegrationGuide}, Adding  REST API client connectors].
+link:{LinkFuseOnlineIntegrationGuide}#adding-api-connectors_add-client-connector[{NameOfFuseOnlineIntegrationGuide}, Adding REST API client connectors].
 
 When a connector for the REST API you want to connect to
 is available in {prodname},

--- a/doc/connecting/topics/as_connecting-to-servicenow.adoc
+++ b/doc/connecting/topics/as_connecting-to-servicenow.adoc
@@ -9,7 +9,7 @@
 An integration can retrieve records from a ServiceNow table or add records to 
 a ServiceNow import set, which ServiceNow uses to update a table. 
 In an integration, to connect to ServiceNow,
-create a ServiceNow connection and then add that connection to an integration.
+create a ServiceNow connection and then add that connection to an integration flow.
 For details, see:
 
 * xref:create-servicenow-connection_{context}[]

--- a/doc/connecting/topics/as_connecting-to-slack.adoc
+++ b/doc/connecting/topics/as_connecting-to-slack.adoc
@@ -9,20 +9,20 @@
 As a business user, you can create an integration that connects to Slack. A 
 connection to Slack can do either one of the following:
 
-* Trigger execution of the integration when a Slack channel that you specify
+* Trigger execution of a simple integration when a Slack channel that you specify
 receives a message. The integration passes the message to the next
-step in the integration. For example, you can monitor a Slack channel 
+step in the flow. For example, you can monitor a Slack channel 
 for keyword instances such as product names. Upon finding messages that
 contain those product names, the integration can notify the appropriate contact 
 in a Gmail connection. 
 
 * Deliver a message to a particular user or to a channel. For example, this 
 behavior is useful when an integration downloads a file from an FTP server and 
-processes it in some way. You can finish an integration by 
-notifying a Slack channel or user that the process was successful.
+processes it in some way. An integration flow can 
+notify a Slack channel or user that the process was successful.
 
 To connect to Slack in an integration, create a Slack 
-connection and then add the connection to an integration. 
+connection and then add the connection to an integration flow. 
 Details are in the following topics:
 
 * xref:creating-slack-connections_{context}[]

--- a/doc/connecting/topics/as_connecting-to-telegram.adoc
+++ b/doc/connecting/topics/as_connecting-to-telegram.adoc
@@ -8,9 +8,9 @@
 As a business user, you can create an integration that connects to Telegram. A 
 connection to Telegram can do either one of the following:
 
-* Trigger execution of the integration when a Telegram bot that you specify
+* Trigger execution of a simple integration when a Telegram bot that you specify
 receives a message. The integration passes the message to the next
-step in the integration. For example, after an integration receives a 
+step in the flow. For example, after a simple integration receives a 
 message there might be a filter step that watches 
 for keyword instances such as product names. Upon finding messages that
 contain those product names, the integration can notify the appropriate contact 
@@ -18,11 +18,11 @@ in a Gmail connection or in a different Telegram connection.
 
 * Deliver a message to a particular Telegram chat. For example, this 
 behavior is useful when an integration downloads a file from an FTP server and 
-processes it in some way. You can finish an integration by 
-notifying a Telegram chat that the process was successful.
+processes it in some way. You can add a Telegram connection that 
+notifies a Telegram chat that the process was successful.
 
 To connect to Telegram in an integration, create a Telegram 
-connection and then add the connection to an integration. 
+connection and then add the connection to an integration flow. 
 Details are in the following topics:
 
 * xref:creating-telegram-connections_{context}[]

--- a/doc/connecting/topics/as_trigger-integration-with-timer.adoc
+++ b/doc/connecting/topics/as_trigger-integration-with-timer.adoc
@@ -6,10 +6,10 @@
 = Triggering integration execution with a timer
 :context: timer
 
-To trigger execution of an integration according to a schedule that
-you specify, add a timer connection as an integration's start
+To trigger execution of a simple integration according to a schedule that
+you specify, add a timer connection as a simple integration's start
 connection. {prodname} provides a timer connection, which you can use
-to start as many integrations as you like. You do not need to create
+to start as many simple integrations as you like. You do not need to create
 a timer connection unless you inadvertently delete the provided
 timer connection. Details are in the following topics:
 

--- a/doc/connecting/topics/as_triggering-integrations-with-http-requests.adoc
+++ b/doc/connecting/topics/as_triggering-integrations-with-http-requests.adoc
@@ -6,7 +6,7 @@
 = Triggering integration execution with an HTTP request (Webhook)
 :context: webhook
 
-You can trigger execution of an integration by sending an HTTP `GET` or `POST`
+You can trigger execution of a simple integration by sending an HTTP `GET` or `POST`
 request to an HTTP endpoint that {prodname} exposes. The following topics
 provide details: 
 

--- a/doc/connecting/topics/c_user-roles-for-connecting-to-concur.adoc
+++ b/doc/connecting/topics/c_user-roles-for-connecting-to-concur.adoc
@@ -25,7 +25,7 @@ role would do the following:
 * One set for access to the SAP Concur implementation site
 * Another set for access to the SAP Concur production site
 
-. Configure the SAP Connector for access to appropriate SAP Concur site. 
+. Configure the SAP Concur connector for access to the appropriate SAP Concur site. 
 . Create a SAP Concur connection. 
 
 A business user can then create an integration that uses the 

--- a/doc/connecting/topics/p_add-api-client-connection.adoc
+++ b/doc/connecting/topics/p_add-api-client-connection.adoc
@@ -5,32 +5,33 @@
 = Adding an API client connection to an integration
 
 In an integration, to connect to a REST API, add a connection to that
-REST API to the integration. 
+REST API to a flow. 
 
-In this release, in an integration, a connection to a REST API can be
-the finish connection or a middle connection. It cannot be the
-start connection. 
+In this release, a connection to a REST API can be in the 
+middle of a flow or it can be the finish connection in a simple
+integration. In other words, a connection to a REST API 
+cannot be a start connection. 
  
 .Prerequisites
 * You created a connection to the REST API.
-* You are creating or editing an integration.
-* The integration already has its start connection. 
+* You are creating or editing a flow.
+* The flow already has its start connection. 
 * {prodname} is prompting you to select a finish connection
-or a connection that is not the start connection.
+or to choose a step.
 
 .Procedure
 
-. On the page that displays available connections, click the REST API
-connection that you want to add to the integration.
+. On the page that displays available steps, click the REST API
+connection that you want to add to the flow.
 . Click the action that you want the connection to perform.
 The actions that are available are based on the resource operations
-specified in the OpenAPI file that was uploaded to {prodname} and that
-describes the API you are connecting to.
+specified in the OpenAPI document that was uploaded to {prodname} and that
+describes the API that you are connecting to.
 . Depending on the action you select, enter any parameters that
 {prodname} prompts for.
 . Click *Done*.
 
 .Result
-The connection appears in the integration flow 
+The connection appears in the flow 
 in the location where you added it. 
  

--- a/doc/connecting/topics/p_add-concur-connection.adoc
+++ b/doc/connecting/topics/p_add-concur-connection.adoc
@@ -4,37 +4,32 @@
 [id='add-concur-connection_{context}']
 = Adding a SAP Concur connection to an integration
 
-In an integration, a connection to SAP Concur is a middle or finish
-connection and not a start connection. A connection to SAP Concur can perform
-any one of 85 actions.  
+You can add a SAP Concur connection to the middle of a flow or
+as the finish connection in a simple integration. 
+A connection to SAP Concur can perform any one of 85 actions.  
 
 .Prerequisites
 * You created a SAP Concur connection.
-
-* You are creating an integration or updating an integration to
-add a connection to that integration. If you need to, see the 
-link:{LinkFuseOnlineIntegrationGuide}#procedure-for-creating-an-integration_create[general procedure for creating an integration]
-or see link:{LinkFuseOnlineIntegrationGuide}#updating-integrations_manage[updating integrations].
+* You are creating or editing a flow. 
+* {prodname} is prompting you to choose a step, or to choose the
+finish connection in a simple integration.
 
 .Procedure
-The instructions below
-assume that {prodname} is prompting you to select a
-finish connection or a middle connection.
 
-. On the page that displays available connections, click the SAP Concur
-connection that you want to add to the integration. When the integration
+. Click the SAP Concur
+connection that you want to add to the flow. When the integration
 uses the connection that you select to connect to SAP Concur, {prodname}
 uses the credentials defined in that connection.
 
 . Click the action that you want the selected connection to perform.  Each
-SAP Concur connection that you add to an integration performs only the action 
+SAP Concur connection that you add to a flow performs only the action 
 you choose.
 +
 For details about SAP Concur actions, visit the 
 https://developer.concur.com/api-explorer/[SAP Concur developer center]
 and expand *v3.0*.
 
-. Click *Done* to add the connection to the integration.
+. Click *Done* to add the connection to the flow.
 
 .Result
 The connection appears in the integration flow 

--- a/doc/connecting/topics/p_add-gmail-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_add-gmail-connection-finish-middle.adoc
@@ -5,9 +5,9 @@
 = Sending an email from a Gmail account
 
 In an integration, you can send an email from a Gmail account either
-in the middle of the integration or to finish the integration.  
-To do this, add a Gmail connection to the middle of an integration or as the 
-integration's finish connection. 
+in the middle of a flow or to finish a simple integration.  
+To do this, add a Gmail connection to the middle of a flow or as 
+a simple integration's finish connection. 
 
 .Prerequisites
 
@@ -15,25 +15,13 @@ integration's finish connection.
 * You are familiar with the
 link:{LinkFuseOnlineConnectorGuide}#alternative-for-populating-email-to-send_gmail[alternatives for populating an email to send]
 and you have a plan for populating such emails. 
+* {prodname} is prompting you to choose a step or to choose the finish 
+connection for a simple integration. 
  
 .Procedure
-
-. Start creating the integration.
-. Add and configure the start connection.
-. On the *Choose a Finish Connection* page, do one of the following:
-+
-* To finish an integration by sending an email from a Gmail
-account, click the Gmail connection that is authorized to access
-the Gmail account that you want to send the email from. 
-* To send an email in the middle of an integration:
-+
-.. Click the connection that you want to use to finish the integration. 
-.. Configure that connection. 
-.. When the finish connection is part of the integration, in the left panel, 
-hover over the plus sign where you want to add a Gmail connection and click
-*Add a connection*. 
-.. Click the Gmail connection that you want to use
-to send an email in the middle of an integration. 
+ 
+. Click the Gmail connection that you want to use
+to send an email. 
 
 . On the *Choose an Action* page, click *Send Email*. 
 . On the *Configure Send Email* page, do one of the following:
@@ -63,7 +51,7 @@ blank in the action configuration. Enter values in other action fields as needed
 A value that you specify in a *Send Email* action configuration field
 has precedence over a value that is mapped from a previous step. 
 
-. Click *Done* to add the connection to the integration. 
+. Click *Done* to add the connection to the flow. 
 
 .Result and next steps
 

--- a/doc/connecting/topics/p_add-gmail-connection-start.adoc
+++ b/doc/connecting/topics/p_add-gmail-connection-start.adoc
@@ -6,7 +6,7 @@
 
 To trigger execution of an integration based on email received by 
 a particular Gmail account, add a Gmail connection as the start connection of
-an integration. When the integration is running, the Gmail connection checks 
+a simple integration. When the integration is running, the Gmail connection checks 
 this account for emails at intervals that you control. 
 When the connection finds an unread
 email, it passes the email to the next step in the integration and, by default, 

--- a/doc/connecting/topics/p_add-google-calendar-connection-add-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-add-event.adoc
@@ -5,17 +5,16 @@
 = Adding an event to a Google calendar 
 
 In an integration, you can add an event to a Google calendar 
-in the middle of the integration or to finish the integration.  
-To do this, add a Google Calendar connection to the middle of an integration 
-or as the integration's finish connection. 
+in the middle of a flow or to finish a simple integration.  
+To do this, add a Google Calendar connection to the middle of a flow 
+or as a simple integration's finish connection. 
 
 .Prerequisites
 * A Google Calendar connection is available and this connection
 is authorized to access the Google calendar to which you want to add an 
 event.
-* You are creating or editing an integration and {prodname} is prompting you 
-to add a finish connection or select the connection that you want to add
-in the middle of an integration. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 . Click a Google Calendar connection that is authorized to access
@@ -30,5 +29,5 @@ the calendar that you want to add an event to.
 might want to map values from an event that you obtained in 
 a previous Google Calendar connection. 
 
-. Click *Done* to add the connection to the integration. 
+. Click *Done* to add the connection to the flow. 
 The connection appears in the integration flow in the location where you added it. 

--- a/doc/connecting/topics/p_add-google-calendar-connection-start.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-start.adoc
@@ -5,7 +5,8 @@
 = Triggering an integration when polling returns an event from a Google calendar
 
 To trigger execution of an integration upon obtaining events from 
-a Google Calendar that you specify, add a Google Calendar connection to an integration as 
+a Google Calendar that you specify, add a Google Calendar connection to a 
+simple integration as 
 its start connection. When the integration is running, the Google Calendar
 connection checks the Google calendar for events at intervals that you
 control. When the connection finds events that comply with the way that

--- a/doc/connecting/topics/p_add-google-calendar-connection-to-get-one-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-to-get-one-event.adoc
@@ -5,16 +5,16 @@
 = Obtaining a particular event from a Google calendar
 
 In an integration, you can obtain a particular Google calendar event
-in the middle of an integration. Obtaining a particular event is 
+in the middle of a follows. Obtaining a particular event is 
 useful, for example, when you want to:
 
 * Update the event in a subsequent Google Calendar connection.
 * Announce the event by using a subsequent Twitter connection. 
 
-To obtain one event, add a Google Calendar connection in the middle of 
-an integration.
+To obtain one event, add a Google Calendar connection to the middle of 
+a flow.
 
-NOTE: In this release, while obtaining a specific event in an integration's 
+NOTE: In this release, while obtaining a specific event in a simple integration's 
 finish connection is supported, it is not particularly useful. This is 
 expected to change in a future release.
 
@@ -23,9 +23,8 @@ expected to change in a future release.
 is authorized to access the Google calendar that has the event that
 that you want to get.
 
-* You are creating or editing an integration and {prodname} is prompting you 
-to select the connection that you want to add
-in the middle of an integration. 
+* You are creating or editing a flow and {prodname} is prompting you 
+to choose a step. 
 
 .Procedure
 
@@ -49,6 +48,6 @@ image:shared/images/ThreeVerticalDotsKebab.png[Options] and select
 follows *`eid=`*. For example, an event ID looks something like this: 
 `p1pva2a4t504gbsha12di9ch6k_20181107T150000Z*`.
 
-. Click *Done* to add the connection to the integration. 
-The connection appears in the integration flow in the location 
+. Click *Done* to add the connection to the flow. 
+The connection appears in the flow in the location 
 where you added it. 

--- a/doc/connecting/topics/p_add-google-calendar-connection-update-event.adoc
+++ b/doc/connecting/topics/p_add-google-calendar-connection-update-event.adoc
@@ -5,9 +5,9 @@
 = Updating an event in a Google calendar 
 
 In an integration, you can update an event in a Google calendar
-in the middle of the integration or to finish the integration.  
-To do this, add a Google Calendar connection to the middle of an integration 
-or as the integration's finish connection. 
+in the middle of a flow or to finish a simple integration.  
+To do this, add a Google Calendar connection to the middle of a flow 
+or as a simple integration's finish connection. 
 
 [IMPORTANT]
 ====
@@ -23,11 +23,10 @@ insert a data mapper step between the two Google Calendar connections.
 * A Google Calendar connection is available and this connection
 is authorized to access the Google calendar that has the event that
 you want to update.
-* In the integration, there is an earlier connection to Google Calendar 
+* In the flow, there is an earlier connection to Google Calendar 
 and that connection obtains the event that you want to update. 
-* You are creating or editing an integration and {prodname} is prompting you 
-to add a finish connection or select the connection that you want to add
-in the middle of an integration. 
+* You are creating or editing a flow and {prodname} is prompting you 
+to choose a step. Or, {prodname} is prompting you to choose a finish connection.  
 
 .Procedure
 . Click a Google Calendar connection that is authorized to access
@@ -40,7 +39,7 @@ the calendar that has the event that you want to update.
 Do not enter content in an event field when you want the content 
 in that field to remain unchanged. 
 
-. Click *Done* to add the connection to the integration. 
+. Click *Done* to add the connection to the flow. 
 The connection appears in the integration visualization flow in the 
 location where you added it. 
 . In the integration visualization flow, click the plus sign that is 

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
@@ -123,13 +123,19 @@ a value to the *overlayPosition* field, then the connection places
 the chart on the sheet identified by the *sourceSheetId* field. 
 This is the sheet that provides the data for the chart. 
 + 
-0 identifies the first sheet in the spreadsheet. 
+`0` identifies the first sheet in the spreadsheet. 
 For subsequent sheets, the sheet ID is at the end of the URL when the 
-sheet is visible in a browser. In the following URL, the sheet ID is `206589330`: 
-`\https://docs.google.com/spreadsheets/d/1pa...ngQbKkM/edit#gid=206589330`. 
+sheet is visible in a browser. For example, at the end of the following
+URL, you can see `gid=206589330`: 
++
+`\https://docs.google.com/spreadsheets/d/1pa...ngQbKkM/edit#gid=206589330`
++
+This indicates that the sheet ID is `206589330` and that is the value 
+that you would map to *sheetId*. 
 
 .. Identify the sheet that provides the data for the chart by mapping 
-an integer to the target *sourceSheetId* field. The default is `0`.
+its integer sheet ID to the target *sourceSheetId* field. 
+The default is `0`, which identifies the first sheet in the spreadsheet.
 + 
 You can add a basic chart or a pie chart. Follow one of the following
 sets of instructions according to the kind of chart that you want to add.

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-chart.adoc
@@ -4,25 +4,25 @@
 [id='add-google-sheets-connection-add-chart_{context}']
 = Adding a chart to a sheet 
 
-In the middle of an integration, or to finish an integration, 
+In the middle of a flow, or to finish a simple integration, 
 you can add a basic chart or a pie chart to a Google Sheets spreadsheet.
-To do this, add a Google Sheets connection to the middle of an integration
-or as the integration's finish connection. Then add a data mapping
+To do this, add a Google Sheets connection to the middle of a flow
+or as a simple integration's finish connection. Then add a data mapping
 step just before the connection. In the data mapping step, set 
 options that determine the location, properties, and content of the chart. 
 
 When {prodname} prompts you to configure the *Add charts* 
 action, you can leave some or all fields blank. If you leave a field blank,
-you can map a value to that field in the data mapper step that is
-just before this connection. 
+you can map a value to that field in the data mapper step that you 
+will add just before this connection. 
 
 .Prerequisites
 * You created a Google Sheets connection that is authorized to access
 the Google spreadsheet that you want to add a chart to.
 * You have access to the ID for the spreadsheet that you want to add a chart to.
-* You are creating or editing an integration and {prodname} is prompting you
-to choose the finish connection or to select the step that you want to add
-to the middle of the integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose the finish 
+connection for a simple integration. 
 
 .Procedure
 
@@ -51,10 +51,10 @@ Alternatively, leave the field blank. In the data mapper step that is
 just before this connection, map the chart subtitle from a source field or 
 property to the `subtitle` target field. 
 
-. Click *Done* to add the connection to the integration.
+. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
-. If you want to add any other connections to the integration, add them now. 
+. If you want to add any other connections to the flow, add them now. 
 Then return to these instructions. 
 . In the integration visualization flow, click the plus sign that is
 just before the connection that adds a chart.

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
@@ -4,12 +4,12 @@
 [id='add-google-sheets-connection-add-pivot-table_{context}']
 = Adding a pivot table to a sheet
 
-In the middle of an integration, or to finish an integration, 
+In the middle of a flow, or to finish a simple integration, 
 you can add a pivot table to a Google Sheets spreadsheet.
 A pivot table lets you aggregate, sort, or apply a function to 
 spreadsheet data and display the results in the same spreadsheet. 
-To add a pivot table, add a Google Sheets connection to the middle of an integration
-or as the integration's finish connection. Then add a data mapping
+To add a pivot table, add a Google Sheets connection to the middle of a flow 
+or as a simple integration's finish connection. Then add a data mapping
 step before the connection. In the data mapping step, you set 
 options that determine the location, properties, and content of the 
 pivot table. 
@@ -21,15 +21,14 @@ added in a future release. As a workaround, you can add multiple
 Google Sheets connections that add pivot tables based on the same
 source spreadsheet. 
 
-
 .Prerequisites
 * You created a Google Sheets connection that is authorized to access
 the Google spreadsheet that you want to add a pivot table to.
 * You have access to the ID for the spreadsheet that contains the source
 data for the pivot table. 
-* You are creating or editing an integration and {prodname} is prompting you
-to choose the finish connection or to select the step that you want to add
-to the middle of the integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step.  Or, {prodname} is prompting you to choose the finish
+connection for a simple integration. 
 
 .Procedure
 . Click a Google Sheets connection that is authorized to access
@@ -39,15 +38,15 @@ the spreadsheet that you want to add the pivot table to.
 *SpreadsheetId* field, do one of the following: 
 +
 * Enter the ID of the spreadsheet that you want to add a pivot table to. 
-* Leave the field blank. In the data mapper step that will be just
-before this connection, map the spreadsheet ID from 
+* Leave the field blank. In the data mapper step that you will add just
+before this connection, you will map the spreadsheet ID from 
 a previous connection to this connection. The previous connection must 
 access the spreadsheet that you want to add a pivot table to in this connection.
 
-. Click *Done* to add the connection to the integration.
+. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
-. If you want to add any other connections to this integration, add them 
+. If you want to add any other connections to this flow, add them 
 now. Then return to these instructions. 
 . In the integration visualization flow, click the plus sign that is
 just before the connection that adds a pivot table to a sheet.

--- a/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-add-pivot-table.adoc
@@ -78,16 +78,21 @@ table can be in two different sheets in the same spreadsheet but they
 cannot be in two different spreadsheets. 
 .. Identify the sheet to add the pivot table to by mapping an integer to the 
 *sheetId* field. The default is `0`, which identifies the first sheet
-in the spreadsheet, 
+in the spreadsheet. 
 For subsequent sheets, the sheet ID is at the end of the URL when the 
-sheet is visible in a browser. In the following URL, the sheet ID is `206589330`: 
+sheet is visible in a browser. For example, at the end of the following URL, 
+you can `gid=206589330`: 
++
 `\https://docs.google.com/spreadsheets/d/1pa...ngQbKkM/edit#gid=206589330`. 
++
+This indicates that the sheet ID is `206589330` and that is the value 
+that you would map to *sheetId*. 
 
 .. Identify the sheet that provides the data for generating the pivot table by mapping 
-an integer to the target *sourceSheetId* field.  
+its integer sheet ID to the target *sourceSheetId* field.  
 If you do not map a value to *sourceSheetId*, 
 the connection uses the *sheetId* value, or `0` if no value is mapped
-to *sheetId*. 
+to *sheetId*. `0` identifies the first sheet in the spreadsheet.
 .. Set the source data range for generating the pivot table 
 by mapping an A1 notation value to the target *sourceRange* field. 
 For example, *A2:D5*. 

--- a/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-append-sheet-values.adoc
@@ -5,19 +5,17 @@
 = Appending data to a sheet
 
 You can append data to a sheet 
-in the middle of the integration or to finish the integration.
-To do this, add a Google Sheets connection to the middle of an integration
-or as the integration's finish connection.
+in the middle of a flow or to finish a simple integration.
+To do this, add a Google Sheets connection to the middle of a flow
+or as a simple integration's finish connection.
 
 .Prerequisites
 * You created a Google Sheets connection that is authorized to access the 
 Google spreadsheet in which you want to append data.
 * You have access to the ID for the spreadsheet in which
 you want to append data. 
-* You are creating or editing an integration and {prodname} is prompting you
-to choose the finish connection or to select the step that you want to add
-to the middle of the integration.
-
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 . Click a Google Sheets connection that is authorized to access
@@ -29,7 +27,7 @@ the spreadsheet in which you want to append data.
 +
 * Enter the ID of the spreadsheet that you want to append values to. 
 * Leave the field blank. In this case, after you add this connection 
-to the integration, you must add a data mapper step
+to the flow, you must add a data mapper step
 before this connection. In the data mapper step, map the spreadsheet ID from 
 a previous connection to this connection. The previous connection must 
 access the spreadsheet that you want to append data to in this connection.
@@ -62,7 +60,7 @@ which defaults to *User entered*.
 * *Raw* does nothing. Google Sheets inserts the input data as is.
 * *User entered* enables automatic conversion of recognizable data. 
 
-.. Click *Done* to add the connection to the integration.
+.. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
 +
@@ -70,12 +68,12 @@ The values that you specify to configure the *Append values to a sheet*
 action determine the fields that the data mapper displays for mapping
 to or from this connection.
 
-. If you want to add any other connections to the integration, add them now
+. If you want to add any other connections to the flow, add them now
 and then return to these instructions. 
-. After the integration has all desired connections, 
+. After the flow has all desired connections, 
 in the integration visualization flow, click the plus sign that is
 just before the Google Sheets connection that appends data to a sheet.
-. Click the *Data Mapper* card to add a data mapping step to the integration. 
+. Click the *Data Mapper* card to add a data mapping step to the flow. 
 
 . In the data mapper: 
 

--- a/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-create-spreadsheet.adoc
@@ -4,23 +4,22 @@
 [id='add-google-sheets-connection-create-spreadsheet_{context}']
 = Creating a spreadsheet
 
-To create a new spreadsheet in the middle of an integration, 
+To create a new spreadsheet in the middle of a flow, 
 add a Google Sheets connection between the start and finish connections. 
-While you can also finish an integration with a Google Sheets 
+While you can also finish a simple integration with a Google Sheets 
 connection that creates a spreadsheet, you cannot add data to a 
 new spreadsheet in the same connection. Therefore, when you want to 
 create a spreadsheet and add data to the spreadsheet in the same
-integration, the integration requires two Google Sheets connections.
-One connection creates the spreadsheet and then a subsequent spreadsheet
+flow, the flow requires two Google Sheets connections.
+One connection creates the spreadsheet and then a subsequent connection
 adds data to the spreadsheet. 
 
 .Prerequisites
 * You created a Google Sheets connection that is authorized to
 access the Google account in which you want to create the 
 spreadsheet. 
-* You are creating or editing an integration and {prodname} is prompting you
-to select the step that you want to add to the middle of the integration,
-or that you want to add to finish the integration. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
@@ -35,12 +34,12 @@ new spreadsheet should use, for example, `India Standard Time`, or `Tokyo`.
 .. In the *Locale* field, enter the locale of the 
 new spreadsheet, for example, `Canada`, or `Hong Kong`.
 
-. Click *Done* to add the connection to the integration.
+. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
 
 .Result
 A connection that creates a spreadsheet returns the spreadsheet ID for 
-the new spreadsheet. In subsequent integration steps, you can map 
+the new spreadsheet. In subsequent steps, you can map 
 this spreadsheet ID to the spreadsheet ID in a connection 
 that accesses the new spreadsheet, for example, to update it. 

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-properties.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-properties.adoc
@@ -5,7 +5,7 @@
 = Triggering an integration when polling returns spreadsheet properties
 
 To trigger execution of an integration upon obtaining properties from
-a Google Sheets spreadsheet, add a Google Sheets connection to an integration as
+a Google Sheets spreadsheet, add a Google Sheets connection to a simple integration as
 its start connection. When the integration is running, the Google Sheets
 connection polls the spreadsheet at the interval that you specified, 
 obtains the spreadsheet properties, and passes the result to the 
@@ -39,4 +39,4 @@ specify how often you want the connection to obtain properties.
 
 . Click *Done* to add this Google Sheets connection as the integration's
 start connection. In the integration visualization panel, the connection 
-appears as the first step in the integration.
+appears as the first step in the integration's flow.

--- a/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-get-sheet-values.adoc
@@ -5,7 +5,7 @@
 = Triggering an integration when polling returns spreadsheet data
 
 To trigger execution of an integration upon obtaining data from a
-Google Sheets spreadsheet, add a Google Sheets connection to an integration 
+Google Sheets spreadsheet, add a Google Sheets connection to a simple integration 
 as its start connection. When the integration is running, the Google Sheets 
 connection polls the spreadsheet at the interval that you specified, obtains
 the data that you identified, and passes the data to the next step in the 
@@ -65,17 +65,22 @@ where each column object contains a value for each desired row.
 select *Yes*. A setting of *No* configures the action to
 return data as a collection of values. That is,
 the connection passes a collection of row objects or a collection of
-column objects to the next step in the integration. 
+column objects to the next step in the flow. 
 Select *Yes* to enable the connection to split the returned data 
 according to the setting of *Major Dimension*. For example, if 
 *Major Dimension* is set to *Rows* then the connection returns row
-objects. Each row object triggers a separate execution of the integration. 
-That is, {prodname} executes the integration once for each returned row
+objects. Each row object triggers a separate execution of the flow. 
+That is, {prodname} executes the flow once for each returned row
 object. For example, if the poll returns 5 rows then {prodname} executes
-the integration 5 times.
+the flow 5 times.
 +
 {prodname} also provides discrete *Split* and *Aggregate* steps, which 
-you can add to an integration. 
+you can add to a flow. 
+If you want to process individual objects in one or more steps and 
+then aggregate the row or column objects, do not split the Google Sheets 
+connection result. Instead, accept the default, *No*, and then add a 
+split step to the flow after this connection. A split step is 
+required if you want an aggregate step in the flow. 
 
 .. In the *Delay* field, accept the default of 30 seconds or
 specify how often you want the connection to obtain spreadsheet data.

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-properties.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-properties.adoc
@@ -5,15 +5,17 @@
 = Updating spreadsheet properties
 
 In an integration, you can update the properties of a spreadsheet 
-in the middle of the integration or to finish the integration.
-To do this, add a Google Sheets connection to the middle of an integration
-or as the integration's finish connection.
+in the middle of a flow or to finish a simple integration.
+To do this, add a Google Sheets connection to the middle of a flow
+or as a simple integration's finish connection.
 
 Properties include the spreadsheet's title, locale, and time zone. 
 
 When {prodname} prompts you to configure the *Update spreadsheet properties* 
-action, you can leave some or all fields blank. In a data mapper step before
-this connection, you can map values from previous integration steps to 
+action, you can leave some or all fields blank. If you leave a field blank, then 
+in a data mapper step that 
+is in the flow (you add it later) before this connection, you map 
+fields from previous steps to 
 blank *Update spreadsheet properties* action configuration fields. 
 
 .Prerequisites
@@ -22,9 +24,8 @@ blank *Update spreadsheet properties* action configuration fields.
 Google spreadsheet whose properties you want to update.
 * You have access to the spreadsheet ID for the spreadsheet whose properties 
 you want to update.
-* You are creating or editing an integration and {prodname} is prompting you
-to choose the finish connection or to select the step that you want to add
-to the middle of the integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
@@ -37,7 +38,7 @@ the spreadsheet whose properties you want to update.
 +
 * Enter the ID of the spreadsheet whose properties you want to update. 
 * Leave the field blank. In this case, after you add this connection 
-to the integration, you must add a data mapper step
+to the flow, you must add a data mapper step that is 
 before this connection. In the data mapper step, map the spreadsheet ID from 
 a previous connection to this connection. The previous connection must 
 access the spreadsheet that you want to update in this connection.
@@ -47,19 +48,19 @@ Alternatively, you can leave the fields blank. If you do, then in a data mapper
 step that you add later, just before this connection, you can map the fields that
 you want to change. 
 
-.. Click *Done* to add the connection to the integration.
+.. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
 
-. If you want to add any other connections to the integration, add 
+. If you want to add any other connections to the flow, add 
 them now and then return to these instructions. 
-. After the integration has all desired connections, you might want to 
+. After the flow has all desired connections, you might want to 
 use a data mapper step to update spreadsheet properties:
 
 .. In the integration visualization flow, click the plus sign that is
 just before the Google Sheets connection that updates properties.
-.. Click the *Data Mapper* card to add a data mapping step to 
-the integration. 
+.. Click *Data Mapper* to add a data mapping step to 
+the flow. 
 
 .. In the data mapper, if you did not specify a spreadsheet ID when 
 you configured the *Update spreadsheet properties* action, map a 

--- a/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
+++ b/doc/connecting/topics/p_add-google-sheets-connection-update-sheet-values.adoc
@@ -5,18 +5,17 @@
 = Updating data in a sheet
 
 In an integration, you can update data in a spreadsheet
-in the middle of the integration or to finish the integration.
-To do this, add a Google Sheets connection to the middle of an integration
-or as the integration's finish connection.
+in the middle of a flow or to finish a simple integration.
+To do this, add a Google Sheets connection to the middle of a flow
+or as a simple integration's finish connection.
 
 .Prerequisites
 * You created a Google Sheets connection that is authorized to access the 
 Google spreadsheet that you want to update.
 * You have access to the spreadsheet ID for the spreadsheet that you want
 to update.  
-* You are creating or editing an integration and {prodname} is prompting you
-to choose the finish connection or to select the step that you want to add
-to the middle of the integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 . Click a Google Sheets connection that is authorized to access
@@ -28,7 +27,7 @@ the spreadsheet that you want to update.
 +
 * Enter the ID of the spreadsheet that you want to update. 
 * Leave the field blank. In this case, after you add this connection 
-to the integration, you must add a data mapper step
+to the flow, you must add a data mapper step
 before this connection. In the data mapper step, map the spreadsheet ID from 
 a previous connection to this connection. The previous connection must 
 access the spreadsheet that you want to update in this connection.
@@ -59,16 +58,16 @@ which defaults to *User entered*.
 * *Raw* does nothing. Google Sheets inserts the input data as is.
 * *User entered* enables automatic conversion of recognizable data. 
 
-.. Click *Done* to add the connection to the integration.
+.. Click *Done* to add the connection to the flow.
 The connection appears in the integration visualization flow in the
 location where you added it.
-. If you want to add any other connections to the integration, add 
+. If you want to add any other connections to the flow, add 
 them now and then return to these instructions. 
-. After the integration has all desired connections, 
+. After the flow has all desired connections, 
 in the integration visualization flow, click the plus sign that is
 just before the Google Sheets connection that updates sheet values.
 . Click the *Data Mapper* card to add a data mapping step to 
-the integration. 
+the flow. 
 
 . In the data mapper: 
 

--- a/doc/connecting/topics/p_add-kudu-connection-get-records.adoc
+++ b/doc/connecting/topics/p_add-kudu-connection-get-records.adoc
@@ -5,7 +5,7 @@
 = Triggering an integration when scanning returns records from a Kudu table
 
 To trigger execution of an integration upon obtaining data from a 
-Kudu table, add a Kudu connection to an integration as its start 
+Kudu table, add a Kudu connection to a simple integration as its start 
 connection. When the integration is running, the Kudu connection 
 scans the table that you specified at the interval that you specified, 
 obtains all records in the table, and passes a collection of the
@@ -45,7 +45,7 @@ When the integration contains all the connections that are needed,
 consider whether you need to split the collection of records that
 the Kudu connection returns. If you want to execute integration steps 
 for each record that you obtained from the Kudu table, then after the
-Kudu connection, add a Split step. Also, 
+Kudu connection, add a split step. Also, 
 you probably need to follow the Kudu connection with a data 
 mapping step that maps data obtained from Kudu to fields in
 subsequent connections in the integration. 

--- a/doc/connecting/topics/p_add-log-connection.adoc
+++ b/doc/connecting/topics/p_add-log-connection.adoc
@@ -6,24 +6,21 @@
 
 To log information about the messages that an integration processes, 
 add one or more log connections to the integration. A log connection takes
-each input message from the previous step in the integration, sends 
+each input message from the previous step in the flow, sends 
 the details that you specify to the integration's log, and passes the message
-to the next step in the integration. 
+to the next step in the flow. 
 
 {prodname} provides a log connection that you can add to any number
-of integrations, and that you can add any number of times to the same
-integration. You do not need to create a log connection unless you
+of flows, and that you can add any number of times to the same
+flow. You do not need to create a log connection unless you
 inadvertently delete the provided log connection. 
 
 .Prerequisites
 * You have chosen to add a log connection rather than a log step to an
 integration. For help with this, see 
 link:{LinkFuseOnlineConnectorGuide}#comparison-log-step-connection_connect-to-log[Comparison of log step and log connection].
-* You must be creating or editing an integration. If you are creating an
-integration then the integration must already have its start connection. 
-* {prodname} is prompting you to choose a new integration's finish connection 
-or is prompting you to choose the
-connection that you want to add to an integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
@@ -87,7 +84,7 @@ there was one. This is comparable to the information that {prodname}
 provides for each integration step, which you can view in the 
 *Activity* tab of the integration summary. 
 
-. Click *Done* to add the log connection to the integration. 
+. Click *Done* to add the log connection to the flow. 
 
 .Additional resource
 

--- a/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-finish.adoc
@@ -4,15 +4,15 @@
 [id='add-servicenow-connection-finish_{context}']
 = Copying records to ServiceNow during or to finish an integration
 
-In the middle of an integration, or to finish an integration, 
-you can copy records to 
-ServiceNow. To do this, add a ServiceNow connection to an integration
-as the finish connection or as a middle connection. 
+You can copy records to ServiceNow in the middle of a flow 
+or to finish a simple integration. 
+To do this, add a ServiceNow connection to the middle of a flow 
+or as a simple integration's finish connection. 
 
 .Prerequisites
 
-* You are creating or editing an integration. 
-* The integration has a start connection.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 * You know the name of the ServiceNow import set that you want to 
 add records to. Your ServiceNow administrator can
 help you identify the appropriate import set. If the import set 
@@ -23,16 +23,7 @@ of records.
 
 .Procedure
 
-. Do one of the following:
-+
-* To finish the integration by copying records to ServiceNow, 
-on the *Choose a Finish Connection* page, click the ServiceNow connection that
-you want to use to finish the integration. 
-* To copy records to ServiceNow in the middle of an integration,
-after the integration has a start connection and a finish connection, 
-in the integration visualization panel on the left, hover over the plus sign
-that is in the location where you want to copy records to ServiceNow. 
-Click *Add a connection*, and click the ServiceNow connection that you
+. Click the ServiceNow connection that you
 want to add to the integration. 
 
 . Click the *Add Record* action. 
@@ -41,7 +32,7 @@ you want to add records to.
 . Click *Next*. 
 
 .Results
-* {prodname} adds the connection to the integration. 
+* {prodname} adds the connection to the flow. 
 * Typically, a data mapper step is needed before this connection.
 In the integration visualization panel, 
 {prodname} displays 

--- a/doc/connecting/topics/p_add-servicenow-connection-start.adoc
+++ b/doc/connecting/topics/p_add-servicenow-connection-start.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-servicenow.adoc
 
 [id='add-servicenow-connection-start_{context}']
-= Starting an integration by obtaining records from ServiceNow
+= Obtaining records from ServiceNow to trigger integration execution
 
-To start an integration by obtaining records from ServiceNow,
-add a ServiceNow connection to an integration as the start connection.
+To trigger execution of an integration upon receiving records from ServiceNow,
+add a ServiceNow connection to a simple integration as its start connection.
 
 .Prerequisites
 * You created a ServiceNow connection. 
@@ -15,7 +15,6 @@ records from.
 only the records that you want.
 You can find information about ServiceNow queries here:
 https://docs.servicenow.com/bundle/jakarta-platform-user-interface/page/use/using-lists/concept/c_EncodedQueryStrings.html[ServiceNow encoded queries]. 
-
 
 .Procedure
 
@@ -36,7 +35,7 @@ incidents (`state=1`) that have a medium impact (`impact=2`).
 If you do not enter a query and the records in the table do not change,  
 then the connection obtains the same records every time. 
 .. In the *Limit of elements per page* field, enter the maximum number of
-records that you want the connection to obtain.  In this release, 
+records that you want the connection to obtain. In this release, 
 you must enter a value, the recommendation is to enter `1000` or less, 
 and pagination is not supported. 
 .. In the *Period* field, indicate how often you want to obtain records.

--- a/doc/connecting/topics/p_add-slack-connection-middle-finish.adoc
+++ b/doc/connecting/topics/p_add-slack-connection-middle-finish.adoc
@@ -4,21 +4,20 @@
 [id='add-slack-connection-middle-finish_{context}']
 = Adding a Slack connection to send a message to a Slack channel or user
 
-In an integration, you can send a message to a Slack channel or Slack user to
-finish an integration or in the middle of an integration. 
+In an integration, you can send a message to a Slack channel or Slack user
+in the middle of a flow or to finish a simple integration. To do this, add 
+a Slack connection to the middle of a flow or as a simple integration's 
+finish connection.   
 
 .Prerequisites
 
 * You created a Slack connection.
-* You are creating or editing an integration. If you are creating an integration, then
-{prodname} might be prompting you to choose a finish connection. 
-To add a middle connection, hover over the plus
-sign in the left panel in the location where you want to add the
-connection and select *Add a connection*. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
-. Click the Slack connection that you want to add to the integration. 
+. Click the Slack connection that you want to add to the flow. 
 . Select the action that you want the connection to perform.
 +
 * Click *Username* to send a message to one user. To configure this action,
@@ -28,9 +27,9 @@ to.
 this action, in the *Channel* field, specify the channel to publish 
 the message to. 
 
-. Click *Done* to add the connection to the integration. 
-. Optionally, add additional connections to the integration. Whether 
-additional connections are needed depends on what you want the integration
+. Click *Done* to add the connection to the flow. 
+. Optionally, add additional connections to the flow. Whether 
+additional connections are needed depends on what you want the flow
 to do. The important point is to add all connections before you 
 continue. 
 . Add a data mapping step just before the Slack connection that you added

--- a/doc/connecting/topics/p_add-slack-connection-start.adoc
+++ b/doc/connecting/topics/p_add-slack-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-slack.adoc
 
 [id='add-slack-connection-start_{context}']
-= Adding a Slack connection to trigger execution upon receiving messages
+= Adding a Slack connection to trigger integration execution upon receiving messages
 
 A Slack connection that starts an integration triggers execution of the 
 integration when the connection finds messages on a Slack channel that 

--- a/doc/connecting/topics/p_add-telegram-connection-middle-finish.adoc
+++ b/doc/connecting/topics/p_add-telegram-connection-middle-finish.adoc
@@ -4,21 +4,20 @@
 [id='add-telegram-connection-middle-finish_{context}']
 = Adding a Telegram connection to send a message to a Telegram chat
 
-In an integration, you can send a message to a Telegram chat to
-finish an integration or in the middle of an integration. 
+In an integration, you can send a message to a Telegram chat in the 
+middle of a flow or to finish a simple integration. To do this, add 
+a Telegram connection to the middle of a flow or as a simple 
+integration's finish connection. 
 
 .Prerequisites
 
-* You created a <<creating-telegram-connections_{context},Telegram connection>>. 
-* You are creating or editing an integration. If you are creating an integration, then
-{prodname} might be prompting you to choose a finish connection. 
-To add a middle connection, hover over the plus
-sign in the left panel in the location where you want to add the
-connection and select *Add a connection*. 
+* You created a Telegram connection. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
-. Click the Telegram connection that you want to add to the integration. 
+. Click the Telegram connection that you want to add to the flow. 
 . Click the *Send a Text Message* action. 
 . In the *Chat Id* field, enter the ID for the Telegram chat that you are sending
 a message to. 
@@ -42,4 +41,4 @@ token in the clipboard.
 +
 The response is in JSON format. The JSON `chat` object contains the chat ID. 
 
-. Click *Done* to add the connection to the integration. 
+. Click *Done* to add the connection to the flow. 

--- a/doc/connecting/topics/p_add-telegram-connection-start.adoc
+++ b/doc/connecting/topics/p_add-telegram-connection-start.adoc
@@ -10,8 +10,8 @@ chat bot that you specify.
 
 .Prerequisites
 
-* You created a xref:creating-telegram-connections_{context}[Telegram connection]. 
-* You are creating an integration and {prodname} is prompting you to 
+* You created a Telegram connection. 
+* You are creating a simple integration and {prodname} is prompting you to 
 choose how you want to start the integration. 
 
 .Procedure
@@ -20,5 +20,5 @@ choose how you want to start the integration.
 . Click the *Read Messages* action to receive all messages that are sent
 to the chat bot. 
 +
-The connection identifies the chat bot that you want to 
+The connection configuration identifies the chat bot that you want to 
 receive messages from. No other configuration is required. 

--- a/doc/connecting/topics/p_add-timer-connection.adoc
+++ b/doc/connecting/topics/p_add-timer-connection.adoc
@@ -5,9 +5,9 @@
 = Adding a timer connection to trigger integration execution
 
 To trigger execution of an integration according to a schedule that
-you specify, add a timer connection as an integration's start
-connection. A timer connection cannot be in the middle of an 
-integration or at the end of an integration. 
+you specify, add a timer connection as a simple integration's start
+connection. A timer connection cannot be in the middle of a
+flow nor at the end of a flow. 
 
 .Procedure
 
@@ -23,11 +23,11 @@ a different name.
 . On the *Choose an Action* page, click *Cron Timer* or *Simple Timer*. 
 +
 * A `cron` timer requires a `cron` expression that specifies the
-schedule for when to trigger integration execution. 
+schedule for triggering integration execution. 
 * A simple timer prompts you to specify a period and its time unit, 
 for example, `5 seconds`, `1 hour`. Available units are 
 milliseconds, seconds, minutes, hours, days. 
-. According the type of timer you are adding, enter a `cron` expression 
+. According the type of timer that you are adding, enter a `cron` expression 
 or a period with a selected time unit. 
 . Click *Done* to add the *Timer* connection as the integration's 
 start connection.  

--- a/doc/connecting/topics/p_adding-amq-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-finish.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-amq.adoc
 
 [id='adding-amq-connection-finish_{context}']
-= Finishing an integration by publishing AMQ messages
+= Publishing AMQ messages to finish an integration
 
-To finish an integration by publishing messages to a Red Hat AMQ broker, 
-add a Red Hat AMQ connection as the finish connection.
+To finish a simple integration by publishing messages to a Red Hat AMQ broker, 
+add a Red Hat AMQ connection as the simple integration's finish connection.
 
 .Prerequisites
 * You created a connection to the Red Hat AMQ broker that you want to publish 
@@ -20,7 +20,7 @@ connection.
 . On the *Choose a Finish Connection* page, click the Red Hat AMQ connection that
 you want to use to finish the integration. 
 . On the *Choose an Action* page, click the *Publish messages* action to
-publish messages to the queue or topic you specify. 
+publish messages to the queue or topic that you specify. 
 . In the *Destination Name* field, enter the name of the queue or 
 topic to send messages to. 
 . For the *Destination Type*, accept *Queue* or select *Topic*. 
@@ -65,5 +65,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the  end of the integration flow. 

--- a/doc/connecting/topics/p_adding-amq-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-middle.adoc
@@ -5,29 +5,22 @@
 = Publishing AMQ messages in the middle of an integration
 
 In the middle of an integration, to publish messages to a Red Hat AMQ broker, 
-add a Red Hat AMQ connection between the start and
-finish connections. 
+add a Red Hat AMQ connection to the middle of a flow. 
 
 .Prerequisites
 * You created a connection to the Red Hat AMQ broker that you want to publish messages to.
-* You are creating or editing an integration.
-* The integration's start and finish connections have already been
-added. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection.  
 
 .Procedure
 
-. In the integration visualization panel on the left, click the plus sign
-that is in the location where you want to add the connection.
-. Click *Add a connection*. 
-
-. On the *Choose a Connection* page, click the Red Hat AMQ connection that you
-want the integration to use after the start connection and before
-the finish connection.
+. Click the Red Hat AMQ connection that you
+want in the middle of the flow.
 
 . On the *Choose an Action* page, select one of the following actions:
 +
 * *Publish messages* action to
-publish messages to the queue or topic you specify. To configure this
+publish messages to the queue or topic that you specify. To configure this
 action:
 .. In the *Destination Name* field, enter the name of the queue or 
 topic to send messages to. 
@@ -35,7 +28,7 @@ topic to send messages to.
 .. Select *Persistent* to guarantee message delivery even if
 a connection fails. 
 +
-* *Request response using messages* to send messages to the JMS destination
+* *Request response using messages* to send messages to the JMS destination that 
 you specify and receive a response. To configure this action:
 
 .. In the *Destination Name* field, enter the name of the queue or topic 
@@ -67,7 +60,6 @@ The default is 5000 milliseconds (5 seconds).
 
 . Click *Next* to specify the action's input type and then the action's
 output type. 
-
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 

--- a/doc/connecting/topics/p_adding-amq-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-amq-connection-start.adoc
@@ -2,9 +2,9 @@
 // as_connecting-to-amq.adoc
 
 [id='adding-amq-connection-start_{context}']
-= Starting an integration based on receiving AMQ messages
+= Adding an AMQ connection to trigger integration execution upon receiving messages
 
-To trigger execution of an integration based on receiving a message
+To trigger execution of an integration upon receiving a message
 from a Red Hat AMQ broker, add a Red Hat AMQ connection as the start connection.
 
 .Prerequisite
@@ -18,7 +18,7 @@ messages from.
 . On the *Choose a Start Connection* page, click the Red Hat AMQ connection that
 you want to use to start the integration. 
 . On the *Choose an Action* page, click the *Subscribe for messages* action
-to receive messages from the queue or topic you specify. 
+to receive messages from the queue or topic that you specify. 
 . To configure the action:
 .. In the *Destination Name* field, enter the name of the queue or topic 
 to receive data from. 
@@ -40,7 +40,7 @@ The message consumer receives only those messages whose headers and
 properties match the message selector expression. A message selector cannot select messages on 
 the basis of the content of the message body.
 
-.  Click *Next* to specify the action's output type. 
+. Click *Next* to specify the action's output type. 
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 
@@ -78,5 +78,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow.

--- a/doc/connecting/topics/p_adding-amqp-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-finish.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-finish_{context}']
-= Finishing an integration by publishing AMQP messages
+= Publishing AMQP messages to finish an integration
 
 To finish an integration by publishing messages to an AMQP broker,
-add an AMQP connection as the finish connection. 
+add an AMQP connection as the integration's finish connection. 
 
 .Prerequisites
 * You created an AMQP connection to the broker that you want to publish
@@ -18,7 +18,7 @@ messages to.
 . On the *Choose a Finish Connection* page, click the AMQP connection that
 you want to use to finish the integration. 
 . On the *Choose an Action* page, click *Publish messages* to
-publish messages to the queue or topic you specify. 
+publish messages to the queue or topic that you specify. 
 . In the *Destination Name* field, enter the name of the queue or 
 topic to send messages to. 
 . For the *Destination Type*, accept *Queue* or select *Topic*. 
@@ -63,5 +63,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the end of the integration flow. 

--- a/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
@@ -2,33 +2,25 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-middle_{context}']
-= Publishing messages to AMQP in the middle of an integration
+= Publishing messages to AMQP in the middle of a flow
 
-In the middle of an integration, to publish messages to an AMQP broker,
-add an AMQP connection between the start and 
-finish connections. 
+In the middle of a flow, to publish messages to an AMQP broker,
+add an AMQP connection to the middle of the flow. 
 
 .Prerequisites
 * You created a connection to the AMQP broker that you want to publish 
 messages to.
-* You are creating or editing an integration. 
-* You already added the start and finish connections to the
-integration.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step.
 
 .Procedure
 
-. In the integration visualization panel on the left, click the plus
-sign in the location where you want to add the connection. 
-. Click *Add a connection*. 
-
-. On the *Choose a Connection* page, click the AMQP connection that you 
-want the integration to use after the start connection and before 
-the finish connection. 
+. Click the AMQP connection that you want to use to publish messages. 
 
 . On the *Choose an Action* page, select one of the following actions:
 +
 * *Publish messages* to
-publish messages to the queue or topic you specify. To configure this
+publish messages to the queue or topic that you specify. To configure this
 action:
 .. In the *Destination Name* field, enter the name of the queue or 
 topic to send messages to. 

--- a/doc/connecting/topics/p_adding-amqp-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-start.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-amqp.adoc
 
 [id='adding-amqp-connection-start_{context}']
-= Starting an integration based on receiving AMQP messages
+= Adding an AMQP connection to trigger integration execution upon receiving messages
 
-To trigger execution of an integration based on receiving messages from
-an AMQP broker, add an AMQP connection as the start connection. 
+To trigger execution of an integration upon receiving messages from
+an AMQP broker, add an AMQP connection as the integration's start connection. 
 
 .Prerequisites
 * You created a connection to the AMQP broker that you want to receive 
@@ -18,7 +18,7 @@ to choose the start connection.
 . On the *Choose a Start Connection* page, click the AMQP connection that
 you want to use to start the integration. 
 . On the *Choose an Action* page, click the *Subscribe for messages* action
-to receive messages from the queue or topic you specify. 
+to receive messages from the queue or topic that you specify. 
 . To configure the action:
 .. In the *Destination Name* field, enter the name of the queue or topic 
 to receive data from. 
@@ -40,9 +40,7 @@ The message consumer receives only those messages whose headers and
 properties match the message selector expression. A message selector cannot select messages on 
 the basis of the content of the message body.
 
-
-.  Click *Next* to specify the action's output type. 
-
+. Click *Next* to specify the action's output type. 
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 
@@ -80,5 +78,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-db-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-db-connection-finish-middle.adoc
@@ -4,26 +4,25 @@
 [id='adding-db-connection-finish-middle_{context}']
 = Accessing a database in the middle or to complete an integration
 
-To finish an integration by accessing a database, add a database
-connection as the finish connection. To access 
-a database in the middle of an integration, add a database connection
-between the start and finish connections.
+In an integration, you can access a database in the 
+middle of a flow or to finish a simple integration. To do this, add 
+a database connection to the middle of a flow or as a simple 
+integration's finish connection. 
 
 .Prerequisites
 * You created a database connection.
-* You are creating or editing an integration.
-* You are on the {prodname} *Choose a Finish Connection* page or the
-*Choose a Connection* page.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
-. Click the database connection for the database you want to access.
+. Click the database connection for the database that you want to access.
 . On the *Choose an Action* page, click one of the following:
 +
 * *Invoke SQL* operates on data by executing the
 SQL statement you specify.
 * *Invoke stored procedure* operates on data by invoking
-the stored procedure you specify or select.
+the stored procedure that you specify or select.
 . If you selected *Invoke SQL*, in the *SQL Statement* field:
 ** For a middle connection, enter a SQL `SELECT` statement that obtains
 one or more records or enter a SQL `INSERT`, `UPDATE`, or
@@ -52,12 +51,12 @@ in queries.
 checking that a specified SQL query is syntactically correct and
 confirming that the query or stored procedure target data exists. If
 verification is successful then {prodname} adds the connection to
-the integration. If verification fails then {prodname} displays a message
+the flow. If verification fails then {prodname} displays a message
 about the problem. Update your input as needed and try again.
 
 .Specifying parameters in queries
 
-When you access a database in the middle of an integration or to complete
+When you access a database in the middle of a flow or to finish
 an integration, you can specify placeholder parameters in the SQL query 
 or there can be placeholders in the stored procedure. For example: 
 
@@ -68,7 +67,7 @@ DELETE FROM TODO WHERE task LIKE :#param_3
 ----
 
 To specify the values of these placeholders, add a data mapping step
-to your integration before the database connection. In the data mapping
+to the flow before the database connection. In the data mapping
 step, map the appropriate source data fields to the target data
 fields, for example, map source data to the `:#param_1`, `:#param_2`, and
 `:#param_3` target fields. See

--- a/doc/connecting/topics/p_adding-db-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-db-connection-start.adoc
@@ -22,7 +22,7 @@ database connection that you want to use to start an integration.
 * *Periodic SQL invocation* obtains data by periodically invoking the
 SQL query you specify.
 * *Periodic stored procedure invocation* obtains data by periodically invoking
-the stored procedure you specify or select.
+the stored procedure that you specify or select.
 . If you selected *Periodic SQL invocation*, in the *Query* field,
 enter a SQL `SELECT` statement to obtain one or more records. For 
 example: `*SELECT * from my_db_table*`.

--- a/doc/connecting/topics/p_adding-dropbox-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-finish.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-dropbox.adoc
 
 [id='adding-dropbox-connection-finish_{context}']
-= Finishing an integration by adding files to Dropbox
+= Adding files to Dropbox to finish an integration
 
 To finish an integration by uploading files to Dropbox,
-add a Dropbox connection as the finish connection.
+add a Dropbox connection as the integration's finish connection.
 
 .Prerequisites
 * You created a Dropbox connection. 
@@ -22,7 +22,7 @@ Dropbox account that this connection accesses.
 . In the *Remote Path* field, enter the 
 local filename path for file that you want to upload. Dropbox stores the file with the 
 same path and name. In this release, you can upload only a single file. 
-. For the *Upload mode*, 
+. For the *Upload mode*:
 +
 * Select *Add* to upload a file only when a file with the same name is not already
 in the same Dropbox folder. If a file with the same name is already
@@ -70,5 +70,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the end of the integration flow. 

--- a/doc/connecting/topics/p_adding-dropbox-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-middle.adoc
@@ -4,22 +4,17 @@
 [id='adding-dropbox-connection-middle_{context}']
 = Accessing Dropbox in the middle of an integration
 
-To upload a file to Dropbox in the middle of an integration,
-add a Dropbox connection between the start and 
-finish connections. 
+To upload a file to Dropbox in the middle of a flow,
+add a Dropbox connection to the middle of the flow. 
 
 .Prerequisites
 * You created a Dropbox connection.
-* You are creating or editing an integration.
-* The integration already has its start and finish connections.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step.
 
 .Procedure
 
-. In the integration visualization panel on the left, 
-hover over the plus sign that is in the location
-where you want to add a Dropbox connection.
-. In the popup, click *Add a connection*.
-. On the *Choose a Connection* page, click the Dropbox connection that you 
+. Click the Dropbox connection that you 
 want the integration to use. 
 
 . On the *Choose an Action* page, click *Upload* to 
@@ -27,9 +22,9 @@ add the current integration data to the
 Dropbox account that this connection accesses. To configure this
 action:
 .. In the *Remote Path* field, specify the local path and 
-file name of the file you want to upload. Dropbox stores the file with the 
+file name of the file that you want to upload. Dropbox stores the file with the 
 same path and name. In this release, you can upload only a single file. 
-.. For the *Upload mode*, 
+.. For the *Upload mode*:
 +
 ** Select *Add* to upload a file only when a file with the same name is not already
 in the same Dropbox folder. If a file with the same name is already

--- a/doc/connecting/topics/p_adding-dropbox-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-dropbox-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-dropbox.adoc
 
 [id='adding-dropbox-connection-start_{context}']
-= Starting an integration by obtaining files from Dropbox
+= Obtaining files from Dropbox to trigger integration execution
 
 To start an integration by downloading files from Dropbox, 
 add a Dropbox connection as the start connection.
@@ -61,5 +61,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-ftp-finish-middle-connection.adoc
+++ b/doc/connecting/topics/p_adding-ftp-finish-middle-connection.adoc
@@ -4,28 +4,20 @@
 [id='adding-ftp-finish-middle-connection_{context}']
 = Uploading files to an FTP or SFTP server
 
-To finish an integration by uploading files to an FTP or SFTP server, 
-add an FTP or SFTP connection as the integration's finish connection. You can also
-upload files to an FTP or SFTP server in the middle of an integration. To
-do this, add an FTP or SFTP connection as a middle connection.  
+In an integration, you can upload files to an FTP or SFTP server 
+in the middle of a flow or to finish a simple integration. To do this, 
+add an FTP or SFTP connection to the middle of a flow or as a simple 
+integration's finish connection. 
 
 .Prerequisite
-You created an FTP or SFTP connection. 
+* You created an FTP or SFTP connection. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
-. Start creating the integration.
-. Add and configure the start connection.
-. On the *Choose a Finish Connection* page, do one of the following:
-+
-* To finish an integration by uploading files, click the FTP or SFTP connection that
-you want to use. 
-* To upload files in the middle of an integration, click the connection you
-want to use to finish the integration. Configure that connection. When the
-finish connection is part of the integration, in the left panel, hover over
-the plus sign where you want to add an FTP or SFTP connection and click
-*Add a connection*. Click the FTP or SFTP connection that you want to use
-to upload files in the middle of an integration. 
+. Click the FTP or SFTP connection that you want to use
+to upload files. 
 
 . On the *Choose an Action* page, click *Upload*. 
 . In the *File name expression* field, if you want to upload only one
@@ -39,7 +31,7 @@ file, leave this field blank.
 If the *File name expression* field contains an expression, 
 then the connection stores the specified file in this directory. If the
 *File name expression* field is blank, then the connection uploads to
-this directory all files that were received from the previous integration step. 
+this directory all files that were received from the previous step. 
 . In the *If file exists* field, indicate the behavior when you are 
 uploading a file that has the same path and name as a file that is on
 the server. Accept the default, *Override*, to overwrite

--- a/doc/connecting/topics/p_adding-ftp-start-connection.adoc
+++ b/doc/connecting/topics/p_adding-ftp-start-connection.adoc
@@ -34,7 +34,7 @@ poll. The connection watches this directory for any content and downloads
 all files when it finds any content.
 . In the *Milliseconds before polling starts* field, accept the default 
 of *1000* milliseconds or change the number of milliseconds.
-. In the *Milliseconds before the next poll* field, accept the default
+. In the *Milliseconds before the next poll* field, accept the default 
 of *500* milliseconds or change the number of milliseconds. This is the
 interval between polls. 
 . In the *Delete after download* field, accept the default of *No*
@@ -77,5 +77,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-http-connections.adoc
+++ b/doc/connecting/topics/p_adding-http-connections.adoc
@@ -8,29 +8,15 @@ You can add an HTTP or HTTPS connection to
 any number of integrations.
 
 .Prerequisite
-You created an HTTP or HTTPS connection. 
+* You created an HTTP or HTTPS connection. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a 
+start connection, or to choose a finish connection. 
 
 .Procedure
 
-. Do one of the following:
-+
-* To start an integration by periodically invoking an HTTP or HTTPS endpoint, 
-add an HTTP or HTTPS connection as the integration's start connection. 
-* To finish an integration by invoking an HTTP or HTTPS endpoint once, 
-add an HTTP or HTTPS connection as the integration's finish connection. 
-* In the middle of an integration, to invoke an HTTP or HTTPS endpoint
-once, add an HTTP or HTTPS connection
-after the start connection and before the finish connection. 
-
-+
-If you are creating an integration, {prodname} prompts you to choose
-and configure the start connection, and then choose and configure the
-finish connection. To add a middle connection, hover over the plus sign
-in the left panel at the location where you want to add the connection, 
-and select *Add a connection*. 
-
 . Click the HTTP or HTTPS connection that you want to add to the
-integration. 
+flow. 
 . Select the action that you want the connection to perform:
 + 
 * If you are adding a start connection, then *Periodic invoke URL*
@@ -38,7 +24,7 @@ is the only available action. This action invokes the endpoint at intervals
 that you specify and triggers the integration if the endpoint returns
 any data. 
 
-* If you are adding a finish or middle connection, then *Invoke URL* 
+* If you are adding a middle or finiah connection, then *Invoke URL* 
 is the only available action. This action invokes the endpoint once. 
 
 . In the *URL Path* field, specify the location of the endpoint that you 
@@ -64,7 +50,6 @@ or specify a number and its unit (milliseconds, seconds, minutes, or hours)
 to indicate how long to wait between invocations. 
 
 . Click *Done* to specify the action's input or output type. 
-
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 

--- a/doc/connecting/topics/p_adding-kafka-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-kafka-connection-finish-middle.adoc
@@ -4,29 +4,20 @@
 [id='adding-kafka-connection-finish-middle_{context}']
 = Publishing data to a Kafka broker
 
-In an integration, you can publish data to a Kafka broker to finish
-an integration. To do this, add a Kafka connection as the integration's 
-finish connection. To publish data to a Kafka broker in the
-middle of integration, add a Kafka connection to an integration after
-the start connection and before the finish connection. 
+In an integration, you can publish data to a Kafka broker in 
+the middle of a flow or to finish a simple integration. 
+To do this, add a Kafka connection to the middle of a flow or
+as a simple integration's finish connection. 
 
 .Prerequisites
 * You created a connection to a Kafka broker.
-* You are creating or editing an integration and the integration already
-has a start connection. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection. 
 
 .Procedure
 
-. On the *Choose a Finish Connection* page, do one of the following:
-+
-* To finish an integration by publishing data, click the Kafka connection 
-that you want to use. 
-* To publish data in the middle of an integration, click the connection that you
-want to use to finish the integration. Configure that connection. When the
-finish connection is part of the integration, in the left panel, hover over
-the plus sign where you want to add a Kafka connection and click
-*Add a connection*. Click the Kafka connection that you want to use
-to publish a message in the middle of an integration. 
+. Click the Kafka connection that you want to use
+to publish messages. 
 
 . On the *Choose an Action* page, click *Publish*. 
 . In the *Topic Name* field, click the down carat to display a list

--- a/doc/connecting/topics/p_adding-kafka-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-kafka-connection-start.adoc
@@ -2,9 +2,9 @@
 // as_connecting-to-kafka.adoc
 
 [id='adding-kafka-connection-start_{context}']
-= Obtaining data from a Kafka broker
+= Obtaining data from a Kafka broker to trigger integration execution
 
-To trigger execution of an integration based on receiving data
+To trigger execution of an integration upon receiving data
 from a Kafka broker, add a Kafka connection as the start connection. When 
 the integration is running, the Kafka connection continuously watches for data
 in the Kafka topic that you specify. When the connection finds new data,
@@ -61,5 +61,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-mqtt-connection-finish-middle.adoc
+++ b/doc/connecting/topics/p_adding-mqtt-connection-finish-middle.adoc
@@ -4,29 +4,20 @@
 [id='adding-mqtt-connection-finish-middle_{context}']
 = Publishing a message to an MQTT broker
 
-In an integration, you can publish a message to an MQTT broker to finish
-an integration. To do this, add an MQTT connection as the integration's 
-finish connection. To publish a message to an MQTT broker in the
-middle of integration, add an MQTT connection to an integration after
-the start connection and before the finish connection. 
+In an integration, you can publish a message to an MQTT broker 
+in the middle of a flow or to finish a simple integration. 
+To do this, add an MQTT connection to the middle of a flow or
+as the integration's finish connection.  
 
 .Prerequisites
 * You created an MQTT connection.
-* You are creating or editing an integration and the integration
-already has a start connection. 
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. Or, {prodname} is prompting you to choose a finish connection.  
 
 .Procedure
 
-. On the *Choose a Finish Connection* page, do one of the following:
-+
-* To finish an integration by publishing a message, click the MQTT connection 
-that you want to use. 
-* To publish a message in the middle of an integration, click the connection that you
-want to use to finish the integration. Configure that connection. When the
-finish connection is part of the integration, in the left panel, hover over
-the plus sign where you want to add an MQTT connection and click
-*Add a connection*. Click the MQTT connection that you want to use
-to publish a message in the middle of an integration. 
+. Click the MQTT connection that you want to use
+to publish a message. 
 
 . On the *Choose an Action* page, click *Publish*. 
 . In the *MQTT queue/topic name* field, specify the name of the queue or

--- a/doc/connecting/topics/p_adding-mqtt-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-mqtt-connection-start.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-mqtt.adoc
 
 [id='adding-mqtt-connection-start_{context}']
-= Obtaining a message from an MQTT broker
+= Obtaining a message from an MQTT broker to trigger integration execution
 
 To trigger execution of an integration based on receiving a message
 from an MQTT broker, add an MQTT connection as the start connection. When 
@@ -25,7 +25,6 @@ to receive messages from the queue or topic that you specify.
 . In the *MQTT queue/topic name* field, enter the name of the queue or topic 
 to subscribe to in order to receive data. 
 . Click *Next* to specify the action's output type. 
-
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 
@@ -63,5 +62,4 @@ you hover over the step that processes this type.
 . Click *Done*. 
 
 .Result
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-s3-connection-finish.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-finish.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='adding-s3-connection-finish_{context}']
-= Finishing an integration by adding data to Amazon S3
+= Adding data to Amazon S3 to finish an integration
 
 To finish an integration by copying data to Amazon S3, 
-add an Amazon S3 connection as the finish connection in an integration. 
+add an Amazon S3 connection as a simple integration's finish connection. 
 
 .Prerequisite
 You created an Amazon S3 connection.
@@ -18,7 +18,8 @@ You created an Amazon S3 connection.
 you want to use to finish the integration. 
 
 . Click the action that you want the connection to perform:
-.. *Copy Object* adds one or more objects to the bucket. 
++
+* *Copy Object* adds one or more objects to the bucket. 
 +
 To add one file to the bucket, you can enter its name in the *File Name* field.
 +
@@ -30,7 +31,7 @@ If you used the poll action
 to obtain multiple files and you specify a file name then the *Copy Object*
 action adds only the last file that was received from the poll action. 
 
-.. *Delete Object* deletes an object from the bucket. In the
+* *Delete Object* deletes an object from the bucket. In the
 *File Name* field, specify the name of the object that you want to delete.
 If the specified file is not in the bucket, the integration continues 
 with no error. 
@@ -73,5 +74,4 @@ distinguish this type. This description appears in the data mapper when
 you hover over the step that processes this type. 
 . Click *Done*. 
 
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the end of the integration flow. 

--- a/doc/connecting/topics/p_adding-s3-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-middle.adoc
@@ -5,22 +5,20 @@
 = Adding data to Amazon S3 in the middle of an integration
 
 In the middle of an integration, to add data to Amazon S3, 
-add an Amazon S3 connection between the start and
-finish connections of an integration.
+add an Amazon S3 connection to the middle of a flow.
 
 .Prerequisite
-You created an Amazon S3 connection.
+* You created an Amazon S3 connection.
+* You are creating or editing a flow and {prodname} is prompting you
+to choose a step. 
 
 .Procedure
 
-. Add the start and finish connections.
-. In the left panel, hover over the plus sign that is in the location
-where you want to add the Amazon S3 connection.
-. In the pop-up, click *Add a Connection*.
-. Click the Amazon S3 connection that you want to use as a middle
-connection in the integration.
+. Click the Amazon S3 connection that you want to use in the middle
+of a flow.
 . Click the action that you want the connection to perform:
-.. *Copy Object* adds one or more objects to the bucket. 
++
+* *Copy Object* adds one or more objects to the bucket. 
 +
 To add one file to the bucket, you can enter its name in the *File Name* field.
 +
@@ -32,7 +30,7 @@ If you used the poll action
 to obtain multiple files and you specify a file name then the *Copy Object*
 action adds only the last file that was received from the poll action. 
 
-.. *Delete Object* deletes an object from the bucket. In the
+* *Delete Object* deletes an object from the bucket. In the
 *File Name* field, specify the name of the object that you want to delete.
 If the specified file is not in the bucket, the integration continues 
 with no error. 

--- a/doc/connecting/topics/p_adding-s3-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-s3-connection-start.adoc
@@ -2,10 +2,10 @@
 // as_connecting-to-amazon-s3.adoc
 
 [id='adding-s3-connection-start_{context}']
-= Starting an integration by obtaining data from Amazon S3
+= Obtaining data from Amazon S3 to trigger integration execution
 
 To start an integration by obtaining data from an Amazon S3 bucket, 
-add an Amazon S3 connection as the start connection in an integration.
+add an Amazon S3 connection as a simple integration's start connection.
 
 .Prerequisite
 You created an Amazon S3 connection.
@@ -18,6 +18,7 @@ You created an Amazon S3 connection.
 you want to use to start the integration.
 . On the *Choose an Action* page, click the action that you
 want the connection to perform:
++
 * *Get Object* obtains a file from the bucket that the connection
 accesses. In the *File Name* field, enter the name of the file that you want
 to obtain. If the specified file is not in the bucket, it is a runtime error.
@@ -46,7 +47,6 @@ only when its name starts with that string.
 *Obtain files and then delete them from the bucket*.
 
 . After you configure the action, click *Done* to specify the action's output type. 
-
 
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 
@@ -83,5 +83,4 @@ distinguish this type. This description appears in the data mapper when
 you hover over the step that processes this type. 
 . Click *Done*. 
 
-The connection appears in the integration flow 
-in the location where you added it. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_adding-sf-connections.adoc
+++ b/doc/connecting/topics/p_adding-sf-connections.adoc
@@ -4,34 +4,32 @@
 [id='adding-sf-connections_{context}']
 = Adding a Salesforce connection to an integration
 
-In an integration, you can connect to Salesforce to start or finish the
-integration, or in the middle of an integration. To connect to Salesforce,
+In an integration, you can connect to Salesforce in the middle of 
+a flow or to start or finish a simple integration. To do this,
 add a Salesforce connection to the integration.
 
 .Prerequisites
 * You created a Salesforce connection. 
-* You are creating or updating an integration. If you need to, see the 
-link:{LinkFuseOnlineIntegrationGuide}#procedure-for-creating-an-integration_create[general procedure for creating an integration]
-or see link:{LinkFuseOnlineIntegrationGuide}#updating-integrations_manage[updating integrations].
-* {prodname} is prompting you to select a start connection, a
-finish connection or a middle connection.
+* You are creating or updating an integration. 
+* {prodname} is prompting you to choose a start connection, or to choose a 
+finish connection, or to choose a step.
 
 .Procedure
 
-. On the page that displays available connections, click the Salesforce
-connection that you want to add to the integration. When the integration
-uses the connection you select to connect to Salesforce, {prodname}
+. Click the Salesforce
+connection that you want to add to the flow. When the integration
+uses the connection that you select to connect to Salesforce, {prodname}
 uses the credentials defined in that connection.
 
 . Click the action that you want the selected connection to perform.  Each
 Salesforce connection
-that you add to an integration performs only the action you choose.
+that you add to a flow performs only the action you choose.
 
 . Specify the Salesforce object that the action operates on, for example, it
 might be a contact, lead or price book entry. Click in the *Object* field
 to select from a list of Salesforce objects or enter the name of the object.
 
-. Click *Done* to add the connection to the integration.
+. Click *Done* to add the connection to the flow.
 
 .Result
 The connection appears in the integration flow 

--- a/doc/connecting/topics/p_adding-twitter-connections.adoc
+++ b/doc/connecting/topics/p_adding-twitter-connections.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-twitter.adoc
 
 [id='adding-twitter-connections_{context}']
-= Adding a Twitter connection to an integration
+= Adding a Twitter connection to trigger integration execution
 
 In an integration, a connection to Twitter can trigger execution of
 an integration when a tweet contains your Twitter handle or when 
@@ -16,7 +16,7 @@ prompting you to choose the start connection.
 
 .Procedure
 
-. On the page that displays available connections, click the Twitter
+. Click the Twitter
 connection that you want to add to the integration. When the integration
 uses the selected connection to connect to Twitter, {prodname} uses the
 credentials defined in that connection.
@@ -24,7 +24,7 @@ credentials defined in that connection.
 . Click the action that you want the selected connection to perform.
 A Twitter connection that you add to an integration performs only
 the action you choose.
-
++
 *  *Mention* triggers execution of the integration when a tweet contains
 your handle.
 * *Search* triggers execution of the integration when a tweet contains
@@ -37,5 +37,4 @@ how often to search and keywords to search for.
 . Click *Done* to add the connection to the integration.
 
 .Result
-The connection appears in the integration flow 
-as the start connection. 
+The connection appears at the beginning of the integration flow. 

--- a/doc/connecting/topics/p_connecting-to-proprietary-databases.adoc
+++ b/doc/connecting/topics/p_connecting-to-proprietary-databases.adoc
@@ -23,5 +23,5 @@ link:{LinkFuseOnlineConnectorGuide}#create-database-connection[Creating database
 
 . In an integration, you add the connection to your database. 
 See 
-link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-start_db[Start an integration by accessing a database] or 
-link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-finish-middle_db[Access a database in the middle of an integration or to finish an integration]. 
+link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-start_db[Starting an integration by accessing a database] or 
+link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-finish-middle_db[Accessing a database in the middle of an integration or to finish an integration]. 

--- a/doc/connecting/topics/p_create-replacement-log-connection.adoc
+++ b/doc/connecting/topics/p_create-replacement-log-connection.adoc
@@ -4,7 +4,7 @@
 [id='create-replacement-log-connection_{context}']
 = Creating a replacement log connection
 
-{prodname} provides a log connection that you can add to an integration to
+{prodname} provides a log connection that you can add to a flow to
 log information about each message that an integration processes. If you 
 inadvertently delete the provided log connection, then you can create a 
 new log connection from the *Log* connector that {prodname} provides.  

--- a/doc/connecting/topics/p_create-webhook-connection.adoc
+++ b/doc/connecting/topics/p_create-webhook-connection.adoc
@@ -5,7 +5,7 @@
 = Using the Webhook connection 
 
 {prodname} provides a Webhook connection that you can use in 
-any number of integrations as the start connection. Each time you 
+any number of simple integrations as the start connection. Each time you 
 add this Webhook connection to an integration, {prodname} provides a new 
 random token for use with that integration. You paste this token at the 
 end of your `GET` or `POST` request. You do not need to create  

--- a/doc/connecting/topics/p_creating-kafka-connections.adoc
+++ b/doc/connecting/topics/p_creating-kafka-connections.adoc
@@ -10,7 +10,7 @@ create a connection to Kafka and then add that connection to an
 integration.
 
 .Prerequisite
-You must know the  URI for the Kafka broker that you want to connect to. 
+You must know the URI for the Kafka broker that you want to connect to. 
 
 .Procedure
 

--- a/doc/connecting/topics/p_identify-concur-fields-for-mapping.adoc
+++ b/doc/connecting/topics/p_identify-concur-fields-for-mapping.adoc
@@ -15,11 +15,9 @@ Suppose that an integration starts by executing a SQL stored procedure
 that obtains new project codes. The integration finishes by adding
 new project codes to SAP Concur. 
 The following procedure provides an example of a data mapper step before
-the SAP Concur connection. 
+the SAP Concur connection. The integration visualization flow is on the 
+left and {prodname} is prompting you to choose a step. 
 
-. In {prodname}, in the left panel, hover over the plus sign that is
-between the database connection and the SAP Concur connection to display a pop-up in which
-you click *Add a Step*.
 . Click *Data Mapper*. When the data fields
 appear, the *Sources* panel on the left displays the fields that are
 available from the database connection. In this example, the

--- a/doc/connecting/topics/p_start-with-webhook-connection.adoc
+++ b/doc/connecting/topics/p_start-with-webhook-connection.adoc
@@ -35,7 +35,7 @@ that helps you distinguish this data type.
 .. Click *Done*. 
 . Add the finish connection to the integration. 
 . Add any other needed connections.
+. Add any other needed steps.
 . Immediately after the start connection, add a data mapper step. 
-. Add any other needed steps. 
 . Click *Publish*, give the integration a name and optionally, a description, 
 and click *Publish* again. 

--- a/doc/connecting/topics/r_alternatives-for-populating-email-to-send.adoc
+++ b/doc/connecting/topics/r_alternatives-for-populating-email-to-send.adoc
@@ -4,8 +4,8 @@
 [id='alternatives-for-populating-email-to-send_{context}']
 = Alternatives for populating email to send
 
-A Gmail connection that finishes an integration or that is
-in the middle of an integration sends an email from the Gmail
+A Gmail connection that finishes a simple integration or that is
+in the middle of a flow sends an email from the Gmail
 account that the connection is authorized to access. There are 
 several ways to populate the content of the email that the connection
 sends. Before you add a Gmail connection that sends an email, consider 
@@ -15,7 +15,7 @@ The alternatives for populating an email to send are as follows:
 
 * Add a data mapper step just before the Gmail connection that sends
 an email. In this data mapper step, map data fields that are output 
-from previous integration steps to Gmail connection *Send Email* action fields. 
+from previous steps to Gmail connection *Send Email* action fields. 
 The *Send Email* action fields are: 
 + 
 ** *Email to*
@@ -28,7 +28,7 @@ The *Send Email* action fields are:
 If you add a data mapper step then you can map one, some, or all 
 *Send Email* action fields. 
 
-* When you add a Gmail connection to an integration, configure the 
+* When you add a Gmail connection to a flow, configure the 
 action by specifying values
 in the *Send Email* action fields. 
 You can specify values in one, some, or all fields. 
@@ -50,11 +50,11 @@ For example, suppose you specify
 email field from a previous step to the Gmail *Email to* field. The integration
 always uses `people@redhat.com` and only `people@redhat.com` as the email address. 
 
-When you add a Gmail connection that sends an email, no action configuration
-parameters are required. This is because you might choose to populate an
+When you add a Gmail connection that sends an email, all action configuration
+parameters are optional. This is because you might choose to populate an
 email entirely by mapping integration data to the *Send Email* action
 fields. However, the presence of an email address
-in the *Email to* field, either by configuration specification or by 
+in the *Email to* field, either by action configuration specification or by 
 mapping, is required. Without an email address to send
 the message to, {prodname} generates a runtime error and the integration
 stops executing. 

--- a/doc/connecting/topics/r_comparison-log-step-connection.adoc
+++ b/doc/connecting/topics/r_comparison-log-step-connection.adoc
@@ -8,9 +8,7 @@ To log information about the messages that an integration processes,
 you can add one or more log steps to an integration and/or you can
 add one or more log connections to an integration. 
 
-A log connection cannot be an integration’s start connection. 
-Typically, a log connection is most useful as an integration’s 
-finish connection. 
+A log connection cannot be a simple integration’s start connection. 
 
 The following
 table indicates whether a log step or a log connection 
@@ -44,8 +42,8 @@ can do what you want.
 |image:images/CheckMark.png[Yes]
 |
 
-|Finish an integration.
-|
+|Finish a simple integration.
+|image:images/CheckMark.png[Yes]
 |image:images/CheckMark.png[Yes]
 
 
@@ -56,5 +54,5 @@ can do what you want.
 |====
 
 .Additional resources
-* link:{LinkFuseOnlineIntegrationGuide}#add-log-step_create[Add a log step to an integration] in {NameOfFuseOnlineIntegrationGuide}.
-* link:{LinkFuseOnlineConnectorGuide}#add-log-connection_connect-to-log[Add a log connection to an integration]
+* link:{LinkFuseOnlineIntegrationGuide}#add-log-step_create[Adding a log step to an integration] in {NameOfFuseOnlineIntegrationGuide}.
+* link:{LinkFuseOnlineConnectorGuide}#add-log-connection_connect-to-log[Adding a log connection to an integration]

--- a/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
+++ b/doc/connecting/topics/r_example-sf-servicenow-integration.adoc
@@ -4,7 +4,7 @@
 [id='example-sf-servicenow-integration_{context}']
 = Example Salesforce to ServiceNow integrations
 
-This example describes two integrations:
+This example describes two simple integrations:
 
 * One integration obtains new
 cases from Salesforce and adds them as incidents to ServiceNow. 

--- a/doc/connecting/topics/r_how-requests-are-handled.adoc
+++ b/doc/connecting/topics/r_how-requests-are-handled.adoc
@@ -5,7 +5,7 @@
 = How {prodname} handles HTTP requests
 
 You can specify an HTTP `GET` or `POST` request to trigger execution of
-an integration. Although a `GET` request usually obtains data and a
+a simple integration. Although a `GET` request usually obtains data and a
 `POST` request usually updates data, you can use either request  
 to trigger an integration that does either operation. Any parameters 
 in the request are available for mapping to data fields in the
@@ -24,7 +24,7 @@ return code is `5xx`.
 no data in the HTTP body of the response that contains the status header.
 * Passes the data in the request to the next connection in the integration. 
 
-This means that you can define an integration that is triggered by
+This means that you can define a simple integration that is triggered by
 a `GET` request and that updates data rather than obtaining data. 
-Likewise, you can define an integration that is triggered by a `POST` request 
+Likewise, you can define a simple integration that is triggered by a `POST` request 
 and that obtains data rather than updating data.

--- a/doc/connecting/topics/r_supported-connectors.adoc
+++ b/doc/connecting/topics/r_supported-connectors.adoc
@@ -94,14 +94,14 @@ JDBC driver for that database.
 a Telegram chat bot.
 
 |link:{LinkFuseOnlineConnectorGuide}#triggering-integrations-with-timers_connectors[Timer]
-| Set a simple timer or a `cron` timer to trigger integration execution.
+| Set a simple timer or a `cron` timer to trigger execution of a simple integration.
 
 |link:{LinkFuseOnlineConnectorGuide}#connecting-to-twitter_connectors[Twitter]
-|Trigger execution of an integration upon tweets that mention you or that
-contain data you specify.
+|Trigger execution of a simple integration upon tweets that mention you or that
+contain data that you specify.
 
 |link:{LinkFuseOnlineConnectorGuide}#triggering-integrations-with-http-requests_connectors[Webhook]
-|Trigger integrations with HTTP `GET` or `POST` requests.
+|Trigger execution of simple integrations with HTTP `GET` or `POST` requests.
 
 |===
 


### PR DESCRIPTION
Updates the connector guide to qualify the term "integration" where needed, insert the term "flow" where needed, and update the text to reflect the combination of step cards and connection cards. 