### PR TITLE
refactor(monitoring): Use targetPort instead of port for Prometheus ServiceMonitor resources

### DIFF
--- a/install/addons/syndesis-db-servicemonitor.yml
+++ b/install/addons/syndesis-db-servicemonitor.yml
@@ -11,7 +11,7 @@ metadata:
   name: syndesis-db-metrics
 spec:
   endpoints:
-  - port: metrics
+  - targetPort: metrics
   selector:
     matchLabels:
       syndesis.io/component: syndesis-db

--- a/install/addons/syndesis-meta-servicemonitor.yml
+++ b/install/addons/syndesis-meta-servicemonitor.yml
@@ -11,7 +11,7 @@ metadata:
   name: syndesis-meta
 spec:
   endpoints:
-  - port: prometheus
+  - targetPort: metrics
   selector:
     matchLabels:
       syndesis.io/component: syndesis-meta

--- a/install/addons/syndesis-server-servicemonitor.yml
+++ b/install/addons/syndesis-server-servicemonitor.yml
@@ -11,7 +11,7 @@ metadata:
   name: syndesis-server
 spec:
   endpoints:
-  - port: prometheus
+  - targetPort: metrics
   selector:
     matchLabels:
       syndesis.io/component: syndesis-server

--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -124,11 +124,6 @@
       port: 5432
       protocol: TCP
       targetPort: 5432
-    - name: metrics
-      nodePort: 0
-      port: 9187
-      protocol: TCP
-      targetPort: 9187
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -257,7 +252,7 @@
             initialDelaySeconds: 30
           ports:
           - containerPort: 9187
-            name: prometheus
+            name: metrics
           resources:
             limits:
               memory: 256Mi

--- a/install/generator/04-syndesis-meta.yml.mustache
+++ b/install/generator/04-syndesis-meta.yml.mustache
@@ -13,10 +13,6 @@
       protocol: TCP
       targetPort: 8080
       name: http
-    - port: 8181
-      protocol: TCP
-      targetPort: 8181
-      name: prometheus
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -103,6 +99,8 @@
           - containerPort: 8080
             name: http
             protocol: TCP
+          - containerPort: 8181
+            name: metrics
           - containerPort: 9779
             name: prometheus
             protocol: TCP

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -31,10 +31,6 @@
       protocol: TCP
       targetPort: 8080
       name: http
-    - port: 8181
-      protocol: TCP
-      targetPort: 8181
-      name: prometheus
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -134,6 +130,8 @@
           ports:
           - containerPort: 8080
             name: http
+          - containerPort: 8181
+            name: metrics
           - containerPort: 9779
             name: prometheus
           - containerPort: 8778

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -603,11 +603,6 @@ objects:
       port: 5432
       protocol: TCP
       targetPort: 5432
-    - name: metrics
-      nodePort: 0
-      port: 9187
-      protocol: TCP
-      targetPort: 9187
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -733,7 +728,7 @@ objects:
             initialDelaySeconds: 30
           ports:
           - containerPort: 9187
-            name: prometheus
+            name: metrics
           resources:
             limits:
               memory: 256Mi
@@ -791,10 +786,6 @@ objects:
       protocol: TCP
       targetPort: 8080
       name: http
-    - port: 8181
-      protocol: TCP
-      targetPort: 8181
-      name: prometheus
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -875,6 +866,8 @@ objects:
           - containerPort: 8080
             name: http
             protocol: TCP
+          - containerPort: 8181
+            name: metrics
           - containerPort: 9779
             name: prometheus
             protocol: TCP
@@ -1115,10 +1108,6 @@ objects:
       protocol: TCP
       targetPort: 8080
       name: http
-    - port: 8181
-      protocol: TCP
-      targetPort: 8181
-      name: prometheus
     selector:
       app: syndesis
       syndesis.io/app: syndesis
@@ -1212,6 +1201,8 @@ objects:
           ports:
           - containerPort: 8080
             name: http
+          - containerPort: 8181
+            name: metrics
           - containerPort: 9779
             name: prometheus
           - containerPort: 8778


### PR DESCRIPTION
fixes #4967