### PR TITLE
user doc: Adds note to use the Settings page for oauth

### DIFF
--- a/doc/connecting/topics/p_create-gmail-connection.adoc
+++ b/doc/connecting/topics/p_create-gmail-connection.adoc
@@ -28,7 +28,7 @@ which takes you to a *Sign in with Gmail* page.
 +
 If *Connect Gmail* does not appear, then your {prodname} environment
 is not registered as a Google client application. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Register with Google].
+link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering with Google].
 When you try to create a Gmail connection and your {prodname} environment 
 is not registered as a Google client application, then {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/connecting/topics/p_create-google-calendar-connection.adoc
+++ b/doc/connecting/topics/p_create-google-calendar-connection.adoc
@@ -30,7 +30,7 @@ which takes you to a Google sign-in page.
 If *Connect Google Calendar* does not appear, then your {prodname} environment
 is not registered as a Google client application with the Google Calendar API
 enabled. See 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Register with Google]. 
+link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering with Google]. 
 When your environment is not registered with
 Google, then when you try to create a Google Calendar connection, {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/connecting/topics/p_create-google-sheets-connection.adoc
+++ b/doc/connecting/topics/p_create-google-sheets-connection.adoc
@@ -31,7 +31,7 @@ which takes you to a Google sign-in page.
 If *Connect Google Sheets* does not appear, then your {prodname} environment
 is not registered as a Google client application with the Google Sheets API
 enabled. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Register with Google].
+link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering with Google].
 When your environment is not registered with
 Google, then when you try to create a Google Sheets connection, {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/shared/p_create-sf-connection.adoc
+++ b/doc/shared/p_create-sf-connection.adoc
@@ -23,6 +23,8 @@ email message that welcomed you to the Red Hat Fuse Online Evaluation program.
 * {prodname} is open in a web browser. 
 * You must have already registered your {prodname} environment as an
 application that can access Salesforce. 
+* You added the Salesforce client ID and client secret that you received
+after registration to the {prodname} *Settings* page. 
 +
 ifeval::["{context}" == "t2sf"]
 If you did not already register {prodname}, see 
@@ -47,6 +49,15 @@ or more connections.
 . Click the *Salesforce* connector.
 . Click *Connect Salesforce* to display a Salesforce authorization page.
 You might need to log in to Salesforce before you see the authorization page.
++
+If *Connect Salesforce* does not appear, then your {prodname} environment
+is not registered as a Salesforce client application. See
+link:{LinkFuseOnlineConnectorGuide}#register-with-sf_salesforce[Registering with Salesforce].
+When you try to create a Salesforce connection and your {prodname} environment 
+is not registered as a Salesforce client application, then {prodname} displays
+multiple fields that prompt for authorization information. While you can
+create a Salesforce connection by entering values in these fields, 
+it is not recommended. 
 +
 [NOTE]
 ====

--- a/doc/shared/p_create-twitter-connection.adoc
+++ b/doc/shared/p_create-twitter-connection.adoc
@@ -21,6 +21,9 @@ email message that welcomed you to the Red Hat Fuse Online Evaluation program.
 * {prodname} is open in a web browser. 
 * You registered your {prodname} environment as an application
 that can access Twitter.
+* You added the Twitter consumer API key and consumer API secret key that you received
+after registration to the {prodname} *Settings* page. 
+
 
 .Procedure
 
@@ -32,6 +35,16 @@ you use to create one or more connections.
 . Click the *Twitter* connector.
 . Click *Connect Twitter* to display a Twitter authorization page.
 You might need to log in to Twitter before you see the authorization page.
++
+If *Connect Twitter* does not appear, then your {prodname} environment
+is not registered as a Twitter client application. See
+link:{LinkFuseOnlineConnectorGuide}#register-with-twitter_twitter[Registering with Twitter].
+When you try to create a Twitter connection and your {prodname} environment 
+is not registered as a Twitter client application, then {prodname} displays
+multiple fields that prompt for authorization information. While you can
+create a Twitter connection by entering values in these fields, 
+it is not recommended. 
+
 . Click *Authorize app* to return to {prodname}.
 . In the *Connection Name* field, enter your choice of a name that
 helps you distinguish this connection from any other connections.


### PR DESCRIPTION
Copies caution that was already in place for Google connections, to Twitter and Salesforce. This is the caution that when you go to create a connection, if you see the specific authorization fields, that while you can enter values in these fields and create a connection, it is not recommended. 