### PR TITLE
refactor: remove `clean` goal from second Maven...

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -75,7 +75,7 @@
     <commons.compress.version>1.18</commons.compress.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.21.0.fuse-730054</camel.version>
+    <camel.version>2.21.0.fuse-730074</camel.version>
     <camel-k-runtime.version>0.3.1</camel-k-runtime.version>
 
     <dep.plugin.dependency.version>3.0.2</dep.plugin.dependency.version>

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -275,10 +275,10 @@ build_and_stage_artefacts() {
 
     if [ $(hasflag --snapshot-release) ]; then
         echo "==== Building locally (--no-maven-release)"
-        ./mvnw ${maven_opts} clean install -Pflash
+        ./mvnw ${maven_opts} install -Pflash
     else
         echo "==== Building and staging Maven artefacts to Sonatype"
-        ./mvnw ${maven_opts} -Prelease clean deploy -DstagingDescription="Staging Syndesis for $(readopt --release-version)"
+        ./mvnw ${maven_opts} -Prelease deploy -DstagingDescription="Staging Syndesis for $(readopt --release-version)"
     fi
 }
 


### PR DESCRIPTION
... invocation in release command

We call Maven to build everything we call to install/deploy to staging
repository with `clean` which builds everything again. I think the
second `clean` can be removed and the artifacts already built can be
reused. This should speed up the release build considerably.