### PR TITLE
fix: don't trigger data shape reconciliation when the mapper initializes

### DIFF
--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -43,7 +43,7 @@ import {
   IndexedStep,
 } from '../../edit-page.models';
 import { SPLIT, AGGREGATE } from '@syndesis/ui/store';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, tap } from 'rxjs/operators';
 /*
  * Example host component:
  *
@@ -326,6 +326,7 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
       kind: INTEGRATION_SET_ACTION,
       position: this.position,
       stepKind: 'mapper',
+      skipReconcile: true,
       action: {
         actionType: 'step',
         descriptor: {
@@ -380,7 +381,12 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
   private registerSaveMappingHandler(): Subscription {
     //subscribe to mapping save callback from data mapper
     return this.cfg.mappingService.saveMappingOutput$
-      .pipe(debounceTime(500))
+      .pipe(
+        tap(saveHandler =>
+          this.cfg.mappingService.handleMappingSaveSuccess(saveHandler)
+        ),
+        debounceTime(500)
+      )
       .subscribe((saveHandler: Function) => {
         const json = this.cfg.mappingService.serializeMappingsToJSON();
         this.mappings.emit(JSON.stringify(json));


### PR DESCRIPTION
fixes #4960