### PR TITLE
fix: hide the log connection in favor of the log step

### DIFF
--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -237,3 +237,6 @@ export interface DescriptorRequest {
   inputShape: DataShape;
   outputShape: DataShape;
 }
+
+export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';
+export const HIDE_FROM_CONNECTION_PAGES = 'hide-from-connection-pages';

--- a/app/ui/src/app/store/connection/connection.store.ts
+++ b/app/ui/src/app/store/connection/connection.store.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { Connections, Connection } from '@syndesis/ui/platform';
+import {
+  Connections,
+  Connection,
+  HIDE_FROM_CONNECTION_PAGES,
+} from '@syndesis/ui/platform';
 import { ConnectionService } from '@syndesis/ui/store/connection/connection.service';
 
 import { AbstractStore } from '@syndesis/ui/store/entity/entity.store';
@@ -24,7 +28,8 @@ export class ConnectionStore extends AbstractStore<
 
   get listVisible() {
     // Returns the list of visible connections
-    return this.list.map(lst => lst.filter(c => !c.metadata || !c.metadata['hide-from-connection-pages']));
+    return this.list.map(lst =>
+      lst.filter(c => !c.metadata || !c.metadata[HIDE_FROM_CONNECTION_PAGES])
+    );
   }
-
 }

--- a/app/ui/src/app/store/connector/connector.store.ts
+++ b/app/ui/src/app/store/connector/connector.store.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { Connectors, Connector } from '@syndesis/ui/platform';
+import {
+  Connectors,
+  Connector,
+  HIDE_FROM_CONNECTION_PAGES,
+} from '@syndesis/ui/platform';
 
 import { AbstractStore } from '@syndesis/ui/store/entity/entity.store';
 import { EventsService } from '@syndesis/ui/store/entity/events.service';
@@ -32,6 +36,8 @@ export class ConnectorStore extends AbstractStore<
   }
 
   get listVisible() {
-    return this.list.map(lst => lst.filter(c => !c.metadata || !c.metadata['hide-from-connection-pages']));
+    return this.list.map(lst =>
+      lst.filter(c => !c.metadata || !c.metadata[HIDE_FROM_CONNECTION_PAGES])
+    );
   }
 }


### PR DESCRIPTION
 fixes #4935 

Please make sure that this PR is indeed hiding the thing we want to hide, for reference:

![image](https://user-images.githubusercontent.com/351660/54557849-806a1700-4992-11e9-9dc1-935d27db847c.png)

Also this PR adds support to hide connections/steps via setting `hide-from-step-select` to true in the step or connection's metadata map.

@zregvart @christophd I wonder, should I be checking the connector too for this test?  I thought the connection metadata should be enough.
