### PR TITLE
fix: #4905 #4879 Data shapes for aggregate step mixed up

### DIFF
--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -716,8 +716,8 @@ export class CurrentFlowService {
         const subsequent = this.getSubsequentStepWithDataShape(position);
         this.fetchStepDescriptor(
           step,
-          previous.action.descriptor.outputDataShape,
           subsequent.action.descriptor.inputDataShape,
+          previous.action.descriptor.outputDataShape,
           then
         );
         break;


### PR DESCRIPTION
(cherry picked from commit 7cb45f800bf642fd6eb96f329d4ccb3015692ff9)

backport fix to 1.6.x