### PR TITLE
fix: Partial revert of 53d5aadc2bc5f999fd6c08cd1fd92bf50237068b

### DIFF
--- a/app/s2i/src/main/resources/settings.xml
+++ b/app/s2i/src/main/resources/settings.xml
@@ -100,6 +100,14 @@
     </profile>
   </profiles>
 
+  <mirrors>
+     <mirror>
+       <id>internal.mirror</id>
+       <url>${mavenMirror}</url>
+       <mirrorOf>${mavenMirrorOf}</mirrorOf>
+     </mirror>
+  </mirrors>
+
   <activeProfiles>
     <activeProfile>additional-repositories</activeProfile>
   </activeProfiles>


### PR DESCRIPTION
* Restores the maven mirror options that are required if building s2i
  using a maven mirror, eg. nexus.