### PR TITLE
fix: #4994 Fix data mapping when split option on GoogleSheets is enabled

### DIFF
--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
@@ -97,9 +97,7 @@ public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoo
         Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
         Assert.assertEquals("get", options.get("methodName"));
 
-        @SuppressWarnings("unchecked")
-        List<String> model = inbound.getIn().getBody(List.class);
-        Assert.assertEquals(1, model.size());
-        JSONAssert.assertEquals(String.format(expectedValueModel, getSpreadsheetId()), model.get(0), JSONCompareMode.STRICT);
+        String model = inbound.getIn().getBody(String.class);
+        JSONAssert.assertEquals(String.format(expectedValueModel, getSpreadsheetId()), model, JSONCompareMode.STRICT);
     }
 }


### PR DESCRIPTION
... by returning json bean string instead of single element list. Fixes #4994 