### PR TITLE
fix: #5096 Prevent stream already closed errors on Http based connectors

### DIFF
--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderStartEndpointCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderStartEndpointCustomizer.java
@@ -15,12 +15,21 @@
  */
 package io.syndesis.connector.apiprovider;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectReader;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeAware;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
+import io.syndesis.connector.support.processor.HttpMessageToDefaultMessageProcessor;
 import io.syndesis.connector.support.processor.HttpRequestWrapperProcessor;
 import io.syndesis.connector.support.processor.util.SimpleJsonSchemaInspector;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
@@ -31,14 +40,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.processor.Pipeline;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class ApiProviderStartEndpointCustomizer implements ComponentProxyCustomizer, CamelContextAware, DataShapeAware {
 
@@ -67,6 +68,8 @@ public class ApiProviderStartEndpointCustomizer implements ComponentProxyCustomi
                 throw new RuntimeCamelException(e);
             }
         }
+
+        beforeConsumers.add(new HttpMessageToDefaultMessageProcessor());
 
         // removes all non Syndesis.* headers, this is so the headers that might
         // influence HTTP components in the flow after this connector don't

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -79,7 +79,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-processor</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorCustomizer.java
+++ b/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.http;
+
+import java.util.Map;
+import io.syndesis.connector.support.processor.HttpMessageToDefaultMessageProcessor;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
+public class HttpConnectorCustomizer implements ComponentProxyCustomizer {
+
+    @Override
+    public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        component.setBeforeConsumer(new HttpMessageToDefaultMessageProcessor());
+    }
+}

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/http4.json
@@ -86,6 +86,9 @@
       "description": "Periodically invoke an http endpoint URL",
       "descriptor": {
         "connectorFactory": "io.syndesis.connector.http.HttpConnectorFactories$Http4",
+        "connectorCustomizers": [
+          "io.syndesis.connector.http.HttpConnectorCustomizer"
+        ],
         "inputDataShape": {
           "kind": "none"
         },

--- a/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
+++ b/app/connector/http/src/main/resources/META-INF/syndesis/connector/https4.json
@@ -86,6 +86,9 @@
       "description": "Periodically invoke an http endpoint URL",
       "descriptor": {
         "connectorFactory": "io.syndesis.connector.http.HttpConnectorFactories$Https4",
+        "connectorCustomizers": [
+          "io.syndesis.connector.http.HttpConnectorCustomizer"
+        ],
         "inputDataShape": {
           "kind": "none"
         },

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpMessageToDefaultMessageProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpMessageToDefaultMessageProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.http.common.HttpMessage;
+import org.apache.camel.impl.DefaultMessage;
+import org.apache.camel.util.ExchangeHelper;
+
+/**
+ * Integrations may frequently overwrite message body content. HttpMessage is having issues with that
+ * as it tries to read the request input stream cache multiple times in that case. This results to stream already closed
+ * errors while processing the message body.
+ *
+ * Normal stream caching mechanisms on the http message implementation do not solve this issue as message body gets frequently
+ * replaced while running the integration and this in particular is not covered.
+ *
+ * This replaces the message on the exchange so the type of the message is no longer HttpMessage and when copies of the message
+ * are attempted the HTTP request stream is not read the second time. At which point the HTTP request stream might be closed.
+ */
+public class HttpMessageToDefaultMessageProcessor implements Processor {
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        final Message message = exchange.getIn();
+        if (message instanceof HttpMessage) {
+            final Message replacement = new DefaultMessage(exchange.getContext());
+            replacement.copyFrom(message);
+            ExchangeHelper.replaceMessage(exchange, replacement, false);
+        }
+    }
+}

--- a/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WebhookConnectorCustomizerTest.java
+++ b/app/connector/webhook/src/test/java/io/syndesis/connector/webhook/WebhookConnectorCustomizerTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.connector.support.processor.HttpMessageToDefaultMessageProcessor;
 import io.syndesis.connector.support.processor.HttpRequestWrapperProcessor;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
@@ -83,7 +84,9 @@ public class WebhookConnectorCustomizerTest {
         assertThat(beforeConsumer).isInstanceOf(Pipeline.class);
         final Pipeline pipeline = (Pipeline) beforeConsumer;
         final Collection<Processor> processors = pipeline.getProcessors();
-        assertThat(processors).hasSize(2).anySatisfy(p -> assertThat(p).isInstanceOf(HttpRequestWrapperProcessor.class));
+        assertThat(processors).hasSize(3);
+        assertThat(processors).anySatisfy(p -> assertThat(p).isInstanceOf(HttpRequestWrapperProcessor.class));
+        assertThat(processors).anySatisfy(p -> assertThat(p).isInstanceOf(HttpMessageToDefaultMessageProcessor.class));
 
         final HttpRequestWrapperProcessor wrapper = (HttpRequestWrapperProcessor) processors.stream().filter(p -> p instanceof HttpRequestWrapperProcessor)
             .findFirst().get();
@@ -100,6 +103,7 @@ public class WebhookConnectorCustomizerTest {
     @Test
     public void shouldDestroyAllOutput() throws Exception {
         final WebhookConnectorCustomizer customizer = new WebhookConnectorCustomizer();
+        customizer.setCamelContext(mock(CamelContext.class));
         customizer.customize(component, Collections.emptyMap());
 
         final Processor afterConsumer = component.getAfterConsumer();


### PR DESCRIPTION
fixes #5096

This PR add Http request wrapper processors to Http based connectors in order to replace HttpMessage with DefaultMessage on the exchanges.

This is because the HttpMessage implementation raises stream closed errors when integration frequently replaces message bodies in out messages (e.g. with data mapper)