### PR TITLE
fix: #4969 Handle aggregate step when no input data shape is provided

### DIFF
--- a/app/ui/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui/src/app/integration/edit-page/current-flow.service.ts
@@ -716,7 +716,7 @@ export class CurrentFlowService {
         const subsequent = this.getSubsequentStepWithDataShape(position);
         this.fetchStepDescriptor(
           step,
-          subsequent.action.descriptor.inputDataShape,
+          typeof subsequent !== 'undefined' ? subsequent.action.descriptor.inputDataShape : undefined,
           previous.action.descriptor.outputDataShape,
           then
         );


### PR DESCRIPTION
(cherry picked from commit 314c1923ff0bf908c8e04536362e3159c049fada)

backport fix to 1.6.x