### PR TITLE
fix: #4867 Add proper error handling for integration publish process

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeploymentBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeploymentBase.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.syndesis.common.model.WithModificationTimestamps;
 import io.syndesis.common.model.WithResourceId;
 import io.syndesis.common.model.WithVersion;
@@ -44,4 +45,11 @@ public interface IntegrationDeploymentBase extends WithResourceId, WithVersion, 
     }
 
     Optional<String> getStatusMessage();
+
+    IntegrationDeploymentError getError();
+
+    @JsonIgnore
+    default boolean hasError() {
+        return getError() != null;
+    }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeploymentError.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeploymentError.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.server.dao;
+package io.syndesis.common.model.integration;
 
-import io.syndesis.server.dao.manager.DataAccessObject;
-import io.syndesis.common.model.integration.IntegrationDeployment;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
 
-public interface IntegrationDeploymentDao extends DataAccessObject<IntegrationDeployment> {
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationDeploymentError.Builder.class)
+@SuppressWarnings("immutables")
+public interface IntegrationDeploymentError {
 
-    boolean hasError(String id);
+    String getType();
 
-    @Override
-    default Class<IntegrationDeployment> getType() {
-        return IntegrationDeployment.class;
+    String getMessage();
+
+    class Builder extends ImmutableIntegrationDeploymentError.Builder {
+        // allow access to ImmutableIntegrationDeploymentError.Builder
     }
 }

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationErrorHandler.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationErrorHandler.java
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.server.dao;
 
-import io.syndesis.server.dao.manager.DataAccessObject;
-import io.syndesis.common.model.integration.IntegrationDeployment;
+package io.syndesis.integration.api;
 
-public interface IntegrationDeploymentDao extends DataAccessObject<IntegrationDeployment> {
+import java.util.function.Consumer;
 
-    boolean hasError(String id);
-
-    @Override
-    default Class<IntegrationDeployment> getType() {
-        return IntegrationDeployment.class;
-    }
+/**
+ * @author Christoph Deppisch
+ */
+@FunctionalInterface
+public interface IntegrationErrorHandler extends Consumer<Throwable> {
 }

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationProjectGenerator.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationProjectGenerator.java
@@ -26,11 +26,12 @@ public interface IntegrationProjectGenerator {
      * Generate the project files in form of tar input stream
      *
      * @param integration the Integration
+     * @param errorHandler the error handler is provided with potential async errors raised during project generation
      * @return an {@link InputStream} which holds a tar archive and which can be directly used for
      * an S2I build
      * @throws IOException if generating fails
      */
-    InputStream generate(Integration integration) throws IOException;
+    InputStream generate(Integration integration, IntegrationErrorHandler errorHandler) throws IOException;
 
     Properties generateApplicationProperties(Integration deployment);
 

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -149,7 +149,11 @@
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/StateUpdate.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/StateUpdate.java
@@ -19,11 +19,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import io.syndesis.common.model.integration.IntegrationDeploymentError;
 import io.syndesis.common.model.integration.IntegrationDeploymentState;
 
 public class StateUpdate {
 
     private final IntegrationDeploymentState state;
+    private final IntegrationDeploymentError error;
     private final String statusMessage;
     private final Map<String, String> stepsPerformed;
 
@@ -37,9 +39,14 @@ public class StateUpdate {
     }
 
     public StateUpdate(IntegrationDeploymentState state, Map<String, String> stepsPerformed, String statusMessage) {
+        this(state, stepsPerformed, statusMessage, null);
+    }
+
+    public StateUpdate(IntegrationDeploymentState state, Map<String, String> stepsPerformed, String statusMessage, IntegrationDeploymentError error) {
         this.state = state;
         this.stepsPerformed = Optional.ofNullable(stepsPerformed).orElseGet(Collections::emptyMap);
         this.statusMessage = statusMessage;
+        this.error = error;
     }
 
     public IntegrationDeploymentState getState() {
@@ -52,5 +59,9 @@ public class StateUpdate {
 
     public Map<String, String> getStepsPerformed() {
         return stepsPerformed;
+    }
+
+    public IntegrationDeploymentError getError() {
+        return error;
     }
 }

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/IntegrationDeploymentJsonDbDao.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/IntegrationDeploymentJsonDbDao.java
@@ -15,9 +15,9 @@
  */
 package io.syndesis.server.jsondb.dao;
 
+import io.syndesis.common.model.integration.IntegrationDeployment;
 import io.syndesis.server.dao.IntegrationDeploymentDao;
 import io.syndesis.server.jsondb.JsonDB;
-import io.syndesis.common.model.integration.IntegrationDeployment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -33,4 +33,9 @@ public class IntegrationDeploymentJsonDbDao extends JsonDbDao<IntegrationDeploym
         super(jsondb);
     }
 
+    @Override
+    public boolean hasError(String id) {
+        IntegrationDeployment integrationDeployment = fetch(id);
+        return integrationDeployment.hasError();
+    }
 }

--- a/app/ui/src/app/integration/integration_detail/integration-detail.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration-detail.component.html
@@ -46,7 +46,7 @@
                 {{ 'integrations.unpublished' | synI18n }}
               </ng-container>
               <ng-container *ngSwitchCase="'Error'">
-                <span class="pficon pficon-error"></span> {{ 'integrations.' + integration.currentState | synI18n }}<span *ngIf="integration.deploymentVersion"> version {{ integration.deploymentVersion }}</span>
+                <span class="pficon pficon-error-circle-o"></span> {{ 'integrations.' + integration.currentState | synI18n }}<span *ngIf="integration.deploymentVersion"> version {{ integration.deploymentVersion }}</span>
               </ng-container>
             </ng-container>
           </div>

--- a/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.html
+++ b/app/ui/src/app/integration/integration_detail/integration_history/integration-history.component.html
@@ -48,7 +48,15 @@
                   <ng-container *ngSwitchCase="'Unpublished'">
                   </ng-container>
                   <ng-container *ngSwitchCase="'Error'">
-                    <span class="pficon pficon-error"></span>
+                    <span class="pficon pficon-error-circle-o"></span>
+                  </ng-container>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngIf="deployment.version !== integration.deploymentVersion">
+                <ng-container [ngSwitch]="deployment.currentState">
+                  <ng-container *ngSwitchCase="'Error'">
+                    <span class="pficon pficon-error-circle-o"></span>
                   </ng-container>
                 </ng-container>
               </ng-container>

--- a/app/ui/src/app/integration/list/status.component.ts
+++ b/app/ui/src/app/integration/list/status.component.ts
@@ -31,6 +31,8 @@ export class IntegrationStatusComponent {
         return 'primary';
       case 'Unpublished':
         return 'inactive';
+      case 'Error':
+        return 'danger';
       default:
         return currentState;
     }

--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -99,6 +99,7 @@
       "published": "Running",
       "unpublished": "Stopped",
       "pending": "Pending",
+      "error": "Error",
       "cicd-modal": {
         "title": "Mark Integration for Continuous Integration/Continuous Deployment",
         "body": "Tag this integration for release in one or more of the following environments.",


### PR DESCRIPTION
This PR fixes #4867 and adds proper error handling to the integration publishing process. 

When the integration project runtime .tar is created potential errors are now propagated as the deployment state marking the deployment as failed. 

In such a situation the s2i build is still triggered (could not avoid this as the .tar is immediately streamed to s2i build) but the initial project generating error is neither lost nor gets overwritten by subsequent integration state change checks.

I made sure that the deploy step is not triggered in this error situation and that the user is informed via the UI that something went wrong.

![Bildschirmfoto 2019-03-15 um 15 41 46](https://user-images.githubusercontent.com/195264/54440344-cc228380-473a-11e9-9cda-fb308a0bd775.png)

Also the integration deployment overview now properly reflects the deployment history with previous errors and the actual deployment state (pending indicator).

![Bildschirmfoto 2019-03-15 um 14 20 56](https://user-images.githubusercontent.com/195264/54440357-d3499180-473a-11e9-9392-d58f21256d9b.png)

Also fixed some small issues in UI related to error icons and error labels