### PR TITLE
chore: release speed up

### DIFF
--- a/doc/sdh/cli/cmd_release.adoc
+++ b/doc/sdh/cli/cmd_release.adoc
@@ -50,6 +50,8 @@ Options for release:
                               Works only when on a branch, not when checked out directly.
 
     --log <log-file>          Write full log to <log-file>, only print progress to screen
+    --skip-tests              Do not run tests
+    --no-strict-checksums     Do not insist on strict checksum policy for downloaded Maven artifacts
     --man                     Open HTML documentation in the Syndesis Developer Handbook
 ----
 

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -31,6 +31,7 @@ release::usage() {
                               Works only when on a branch, not when checked out directly.
     --log <log-file>          Write full log to <log-file>, only print progress to screen
     --skip-tests              Do not run tests
+    --no-strict-checksums     Do not insist on strict checksum policy for downloaded Maven artifacts
 EOT
 }
 
@@ -438,6 +439,10 @@ extract_maven_opts() {
 
     if [ $(hasflag --skip-tests) ]; then
         maven_opts="$maven_opts -DskipTests -DskipITs"
+    fi
+
+    if [ ! $(hasflag --no-strict-checksums) ]; then
+        maven_opts="$maven_opts -C"
     fi
 
     echo $maven_opts

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -30,6 +30,7 @@ release::usage() {
                               to the git remote to which the currently checked out branch is attached to.
                               Works only when on a branch, not when checked out directly.
     --log <log-file>          Write full log to <log-file>, only print progress to screen
+    --skip-tests              Do not run tests
 EOT
 }
 
@@ -433,6 +434,10 @@ extract_maven_opts() {
     local settings_xml=$(readopt --settings-xml --settings)
     if [ -n "${settings_xml}" ]; then
         maven_opts="$maven_opts -s $settings_xml"
+    fi
+
+    if [ $(hasflag --skip-tests) ]; then
+        maven_opts="$maven_opts -DskipTests -DskipITs"
     fi
 
     echo $maven_opts


### PR DESCRIPTION
This adds `--skip-tests` and enables by default strict checksum policy (can be disabled with `--no-strict-checksums`.
This should speed up the release if run against the same local repository and with `--skip-tests`.