### PR TITLE
fix(#4889): Redo input DataShape of OData Delete

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -32,7 +32,7 @@ import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
-final class ODataComponent extends ComponentProxyComponent implements ODataConstants {
+public final class ODataComponent extends ComponentProxyComponent implements ODataConstants {
 
     private static final Pattern NUMBER_ONLY_PATTERN = Pattern.compile("-?\\d+");
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataDeleteCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataDeleteCustomizer.java
@@ -20,6 +20,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.olingo4.internal.Olingo4Constants;
 import org.apache.camel.util.ObjectHelper;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class ODataDeleteCustomizer extends AbstractProducerCustomizer {
 
@@ -27,8 +28,12 @@ public class ODataDeleteCustomizer extends AbstractProducerCustomizer {
     protected void beforeProducer(Exchange exchange) throws IOException {
         Message in = exchange.getIn();
 
-        String keyPredicate = in.getBody(String.class);
-        if (! ObjectHelper.isEmpty(keyPredicate)) {
+        String body = in.getBody(String.class);
+        JsonNode node = OBJECT_MAPPER.readTree(body);
+        JsonNode keyPredicateNode = node.get(KEY_PREDICATE);
+
+        if (! ObjectHelper.isEmpty(keyPredicateNode)) {
+            String keyPredicate = keyPredicateNode.asText();
             in.setHeader(Olingo4Constants.PROPERTY_PREFIX + KEY_PREDICATE, keyPredicate);
         }
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadCustomizer.java
@@ -18,12 +18,25 @@ package io.syndesis.connector.odata.customizer;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.camel.Exchange;
+import io.syndesis.connector.odata.component.ODataComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 public class ODataReadCustomizer extends AbstractODataCustomizer {
 
+    /*
+     * The component subsumes the split property from the options map
+     * and makes it available via a getter, hence the need to look at the
+     * component rather than the options
+     */
+    private boolean hasSplitProperty(ComponentProxyComponent component) {
+        return
+            (component instanceof ODataComponent) &&
+                ((ODataComponent)component).isSplitResult();
+    }
+
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        setSplit(hasSplitProperty(component));
         component.setBeforeConsumer(this::beforeConsumer);
     }
 

--- a/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
+++ b/app/connector/odata/src/main/resources/META-INF/syndesis/connector/odata.json
@@ -170,9 +170,7 @@
         ],
         "connectorFactory": "io.syndesis.connector.odata.component.ODataComponentFactory",
         "inputDataShape": {
-          "kind": "java",
-          "name": "ODataEntityID",
-          "type": "java.lang.String"
+          "kind": "json-schema"
         },
         "outputDataShape": {
           "kind": "json-instance"

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -84,9 +84,9 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
-        testListResult(result, 1, TEST_SERVER_DATA_2);
-        testListResult(result, 2, TEST_SERVER_DATA_3);
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
     }
 
     @Test
@@ -110,9 +110,9 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
-        testListResult(result, 1, TEST_SERVER_DATA_2);
-        testListResult(result, 2, TEST_SERVER_DATA_3);
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
     }
 
     /**
@@ -137,9 +137,9 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
-        testListResult(result, 1, TEST_SERVER_DATA_2);
-        testListResult(result, 2, TEST_SERVER_DATA_3);
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
     }
 
     /**
@@ -169,9 +169,9 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
-        testListResult(result, 1, TEST_SERVER_DATA_2);
-        testListResult(result, 2, TEST_SERVER_DATA_3);
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_1);
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_1);
     }
 
     /**
@@ -227,7 +227,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_1);
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_1);
     }
 
     @Test
@@ -253,7 +253,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
     }
 
     @Test
@@ -278,7 +278,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
     }
 
     @Test
@@ -300,7 +300,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
     @SuppressWarnings( "unchecked" )
@@ -322,10 +322,10 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        List<String> json = extractJsonFromExchgMsg(result, 0, List.class);
-        assertEquals(1, json.size());
+        String json = extractJsonFromExchgMsg(result, 0, String.class);
+        assertNotNull(json);
         String expected = testData(TEST_SERVER_DATA_1_WITH_COUNT);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
     }
 
     @SuppressWarnings( "unchecked" )
@@ -348,15 +348,15 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        List<String> json = extractJsonFromExchgMsg(result, 0, List.class);
-        assertEquals(1, json.size());
+        String json = extractJsonFromExchgMsg(result, 0, String.class);
+        assertNotNull(json);
         String expected = testData(TEST_SERVER_DATA_2);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
 
-        json = extractJsonFromExchgMsg(result, 1, List.class);
-        assertEquals(1, json.size());
+        json = extractJsonFromExchgMsg(result, 1, String.class);
+        assertNotNull(json);
         expected = testData(TEST_SERVER_DATA_1);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
     }
 
     @Test
@@ -377,7 +377,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
     @Test
@@ -398,7 +398,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
     @Test
@@ -422,9 +422,9 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
-        testListResult(result, 1, TEST_SERVER_DATA_2);
-        testListResult(result, 2, TEST_SERVER_DATA_3);
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
 
         Olingo4Endpoint olingo4Endpoint = context.getEndpoint(OLINGO4_READ_ENDPOINT, Olingo4Endpoint.class);
         assertNotNull(olingo4Endpoint);
@@ -462,29 +462,29 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         result.assertIsSatisfied();
 
         for (int i = 0; i < expectedMsgCount; ++i) {
-            List<String> json = extractJsonFromExchgMsg(result, i, List.class);
-            assertEquals(1, json.size());
+            String json = extractJsonFromExchgMsg(result, i, String.class);
+            assertNotNull(json);
 
             String expected;
             switch (i) {
                 case 0:
                     expected = testData(TEST_SERVER_DATA_1);
-                    JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
                     break;
                 case 1:
                     expected = testData(TEST_SERVER_DATA_2);
-                    JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
                     break;
                 case 2:
                     expected = testData(TEST_SERVER_DATA_3);
-                    JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
                     break;
                 default:
                     //
                     // Subsequent polling messages should be empty
                     //
                     expected = testData(TEST_SERVER_DATA_EMPTY);
-                    JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
             }
         }
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
@@ -218,6 +218,89 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         checkTestServerSchemaMap(checkShape(metadata.outputShape, ObjectSchema.class));
     }
 
+    @Test
+    public void testDeleteMetaDataRetrieval() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
+
+        String resourcePath = "Products";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(METHOD_NAME, Methods.DELETE.id());
+        parameters.put(SERVICE_URI, defaultTestServer.servicePlainUri());
+        parameters.put(RESOURCE_PATH, resourcePath);
+
+        String componentId = "odata";
+        String actionId = "io.syndesis:" + Methods.DELETE.connectorId();
+
+        SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
+        assertNotNull(metadata);
+
+        Map<String, List<PropertyPair>> properties = metadata.properties;
+        assertFalse(properties.isEmpty());
+
+        //
+        // The method names are important for collecting prior
+        // to the filling in of the integration step (values such as resource etc...)
+        //
+        List<PropertyPair> resourcePaths = properties.get(RESOURCE_PATH);
+        assertNotNull(resourcePaths);
+        assertFalse(resourcePaths.isEmpty());
+
+        PropertyPair pair = resourcePaths.get(0);
+        assertNotNull(pair);
+        assertEquals(resourcePath, pair.getValue());
+
+        DataShape inputShape = metadata.inputShape;
+        Map<String, JsonSchema> schemaMap = checkShape(inputShape, ObjectSchema.class);
+        assertNotNull(schemaMap.get(KEY_PREDICATE));
+
+        DataShape outputShape = metadata.outputShape;
+        assertEquals(DataShapeKinds.JSON_INSTANCE, outputShape.getKind());
+    }
+
+    @Test
+    public void testUpdateMetaDataRetrieval() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
+    
+        String resourcePath = "Products";
+    
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(METHOD_NAME, Methods.PATCH.id());
+        parameters.put(SERVICE_URI, defaultTestServer.servicePlainUri());
+        parameters.put(RESOURCE_PATH, resourcePath);
+    
+        String componentId = "odata";
+        String actionId = "io.syndesis:" + Methods.PATCH.connectorId();
+    
+        SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
+        assertNotNull(metadata);
+    
+        Map<String, List<PropertyPair>> properties = metadata.properties;
+        assertFalse(properties.isEmpty());
+    
+        //
+        // The method names are important for collecting prior
+        // to the filling in of the integration step (values such as resource etc...)
+        //
+        List<PropertyPair> resourcePaths = properties.get(RESOURCE_PATH);
+        assertNotNull(resourcePaths);
+        assertFalse(resourcePaths.isEmpty());
+    
+        PropertyPair pair = resourcePaths.get(0);
+        assertNotNull(pair);
+        assertEquals(resourcePath, pair.getValue());
+    
+        DataShape inputShape = metadata.inputShape;
+        Map<String, JsonSchema> schemaMap = checkShape(inputShape, ObjectSchema.class);
+        checkTestServerSchemaMap(schemaMap);
+        assertNotNull(schemaMap.get(KEY_PREDICATE));
+    
+        DataShape outputShape = metadata.outputShape;
+        assertEquals(DataShapeKinds.JSON_INSTANCE, outputShape.getKind());
+    }
+
     /**
      * Needs to supply server certificate since the server is unknown to the default
      * certificate authorities that is loaded into the keystore by default

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -88,6 +89,9 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
                         .putConfiguredProperty(METHOD_NAME, Methods.DELETE.id())
                         .addConnectorCustomizer(ODataDeleteCustomizer.class.getName())
                         .connectorFactory(ODataComponentFactory.class.getName())
+                        .inputDataShape(new DataShape.Builder()
+                                        .kind(DataShapeKinds.JSON_SCHEMA)
+                                        .build())
                         .outputDataShape(new DataShape.Builder()
                                          .kind(DataShapeKinds.JSON_INSTANCE)
                                          .build())
@@ -119,7 +123,10 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
                                                             .property(SERVICE_URI, defaultTestServer.servicePlainUri()));
 
         String resourcePath = defaultTestServer.resourcePath();
-        String keyPredicate = "1";
+
+        ObjectNode keyPredicateJson = OBJECT_MAPPER.createObjectNode();
+        keyPredicateJson.put(KEY_PREDICATE, "1");
+
         Step odataStep = createODataStep(odataConnector, resourcePath);
         Step mockStep = createMockStep();
         Integration odataIntegration = createIntegration(directStep, odataStep, mockStep);
@@ -134,7 +141,8 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         ProducerTemplate template = context.createProducerTemplate();
 
         context.start();
-        template.sendBody(directEndpoint, keyPredicate);
+        String inputJson = OBJECT_MAPPER.writeValueAsString(keyPredicateJson);
+        template.sendBody(directEndpoint, inputJson);
 
         result.assertIsSatisfied();
 
@@ -156,7 +164,10 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
 
 
         String resourcePath = defaultTestServer.resourcePath();
-        String keyPredicate = "ID=2";
+
+        ObjectNode keyPredicateJson = OBJECT_MAPPER.createObjectNode();
+        keyPredicateJson.put(KEY_PREDICATE, "ID=2");
+
         Step odataStep = createODataStep(odataConnector, resourcePath);
         Step mockStep = createMockStep();
         Integration odataIntegration = createIntegration(directStep, odataStep, mockStep);
@@ -171,7 +182,8 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         ProducerTemplate template = context.createProducerTemplate();
 
         context.start();
-        template.sendBody(directEndpoint, keyPredicate);
+        String inputJson = OBJECT_MAPPER.writeValueAsString(keyPredicateJson);
+        template.sendBody(directEndpoint, inputJson);
 
         result.assertIsSatisfied();
 
@@ -208,7 +220,10 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
 
         context.start();
         for (int i = 1; i <= initialResultCount; ++i) {
-            template.sendBody(directEndpoint, String.valueOf(i));
+            ObjectNode keyPredicateJson = OBJECT_MAPPER.createObjectNode();
+            keyPredicateJson.put(KEY_PREDICATE, String.valueOf(i));
+            String inputJson = OBJECT_MAPPER.writeValueAsString(keyPredicateJson);
+            template.sendBody(directEndpoint, inputJson);
         }
 
         result.assertIsSatisfied();


### PR DESCRIPTION
* odata.json
 * Configure Delete to have a json-schema model on input in line with
   Create and Patch

* ODataMetadateRetrieval
 * Breaks shaping out into individual methods for better readability
 * Modifies Delete datashape to use json-schema with key-predicate

* ...Customizer
 * Delete to extract key predicate from json model
 * Read to observe split property to ensure results are formatted in the
   expected manner. Without this, Read will not map to Delete using the
   DataMapper

* Tests
 * Fixes tests so that, when split, results are not assumed to be in a list
   as this makes little sense when there is most likely 1 result per message

(cherry picked from commit c1d463579090790c245e988041963ed2fa915100)