### PR TITLE
fix: #4879 Data shape meta lookup (split/aggregate) for user defined specs

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -29,6 +29,7 @@ import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Christoph Deppisch
@@ -47,34 +48,38 @@ class AggregateMetadataHandler implements StepMetadataHandler {
 
     @Override
     public DynamicActionMetadata handle(DynamicActionMetadata metadata) {
-        try {
-            DataShape outputShape = metadata.outputShape();
-            DataShape inputShape = metadata.inputShape();
+        DataShape outputShape = metadata.outputShape();
+        DataShape inputShape = metadata.inputShape();
 
+        try {
             if (metadata.outputShape() != null) {
                 outputShape = adaptOutputShape(new DataShape.Builder()
-                                                        .createFrom(metadata.outputShape())
-                                                        .decompress()
-                                                        .build());
+                        .createFrom(metadata.outputShape())
+                        .decompress()
+                        .build());
             }
+        } catch (IOException e) {
+            LOG.warn("Unable to read input data shape on dynamic meta data inspection", e);
+            LOG.warn("Using original input shape as fallback");
+        }
 
+        try {
             if (metadata.inputShape() != null) {
                 inputShape = adaptInputShape(new DataShape.Builder()
                                                         .createFrom(metadata.inputShape())
                                                         .decompress()
                                                         .build());
             }
-
-            return new DynamicActionMetadata.Builder()
-                    .createFrom(metadata)
-                    .inputShape(inputShape)
-                    .outputShape(outputShape)
-                    .build();
         } catch (IOException e) {
             LOG.warn("Unable to read output data shape on dynamic meta data inspection", e);
+            LOG.warn("Using original output shape as fallback");
         }
 
-        return metadata;
+        return new DynamicActionMetadata.Builder()
+                .createFrom(metadata)
+                .inputShape(inputShape)
+                .outputShape(outputShape)
+                .build();
     }
 
     DataShape adaptInputShape(DataShape dataShape) throws IOException {
@@ -93,31 +98,42 @@ class AggregateMetadataHandler implements StepMetadataHandler {
 
         DataShape collectionShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_COLLECTION).orElse(dataShape);
 
-        if (collectionShape.getKind().equals(DataShapeKinds.JSON_SCHEMA)) {
-            String specification = collectionShape.getSpecification();
-            JsonSchema schema = Json.reader().forType(JsonSchema.class).readValue(specification);
+        String specification = collectionShape.getSpecification();
+        if (StringUtils.hasText(specification)) {
+            if (collectionShape.getKind() == DataShapeKinds.JSON_SCHEMA) {
+                JsonSchema schema = Json.reader().forType(JsonSchema.class).readValue(specification);
 
-            if (schema.isArraySchema()) {
-                ArraySchema.Items items = ((ArraySchema) schema).getItems();
-                JsonSchema itemSchema = items.asSingleItems().getSchema();
-                itemSchema.set$schema(schema.get$schema());
-                if (items.isSingleItems()) {
+                if (schema.isArraySchema()) {
+                    ArraySchema.Items items = ((ArraySchema) schema).getItems();
+                    JsonSchema itemSchema = items.asSingleItems().getSchema();
+                    itemSchema.set$schema(schema.get$schema());
+                    if (items.isSingleItems()) {
+                        return new DataShape.Builder().createFrom(collectionShape)
+                                .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
+                                .specification(Json.writer().writeValueAsString(itemSchema))
+                                .addAllVariants(extractVariants(dataShape, collectionShape, VARIANT_COLLECTION))
+                                .build();
+                    }
+                } else {
                     return new DataShape.Builder().createFrom(collectionShape)
-                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
-                                                        .specification(Json.writer().writeValueAsString(itemSchema))
-                                                        .addAllVariants(extractVariants(dataShape, collectionShape, VARIANT_COLLECTION))
-                                                        .build();
+                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
+                            .build();
                 }
-            }
-        } else if (collectionShape.getKind().equals(DataShapeKinds.JSON_INSTANCE)) {
-            String specification = collectionShape.getSpecification();
-            List<Object> items = Json.reader().forType(List.class).readValue(specification);
-            if (!items.isEmpty()) {
-                return new DataShape.Builder().createFrom(collectionShape)
-                                                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
-                                                        .specification(Json.writer().writeValueAsString(items.get(0)))
-                                                        .addAllVariants(extractVariants(dataShape, collectionShape, VARIANT_COLLECTION))
-                                                        .build();
+            } else if (collectionShape.getKind() == DataShapeKinds.JSON_INSTANCE) {
+                if (isJsonInstanceArraySpec(specification)) {
+                    List<Object> items = Json.reader().forType(List.class).readValue(specification);
+                    if (!items.isEmpty()) {
+                        return new DataShape.Builder().createFrom(collectionShape)
+                                .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
+                                .specification(Json.writer().writeValueAsString(items.get(0)))
+                                .addAllVariants(extractVariants(dataShape, collectionShape, VARIANT_COLLECTION))
+                                .build();
+                    }
+                } else {
+                    return new DataShape.Builder().createFrom(collectionShape)
+                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_ELEMENT)
+                            .build();
+                }
             }
         }
 
@@ -138,28 +154,40 @@ class AggregateMetadataHandler implements StepMetadataHandler {
         }
 
         DataShape singleElementShape = dataShape.findVariantByMeta(VARIANT_METADATA_KEY, VARIANT_ELEMENT).orElse(dataShape);
+        String specification = singleElementShape.getSpecification();
+        if (StringUtils.hasText(specification)) {
+            if (singleElementShape.getKind() == DataShapeKinds.JSON_SCHEMA) {
+                JsonSchema schema = Json.reader().forType(JsonSchema.class).readValue(specification);
 
-        if (singleElementShape.getKind().equals(DataShapeKinds.JSON_SCHEMA)) {
-            String specification = singleElementShape.getSpecification();
-            JsonSchema schema = Json.reader().forType(JsonSchema.class).readValue(specification);
+                if (schema.isArraySchema()) {
+                    return new DataShape.Builder().createFrom(singleElementShape)
+                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
+                            .build();
+                }
 
-            ArraySchema collectionSchema = new ArraySchema();
-            collectionSchema.set$schema(Optional.ofNullable(schema.get$schema()).orElse(JSON_SCHEMA_ORG_SCHEMA));
-            collectionSchema.setItemsSchema(schema);
-            schema.set$schema(null);
+                ArraySchema collectionSchema = new ArraySchema();
+                collectionSchema.set$schema(Optional.ofNullable(schema.get$schema()).orElse(JSON_SCHEMA_ORG_SCHEMA));
+                collectionSchema.setItemsSchema(schema);
+                schema.set$schema(null);
 
-            return new DataShape.Builder().createFrom(singleElementShape)
-                                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
-                                            .specification(Json.writer().writeValueAsString(collectionSchema))
-                                            .addAllVariants(extractVariants(dataShape, singleElementShape, VARIANT_ELEMENT))
-                                            .build();
-        } else if (singleElementShape.getKind().equals(DataShapeKinds.JSON_INSTANCE)) {
-            String specification = singleElementShape.getSpecification();
-            return new DataShape.Builder().createFrom(singleElementShape)
-                                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
-                                            .specification("[" + specification + "]")
-                                            .addAllVariants(extractVariants(dataShape, singleElementShape, VARIANT_ELEMENT))
-                                            .build();
+                return new DataShape.Builder().createFrom(singleElementShape)
+                        .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
+                        .specification(Json.writer().writeValueAsString(collectionSchema))
+                        .addAllVariants(extractVariants(dataShape, singleElementShape, VARIANT_ELEMENT))
+                        .build();
+            } else if (singleElementShape.getKind() == DataShapeKinds.JSON_INSTANCE) {
+                if (isJsonInstanceArraySpec(specification)) {
+                    return new DataShape.Builder().createFrom(singleElementShape)
+                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
+                            .build();
+                } else {
+                    return new DataShape.Builder().createFrom(singleElementShape)
+                            .putMetadata(VARIANT_METADATA_KEY, VARIANT_COLLECTION)
+                            .specification("[" + specification + "]")
+                            .addAllVariants(extractVariants(dataShape, singleElementShape, VARIANT_ELEMENT))
+                            .build();
+                }
+            }
         }
 
         return dataShape;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
@@ -77,4 +77,13 @@ interface StepMetadataHandler {
             return variants;
         }
     }
+
+    /**
+     * Checks specification to be a proper Json array instance specification.
+     * @param specification
+     * @return
+     */
+    default boolean isJsonInstanceArraySpec(String specification) {
+        return specification.trim().startsWith("[") && specification.trim().endsWith("]");
+    }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -90,22 +90,7 @@ public class AggregateMetadataHandlerTest {
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
                         .build())
-                .outputShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.JAVA)
-                        .specification(getSpecification("person-spec.json"))
-                        .description("person")
-                        .type(Person.class.getName())
-                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
-                        .addVariant(new DataShape.Builder()
-                                .kind(DataShapeKinds.JAVA)
-                                .specification(getSpecification("person-list-spec.json"))
-                                .collectionType("List")
-                                .type(Person.class.getName())
-                                .collectionClassName(List.class.getName())
-                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
-                                .build())
-                        .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
-                        .build())
+                .outputShape(StepActionHandler.NO_SHAPE)
                 .build();
 
         DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
@@ -119,18 +104,11 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals("person-list", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
-        Assert.assertNotNull(enrichedMetadata.outputShape());
-        Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
-        Assert.assertEquals(getSpecification("person-list-spec.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
-        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
-        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
-        Assert.assertEquals("person", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
+        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.outputShape());
     }
 
     @Test
-    public void shouldExtractJsonSchemaCollectionVariant() throws IOException {
+    public void shouldExtractJsonSchemaOutputCollectionVariant() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(StepActionHandler.NO_SHAPE)
                 .outputShape(new DataShape.Builder()
@@ -183,22 +161,7 @@ public class AggregateMetadataHandlerTest {
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
-                .outputShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.JSON_SCHEMA)
-                        .specification(getSpecification("person-schema.json"))
-                        .description("person-schema")
-                        .type(Person.class.getName())
-                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
-                        .addVariant(new DataShape.Builder()
-                                .kind(DataShapeKinds.JSON_SCHEMA)
-                                .specification(getSpecification("person-list-schema.json"))
-                                .collectionType("List")
-                                .type(Person.class.getName())
-                                .collectionClassName(List.class.getName())
-                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
-                                .build())
-                        .addVariant(dummyShape(DataShapeKinds.JAVA))
-                        .build())
+                .outputShape(StepActionHandler.NO_SHAPE)
                 .build();
 
         DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
@@ -212,18 +175,11 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals("person-list-schema", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
 
-        Assert.assertNotNull(enrichedMetadata.outputShape());
-        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
-        Assert.assertEquals(getSpecification("person-list-schema.json"), enrichedMetadata.outputShape().getSpecification());
-        Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
-        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
-        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
-        Assert.assertEquals("person-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
+        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.outputShape());
     }
 
     @Test
-    public void shouldAutoExtractJsonSchemaVariants() throws IOException {
+    public void shouldAutoConvertAndExtractJsonSchemaVariants() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_SCHEMA)
@@ -248,6 +204,7 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-schema.json")), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -256,6 +213,7 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-schema.json")), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -263,7 +221,45 @@ public class AggregateMetadataHandlerTest {
     }
 
     @Test
-    public void shouldExtractJsonInstanceCollectionVariant() throws IOException {
+    public void shouldExtractAlreadyGivenJsonSchemaVariants() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-schema.json"))
+                        .description("person-schema")
+                        .type(Person.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-list-schema.json"))
+                        .description("person-list-schema")
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(metadata.inputShape().getSpecification(), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals(metadata.outputShape().getSpecification(), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+    }
+
+    @Test
+    public void shouldExtractJsonInstanceOutputCollectionVariant() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(StepActionHandler.NO_SHAPE)
                 .outputShape(new DataShape.Builder()
@@ -298,7 +294,43 @@ public class AggregateMetadataHandlerTest {
     }
 
     @Test
-    public void shouldAutoExtractJsonInstanceVariants() throws IOException {
+    public void shouldExtractJsonInstanceInputElementVariant() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-list-instance.json"))
+                        .description("person-list-instance")
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
+                        .addVariant(new DataShape.Builder()
+                                .kind(DataShapeKinds.JSON_SCHEMA)
+                                .specification(getSpecification("person-instance.json"))
+                                .type(Person.class.getName())
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
+                                .build())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .outputShape(StepActionHandler.NO_SHAPE)
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
+        Assert.assertEquals(getSpecification("person-instance.json"), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals("person-list-instance", enrichedMetadata.inputShape().getVariants().get(1).getDescription());
+
+        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.outputShape());
+    }
+
+    @Test
+    public void shouldAutoConvertAndExtractJsonInstanceVariants() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(new DataShape.Builder()
                         .kind(DataShapeKinds.JSON_INSTANCE)
@@ -323,6 +355,7 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.inputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.inputShape().getSpecification()));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(2, enrichedMetadata.inputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.inputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -331,10 +364,49 @@ public class AggregateMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-instance.json")), StringUtils.trimAllWhitespace(enrichedMetadata.outputShape().getSpecification()));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals("person-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
+    }
+
+    @Test
+    public void shouldExtractAlreadyGivenJsonInstanceVariants() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification(getSpecification("person-instance.json"))
+                        .description("person-instance")
+                        .type(Person.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification(getSpecification("person-list-instance.json"))
+                        .description("person-list-instance")
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(metadata.inputShape().getSpecification(), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals(metadata.outputShape().getSpecification(), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
+        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
     }
 
     private DataShape dummyShape(DataShapeKinds kind) {

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
@@ -47,12 +47,12 @@ public class SplitMetadataHandlerTest {
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
-                        .putMetadata("variant", "collection")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JAVA)
                                 .specification(getSpecification("person-spec.json"))
                                 .type(Person.class.getName())
-                                .putMetadata("variant", "element")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JSON_INSTANCE))
                         .build())
@@ -63,7 +63,7 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JAVA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-spec.json"), enrichedMetadata.outputShape().getSpecification());
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -82,12 +82,12 @@ public class SplitMetadataHandlerTest {
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
-                        .putMetadata("variant", "collection")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_SCHEMA)
                                 .specification(getSpecification("person-schema.json"))
                                 .type(Person.class.getName())
-                                .putMetadata("variant", "element")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -98,7 +98,7 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-schema.json"), enrichedMetadata.outputShape().getSpecification());
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -107,7 +107,7 @@ public class SplitMetadataHandlerTest {
     }
 
     @Test
-    public void shouldAutoExtractJsonSchemaElement() throws IOException {
+    public void shouldAutoConvertAndExtractJsonSchemaElement() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(StepActionHandler.NO_SHAPE)
                 .outputShape(new DataShape.Builder()
@@ -127,10 +127,35 @@ public class SplitMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-schema.json")), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals("person-list-schema", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
+    }
+
+    @Test
+    public void shouldExtractAlreadyGivenJsonSchemaVariant() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(StepActionHandler.NO_SHAPE)
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-schema.json"))
+                        .description("person-schema")
+                        .type(Person.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals(metadata.outputShape().getSpecification(), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
+        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
     }
 
     @Test
@@ -144,12 +169,12 @@ public class SplitMetadataHandlerTest {
                         .collectionType("List")
                         .type(Person.class.getName())
                         .collectionClassName(List.class.getName())
-                        .putMetadata("variant", "collection")
+                        .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_COLLECTION)
                         .addVariant(new DataShape.Builder()
                                 .kind(DataShapeKinds.JSON_INSTANCE)
                                 .specification(getSpecification("person-instance.json"))
                                 .type(Person.class.getName())
-                                .putMetadata("variant", "element")
+                                .putMetadata(StepMetadataHandler.VARIANT_METADATA_KEY, StepMetadataHandler.VARIANT_ELEMENT)
                                 .build())
                         .addVariant(dummyShape(DataShapeKinds.JAVA))
                         .build())
@@ -160,7 +185,7 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
-        Assert.assertEquals("element", enrichedMetadata.outputShape().getMetadata("variant").orElse(""));
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(getSpecification("person-instance.json"), enrichedMetadata.outputShape().getSpecification());
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
@@ -169,7 +194,7 @@ public class SplitMetadataHandlerTest {
     }
 
     @Test
-    public void shouldAutoExtractJsonInstanceElement() throws IOException {
+    public void shouldAutoConvertAndExtractJsonInstanceElement() throws IOException {
         DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
                 .inputShape(StepActionHandler.NO_SHAPE)
                 .outputShape(new DataShape.Builder()
@@ -189,10 +214,35 @@ public class SplitMetadataHandlerTest {
         Assert.assertNotNull(enrichedMetadata.outputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
         Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-instance.json")), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
         Assert.assertEquals(2, enrichedMetadata.outputShape().getVariants().size());
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals(StepMetadataHandler.VARIANT_COLLECTION, enrichedMetadata.outputShape().getVariants().get(1).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
         Assert.assertEquals("person-list-instance", enrichedMetadata.outputShape().getVariants().get(1).getDescription());
+    }
+
+    @Test
+    public void shouldExtractAlreadyGivenJsonInstanceVariant() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(StepActionHandler.NO_SHAPE)
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification(getSpecification("person-instance.json"))
+                        .description("person-instance")
+                        .type(Person.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertEquals(StepActionHandler.NO_SHAPE, enrichedMetadata.inputShape());
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals(metadata.outputShape().getSpecification(), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(StepMetadataHandler.VARIANT_ELEMENT, enrichedMetadata.outputShape().getMetadata(StepMetadataHandler.VARIANT_METADATA_KEY).orElse(""));
+        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(StepMetadataHandler.VARIANT_METADATA_KEY));
     }
 
     private DataShape dummyShape(DataShapeKinds kind) {


### PR DESCRIPTION
(cherry picked from commit d715df0bae715622ec1350e564a5069bbe8e9bf7)

backport fix to 1.6.x