### PR TITLE
fix: #4905 #4879 Data shapes for aggregate step mixed up

### DIFF
--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -718,8 +718,8 @@ export class CurrentFlowService {
         const subsequent = this.getSubsequentStepWithDataShape(position);
         this.fetchStepDescriptor(
           step,
-          previous.action.descriptor.outputDataShape,
           subsequent.action.descriptor.inputDataShape,
+          previous.action.descriptor.outputDataShape,
           then
         );
         break;


### PR DESCRIPTION
Input and output shape were mixed up when lookup aggregate step meta data