### PR TITLE
fix: #4969 Handle aggregate step when no input data shape is provided

### DIFF
--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -719,7 +719,7 @@ export class CurrentFlowService {
         const subsequent = this.getSubsequentStepWithDataShape(position);
         this.fetchStepDescriptor(
           step,
-          subsequent.action.descriptor.inputDataShape,
+          typeof subsequent !== 'undefined' ? subsequent.action.descriptor.inputDataShape : undefined,
           previous.action.descriptor.outputDataShape,
           then
         );


### PR DESCRIPTION
This PR handles integrations where no step subsequent to aggregate provides a proper input shape