### PR TITLE
Fix for #4466 SQL Connector: Return generated keys for INSERT statement 

### DIFF
--- a/app/connector/sql/README.md
+++ b/app/connector/sql/README.md
@@ -1,0 +1,47 @@
+## Run the unittests against other databases using Docker containers
+
+### PostgreSQL
+
+...
+docker run -p 5433:5432/tcp -e POSTGRES_PASSWORD=syndesis -d postgres
+psql -h localhost -p 5433 -U postgres
+
+psql>create database test;
+...
+
+### MySQL
+
+...
+docker run -p 3307:3306/tcp -e MYSQL_ROOT_PASSWORD=syndesis -d mysql
+mysql -p3307 -Uroot -p
+mysql> create database test;
+...
+
+### Oracle
+
+...
+git clone https://github.com/oracle/docker-images.git
+cd docker-images/OracleDatabase/SingleInstance/dockerfiles
+...
+
+Download the 4.3Gb(!) 18.3.0 Linux x86-64 zipfile from 
+http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+
+This makes you accept the license agreement and it also makes you login to the OTN.
+Move the zipfile into the 18.3.0 directory.
+
+Now you are ready to create and run the Docker image using
+...
+./buildDockerImage.sh -v 18.3.0 -s
+
+docker run \
+-p 1521:1521 -p 5500:5500 \
+-e ORACLE_SID=syndesis \
+-e ORACLE_PDB=test \
+-e ORACLE_PWD=syndesis \
+oracle/database:18.3.0-se2
+
+docker exec -ti <container name> sqlplus pdbadmin@ORCLPDB1
+...
+
+For more info see https://github.com/oracle/docker-images/blob/master/OracleDatabase/SingleInstance/README.md#running-oracle-database-18c-express-edition-in-a-docker-container

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-sql</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>commons-dbcp</groupId>

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -128,6 +128,11 @@
       <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- test -->
     <dependency>
@@ -179,6 +184,26 @@
       <groupId>com.vaadin.external.google</groupId>
       <artifactId>android-json</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>jdbc</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
   </dependencies>

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mariadb</artifactId>
-      <scope>runtime</scope>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
@@ -16,13 +16,12 @@
 package io.syndesis.connector.sql;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
 
 import io.syndesis.common.util.SyndesisServerException;
-import io.syndesis.connector.sql.common.DatabaseMetaDataHelper;
+import io.syndesis.connector.sql.common.DbMetaDataHelper;
 import io.syndesis.connector.sql.common.SqlStatementMetaData;
 import io.syndesis.connector.sql.common.SqlStatementParser;
 import org.apache.camel.CamelContext;
@@ -44,8 +43,8 @@ public class SqlConnectorMetaDataExtension extends AbstractMetaDataExtension {
 
         if (sqlStatement != null) {
             try (Connection connection = SqlSupport.createConnection(properties)) {
-                final DatabaseMetaData meta = connection.getMetaData();
-                final String defaultSchema = DatabaseMetaDataHelper.getDefaultSchema(meta.getDatabaseProductName(), String.valueOf(properties.get("user")));
+                DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
+                final String defaultSchema = dbHelper.getDefaultSchema(String.valueOf(properties.get("user")));
                 final String schemaPattern = (String) properties.getOrDefault("schema-pattern", defaultSchema);
                 final SqlStatementParser parser = new SqlStatementParser(connection, schemaPattern, sqlStatement);
                 final SqlStatementMetaData sqlStatementMetaData = parseStatement(parser);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import io.syndesis.connector.sql.common.DatabaseProduct;
+import io.syndesis.connector.sql.common.DbEnum;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
@@ -95,7 +95,7 @@ public class SqlConnectorVerifierExtension extends DefaultComponentVerifierExten
     }
 
     private static void unsupportedDatabase(ResultBuilder builder) {
-        String supportedDatabases = Arrays.stream(DatabaseProduct.values()).map(DatabaseProduct::name).collect(Collectors.joining(","));
+        String supportedDatabases = Arrays.stream(DbEnum.values()).map(DbEnum::name).collect(Collectors.joining(","));
         String msg = "Supported Databases are [" + supportedDatabases + "]";
 
         builder.error(

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/ColumnMetaData.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/ColumnMetaData.java
@@ -25,5 +25,6 @@ public class ColumnMetaData {
     private String name;
     private JDBCType type;
     private int position;
+    private boolean isAutoIncrement;
 
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
@@ -1,15 +1,3 @@
-package io.syndesis.connector.sql.common;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import io.syndesis.connector.sql.db.Db;
-import io.syndesis.connector.sql.db.DbDerby;
-import io.syndesis.connector.sql.db.DbMysql;
-import io.syndesis.connector.sql.db.DbOracle;
-import io.syndesis.connector.sql.db.DbPostgresql;
-import io.syndesis.connector.sql.db.DbStandard;
-
 /*
  * Copyright (C) 2016 Red Hat, Inc.
  *
@@ -25,6 +13,18 @@ import io.syndesis.connector.sql.db.DbStandard;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import io.syndesis.connector.sql.db.Db;
+import io.syndesis.connector.sql.db.DbDerby;
+import io.syndesis.connector.sql.db.DbMysql;
+import io.syndesis.connector.sql.db.DbOracle;
+import io.syndesis.connector.sql.db.DbPostgresql;
+import io.syndesis.connector.sql.db.DbStandard;
+
 public class DbAdapter {
 
     private Db db;

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
@@ -1,0 +1,56 @@
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import io.syndesis.connector.sql.db.Db;
+import io.syndesis.connector.sql.db.DbDerby;
+import io.syndesis.connector.sql.db.DbMysql;
+import io.syndesis.connector.sql.db.DbOracle;
+import io.syndesis.connector.sql.db.DbPostgresql;
+import io.syndesis.connector.sql.db.DbStandard;
+
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class DbAdapter {
+
+    private Db db;
+
+    public DbAdapter(Connection conn) throws SQLException {
+        this.db = getDb(conn);
+    }
+
+    public Db getDb() {
+        return this.db;
+    }
+
+    private Db getDb(Connection conn) throws SQLException {
+        DbEnum dbEnum =  DbEnum.fromName(conn.getMetaData().getDatabaseProductName());
+        switch (dbEnum) {
+
+        case APACHE_DERBY:
+            return new DbDerby();
+        case MYSQL:
+            return new DbMysql();
+        case ORACLE:
+            return new DbOracle();
+        case POSTGRESQL:
+            return new DbPostgresql();
+        default:
+            return new DbStandard();
+        }
+    }
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbEnum.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbEnum.java
@@ -19,26 +19,31 @@ import java.util.Locale;
 
 /**
  * Enumeration of Database products we have tested, and for which we ship
- * drivers for. One caviat is the Oracle Driver which cannot be shipped due to
+ * drivers for. One caveat is the Oracle Driver which cannot be shipped due to
  * restrictions on its license.
  *
  * @since 09/11/17
  * @author kstam
  *
  */
-public enum DatabaseProduct {
-    APACHE_DERBY, ORACLE, POSTGRESQL, MYSQL;
+public enum DbEnum {
+    APACHE_DERBY("APACHE DERBY"),
+    ORACLE("ORACLE"),
+    POSTGRESQL("POSTGRESQL"),
+    MYSQL("MYSQL"),
+    STANDARD("STANDARD");
 
-    /**
-     * Can be used to convert '_' to ' ' in the enum name.
-     *
-     * @return name of the enum.
-     */
-    public String nameWithSpaces() {
-        return name().replaceAll("_", " ");
+    private final String name;
+
+    DbEnum(String name) {
+        this.name = name;
     }
 
-    public static DatabaseProduct fromName(String databaseProductName) {
-        return valueOf(databaseProductName.toUpperCase(Locale.US).replaceAll(" ", "_"));
+    public String getName() {
+        return name;
+    }
+
+    public static DbEnum fromName(final String dbProductName) {
+        return valueOf(dbProductName.toUpperCase(Locale.US).replaceAll(" ", "_"));
     }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
@@ -29,72 +29,45 @@ import java.util.Locale;
 import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.syndesis.connector.sql.db.Db;
 
-public final class DatabaseMetaDataHelper {
+public final class DbMetaDataHelper {
 
-    private DatabaseMetaDataHelper() {
-        // utility class
+    Db db;
+    DatabaseMetaData meta;
+    Connection connection;
+
+    public DbMetaDataHelper(final Connection connection) throws SQLException {
+        this.db = new DbAdapter(connection).getDb();
+        this.connection = connection;
+        this.meta = connection.getMetaData();
     }
 
-    public static String getDefaultSchema(final String databaseProductName, String dbUser) {
-
-        String defaultSchema = null;
-        // Oracle uses the username as schema
-        if (databaseProductName.equalsIgnoreCase(DatabaseProduct.ORACLE.name())) {
-            defaultSchema = dbUser.toUpperCase(Locale.US);
-        } else if (databaseProductName.equalsIgnoreCase(DatabaseProduct.POSTGRESQL.name())) {
-            defaultSchema = "public";
-        } else if (databaseProductName.equalsIgnoreCase(DatabaseProduct.APACHE_DERBY.nameWithSpaces())) {
-            if (dbUser != null) {
-                defaultSchema = dbUser.toUpperCase(Locale.US);
-            } else {
-                defaultSchema = "NULL";
-            }
-        }
-        return defaultSchema;
+    public String getDefaultSchema(final String dbUser) {
+        return db.getDefaultSchema(dbUser);
     }
 
-    public static String adapt(String databaseProductName, String pattern) {
-        if (pattern == null && databaseProductName.equalsIgnoreCase(DatabaseProduct.MYSQL.name())) {
-            return "%";
-        } else {
-            return pattern;
-        }
+    public String adapt(final String pattern) {
+        return db.adaptPattern(pattern);
     }
 
-    public static ResultSet fetchProcedureColumns(final DatabaseMetaData meta, final String catalog,
+    public ResultSet fetchProcedureColumns(final String catalog,
         final String schema, final String procedureName) throws SQLException {
-        if (meta.getDatabaseProductName().equalsIgnoreCase(DatabaseProduct.POSTGRESQL.name())) {
-            return meta.getFunctionColumns(catalog, schema, procedureName, null);
-        }
-
-        return meta.getProcedureColumns(
-                catalog,
-                adapt(meta.getDatabaseProductName(),schema),
-                adapt(meta.getDatabaseProductName(),procedureName),
-                adapt(meta.getDatabaseProductName(),null));
+        return db.fetchProcedureColumns(meta, catalog, schema, procedureName);
     }
 
-    public static ResultSet fetchProcedures(final DatabaseMetaData meta, final String catalog,
+    public ResultSet fetchProcedures(final String catalog,
         final String schemaPattern, final String procedurePattern) throws SQLException {
-        if (meta.getDatabaseProductName().equalsIgnoreCase(DatabaseProduct.POSTGRESQL.name())) {
-            return meta.getFunctions(catalog, schemaPattern, procedurePattern);
-        }
-
-        return meta.getProcedures(
-                catalog,
-                adapt(meta.getDatabaseProductName(),schemaPattern),
-                adapt(meta.getDatabaseProductName(),procedurePattern));
+        return db.fetchProcedures(meta, catalog, schemaPattern, procedurePattern);
     }
 
-
-    static Set<String> fetchTables(final DatabaseMetaData meta, final String catalog,
+    Set<String> fetchTables(final String catalog,
         final String schemaPattern, final String tableNamePattern) throws SQLException {
         Set<String> tablesInSchema = new HashSet<>();
         try (ResultSet rs = meta.getTables(
                 catalog,
-                adapt(meta.getDatabaseProductName(),schemaPattern),
-                adapt(meta.getDatabaseProductName(), tableNamePattern),
+                adapt(schemaPattern),
+                adapt(tableNamePattern),
                 new String[] { "TABLE" });) {
             while (rs.next()) {
                 tablesInSchema.add(rs.getString(3).toUpperCase(Locale.US));
@@ -103,23 +76,23 @@ public final class DatabaseMetaDataHelper {
         return tablesInSchema;
     }
 
-    static List<SqlParam> getJDBCInfoByColumnNames(final DatabaseMetaData meta, String catalog,
+    List<SqlParam> getJDBCInfoByColumnNames(String catalog,
             String schema, String tableName, final List<SqlParam> params) throws SQLException {
         List<SqlParam> paramList = new ArrayList<>();
         for (int i=0; i<params.size(); i++) {
             SqlParam param = params.get(i);
             String columnName = param.getColumn();
-            List<ColumnMetaData> cList = getColumnMetaData(meta, catalog, schema, tableName, columnName, 1);
+            List<ColumnMetaData> cList = getColumnMetaData(catalog, schema, tableName, columnName, 1);
             param.setJdbcType(cList.get(0).getType());
             paramList.add(param);
         }
         return paramList;
     }
 
-    static List<SqlParam> getAutoIncrementColumnList(final DatabaseMetaData meta, String catalog,
+    List<SqlParam> getAutoIncrementColumnList(String catalog,
             String schema, String tableName) throws SQLException {
         List<SqlParam> outParams = new ArrayList<>();
-        List<ColumnMetaData> cList = getColumnMetaData(meta, catalog, schema, tableName, null, -1);
+        List<ColumnMetaData> cList = getColumnMetaData(catalog, schema, tableName, null, -1);
         for (ColumnMetaData columnMetaData : cList) {
             if (columnMetaData.isAutoIncrement()) {
                 SqlParam sqlParam = new SqlParam();
@@ -132,10 +105,10 @@ public final class DatabaseMetaDataHelper {
         return outParams;
     }
 
-    static List<SqlParam> getJDBCInfoByColumnOrder(final DatabaseMetaData meta, String catalog,
+    List<SqlParam> getJDBCInfoByColumnOrder(String catalog,
             String schema, String tableName, final List<SqlParam> params) throws SQLException {
         List<SqlParam> paramList = new ArrayList<>();
-        List<ColumnMetaData> cList = getColumnMetaData(meta, catalog, schema, tableName, null, params.size());
+        List<ColumnMetaData> cList = getColumnMetaData(catalog, schema, tableName, null, params.size());
         for (SqlParam param : params) {
             ColumnMetaData c = cList.get(param.getColumnPos());
             param.setColumn(c.getName());
@@ -146,13 +119,13 @@ public final class DatabaseMetaDataHelper {
     }
 
     @SuppressWarnings("PMD.RemoteInterfaceNamingConvention")
-    private static List<ColumnMetaData> getColumnMetaData(final DatabaseMetaData meta, String catalog, //NOPMD
+    private List<ColumnMetaData> getColumnMetaData(String catalog, //NOPMD
             String schema, String tableName, String columnName, int expectedSize) throws SQLException { //NOPMD
         try (ResultSet columns = meta.getColumns(
                 catalog,
-                adapt(meta.getDatabaseProductName(),schema),
-                adapt(meta.getDatabaseProductName(),tableName),
-                adapt(meta.getDatabaseProductName(),columnName));) {
+                adapt(schema),
+                adapt(tableName),
+                adapt(columnName));) {
             List<ColumnMetaData> columnList = convert(columns);
             if (columnList.isEmpty()) {
                 //Postgresql does lowercase instead, so let's try that if we don't have a match
@@ -173,7 +146,7 @@ public final class DatabaseMetaDataHelper {
     }
 
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
-    /* default */ static List<SqlParam> getOutputColumnInfo(final Connection connection,
+    /* default */ List<SqlParam> getOutputColumnInfo(
             final String sqlSelectStatement) throws SQLException {
         List<SqlParam> paramList = new ArrayList<>();
         try (Statement stmt = connection.createStatement();
@@ -194,11 +167,24 @@ public final class DatabaseMetaDataHelper {
         List<ColumnMetaData> list = new ArrayList<>();
         Integer position = 0;
         while (resultSet.next()) {
+
             ColumnMetaData columnMetaData = new ColumnMetaData();
+//            ResultSetMetaData rsmd = resultSet.getMetaData();
+//            int columnCount = rsmd.getColumnCount();
+
+//            // The column count starts from 1
+//            for (int i = 1; i <= columnCount; i++ ) {
+//               String name = rsmd.getColumnName(i);
+//               System.out.println("Name " + name + " - " + resultSet.getString(name));
+//            }
+
             columnMetaData.setName(resultSet.getString("COLUMN_NAME"));
             columnMetaData.setType(JDBCType.valueOf(resultSet.getInt("DATA_TYPE")));
             String autoIncString = resultSet.getString("IS_AUTOINCREMENT");
-            if ("YES".equalsIgnoreCase(autoIncString)) {
+            String columnDefString = resultSet.getString("COLUMN_DEF");
+
+            if ("YES".equalsIgnoreCase(autoIncString) ||
+                    (columnDefString != null && columnDefString.contains("nextval"))) {
                 columnMetaData.setAutoIncrement(true);
             }
             columnMetaData.setPosition(position++);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
@@ -169,14 +169,6 @@ public final class DbMetaDataHelper {
         while (resultSet.next()) {
 
             ColumnMetaData columnMetaData = new ColumnMetaData();
-//            ResultSetMetaData rsmd = resultSet.getMetaData();
-//            int columnCount = rsmd.getColumnCount();
-
-//            // The column count starts from 1
-//            for (int i = 1; i <= columnCount; i++ ) {
-//               String name = rsmd.getColumnName(i);
-//               System.out.println("Name " + name + " - " + resultSet.getString(name));
-//            }
 
             columnMetaData.setName(resultSet.getString("COLUMN_NAME"));
             columnMetaData.setType(JDBCType.valueOf(resultSet.getInt("DATA_TYPE")));

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -20,6 +20,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Message;
+import org.apache.camel.component.sql.SqlConstants;
 import org.apache.camel.util.ObjectHelper;
 import org.springframework.jdbc.core.SqlParameterValue;
 
@@ -200,5 +202,26 @@ public final class JSONBeanUtil {
             return null;
         }
 
+    }
+
+    /**
+     * Converts Camel Generated Key output to a list of JSON Bean Strings.
+     *
+     * @param in
+     * @param the name of the auto increment column name
+     * @return List of JSON beans.
+     */
+    public static List<String> toJSONBeansFromHeader(Message in, String autoIncrementColumnName) {
+        final List<String> jsonBeans = new ArrayList<>();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> generatedKeys = in.getHeader(SqlConstants.SQL_GENERATED_KEYS_DATA, List.class);
+        Iterator<Map<String, Object>> iterator = generatedKeys.iterator();
+        while (iterator.hasNext()) {
+            final Map<String, Object> map = new HashMap<>();
+            map.put(autoIncrementColumnName, iterator.next().values().iterator().next());
+            final String bean = JSONBeanUtil.toJSONBean(map);
+            jsonBeans.add(bean);
+        }
+        return jsonBeans;
     }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
@@ -36,6 +36,7 @@ public class SqlStatementMetaData {
     private Set<String> tablesInSchema;
     private String schema;
     private String defaultedSqlStatement;
+    private String autoIncrementColumnName;
 
     public SqlStatementMetaData(String sqlStatement) {
         super();

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -16,7 +16,6 @@
 package io.syndesis.connector.sql.common;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,36 +42,38 @@ public class SqlStatementParser {
      */
     private final Connection connection;
     private String schema;
+    private DbMetaDataHelper dbHelper;
     private final SqlStatementMetaData statementInfo;
     private List<String> sqlArray = new ArrayList<>();
     private final List<String> sqlArrayUpperCase = new ArrayList<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStatementParser.class);
 
-    public SqlStatementParser(Connection connection, String sql) {
+    public SqlStatementParser(Connection connection, String sql) throws SQLException {
         super();
         statementInfo = new SqlStatementMetaData(sql.trim());
         this.connection = connection;
+        dbHelper = new DbMetaDataHelper(connection);
         getSchema(null);
     }
 
-    public SqlStatementParser(Connection connection, String schema, String sql) {
+    public SqlStatementParser(Connection connection, String schema, String sql) throws SQLException {
         super();
         statementInfo = new SqlStatementMetaData(sql.trim());
         this.connection = connection;
+        dbHelper = new DbMetaDataHelper(connection);
         this.schema = getSchema(schema);
     }
 
     public SqlStatementMetaData parseSelectOnly() throws SQLException {
 
-        DatabaseMetaData meta = connection.getMetaData();
-        statementInfo.setTablesInSchema(DatabaseMetaDataHelper.fetchTables(meta, null, schema, null));
+        statementInfo.setTablesInSchema(dbHelper.fetchTables(null, schema, null));
         sqlArray = splitSqlStatement(statementInfo.getSqlStatement());
         for (String word : sqlArray) {
             sqlArrayUpperCase.add(word.toUpperCase(Locale.US));
         }
 
         if ("SELECT".equals(sqlArrayUpperCase.get(0))) {
-            parseSelect(meta);
+            parseSelect();
             if (! statementInfo.getInParams().isEmpty()) {
                 throw new SQLException("Your statement is invalid and cannot contain input parameters");
             }
@@ -84,8 +85,7 @@ public class SqlStatementParser {
 
     public SqlStatementMetaData parse() throws SQLException {
 
-        DatabaseMetaData meta = connection.getMetaData();
-        statementInfo.setTablesInSchema(DatabaseMetaDataHelper.fetchTables(meta, null, schema, null));
+        statementInfo.setTablesInSchema(dbHelper.fetchTables(null, schema, null));
         sqlArray = splitSqlStatement(statementInfo.getSqlStatement());
         for (String word : sqlArray) {
             sqlArrayUpperCase.add(word.toUpperCase(Locale.US));
@@ -93,16 +93,16 @@ public class SqlStatementParser {
 
         switch (sqlArrayUpperCase.get(0)) {
             case "INSERT":
-                parseInsert(meta);
+                parseInsert();
                 break;
             case "UPDATE":
-                parseUpdate(meta);
+                parseUpdate();
                 break;
             case "DELETE":
-                parseDelete(meta);
+                parseDelete();
                 break;
             case "SELECT":
-                parseSelect(meta);
+                parseSelect();
                 break;
             default:
                 throw new SQLException("Your statement is invalid and should start with INSERT, UPDATE, SELECT or DELETE");
@@ -127,15 +127,15 @@ public class SqlStatementParser {
         }
         try {
             //finally try setting reasonable default
-            DatabaseMetaData meta = connection.getMetaData();
-            return DatabaseMetaDataHelper.getDefaultSchema(meta.getDatabaseProductName(), meta.getUserName());
+            DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
+            return dbHelper.getDefaultSchema(connection.getMetaData().getUserName());
         } catch (SQLException e) {
             LOGGER.error(e.getMessage(),e);
         }
         return null;
     }
 
-    private void parseInsert(DatabaseMetaData meta) throws SQLException {
+    private void parseInsert() throws SQLException {
         statementInfo.setStatementType(StatementType.INSERT);
         String tableNameInsert = statementInfo.addTable(sqlArrayUpperCase.get(2));
         if (! statementInfo.getTablesInSchema().contains(tableNameInsert)) {
@@ -145,16 +145,16 @@ public class SqlStatementParser {
             List<SqlParam> inputParams = findInsertParams(tableNameInsert);
             if (inputParams.get(0).getColumn() != null) {
                 statementInfo.setInParams(
-                        DatabaseMetaDataHelper.getJDBCInfoByColumnNames(
-                                meta, null, schema, tableNameInsert, inputParams));
+                        dbHelper.getJDBCInfoByColumnNames(
+                                null, schema, tableNameInsert, inputParams));
             } else {
                 statementInfo.setInParams(
-                        DatabaseMetaDataHelper.getJDBCInfoByColumnOrder(
-                                meta, null, schema, tableNameInsert, inputParams));
+                        dbHelper.getJDBCInfoByColumnOrder(
+                                null, schema, tableNameInsert, inputParams));
             }
         }
-        List<SqlParam> autoIncrementParamList = DatabaseMetaDataHelper.getAutoIncrementColumnList(
-                meta, null, schema, tableNameInsert);
+        List<SqlParam> autoIncrementParamList = dbHelper.getAutoIncrementColumnList(
+                null, schema, tableNameInsert);
         if (! autoIncrementParamList.isEmpty()) {
             statementInfo.setOutParams(autoIncrementParamList);
             //SQL only supports one auto increment column
@@ -162,7 +162,7 @@ public class SqlStatementParser {
         }
     }
 
-    private void parseUpdate(DatabaseMetaData meta) throws SQLException  {
+    private void parseUpdate() throws SQLException  {
         statementInfo.setStatementType(StatementType.UPDATE);
         String tableNameUpdate = statementInfo.addTable(sqlArrayUpperCase.get(1));
         if (! statementInfo.getTablesInSchema().contains(tableNameUpdate)) {
@@ -171,12 +171,12 @@ public class SqlStatementParser {
         if (statementInfo.hasInputParams()) {
             List<SqlParam> inputParams = findInputParams(Collections.emptyList());
             statementInfo.setInParams(
-                    DatabaseMetaDataHelper.getJDBCInfoByColumnNames(
-                            meta, null, schema, tableNameUpdate, inputParams));
+                    dbHelper.getJDBCInfoByColumnNames(
+                            null, schema, tableNameUpdate, inputParams));
         }
     }
 
-    private void parseDelete(DatabaseMetaData meta) throws SQLException  {
+    private void parseDelete() throws SQLException  {
         statementInfo.setStatementType(StatementType.DELETE);
         String tableNameDelete = statementInfo.addTable(sqlArrayUpperCase.get(2));
         if (! statementInfo.getTablesInSchema().contains(tableNameDelete)) {
@@ -185,12 +185,12 @@ public class SqlStatementParser {
         if (statementInfo.hasInputParams()) {
             List<SqlParam> inputParams = findInputParams(Collections.emptyList());
             statementInfo.setInParams(
-                    DatabaseMetaDataHelper.getJDBCInfoByColumnNames(
-                            meta, null, schema, tableNameDelete, inputParams));
+                    dbHelper.getJDBCInfoByColumnNames(
+                            null, schema, tableNameDelete, inputParams));
         }
     }
 
-    private void parseSelect(DatabaseMetaData meta) throws SQLException  {
+    private void parseSelect() throws SQLException  {
         statementInfo.setStatementType(StatementType.SELECT);
         List<String> tableNamesSelect = findTablesInSelectStatement();
         if (! tableNamesSelect.isEmpty()) {
@@ -204,10 +204,10 @@ public class SqlStatementParser {
             List<SqlParam> inputParams = findInputParams(Collections.emptyList());
             statementInfo.setTableNames(findTablesInSelectStatement());
             statementInfo.setInParams(
-                    DatabaseMetaDataHelper.getJDBCInfoByColumnNames(
-                            meta, null, schema, statementInfo.getTableNames().get(0), inputParams));
+                    dbHelper.getJDBCInfoByColumnNames(
+                            null, schema, statementInfo.getTableNames().get(0), inputParams));
         }
-        statementInfo.setOutParams(DatabaseMetaDataHelper.getOutputColumnInfo(connection, statementInfo.getDefaultedSqlStatement()));
+        statementInfo.setOutParams(dbHelper.getOutputColumnInfo(statementInfo.getDefaultedSqlStatement()));
     }
 
     List<String> splitSqlStatement(String sql) {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -153,6 +153,13 @@ public class SqlStatementParser {
                                 meta, null, schema, tableNameInsert, inputParams));
             }
         }
+        List<SqlParam> autoIncrementParamList = DatabaseMetaDataHelper.getAutoIncrementColumnList(
+                meta, null, schema, tableNameInsert);
+        if (! autoIncrementParamList.isEmpty()) {
+            statementInfo.setOutParams(autoIncrementParamList);
+            //SQL only supports one auto increment column
+            statementInfo.setAutoIncrementColumnName(autoIncrementParamList.get(0).getName());
+        }
     }
 
     private void parseUpdate(DatabaseMetaData meta) throws SQLException  {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
@@ -30,6 +30,7 @@ import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.sql.SqlConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.SqlParameterValue;
@@ -38,6 +39,8 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
 
     private Map<String, Integer> jdbcTypeMap;
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlConnectorCustomizer.class);
+    private String autoIncrementColumnName;
+    private boolean isRetrieveGeneratedKeys;
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
@@ -52,12 +55,20 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
             final Map<String, SqlParameterValue> sqlParametersValues = JSONBeanUtil.parseSqlParametersFromJSONBean(body, jdbcTypeMap);
             exchange.getIn().setBody(sqlParametersValues);
         }
+        if (isRetrieveGeneratedKeys) {
+            exchange.getIn().setHeader(SqlConstants.SQL_RETRIEVE_GENERATED_KEYS, true);
+        }
     }
 
     private void doAfterProducer(Exchange exchange) {
         final Message in = exchange.getIn();
         //converting SQL Map or List results to JSON Beans
-        List<String> list = JSONBeanUtil.toJSONBeans(in);
+        List<String> list = null;
+        if (isRetrieveGeneratedKeys) {
+            JSONBeanUtil.toJSONBeansFromHeader(in, autoIncrementColumnName);
+        } else {
+            list = JSONBeanUtil.toJSONBeans(in);
+        }
         if (list != null) {
             in.setBody(list);
         }
@@ -71,9 +82,13 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
             final Map<String, Integer> tmpMap = new HashMap<>();
             try (Connection connection = dataSource.getConnection()) {
 
-                SqlStatementMetaData md = new SqlStatementParser(connection, null, sql).parse();
-                for (SqlParam sqlParam: md.getInParams()) {
+                SqlStatementMetaData statementInfo = new SqlStatementParser(connection, null, sql).parse();
+                for (SqlParam sqlParam: statementInfo.getInParams()) {
                     tmpMap.put(sqlParam.getName(), sqlParam.getJdbcType().getVendorTypeNumber());
+                }
+                if (statementInfo.getAutoIncrementColumnName() != null) {
+                    isRetrieveGeneratedKeys = true;
+                    autoIncrementColumnName = statementInfo.getAutoIncrementColumnName();
                 }
             } catch (SQLException e){
                 LOGGER.error(e.getMessage(),e);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
@@ -27,4 +27,6 @@ public interface Db {
         String schema, String procedureName) throws SQLException;
     ResultSet fetchProcedures(DatabaseMetaData meta, String catalog,
         String schemaPattern, String procedurePattern) throws SQLException;
+    String getAutoIncrementGrammar();
+    String getName();
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public interface Db {
+
+    String getDefaultSchema(String dbUser);
+    String adaptPattern(String pattern);
+    ResultSet fetchProcedureColumns(DatabaseMetaData meta, String catalog,
+        String schema, String procedureName) throws SQLException;
+    ResultSet fetchProcedures(DatabaseMetaData meta, String catalog,
+        String schemaPattern, String procedurePattern) throws SQLException;
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+import java.util.Locale;
+
+public class DbDerby extends DbStandard {
+
+    @Override
+    public String getDefaultSchema(String dbUser) {
+        if (dbUser != null) {
+            return dbUser.toUpperCase(Locale.US);
+        } else {
+            return "NULL";
+        }
+    }
+
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
@@ -28,4 +28,13 @@ public class DbDerby extends DbStandard {
         }
     }
 
+    @Override
+    public String getAutoIncrementGrammar() {
+        return "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)";
+    }
+
+    @Override
+    public String getName() {
+        return "Derby";
+    }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbMysql.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbMysql.java
@@ -24,4 +24,14 @@ public class DbMysql extends DbStandard {
         }
         return pattern;
     }
+
+    @Override
+    public String getAutoIncrementGrammar() {
+        return "INT NOT NULL AUTO_INCREMENT PRIMARY KEY";
+    }
+
+    @Override
+    public String getName() {
+        return "Mysql";
+    }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbMysql.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbMysql.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+public class DbMysql extends DbStandard {
+
+    @Override
+    public String adaptPattern(final String pattern) {
+        if (pattern == null) {
+            return "%";
+        }
+        return pattern;
+    }
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
@@ -24,4 +24,8 @@ public class DbOracle extends DbStandard {
         return dbUser.toUpperCase(Locale.US);
     }
 
+    @Override
+    public String getName() {
+        return "Oracle";
+    }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+import java.util.Locale;
+
+public class DbOracle extends DbStandard {
+
+    @Override
+    public String getDefaultSchema(final String dbUser) {
+        return dbUser.toUpperCase(Locale.US);
+    }
+
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DbPostgresql extends DbStandard {
+
+    @Override
+    public String getDefaultSchema(String dbUser) {
+        return "public";
+    }
+
+    @Override
+    public ResultSet fetchProcedureColumns(final DatabaseMetaData meta, final String catalog, final String schema, final String procedureName) throws SQLException {
+        return meta.getFunctionColumns(catalog, schema, procedureName, null);
+    }
+
+    @Override
+    public ResultSet fetchProcedures(final DatabaseMetaData meta, final String catalog, final String schemaPattern,
+            final String procedurePattern) throws SQLException {
+        return meta.getFunctions(catalog, schemaPattern, procedurePattern);
+    }
+}

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
@@ -36,4 +36,14 @@ public class DbPostgresql extends DbStandard {
             final String procedurePattern) throws SQLException {
         return meta.getFunctions(catalog, schemaPattern, procedurePattern);
     }
+
+    @Override
+    public String getAutoIncrementGrammar() {
+        return "SERIAL PRIMARY KEY";
+    }
+
+    @Override
+    public String getName() {
+        return "PostgreSQL";
+    }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
@@ -49,6 +49,14 @@ public class DbStandard implements Db {
                 adaptPattern(procedurePattern));
     }
 
+    @Override
+    public String getAutoIncrementGrammar() {
+        return "NUMBER GENERATED ALWAYS AS IDENTITY";
+    }
 
+    @Override
+    public String getName() {
+        return "Standard";
+    }
 
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.db;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DbStandard implements Db {
+
+    @Override
+    public String getDefaultSchema(final String dbUser) {
+        return null;
+    }
+
+    @Override
+    public String adaptPattern(final String pattern) {
+        return pattern;
+    }
+
+    @Override
+    public ResultSet fetchProcedureColumns(final DatabaseMetaData meta, final String catalog, final String schema, final String procedureName) throws SQLException {
+        return meta.getProcedureColumns(
+                catalog,
+                adaptPattern(schema),
+                adaptPattern(procedureName),
+                adaptPattern(null));
+    }
+
+    @Override
+    public ResultSet fetchProcedures(final DatabaseMetaData meta, final String catalog, final String schemaPattern, final String procedurePattern)
+            throws SQLException {
+        return meta.getProcedures(
+                catalog,
+                adaptPattern(schemaPattern),
+                adaptPattern(procedurePattern));
+    }
+
+
+
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/DerbyContainer.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/DerbyContainer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+public class DerbyContainer extends JdbcDatabaseContainer<DerbyContainer> {
+
+    public DerbyContainer() {
+        super("datagrip/derby-server:10.12");
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "org.apache.derby.jdbc.ClientDriver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:derby://" + getContainerIpAddress() + ":" + getMappedPort(1527) + "/MyDbTest";
+    }
+
+    @Override
+    public String getPassword() {
+        return "derbyuser";
+    }
+
+    @Override
+    public String getUsername() {
+        return "derbyuser";
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "VALUES (1)";
+    }
+
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import io.syndesis.common.model.integration.Step;
+import io.syndesis.connector.sql.common.DbEnum;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
 import org.junit.Assert;
@@ -53,7 +54,30 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
 
     @Override
     protected List<String> setupStatements() {
-        return Collections.singletonList("CREATE TABLE ADDRESS (ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 2, INCREMENT BY 1), street VARCHAR(255), number INTEGER)");
+        String dbProductName = null;
+        try {
+            dbProductName = db.connection.getMetaData().getDatabaseProductName();
+        } catch (SQLException e) {
+            Assert.assertFalse(true);
+            e.printStackTrace();
+        }
+        if (DbEnum.POSTGRESQL.equals(DbEnum.fromName(dbProductName))) {
+            return Collections.singletonList("CREATE TABLE ADDRESS ("
+                    + "ID SERIAL PRIMARY KEY, "
+                    + "street VARCHAR(255), nummer INTEGER)");
+        } else if (DbEnum.MYSQL.equals(DbEnum.fromName(dbProductName))) {
+            return Collections.singletonList("CREATE TABLE ADDRESS ("
+                    + "ID INT NOT NULL AUTO_INCREMENT PRIMARY KEY, "
+                    + "street VARCHAR(255), nummer INTEGER)");
+        } else if (DbEnum.APACHE_DERBY.equals(DbEnum.fromName(dbProductName))) {
+            return Collections.singletonList("CREATE TABLE ADDRESS (ID INTEGER NOT NULL "
+                    + "GENERATED ALWAYS AS IDENTITY (START WITH 2, INCREMENT BY 1), "
+                    + "street VARCHAR(255), number INTEGER)");
+        } else {
+            return Collections.singletonList("CREATE TABLE ADDRESS ("
+                    + "ID NUMBER GENERATED ALWAYS AS IDENTITY, "
+                    + "street VARCHAR(255), nummer INTEGER)");
+        }
     }
 
     @Override

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
@@ -53,7 +53,7 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
 
     @Override
     protected List<String> setupStatements() {
-        return Collections.singletonList("CREATE TABLE ADDRESS (street VARCHAR(255), number INTEGER)");
+        return Collections.singletonList("CREATE TABLE ADDRESS (ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 2, INCREMENT BY 1), street VARCHAR(255), number INTEGER)");
     }
 
     @Override
@@ -87,9 +87,9 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
         parameters.put("street", "LaborInVain");
 
         return Arrays.asList(new Object[][] {
-                { "INSERT INTO ADDRESS VALUES ('East Davie Street', 100)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "100" }),
+                { "INSERT INTO ADDRESS (street, number) VALUES ('East Davie Street', 100)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "100" }),
                         Collections.singletonMap("STREET", new String[] { "East Davie Street" })), Collections.emptyMap()},
-                { "INSERT INTO ADDRESS VALUES (:#street, :#number)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "14" }),
+                { "INSERT INTO ADDRESS (street, number) VALUES (:#street, :#number)", Arrays.asList(Collections.singletonMap("NUMBER", new String[] { "14" }),
                         Collections.singletonMap("STREET", new String[] { "LaborInVain" })), parameters}
         });
     }
@@ -111,6 +111,7 @@ public class SqlConnectorTest extends SqlConnectorTestSupport {
 
         try (Statement stmt = db.connection.createStatement()) {
             stmt.execute("SELECT * FROM ADDRESS");
+
             List<Properties> jsonBeans = resultSetToList(stmt.getResultSet())
                                                     .stream()
                                                     .map(raw -> {

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
@@ -71,13 +71,13 @@ public class JSONBeanUtilTest {
         final ObjectMapper mapper = new ObjectMapper();
         final SimpleOutputBean bean = new SimpleOutputBean();
         bean.setC(50);
-        final String jsonBeanExcpected = mapper.writeValueAsString(bean);
+        final String jsonBeanExpected = mapper.writeValueAsString(bean);
 
         final Map<String, Object> map = new HashMap<>();
         map.put("c", 50);
         map.put("#update-count-1", 0);
         final String jsonBeanActual = JSONBeanUtil.toJSONBean(map);
-        Assert.assertEquals(jsonBeanExcpected, jsonBeanActual);
+        Assert.assertEquals(jsonBeanExpected, jsonBeanActual);
     }
 
     @Test

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
@@ -65,14 +65,14 @@ public final class SqlConnectionRule extends ExternalResource {
                 //ignore
             }
             try (Statement stmt = connection.createStatement()) {
-                stmt.executeUpdate("CREATE TABLE name0 (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))");
+                stmt.executeUpdate("CREATE TABLE NAME0 (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))");
                 stmt.executeUpdate("CREATE TABLE ADDRESS0 (id INTEGER PRIMARY KEY, Address VARCHAR(255), " + "lastName VARCHAR(255))");
             }
         } catch (final SQLException e) {
             throw new AssertionError("Exception during database startup.", e);
         }
 
-        schema = DatabaseMetaDataHelper.getDefaultSchema(connection.getMetaData().getDatabaseProductName(), user);
+        schema = new DbMetaDataHelper(connection).getDefaultSchema(user);
     }
 
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataITCase.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataITCase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import io.syndesis.connector.sql.db.Db;
+
+@RunWith(Parameterized.class)
+public class SqlMetaDataITCase {
+
+    @Rule
+    public JdbcDatabaseContainer<?> database;
+    
+    public SqlMetaDataITCase(final JdbcDatabaseContainer<?> database) {
+        this.database = database;
+    }
+ 
+    @SuppressWarnings("resource")
+    @Parameters
+    public static Collection<Object> databaseContainerImages() {
+        return Arrays.asList(
+                //new DerbyContainer(),  //
+                new PostgreSQLContainer<>(),
+                new MariaDBContainer<>()
+                );
+    }
+
+    @Test
+    public void defaultValuesTest() throws SQLException {
+        try (Statement stmt = database.createConnection("").createStatement()) {
+            final String createTable = "CREATE TABLE TEST (charType CHAR, varcharType VARCHAR(255), "
+                + "numericType NUMERIC, decimalType DECIMAL, smallintType SMALLINT," + "dateType DATE, timeType TIME )";
+            stmt.executeUpdate(createTable);
+            final String sql = String.format("INSERT INTO TEST VALUES ('J', 'Jackson',0, 0, 0, '%s', '%s')", SqlParam.SqlSampleValue.DATE_VALUE,
+                SqlParam.SqlSampleValue.TIME_VALUE);
+            stmt.executeUpdate(sql);
+        }
+
+        String select = "SELECT * FROM TEST where charType=:#myCharValue";
+        final SqlStatementParser sqlParser = new SqlStatementParser(database.createConnection(""), select);
+        final SqlStatementMetaData paramInfo = sqlParser.parse();
+        final List<SqlParam> inputParams = paramInfo.getInParams();
+        // information for input
+        Assert.assertEquals(1, inputParams.size());
+        Assert.assertEquals(Character.class, inputParams.get(0).getTypeValue().getClazz());
+
+        // information for output of select statement
+        final List<SqlParam> outputParams = paramInfo.getOutParams();
+        Assert.assertEquals(7, outputParams.size());
+        Assert.assertEquals(Character.class, outputParams.get(0).getTypeValue().getClazz());
+    }
+
+    @Test
+    public void parseInsertAllColumns() throws SQLException {
+        try (Statement stmt = database.createConnection("").createStatement()) {
+            final String createTable = "CREATE TABLE TEST (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))";
+            stmt.executeUpdate(createTable);
+            stmt.executeUpdate("INSERT INTO TEST VALUES (1, 'Joe', 'Jackson')");
+            stmt.executeUpdate("INSERT INTO TEST VALUES (2, 'Roger', 'Waters')");
+        }
+
+        final String sqlStatement = "INSERT INTO TEST VALUES (:#id, :#first, :#last)";
+        final SqlStatementParser parser = new SqlStatementParser(database.createConnection(""), sqlStatement);
+        final SqlStatementMetaData info = parser.parse();
+
+        final List<SqlParam> paramList = new DbMetaDataHelper(database.createConnection("")).getJDBCInfoByColumnOrder(null, null, "TEST",
+                info.getInParams());
+            Assert.assertEquals("INTEGER", paramList.get(0).getJdbcType().getName());
+            Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
+            Assert.assertEquals("VARCHAR", paramList.get(2).getJdbcType().getName());
+
+    }
+
+    @Test
+    public void parseInsertWithSpecifiedColumnNames() throws SQLException {
+        try (Statement stmt = database.createConnection("").createStatement()) {
+            final String createTable = "CREATE TABLE TEST (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))";
+            stmt.executeUpdate(createTable);
+            stmt.executeUpdate("INSERT INTO TEST (ID, FIRSTNAME, LASTNAME) VALUES (1, 'Joe', 'Jackson')");
+            stmt.executeUpdate("INSERT INTO TEST (ID, FIRSTNAME, LASTNAME) VALUES (2, 'Roger', 'Waters')");
+        }
+
+        final String sqlStatement = "INSERT INTO TEST (ID, FIRSTNAME, LASTNAME) VALUES (:#id, :#first, :#last)";
+        final SqlStatementParser parser = new SqlStatementParser(database.createConnection(""), sqlStatement);
+        final SqlStatementMetaData info = parser.parse();
+
+        final List<SqlParam> paramList = new DbMetaDataHelper(database.createConnection("")).getJDBCInfoByColumnOrder(null, null, "TEST",
+                info.getInParams());
+        Assert.assertEquals("INTEGER", paramList.get(0).getJdbcType().getName());
+        Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
+        Assert.assertEquals("VARCHAR", paramList.get(2).getJdbcType().getName());
+
+    }
+
+    @Test
+    public void parseInsertAutoIncrPK() throws SQLException {
+        Db testDb = new DbAdapter(database.createConnection("")).getDb();
+        try (Statement stmt = database.createConnection("").createStatement()) {
+            final String createTable = "CREATE TABLE TEST (id2 " + testDb.getAutoIncrementGrammar() + ", firstName VARCHAR(255), " + "lastName VARCHAR(255))";
+            stmt.executeUpdate(createTable);
+            stmt.executeUpdate("INSERT INTO TEST (FIRSTNAME, LASTNAME) VALUES ('Joe', 'Jackson')");
+            stmt.executeUpdate("INSERT INTO TEST (FIRSTNAME, LASTNAME) VALUES ('Roger', 'Waters')");
+        }
+
+        final String sqlStatement = "INSERT INTO TEST (FIRSTNAME, LASTNAME) VALUES (:#first, :#last)";
+        final SqlStatementParser parser = new SqlStatementParser(database.createConnection(""), sqlStatement);
+        final SqlStatementMetaData info = parser.parse();
+
+        final List<SqlParam> paramList = new DbMetaDataHelper(database.createConnection("")).getJDBCInfoByColumnNames(null, null, "TEST",
+                info.getInParams());
+        Assert.assertEquals("VARCHAR", paramList.get(0).getJdbcType().getName());
+        Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
+
+    }
+
+    @Test
+    public void parseSelect() throws SQLException {
+        final Statement stmt = database.createConnection("").createStatement();
+        final String createTable = "CREATE TABLE TEST (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))";
+        stmt.executeUpdate(createTable);
+        stmt.executeUpdate("INSERT INTO TEST VALUES (1, 'Joe', 'Jackson')");
+        stmt.executeUpdate("INSERT INTO TEST VALUES (2, 'Roger', 'Waters')");
+
+        final String sqlStatement = "SELECT FIRSTNAME, LASTNAME FROM TEST WHERE ID=:#id";
+        final SqlStatementParser parser = new SqlStatementParser(database.createConnection(""), sqlStatement);
+        final SqlStatementMetaData info = parser.parse();
+
+        final List<SqlParam> paramList = new DbMetaDataHelper(database.createConnection("")).getJDBCInfoByColumnOrder(null, null, "TEST",
+                info.getInParams());
+        Assert.assertEquals("INTEGER", paramList.get(0).getJdbcType().getName());
+    }
+
+    @After
+    public void afterClass() throws SQLException {
+        try (final Statement stmt = database.createConnection("").createStatement()) {
+            stmt.execute("DROP table TEST");
+        }
+    }
+
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.connector.sql.common;
 
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -45,7 +44,6 @@ public class SqlMetaDataTest {
         final SqlStatementParser sqlParser = new SqlStatementParser(db.connection, select);
         final SqlStatementMetaData paramInfo = sqlParser.parse();
 
-        final DatabaseMetaData meta = db.connection.getMetaData();
         final List<SqlParam> inputParams = new DbMetaDataHelper(db.connection).getJDBCInfoByColumnNames(null, db.schema,
             paramInfo.getTableNames().get(0), paramInfo.getInParams());
         // information for input

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
@@ -104,6 +104,26 @@ public class SqlMetaDataTest {
     }
 
     @Test
+    public void parseInsertAutoIncrPK() throws SQLException {
+        try (Statement stmt = db.connection.createStatement()) {
+            final String createTable = "CREATE TABLE NAME4 (id2 INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), firstName VARCHAR(255), " + "lastName VARCHAR(255))";
+            stmt.executeUpdate(createTable);
+            stmt.executeUpdate("INSERT INTO NAME4 (FIRSTNAME, LASTNAME) VALUES ('Joe', 'Jackson')");
+            stmt.executeUpdate("INSERT INTO NAME4 (FIRSTNAME, LASTNAME) VALUES ('Roger', 'Waters')");
+        }
+
+        final String sqlStatement = "INSERT INTO NAME4 (FIRSTNAME, LASTNAME) VALUES (:#first, :#last)";
+        final SqlStatementParser parser = new SqlStatementParser(db.connection, sqlStatement);
+        final SqlStatementMetaData info = parser.parse();
+
+        final List<SqlParam> paramList = DatabaseMetaDataHelper.getJDBCInfoByColumnNames(db.connection.getMetaData(), null, null, "NAME4",
+            info.getInParams());
+        Assert.assertEquals("VARCHAR", paramList.get(0).getJdbcType().getName());
+        Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
+
+    }
+
+    @Test
     public void parseSelect() throws SQLException {
         final Statement stmt = db.connection.createStatement();
         final String createTable = "CREATE TABLE NAME (id INTEGER PRIMARY KEY, firstName VARCHAR(255), " + "lastName VARCHAR(255))";

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlMetaDataTest.java
@@ -46,7 +46,7 @@ public class SqlMetaDataTest {
         final SqlStatementMetaData paramInfo = sqlParser.parse();
 
         final DatabaseMetaData meta = db.connection.getMetaData();
-        final List<SqlParam> inputParams = DatabaseMetaDataHelper.getJDBCInfoByColumnNames(meta, null, db.schema,
+        final List<SqlParam> inputParams = new DbMetaDataHelper(db.connection).getJDBCInfoByColumnNames(null, db.schema,
             paramInfo.getTableNames().get(0), paramInfo.getInParams());
         // information for input
         Assert.assertEquals(1, inputParams.size());
@@ -56,7 +56,7 @@ public class SqlMetaDataTest {
         for (final SqlParam sqlParam : inputParams) {
             select = select.replace(":#" + sqlParam.getName(), "'" + sqlParam.getTypeValue().getSampleValue().toString() + "'");
         }
-        final List<SqlParam> outputParams = DatabaseMetaDataHelper.getOutputColumnInfo(db.connection, select);
+        final List<SqlParam> outputParams = new DbMetaDataHelper(db.connection).getOutputColumnInfo(select);
         Assert.assertEquals(7, outputParams.size());
         Assert.assertEquals(Character.class, outputParams.get(0).getTypeValue().getClazz());
     }
@@ -74,7 +74,7 @@ public class SqlMetaDataTest {
         final SqlStatementParser parser = new SqlStatementParser(db.connection, sqlStatement);
         final SqlStatementMetaData info = parser.parse();
 
-        final List<SqlParam> paramList = DatabaseMetaDataHelper.getJDBCInfoByColumnOrder(db.connection.getMetaData(), null, null, "NAME2",
+        final List<SqlParam> paramList = new DbMetaDataHelper(db.connection).getJDBCInfoByColumnOrder(null, null, "NAME2",
             info.getInParams());
         Assert.assertEquals("INTEGER", paramList.get(0).getJdbcType().getName());
         Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
@@ -95,7 +95,7 @@ public class SqlMetaDataTest {
         final SqlStatementParser parser = new SqlStatementParser(db.connection, sqlStatement);
         final SqlStatementMetaData info = parser.parse();
 
-        final List<SqlParam> paramList = DatabaseMetaDataHelper.getJDBCInfoByColumnNames(db.connection.getMetaData(), null, null, "NAME3",
+        final List<SqlParam> paramList = new DbMetaDataHelper(db.connection).getJDBCInfoByColumnNames(null, null, "NAME3",
             info.getInParams());
         Assert.assertEquals("INTEGER", paramList.get(0).getJdbcType().getName());
         Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
@@ -116,7 +116,7 @@ public class SqlMetaDataTest {
         final SqlStatementParser parser = new SqlStatementParser(db.connection, sqlStatement);
         final SqlStatementMetaData info = parser.parse();
 
-        final List<SqlParam> paramList = DatabaseMetaDataHelper.getJDBCInfoByColumnNames(db.connection.getMetaData(), null, null, "NAME4",
+        final List<SqlParam> paramList = new DbMetaDataHelper(db.connection).getJDBCInfoByColumnNames(null, null, "NAME4",
             info.getInParams());
         Assert.assertEquals("VARCHAR", paramList.get(0).getJdbcType().getName());
         Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
@@ -135,7 +135,7 @@ public class SqlMetaDataTest {
         final SqlStatementParser parser = new SqlStatementParser(db.connection, sqlStatement);
         final SqlStatementMetaData info = parser.parse();
 
-        final List<SqlParam> paramList = DatabaseMetaDataHelper.getOutputColumnInfo(db.connection, info.getDefaultedSqlStatement());
+        final List<SqlParam> paramList = new DbMetaDataHelper(db.connection).getOutputColumnInfo(info.getDefaultedSqlStatement());
         Assert.assertEquals("VARCHAR", paramList.get(0).getJdbcType().getName());
         Assert.assertEquals("VARCHAR", paramList.get(1).getJdbcType().getName());
     }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
@@ -39,7 +39,7 @@ public class SqlParserTest {
         Assert.assertEquals(String.class, info.getInParams().get(0).getTypeValue().getClazz());
         Assert.assertEquals("id", info.getInParams().get(1).getName());
         Assert.assertEquals("ID", info.getInParams().get(1).getColumn());
-        if (db.connection.getMetaData().getDatabaseProductName().equalsIgnoreCase(DatabaseProduct.ORACLE.name())) {
+        if (db.connection.getMetaData().getDatabaseProductName().equalsIgnoreCase(DbEnum.ORACLE.name())) {
             Assert.assertEquals(BigDecimal.class, info.getInParams().get(1).getTypeValue().getClazz());
         } else {
             Assert.assertEquals(Integer.class, info.getInParams().get(1).getTypeValue().getClazz());
@@ -54,7 +54,7 @@ public class SqlParserTest {
         Assert.assertEquals(1, info.getInParams().size());
         Assert.assertEquals("id", info.getInParams().get(0).getName());
         Assert.assertEquals("ID", info.getInParams().get(0).getColumn());
-        if (db.connection.getMetaData().getDatabaseProductName().equalsIgnoreCase(DatabaseProduct.ORACLE.name())) {
+        if (db.connection.getMetaData().getDatabaseProductName().equalsIgnoreCase(DbEnum.ORACLE.name())) {
             Assert.assertEquals(BigDecimal.class, info.getInParams().get(0).getTypeValue().getClazz());
         } else {
             Assert.assertEquals(Integer.class, info.getInParams().get(0).getTypeValue().getClazz());

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredCommon.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredCommon.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import io.syndesis.connector.sql.SqlSupport;
-import io.syndesis.connector.sql.common.DatabaseProduct;
+import io.syndesis.connector.sql.common.DbEnum;
 import io.syndesis.connector.sql.common.stored.StoredProcedureMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ public class SqlStoredCommon {
     public static void setupStoredProcedure(Connection connection, Properties properties) throws Exception {
 
         try {
-            String databaseProductName = connection.getMetaData().getDatabaseProductName();
+            String dbProductName = connection.getMetaData().getDatabaseProductName();
             Map<String,Object> parameters = new HashMap<>();
             for (final String name: properties.stringPropertyNames()) {
                 parameters.put(name.substring(name.indexOf('.') + 1), properties.getProperty(name));
@@ -45,7 +45,7 @@ public class SqlStoredCommon {
             Map<String,StoredProcedureMetadata> storedProcedures = SqlSupport.getStoredProcedures(parameters);
 
             if (!storedProcedures.keySet().contains("DEMO_ADD")
-                    && databaseProductName.equalsIgnoreCase(DatabaseProduct.APACHE_DERBY.nameWithSpaces())) {
+                    && DbEnum.APACHE_DERBY.equals(DbEnum.fromName(dbProductName))) {
                 try (Statement stmt = connection.createStatement()) {
                     stmt.execute(SampleStoredProcedures.DERBY_DEMO_ADD_SQL);
                     LOGGER.info("Created procedure {}", SampleStoredProcedures.DERBY_DEMO_ADD_SQL);
@@ -55,7 +55,7 @@ public class SqlStoredCommon {
                 }
             }
             if (!storedProcedures.keySet().contains("DEMO_OUT")
-                    && databaseProductName.equalsIgnoreCase(DatabaseProduct.APACHE_DERBY.nameWithSpaces())) {
+                    && DbEnum.APACHE_DERBY.equals(DbEnum.fromName(dbProductName))) {
                 try (Statement stmt = connection.createStatement()) {
                     //Create procedure
                     stmt.execute(SampleStoredProcedures.DERBY_DEMO_OUT_SQL);

--- a/app/connector/sql/src/test/resources/test-options.properties
+++ b/app/connector/sql/src/test/resources/test-options.properties
@@ -1,17 +1,17 @@
 # Oracle database configuration to use
-# sql-connector.url=jdbc:oracle:thin:@<hostname>:<port>:<sid>
-# sql-connector.user=<user>
-# sql-connector.password=<password>
+#sql-connector.url=jdbc:oracle:thin:@localhost:1521:syndesis
+#sql-connector.user=system
+#sql-connector.password=syndesis
 
-# Postgres database configuration
-#sql-connector.url=jdbc:postgresql://localhost:5432/test
-#sql-connector.user=<user>
-#sql-connector.password=<password>
+# Postgres database configuration (note port offset)
+#sql-connector.url=jdbc:postgresql://localhost:5433/test
+#sql-connector.user=postgres
+#sql-connector.password=syndesis
 
-# Mysql database configuration
-#sql-connector.url=jdbc:mysql://localhost:3306/test?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
-#sql-connector.user=test
-#sql-connector.password=password
+# Mysql database configuration (note port offset)
+#sql-connector.url=jdbc:mysql://localhost:3307/test?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
+#sql-connector.user=root
+#sql-connector.password=syndesis
 
 # Derby database configuration
 sql-connector.url=jdbc:derby:memory:testdb;create=true

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -115,6 +115,7 @@
     <json-schema-validator.version>2.2.8</json-schema-validator.version>
     <junit.version>4.12</junit.version>
     <powermock.version>2.0.0</powermock.version>
+    <testcontainers.version>1.10.6</testcontainers.version>
 
     <spring-security.version>4.2.6.RELEASE</spring-security.version>
     <resteasy.version>3.6.1.Final</resteasy.version>
@@ -1955,6 +1956,29 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>jdbc</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mariadb</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
       <!-- ========================================== -->
 
       <!-- === Atlasmap -->


### PR DESCRIPTION
SQL Connector: Return generated keys for INSERT statement SQL Connector:  #4466

I'm going to address possible refactoring suggestions made in #4466 in a different PR