### PR TITLE
fix(masthead): remove masthead bg image

### DIFF
--- a/app/ui/src/app/app.component.html
+++ b/app/ui/src/app/app.component.html
@@ -1,20 +1,3 @@
-<div class="pf-c-background-image">
-  <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-    <filter id="image_overlay">
-      <feColorMatrix type="matrix" values="1 0 0 0 0
-              1 0 0 0 0
-              1 0 0 0 0
-              0 0 0 1 0" />
-      <feComponentTransfer color-interpolation-filters="sRGB" result="duotone">
-        <feFuncR type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncR>
-        <feFuncG type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncG>
-        <feFuncB type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncB>
-        <feFuncA type="table" tableValues="0 1"></feFuncA>
-      </feComponentTransfer>
-    </filter>
-  </svg>
-</div>
-
 <div class="pf-c-page" id="page-layout-default-nav">
 
     <pfng-toast-notification-list

--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -24,7 +24,7 @@ body.cards-pf {
 }
 
 .pf-c-page__header {
-  background-color: transparent;
+  background-color: #292e34;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
This PR removes the background image that's visible from the masthead. This change should affect both the productized version as well as upstream Syndesis.

Should help close: #4953

<img width="963" alt="Screen Shot 2019-03-18 at 3 43 33 PM" src="https://user-images.githubusercontent.com/5942899/54559078-91685780-4995-11e9-930e-d3d12357f8b8.png">
