### PR TITLE
chore: Ensure spring security oauth2 2.0.16

### DIFF
--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -39,10 +39,10 @@
     <google-api-services-sheets-version>v4-rev551-1.22.0</google-api-services-sheets-version>
   </properties>
 
-  <!-- ToDo add once camel component made it into the fuse build -->
-  <!--dependencyManagement>
+  <dependencyManagement>
     <dependencies>
-      <dependency>
+      <!-- ToDo add once camel component made it into the fuse build -->
+      <!--dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
         <version>${camel.version}</version>
@@ -56,9 +56,21 @@
             <artifactId>guava-jdk5</artifactId>
           </exclusion>
         </exclusions>
+      </dependency-->
+
+      <dependency>
+        <groupId>org.springframework.security.oauth</groupId>
+        <artifactId>spring-security-oauth2</artifactId>
+        <version>2.0.16.RELEASE</version>
+        <exclusions>
+          <exclusion>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
-  </dependencyManagement-->
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Make sure 2.0.16.RELEASE is used as managed version 2.0.15 is having security issues