### PR TITLE
chore(bgcolor): update header bg color to path latest pf4

### DIFF
--- a/app/ui/src/scss/utils/_overrides.scss
+++ b/app/ui/src/scss/utils/_overrides.scss
@@ -24,7 +24,8 @@ body.cards-pf {
 }
 
 .pf-c-page__header {
-  background-color: #292e34;
+  --pf-c-page__header-brand--md--BackgroundColor: #151515;
+  background-color: var(--pf-c-page__header-brand--md--BackgroundColor);
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
This PR updates the background color of the masthead to align with PF4 spec.

Before:
<img width="928" alt="Screen Shot 2019-03-25 at 1 22 54 PM" src="https://user-images.githubusercontent.com/5942899/54940801-d8100180-4f01-11e9-9313-27f556ec1214.png">

After:
<img width="882" alt="Screen Shot 2019-03-25 at 1 40 23 PM" src="https://user-images.githubusercontent.com/5942899/54941646-c16aaa00-4f03-11e9-9dc9-1e8c948d801f.png">

