### PR TITLE
chore: upgrade Spring Boot to 1.5.17.RELEASE

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -59,7 +59,7 @@
     <kubernetes.client.version>3.1.12.fuse-730022</kubernetes.client.version>
 
     <spring.version>4.3.18.RELEASE</spring.version>
-    <spring-boot.version>1.5.16.RELEASE</spring-boot.version>
+    <spring-boot.version>1.5.17.RELEASE</spring-boot.version>
     <spring-cloud.version>Dalston.SR5</spring-cloud.version>
 
     <swagger.version>1.5.19</swagger.version>


### PR DESCRIPTION
This is the version used in 2.21 version of the Fuse fork[1].

[1] https://repository.jboss.org/nexus/content/groups/ea/org/apache/camel/camel-parent/2.21.0.fuse-730072/camel-parent-2.21.0.fuse-730072.pom