### PR TITLE
fix(styles): ensure main page section container applies correct bg color

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -36,7 +36,7 @@ body.cards-pf {
 .pf-c-page__main {
   z-index: 100;
   .pf-c-page__main-section {
-    background-color: #ededed;
+    background-color: $color-pf-custom-gray;
     margin-top: 76px;
     overflow: auto;
     padding-top: 0;


### PR DESCRIPTION
This PR updates `pf-c-page__main-section` to use the proper color reference so that the page background isn't different between various views of the app.

Should help close https://github.com/syndesisio/syndesis/issues/4765