### PR TITLE
Hibernate Validator upgrade and RESTEasy 4 groundwork

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/activemq/pom.xml
+++ b/app/connector/activemq/pom.xml
@@ -147,7 +147,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/api-provider/pom.xml
+++ b/app/connector/api-provider/pom.xml
@@ -108,7 +108,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/aws-s3/pom.xml
+++ b/app/connector/aws-s3/pom.xml
@@ -138,7 +138,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/fhir/pom.xml
+++ b/app/connector/fhir/pom.xml
@@ -170,7 +170,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/gmail/pom.xml
+++ b/app/connector/gmail/pom.xml
@@ -135,7 +135,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/google-calendar/pom.xml
+++ b/app/connector/google-calendar/pom.xml
@@ -139,7 +139,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -287,7 +287,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -130,7 +130,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/irc/pom.xml
+++ b/app/connector/irc/pom.xml
@@ -99,7 +99,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/kafka/pom.xml
+++ b/app/connector/kafka/pom.xml
@@ -104,7 +104,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/log/pom.xml
+++ b/app/connector/log/pom.xml
@@ -78,7 +78,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -281,7 +281,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -201,7 +201,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/salesforce/pom.xml
+++ b/app/connector/salesforce/pom.xml
@@ -137,7 +137,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -166,7 +166,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/support/maven-plugin/pom.xml
+++ b/app/connector/support/maven-plugin/pom.xml
@@ -99,7 +99,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -90,7 +90,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/timer/pom.xml
+++ b/app/connector/timer/pom.xml
@@ -81,7 +81,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -225,7 +225,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/integration/api/pom.xml
+++ b/app/integration/api/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -145,7 +145,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/integration/runtime-camelk/pom.xml
+++ b/app/integration/runtime-camelk/pom.xml
@@ -47,7 +47,7 @@
       <artifactId>integration-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/integration/runtime-springboot/pom.xml
+++ b/app/integration/runtime-springboot/pom.xml
@@ -193,7 +193,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -152,7 +152,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -176,6 +176,12 @@
       <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- === Micrometer ================================================================== -->
 
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -52,7 +52,7 @@
     <node.version>v10.15.1</node.version>
     <yarn.version>v1.13.0</yarn.version>
 
-    <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
+    <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
 
     <jackson.version>2.9.8</jackson.version>
     <json-patch.version>1.9</json-patch.version>
@@ -1467,6 +1467,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-validator-provider-11</artifactId>
+        <version>${resteasy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-servlet</artifactId>
         <version>1.4.26.Final</version>
@@ -1559,6 +1571,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1631,9 +1647,21 @@
       </dependency>
 
       <dependency>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernate.validator.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator-annotation-processor</artifactId>
+        <version>${hibernate.validator.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>2.0.1.Final</version>
       </dependency>
 
       <dependency>
@@ -1945,13 +1973,6 @@
         <groupId>org.powermock</groupId>
         <artifactId>powermock-core</artifactId>
         <version>${powermock.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -174,7 +174,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/server/builder/maven-plugin/pom.xml
+++ b/app/server/builder/maven-plugin/pom.xml
@@ -341,7 +341,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/controller/pom.xml
+++ b/app/server/controller/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -153,7 +153,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/dao/pom.xml
+++ b/app/server/dao/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
 

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -274,7 +274,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -28,8 +28,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
-import javax.validation.groups.ConvertGroup;
-import javax.validation.groups.Default;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -49,7 +47,6 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.ConnectionOverview;
 import io.syndesis.common.model.connection.Connector;
-import io.syndesis.common.model.validation.AllValidations;
 import io.syndesis.server.credential.CredentialFlowState;
 import io.syndesis.server.credential.Credentials;
 import io.syndesis.server.dao.manager.DataManager;
@@ -145,7 +142,7 @@ public class ConnectionHandler
     }
 
     @Override
-    public Connection create(@Context SecurityContext sec, @ConvertGroup(from = Default.class, to = AllValidations.class) final Connection connection) {
+    public Connection create(@Context SecurityContext sec, final Connection connection) {
         final Date rightNow = new Date();
 
         // Lets make sure we store encrypt secrets.
@@ -191,7 +188,7 @@ public class ConnectionHandler
     }
 
     @Override
-    public void update(final String id, @ConvertGroup(from = Default.class, to = AllValidations.class) final Connection connection) {
+    public void update(final String id, final Connection connection) {
         // Lets make sure we store encrypt secrets.
         Map<String, String> configuredProperties = connection.getConfiguredProperties();
         Map<String, ConfigurationProperty> connectorProperties = getConnectorProperties(connection.getConnectorId());

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -17,8 +17,6 @@ package io.syndesis.server.endpoint.v1.handler.integration;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Validator;
-import javax.validation.groups.ConvertGroup;
-import javax.validation.groups.Default;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -42,7 +40,6 @@ import io.syndesis.common.model.filter.Op;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.IntegrationDeployment;
 import io.syndesis.common.model.integration.IntegrationOverview;
-import io.syndesis.common.model.validation.AllValidations;
 import io.syndesis.server.api.generator.APIGenerator;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.dao.manager.EncryptionComponent;
@@ -92,8 +89,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     }
 
     @Override
-    public Integration create(@Context final SecurityContext sec,
-        @ConvertGroup(from = Default.class, to = AllValidations.class) final Integration integration) {
+    public Integration create(@Context final SecurityContext sec, final Integration integration) {
         final Integration encryptedIntegration = encryptionSupport.encrypt(integration);
 
         final Integration updatedIntegration = new Integration.Builder().createFrom(encryptedIntegration)
@@ -208,8 +204,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     }
 
     @Override
-    public void update(final String id,
-        @ConvertGroup(from = Default.class, to = AllValidations.class) final Integration integration) {
+    public void update(final String id, final Integration integration) {
         final Integration existing = getIntegration(id);
 
         Integration updatedIntegration = new Integration.Builder().createFrom(encryptionSupport.encrypt(integration))

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/Creator.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/Creator.java
@@ -17,6 +17,8 @@ package io.syndesis.server.endpoint.v1.operations;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.groups.ConvertGroup;
+import javax.validation.groups.Default;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
@@ -26,13 +28,15 @@ import javax.ws.rs.core.SecurityContext;
 
 import io.syndesis.server.dao.manager.WithDataManager;
 import io.syndesis.common.model.WithId;
+import io.syndesis.common.model.validation.AllValidations;
 
 public interface Creator<T extends WithId<T>> extends Resource, WithDataManager {
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes("application/json")
-    default T create(@Context SecurityContext sec, @NotNull @Valid T obj) {
+    default T create(@Context SecurityContext sec,
+        @NotNull @Valid @ConvertGroup(from = Default.class, to = AllValidations.class) T obj) {
         return getDataManager().create(obj);
     }
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/Updater.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/Updater.java
@@ -24,6 +24,8 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
+import javax.validation.groups.ConvertGroup;
+import javax.validation.groups.Default;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -48,7 +50,8 @@ public interface Updater<T extends WithId<T>> extends Resource, WithDataManager 
     @PUT
     @Path(value = "/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
-    default void update(@NotNull @PathParam("id") @ApiParam(required = true) String id, @NotNull @Valid T obj) {
+    default void update(@NotNull @PathParam("id") @ApiParam(required = true) String id,
+        @NotNull @Valid @ConvertGroup(from = Default.class, to = AllValidations.class) T obj) {
         getDataManager().update(obj);
     }
 
@@ -58,7 +61,7 @@ public interface Updater<T extends WithId<T>> extends Resource, WithDataManager 
     default void patch(@NotNull @PathParam("id") @ApiParam(required = true) String id, @NotNull JsonNode patchJson) throws IOException {
         Class<T> modelClass = resourceKind().getModelClass();
         final T existing = getDataManager().fetch(modelClass, id);
-        if( existing == null ) {
+        if (existing == null) {
             throw new EntityNotFoundException();
         }
 

--- a/app/server/logging/jsondb/pom.xml
+++ b/app/server/logging/jsondb/pom.xml
@@ -120,7 +120,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
@@ -51,7 +51,7 @@ public class HttpClient {
 
         resteasyJacksonProvider.setMapper(mapper);
 
-        final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
+        final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
         providerFactory.register(resteasyJacksonProvider);
 
         final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);

--- a/app/server/monitoring/pom.xml
+++ b/app/server/monitoring/pom.xml
@@ -107,7 +107,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -738,7 +738,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
 

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
@@ -67,7 +67,7 @@ public class ExternalVerifierService implements Verifier {
 
             resteasyJacksonProvider.setMapper(mapper);
 
-            final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
+            final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
             providerFactory.register(resteasyJacksonProvider);
 
             final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);


### PR DESCRIPTION
This upgrades to the latest Hibernate Validator version, and since the REST validation support in RESTEasy still depends on the older version of Hibernate Validator (v5) prepares a bit for the RESTEasy v4 which is in CR right now.

We can't upgrade to RESTEasy v4 as the Spring Boot starter for RESTEasy is not updated to RESTEasy v4 and will fail to run if we do upgrade.

For the same reason some groundwork for supporting RESTEasy v4 when the Spring Boot starter ends up supporting it is in this PR.