### PR TITLE
fix: #5110 Add support for Json array Strings in Google Sheets

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
 import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.common.util.Json;
+import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.connector.sheets.meta.GoogleSheetsMetaDataHelper;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
@@ -84,7 +85,12 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
         if (in.getBody() instanceof List) {
             jsonBeans = in.getBody(List.class);
         } else if (in.getBody(String.class) != null) {
-            jsonBeans = Collections.singletonList(in.getBody(String.class));
+            String body = in.getBody(String.class);
+            if (JsonUtils.isJsonArray(body)) {
+                jsonBeans = JsonUtils.arrayToJsonBeans(Json.reader().readTree(body));
+            } else if (JsonUtils.isJson(body)) {
+                jsonBeans = Collections.singletonList(body);
+            }
         }
 
         ValueRange valueRange = new ValueRange();

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -287,4 +287,66 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
         Assert.assertNull(valueRange.getValues().get(1).get(2));
     }
+
+    @Test
+    public void testBeforeProducerWithJsonArray() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B2");
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        String body = "[{" +
+                            "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                            "\"A\": \"a1\"," +
+                            "\"B\": \"b1\"" +
+                        "}," +
+                        "{" +
+                            "\"spreadsheetId\": \"" + getSpreadsheetId() + "\"," +
+                            "\"A\": \"a2\"," +
+                            "\"B\": \"b2\"" +
+                        "}]";
+        inbound.getIn().setBody(body);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals("A1:B2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assert.assertEquals(2L, valueRange.getValues().size());
+        Assert.assertEquals(2L, valueRange.getValues().get(0).size());
+        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));
+        Assert.assertEquals(2L, valueRange.getValues().get(1).size());
+        Assert.assertEquals("a2", valueRange.getValues().get(1).get(0));
+        Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
+    }
+
+    @Test
+    public void testBeforeProducerWithJsonObject() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("range", "A1:B2");
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        String body = "{\"spreadsheetId\": \"" + getSpreadsheetId() + "\", \"A\": \"a1\", \"B\": \"b1\" }";
+        inbound.getIn().setBody(body);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals("A1:B2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION));
+        Assert.assertEquals("USER_ENTERED", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption"));
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assert.assertEquals(1L, valueRange.getValues().size());
+        Assert.assertEquals(2L, valueRange.getValues().get(0).size());
+        Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
+        Assert.assertEquals("b1", valueRange.getValues().get(0).get(1));
+    }
 }


### PR DESCRIPTION
Google Sheets update customizer now able to also handle Json Array String as message body. Before it was only handling list typed body. When doing a split in front of the connector we are provided with a Json String body representing the values to update.