### PR TITLE
fix: #5016 Support predicates in combination with parameters in SQL select

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -205,7 +205,7 @@ public class SqlStatementParser {
 
     List<String> splitSqlStatement(String sql) {
         List<String> sqlArray = new ArrayList<>();
-        String[] segments = sql.split("=|\\,|\\s|\\(|\\)", -1);
+        String[] segments = sql.split("!=|=|<=|>=|<|>|,|\\s|\\(|\\)", -1);
         for (String segment : segments) {
             if (!"".equals(segment)) {
                 sqlArray.add(segment);
@@ -264,6 +264,12 @@ public class SqlStatementParser {
                 String column = sqlArray.get(i-1);
                 if ("LIKE".equalsIgnoreCase(column)) {
                     column = sqlArray.get(i-2);
+                }
+                if ("BETWEEN".equalsIgnoreCase(column)) {
+                    column = sqlArray.get(i-2);
+                }
+                if ("AND".equalsIgnoreCase(column)) {
+                    column = sqlArray.get(i-4);
                 }
                 if (column.startsWith(":#") || "VALUES".equalsIgnoreCase(column) || values.contains(column)) {
                     param.setColumnPos(values.indexOf(word));

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorInputParamTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorInputParamTest.java
@@ -16,20 +16,19 @@
 package io.syndesis.connector.sql;
 
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.common.SqlParam;
 import io.syndesis.connector.sql.common.SqlStatementParser;
-import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
-import io.syndesis.common.model.integration.Step;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
 import org.junit.Test;
 
 @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
@@ -38,26 +37,16 @@ public class SqlConnectorInputParamTest extends SqlConnectorTestSupport {
         "(charType, varcharType, numericType, decimalType, smallType) VALUES " +
         "(:#CHARVALUE, :#VARCHARVALUE, :#NUMERICVALUE, :#DECIMALVALUE, :#SMALLINTVALUE)";
 
-    // **************************
-    // Set up
-    // **************************
-
     @Override
-    protected void doPreSetup() throws Exception {
-        try (Statement stmt = db.connection.createStatement()) {
-            stmt.executeUpdate(
-                "CREATE TABLE ALLTYPES (charType CHAR, varcharType VARCHAR(255), " +
-                    "numericType NUMERIC, decimalType DECIMAL, smallType SMALLINT," +
-                    "dateType DATE, timeType TIME )"
-            );
-        }
+    protected List<String> setupStatements() {
+        return Collections.singletonList("CREATE TABLE ALLTYPES (charType CHAR, varcharType VARCHAR(255), " +
+                "numericType NUMERIC, decimalType DECIMAL, smallType SMALLINT," +
+                "dateType DATE, timeType TIME )");
     }
 
-    @After
-    public void after() throws SQLException {
-        try (Statement stmt = db.connection.createStatement()) {
-            stmt.executeUpdate("DROP TABLE ALLTYPES");
-        }
+    @Override
+    protected List<String> cleanupStatements() {
+        return Collections.singletonList("DROP TABLE ALLTYPES");
     }
 
     @Override
@@ -94,7 +83,7 @@ public class SqlConnectorInputParamTest extends SqlConnectorTestSupport {
         String result = template.requestBody("direct:start", JSONBeanUtil.toJSONBean(values), String.class);
 
         Assertions.assertThat(result).isNotNull();
-        
+
         try (Statement stmt = db.connection.createStatement()) {
             stmt.execute("SELECT * FROM ALLTYPES");
             ResultSet resultSet = stmt.getResultSet();

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
@@ -15,42 +15,47 @@
  */
 package io.syndesis.connector.sql;
 
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
+@RunWith(Parameterized.class)
 public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
 
-    // **************************
-    // Set up
-    // **************************
+    private final String sqlQuery;
+    private final List<Map<String, String[]>> expectedResults;
+    private final Map<String, Object> parameters;
 
-    @Override
-    protected void doPreSetup() throws Exception {
-        try (Statement stmt = db.connection.createStatement()) {
-            //stmt.executeUpdate("DROP TABLE ADDRESS");
-            stmt.executeUpdate("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)");
-            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('East Davie Street', 100)");
-            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('Am Treptower Park', 75)");
-            stmt.executeUpdate("INSERT INTO ADDRESS VALUES ('Werner-von-Siemens-Ring', 14)");
-        }
+    public SqlConnectorQueryTest(String sqlQuery, List<Map<String, String[]>> expectedResults, Map<String, Object> parameters) {
+        this.sqlQuery = sqlQuery;
+        this.expectedResults = expectedResults;
+        this.parameters = parameters;
     }
 
-    @After
-    public void after() throws SQLException {
-        try (Statement stmt = db.connection.createStatement()) {
-            stmt.executeUpdate("DROP TABLE ADDRESS");
-        }
+    @Override
+    protected List<String> setupStatements() {
+        return Arrays.asList("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)",
+                                "INSERT INTO ADDRESS VALUES ('East Davie Street', 100)",
+                                "INSERT INTO ADDRESS VALUES ('Am Treptower Park', 75)",
+                                "INSERT INTO ADDRESS VALUES ('Werner-von-Siemens-Ring', 14)");
+    }
+
+    @Override
+    protected List<String> cleanupStatements() {
+        return Collections.singletonList("DROP TABLE ADDRESS");
     }
 
     @Override
@@ -61,11 +66,27 @@ public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
                 builder -> builder.putConfiguredProperty("name", "start")),
             newSqlEndpointStep(
                 "sql-connector",
-                builder -> builder.putConfiguredProperty("query", "SELECT * FROM ADDRESS")),
+                builder -> builder.putConfiguredProperty("query", sqlQuery)),
             newSimpleEndpointStep(
                 "log",
                 builder -> builder.putConfiguredProperty("loggerName", "test"))
         );
+    }
+
+    // **************************
+    // Parameters
+    // **************************
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "SELECT * FROM ADDRESS", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "100", "75", "14" }),
+                        Collections.singletonMap("STREET", new String[] { "East Davie Street", "Am Treptower Park", "Werner-von-Siemens-Ring" })), Collections.emptyMap()},
+                { "SELECT * FROM ADDRESS WHERE number = 14", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "14" }),
+                        Collections.singletonMap("STREET", new String[] { "Werner-von-Siemens-Ring" })), Collections.emptyMap()},
+                { "SELECT street FROM ADDRESS WHERE number = :#number", Collections.singletonList(Collections.singletonMap("STREET", new String[]{ "East Davie Street" })), Collections.singletonMap("number", "100")},
+                { "SELECT * FROM ADDRESS WHERE number = 0", Collections.emptyList(), Collections.emptyMap()}
+        });
     }
 
     // **************************
@@ -74,20 +95,26 @@ public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
 
     @Test
     public void sqlConnectorQueryTest() {
-        List<?> results = template.requestBody("direct:start", null, List.class);
+        String body;
+        if (parameters.isEmpty()) {
+            body = null;
+        } else {
+            body = JSONBeanUtil.toJSONBean(parameters);
+        }
 
-        Assertions.assertThat(results).hasSize(3);
-        Properties rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(0).toString());
-        Assertions.assertThat(rowEntry).hasSize(2);
-        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("100");
-        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("East Davie Street");
+        List<?> results = template.requestBody("direct:start", body, List.class);
 
-        rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(1).toString());
-        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("75");
-        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("Am Treptower Park");
+        List<Properties> jsonBeans = results.stream()
+                .map(Object::toString)
+                .map(JSONBeanUtil::parsePropertiesFromJSONBean)
+                .collect(Collectors.toList());
 
-        rowEntry = JSONBeanUtil.parsePropertiesFromJSONBean(results.get(2).toString());
-        Assertions.assertThat(rowEntry.get("NUMBER")).isEqualTo("14");
-        Assertions.assertThat(rowEntry.get("STREET")).isEqualTo("Werner-von-Siemens-Ring");
+        Assert.assertEquals(expectedResults.isEmpty(), jsonBeans.isEmpty());
+
+        for (Map<String, String[]> result : expectedResults) {
+            for (Map.Entry<String, String[]> resultEntry : result.entrySet()) {
+                validateProperty(jsonBeans, resultEntry.getKey(), resultEntry.getValue());
+            }
+        }
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
@@ -16,40 +16,49 @@
 package io.syndesis.connector.sql;
 
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
+import io.syndesis.common.model.integration.Step;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
-import io.syndesis.common.model.integration.Step;
-import org.assertj.core.api.Assertions;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
+@RunWith(Parameterized.class)
 public class SqlConnectorTest extends SqlConnectorTestSupport {
 
-    // **************************
-    // Set up
-    // **************************
+    private final String sqlQuery;
+    private final List<Map<String, String[]>> expectedResults;
+    private final Map<String, Object> parameters;
 
-    @Override
-    protected void doPreSetup() throws Exception {
-        try (Statement stmt = db.connection.createStatement()) {
-            //stmt.executeUpdate("DROP TABLE ADDRESS");
-            stmt.executeUpdate("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)");
-        }
+    public SqlConnectorTest(String sqlQuery, List<Map<String, String[]>> expectedResults, Map<String, Object> parameters) {
+        this.sqlQuery = sqlQuery;
+        this.expectedResults = expectedResults;
+        this.parameters = parameters;
     }
 
-    @After
-    public void after() throws SQLException {
-        try (Statement stmt = db.connection.createStatement()) {
-            stmt.executeUpdate("DROP TABLE ADDRESS");
-        }
+    @Override
+    protected List<String> setupStatements() {
+        return Collections.singletonList("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)");
+    }
+
+    @Override
+    protected List<String> cleanupStatements() {
+        return Collections.singletonList("DROP TABLE ADDRESS");
     }
 
     @Override
@@ -60,11 +69,29 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
                 builder -> builder.putConfiguredProperty("name", "start")),
             newSqlEndpointStep(
                 "sql-connector",
-                builder -> builder.putConfiguredProperty("query", "INSERT INTO ADDRESS VALUES (:#street, :#number)")),
+                builder -> builder.putConfiguredProperty("query", sqlQuery)),
             newSimpleEndpointStep(
                 "log",
                 builder -> builder.putConfiguredProperty("loggerName", "test"))
         );
+    }
+
+    // **************************
+    // Parameters
+    // **************************
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("number", 14);
+        parameters.put("street", "LaborInVain");
+
+        return Arrays.asList(new Object[][] {
+                { "INSERT INTO ADDRESS VALUES ('East Davie Street', 100)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "100" }),
+                        Collections.singletonMap("STREET", new String[] { "East Davie Street" })), Collections.emptyMap()},
+                { "INSERT INTO ADDRESS VALUES (:#street, :#number)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "14" }),
+                        Collections.singletonMap("STREET", new String[] { "LaborInVain" })), parameters}
+        });
     }
 
     // **************************
@@ -73,20 +100,52 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
 
     @Test
     public void sqlConnectorTest() throws Exception {
+        String body;
+        if (parameters.isEmpty()) {
+            body = null;
+        } else {
+            body = JSONBeanUtil.toJSONBean(parameters);
+        }
 
-        Map<String,Object> values = new HashMap<>();
-        values.put("street", "LaborInVain");
-        values.put("number", 14);
-        String body = JSONBeanUtil.toJSONBean(values);
-
-        String result = template.requestBody("direct:start", body, String.class);
+        template.requestBody("direct:start", body, List.class);
 
         try (Statement stmt = db.connection.createStatement()) {
             stmt.execute("SELECT * FROM ADDRESS");
-            ResultSet resultSet = stmt.getResultSet();
-            resultSet.next();
-            Assertions.assertThat(resultSet.getString(1)).isEqualTo("LaborInVain");
-            Assertions.assertThat(resultSet.getInt(2)).isEqualTo(14);
+            List<Properties> jsonBeans = resultSetToList(stmt.getResultSet())
+                                                    .stream()
+                                                    .map(raw -> {
+                                                        Properties properties = new Properties();
+                                                        properties.putAll(raw);
+                                                        return properties;
+                                                    })
+                                                    .collect(Collectors.toList());
+
+            Assert.assertEquals(expectedResults.isEmpty(), jsonBeans.isEmpty());
+
+            for (Map<String, String[]> result : expectedResults) {
+                for (Map.Entry<String, String[]> resultEntry : result.entrySet()) {
+                    validateProperty(jsonBeans, resultEntry.getKey(), resultEntry.getValue());
+                }
+            }
         }
+    }
+
+    // **************************
+    // Helpers
+    // **************************
+
+    private List<Map<String, Object>> resultSetToList(ResultSet rs) throws SQLException {
+        ResultSetMetaData md = rs.getMetaData();
+        int columns = md.getColumnCount();
+        List<Map<String, Object>> list = new ArrayList<>();
+        while (rs.next()){
+            Map<String, Object> row = new HashMap<>(columns);
+            for(int i = 1; i <= columns; ++i){
+                row.put(md.getColumnName(i).toUpperCase(), rs.getObject(i));
+            }
+            list.add(row);
+        }
+
+        return list;
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlStartConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlStartConnectorTest.java
@@ -15,9 +15,11 @@
  */
 package io.syndesis.connector.sql;
 
-import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -29,21 +31,31 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @SuppressWarnings({"PMD.SignatureDeclareThrowsException"})
+@RunWith(Parameterized.class)
 public class SqlStartConnectorTest extends SqlConnectorTestSupport {
 
-    // **************************
-    // Set up
-    // **************************
+    private final String sqlQuery;
+    private final List<Map<String, String[]>> expectedResults;
+
+    public SqlStartConnectorTest(String sqlQuery, List<Map<String, String[]>> expectedResults) {
+        this.sqlQuery = sqlQuery;
+        this.expectedResults = expectedResults;
+    }
 
     @Override
-    protected void doPreSetup() throws Exception {
-        try (Statement stmt = db.connection.createStatement()) {
-            stmt.executeUpdate("CREATE TABLE NAME (id INTEGER PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255))");
-            stmt.executeUpdate("INSERT INTO NAME VALUES (1, 'Joe', 'Jackson')");
-            stmt.executeUpdate("INSERT INTO NAME VALUES (2, 'Roger', 'Waters')");
-        }
+    protected List<String> cleanupStatements() {
+        return Collections.singletonList("DROP TABLE NAME");
+    }
+
+    @Override
+    protected List<String> setupStatements() {
+        return Arrays.asList("CREATE TABLE NAME (id INTEGER PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255))",
+                "INSERT INTO NAME VALUES (1, 'Joe', 'Jackson')",
+                "INSERT INTO NAME VALUES (2, 'Roger', 'Waters')");
     }
 
     @Override
@@ -54,7 +66,7 @@ public class SqlStartConnectorTest extends SqlConnectorTestSupport {
                 builder -> builder.putConfiguredProperty("name", "start")),
             newSqlEndpointStep(
                 "sql-start-connector",
-                builder -> builder.putConfiguredProperty("query", "SELECT * FROM NAME ORDER BY id")),
+                builder -> builder.putConfiguredProperty("query", sqlQuery)),
             newSimpleEndpointStep(
                 "log",
                 builder -> builder.putConfiguredProperty("loggerName", "test")),
@@ -62,6 +74,23 @@ public class SqlStartConnectorTest extends SqlConnectorTestSupport {
                 "mock",
                 builder -> builder.putConfiguredProperty("name", "result"))
         );
+    }
+
+    // **************************
+    // Parameters
+    // **************************
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "SELECT * FROM NAME ORDER BY id", Arrays.asList(Collections.singletonMap("ID", new String[] { "1", "2" }),
+                        Collections.singletonMap("FIRSTNAME", new String[] { "Joe", "Roger" }),
+                        Collections.singletonMap("LASTNAME", new String[] { "Jackson", "Waters" }))},
+                { "SELECT * FROM NAME WHERE id = 2", Arrays.asList(Collections.singletonMap("ID", new String[] { "2" }),
+                        Collections.singletonMap("FIRSTNAME", new String[] { "Roger" }),
+                        Collections.singletonMap("LASTNAME", new String[] { "Waters" }))},
+                { "SELECT * FROM NAME WHERE id = 99", Collections.emptyList()}
+        });
     }
 
     // **************************
@@ -85,18 +114,12 @@ public class SqlStartConnectorTest extends SqlConnectorTestSupport {
                 .map(JSONBeanUtil::parsePropertiesFromJSONBean)
                 .collect(Collectors.toList());
 
-        validateProperty(jsonBeans, "ID", "1", "2");
-        validateProperty(jsonBeans, "FIRSTNAME", "Joe", "Roger");
-        validateProperty(jsonBeans, "LASTNAME", "Jackson", "Waters");
-    }
+        Assert.assertEquals(expectedResults.isEmpty(), jsonBeans.isEmpty());
 
-    // **************************
-    // Helpers
-    // **************************
-
-    private void validateProperty(List<Properties> jsonBeans, String propertyName, String ... expectedValues) {
-        for (int i = 0; i < expectedValues.length; i++) {
-            Assert.assertEquals(expectedValues[i], jsonBeans.get(i).getProperty(propertyName));
+        for (Map<String, String[]> result : expectedResults) {
+            for (Map.Entry<String, String[]> resultEntry : result.entrySet()) {
+                validateProperty(jsonBeans, resultEntry.getKey(), resultEntry.getValue());
+            }
         }
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
@@ -105,7 +105,7 @@ public class SqlParserTest {
         Assert.assertEquals("lastname", info.getInParams().get(1).getName());
         Assert.assertEquals(String.class, info.getInParams().get(1).getTypeValue().getClazz());
     }
-    
+
     @Test
     public void parseInsertWithSpecifiedColumnNames() throws SQLException {
         final SqlStatementParser parser = new SqlStatementParser(db.connection,
@@ -130,6 +130,87 @@ public class SqlParserTest {
         Assert.assertEquals(1, info.getInParams().size());
         Assert.assertEquals("id", info.getInParams().get(0).getName());
         Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectMultiValuePredicate() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+            "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID=:#id AND FIRSTNAME LIKE :#name");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(2, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+        Assert.assertEquals("name", info.getInParams().get(1).getName());
+        Assert.assertEquals("FIRSTNAME", info.getInParams().get(1).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithNotEquals() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID!=:#id");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(1, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithGreaterThan() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID>:#id");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(1, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithGreaterThanEquals() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID>=:#id");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(1, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithLowerThan() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID<:#id");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(1, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithLowerThanEquals() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID<:#id");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(1, info.getInParams().size());
+        Assert.assertEquals("id", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+    }
+
+    @Test
+    public void parseSelectWithInBetween() throws SQLException {
+        final SqlStatementParser parser = new SqlStatementParser(db.connection,
+                "SELECT FIRSTNAME, LASTNAME FROM NAME0 WHERE ID BETWEEN :#from AND :#to");
+        final SqlStatementMetaData info = parser.parse();
+        Assert.assertEquals("NAME0", info.getTableNames().get(0));
+        Assert.assertEquals(2, info.getInParams().size());
+        Assert.assertEquals("from", info.getInParams().get(0).getName());
+        Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
+        Assert.assertEquals("to", info.getInParams().get(1).getName());
+        Assert.assertEquals("ID", info.getInParams().get(1).getColumn());
     }
 
     @Test
@@ -179,7 +260,7 @@ public class SqlParserTest {
         Assert.assertEquals(1, info.getInParams().get(0).getColumnPos());
         Assert.assertEquals("LASTNAME", info.getInParams().get(0).getColumn());
     }
-    
+
     @Test(expected=SQLException.class)
     public void parseSelectFromNoneExistingTable() throws SQLException {
         final SqlStatementParser parser = new SqlStatementParser(db.connection,


### PR DESCRIPTION
This PR adds support for predicates like (!=,>,<,>=,<=,between ... and) to be used in SQL select statements in combination with parameter placeholders (:#param)

Fixes #5016 