### PR TITLE
fix: Update version number in dictionary

### DIFF
--- a/app/ui/src/assets/dictionary/en-GB.json
+++ b/app/ui/src/assets/dictionary/en-GB.json
@@ -329,7 +329,7 @@
       "pod-events-url": "{{consoleurl}}/project/{{0}}/browse/pods/{{1}}?tab=events",
       "project": {
         "name": "Syndesis (tokenized)",
-        "version": "7.2"
+        "version": "7.3"
       },
       "ok": "Ok",
       "save": "Save",


### PR DESCRIPTION
This updates the version number in the dictionary file from 7.2 to 7.3. 
Without this update, the doc links that are in the code will point to 7.2 doc when they should point to 7.3 doc. So this MUST be backported to the 7.3 release branch. 