### PR TITLE
fix: OData metadata retrieval when split is requested

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
@@ -101,10 +101,16 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
                     //
                     applySchemaSpecification(entitySchema,  outDataShapeBuilder);
                 } else {
-                    ArraySchema collectionSchema = new ArraySchema();
-                    collectionSchema.set$schema("http://json-schema.org/schema#");
-                    collectionSchema.setItemsSchema(entitySchema);
-                    applySchemaSpecification(collectionSchema, outDataShapeBuilder);
+                    Object givenSplitResult = properties.get(ODataConstants.SPLIT_RESULT);
+                    boolean shouldSplit = Boolean.parseBoolean(String.valueOf(givenSplitResult));
+                    if (shouldSplit) {
+                        applySchemaSpecification(entitySchema, outDataShapeBuilder);
+                    } else {
+                        ArraySchema collectionSchema = new ArraySchema();
+                        collectionSchema.set$schema("http://json-schema.org/schema#");
+                        collectionSchema.setItemsSchema(entitySchema);
+                        applySchemaSpecification(collectionSchema, outDataShapeBuilder);
+                    }
                 }
 
                 inDataShape = inDataShapeBuilder.build();


### PR DESCRIPTION
Takes note of the `splitResult` parameter and changes the JSON schema specification accordingly.

Fixes #4912