### PR TITLE
fix(#5151): OData connector to correctly support EDM Complex Values

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -24,6 +24,7 @@ import org.apache.camel.Component;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.olingo4.Olingo4AppEndpointConfiguration;
 import org.apache.camel.component.olingo4.Olingo4Component;
+import org.apache.http.HttpHeaders;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import io.syndesis.connector.odata.ODataConstants;
@@ -204,6 +205,13 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         Olingo4Component component = new Olingo4Component(getCamelContext());
         Olingo4AppEndpointConfiguration configuration = new Olingo4AppEndpointConfiguration();
 
+        //
+        // Ensure that full odata metadata is returned by the olingo request
+        //
+        Map<String, String> httpHeaders = new HashMap<>();
+        httpHeaders.put(HttpHeaders.ACCEPT, "application/json;odata.metadata=full,application/xml,*/*");
+        configuration.setHttpHeaders(httpHeaders);
+
         Object methodName = options.get(METHOD_NAME);
         if (methodName == null) {
             throw new IllegalStateException("No method specified for odata component");
@@ -214,8 +222,8 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         //
         // Ensure at least a blank map exists for this property
         //
-        Map<String, String> httpHeaders = new HashMap<>();
-        configuration.setEndpointHttpHeaders(httpHeaders);
+        Map<String, String> endPointHttpHeaders = new HashMap<>();
+        configuration.setEndpointHttpHeaders(endPointHttpHeaders);
 
         Map<String, Object> resolvedOptions = bundleOptions();
         HttpClientBuilder httpClientBuilder = ODataUtil.createHttpClientBuilder(resolvedOptions);

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/AbstractODataCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/AbstractODataCustomizer.java
@@ -56,7 +56,7 @@ public abstract class AbstractODataCustomizer implements ComponentProxyCustomize
             .addSerializer(new ClientPrimitiveValueSerializer())
             .addSerializer(new ClientEnumValueSerializer())
             .addSerializer(new ClientCollectionValueSerializer())
-            .addSerializer(new ClientComplexValueSerializer(OBJECT_MAPPER));
+            .addSerializer(new ClientComplexValueSerializer());
         OBJECT_MAPPER.registerModule(module);
     }
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/json/ClientComplexValueSerializer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/json/ClientComplexValueSerializer.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import org.apache.olingo.client.api.domain.ClientComplexValue;
 import org.apache.olingo.client.api.domain.ClientProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.syndesis.common.util.StringConstants;
@@ -30,11 +29,8 @@ public class ClientComplexValueSerializer
 
     private static final long serialVersionUID = 1L;
 
-    private ObjectMapper objectMapper;
-
-    public ClientComplexValueSerializer(ObjectMapper objectMapper) {
+    public ClientComplexValueSerializer() {
         this((Class<ClientComplexValue>) null);
-        this.objectMapper = objectMapper;
     }
 
     public ClientComplexValueSerializer(Class<ClientComplexValue> t) {
@@ -48,28 +44,15 @@ public class ClientComplexValueSerializer
 
     @Override
     public void serialize(ClientComplexValue value, JsonGenerator generator, SerializerProvider provider) throws IOException {
-        generator.writeStartArray();
+        generator.writeStartObject();
 
-        Iterator<?> iterator = value.iterator();
+        Iterator<ClientProperty> iterator = value.iterator();
         while (iterator.hasNext()) {
-            Object element = iterator.next();
-            if (element instanceof ClientProperty) {
-                ClientProperty property = (ClientProperty) element;
-                String propertyName = property.getName();
-                String propertyValue = objectMapper.writeValueAsString(property);
-
-                StringBuilder builder = new StringBuilder();
-                builder
-                    .append(OPEN_BRACE)
-                    .append(propertyName)
-                    .append(COLON)
-                    .append(propertyValue)
-                    .append(CLOSE_BRACE);
-
-                generator.writeString(builder.toString());
-            }
+            ClientProperty property = iterator.next();
+            generator.writeFieldName(property.getName());
+            generator.writeObject(property.getValue());
         }
 
-        generator.writeEndArray();
+        generator.writeEndObject();
     }
 }

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/EdmTypeConvertor.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/EdmTypeConvertor.java
@@ -15,13 +15,18 @@
  */
 package io.syndesis.connector.odata.meta;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.olingo.commons.api.edm.EdmComplexType;
 import org.apache.olingo.commons.api.edm.EdmElement;
+import org.apache.olingo.commons.api.edm.EdmEntityType;
 import org.apache.olingo.commons.api.edm.EdmEnumType;
 import org.apache.olingo.commons.api.edm.EdmNavigationProperty;
 import org.apache.olingo.commons.api.edm.EdmParameter;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveType;
 import org.apache.olingo.commons.api.edm.EdmProperty;
+import org.apache.olingo.commons.api.edm.EdmStructuredType;
 import org.apache.olingo.commons.api.edm.EdmType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,11 +49,21 @@ public class EdmTypeConvertor {
         return metadata;
     }
 
-    private PropertyMetadata visit(EdmEnumType type) {
+    private Set<PropertyMetadata> properties(EdmStructuredType structuredType) {
+        Set<PropertyMetadata> properties = new HashSet<>();
+        List<String> propertyNames = structuredType.getPropertyNames();
+        for (String propertyName : propertyNames) {
+            EdmElement property = structuredType.getProperty(propertyName);
+            properties.add(visit(property));
+        }
+        return properties;
+    }
+
+    public PropertyMetadata visit(EdmEnumType type) {
         return visit(type.getUnderlyingType());
     }
 
-    private PropertyMetadata visit(EdmPrimitiveType type) {
+    public PropertyMetadata visit(EdmPrimitiveType type) {
         switch (type.getName()) {
             case "Boolean":
                 return property(Boolean.class);
@@ -77,12 +92,18 @@ public class EdmTypeConvertor {
         }
     }
 
-    @SuppressWarnings("PMD")
-    private PropertyMetadata visit(EdmComplexType type) {
-        return property(Object.class);
+    public PropertyMetadata visit(EdmComplexType type) {
+        PropertyMetadata property = property(Object.class);
+        Set<PropertyMetadata> childProperties = properties(type);
+        property.setChildProperties(childProperties);
+        return property;
     }
 
-    private PropertyMetadata visit(EdmType type) {
+    public Set<PropertyMetadata> visit(EdmEntityType entityType) {
+        return properties(entityType);
+    }
+
+    public PropertyMetadata visit(EdmType type) {
         if (type instanceof EdmEnumType) {
             return visit((EdmEnumType) type);
         } else if (type instanceof EdmPrimitiveType) {
@@ -97,7 +118,9 @@ public class EdmTypeConvertor {
     public PropertyMetadata visit(EdmNavigationProperty property) {
         this.nullable = property.isNullable();
         this.isCollection = property.isCollection();
-        return visit(property.getType());
+        PropertyMetadata metaProperty = property(Object.class);
+        metaProperty.setChildProperties(visit(property.getType()));
+        return metaProperty;
     }
 
     public PropertyMetadata visit(EdmParameter property) {

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataExtension.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataExtension.java
@@ -16,7 +16,6 @@
 package io.syndesis.connector.odata.meta;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -30,7 +29,6 @@ import org.apache.olingo.client.api.communication.response.ODataRetrieveResponse
 import org.apache.olingo.client.api.http.HttpClientFactory;
 import org.apache.olingo.client.core.ODataClientFactory;
 import org.apache.olingo.commons.api.edm.Edm;
-import org.apache.olingo.commons.api.edm.EdmElement;
 import org.apache.olingo.commons.api.edm.EdmEntityContainer;
 import org.apache.olingo.commons.api.edm.EdmEntitySet;
 import org.apache.olingo.commons.api.edm.EdmEntityType;
@@ -106,18 +104,10 @@ public class ODataMetaDataExtension extends AbstractMetaDataExtension implements
             return;
         }
 
-        EdmEntityType entityType = entitySet.getEntityType();
-        List<String> propertyNames = entityType.getPropertyNames();
-        for (String propertyName : propertyNames) {
-            EdmElement property = entityType.getProperty(propertyName);
-            PropertyMetadata convertedType = convert(property);
-            odataMetadata.addEntityProperty(convertedType);
-        }
-    }
-
-    private PropertyMetadata convert(EdmElement property) {
         EdmTypeConvertor visitor = new EdmTypeConvertor();
-        return visitor.visit(property);
+        EdmEntityType entityType = entitySet.getEntityType();
+        Set<PropertyMetadata> properties = visitor.visit(entityType);
+        odataMetadata.setEntityProperties(properties);
     }
 
     private void extractEdmNames(ODataMetadata odataMetadata, Edm edm) {

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -150,7 +151,15 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
                 schema = factory.numberSchema();
                 break;
             case OBJECT:
-                schema = factory.objectSchema();
+                ObjectSchema objectSchema = factory.objectSchema();
+                Set<PropertyMetadata> childProperties = propertyMetadata.getChilldProperties();
+                if (childProperties != null) {
+                    for (PropertyMetadata childProperty : childProperties) {
+                        JsonSchema childSchema = schemaFor(childProperty);
+                        objectSchema.putProperty(childProperty.getName(), childSchema);
+                    }
+                }
+                schema = objectSchema;
                 break;
             default:
                 schema = factory.anySchema();

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetadata.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetadata.java
@@ -46,6 +46,7 @@ public class ODataMetadata implements ODataConstants {
         private TypeClass type;
         private boolean array;
         private boolean required;
+        private Set<PropertyMetadata> chilldProperties;
 
         public PropertyMetadata(String name, Class<?> type) {
             this.name = name;
@@ -75,6 +76,14 @@ public class ODataMetadata implements ODataConstants {
         public void setRequired(boolean required) {
             this.required = required;
         }
+
+        public Set<PropertyMetadata> getChilldProperties() {
+            return chilldProperties;
+        }
+
+        public void setChildProperties(Set<PropertyMetadata> childProperties) {
+            this.chilldProperties = childProperties;
+        }
     }
 
     private Set<String> entityNames;
@@ -95,6 +104,10 @@ public class ODataMetadata implements ODataConstants {
         }
 
         entityProperties.add(property);
+    }
+
+    public void setEntityProperties(Set<PropertyMetadata> properties) {
+        entityProperties = properties;
     }
 
     public boolean hasEntityNames() {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/BaseOlingo4Test.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/BaseOlingo4Test.java
@@ -20,12 +20,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.olingo4.Olingo4AppEndpointConfiguration;
 import org.apache.camel.component.olingo4.Olingo4Component;
 import org.apache.camel.main.Main;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.olingo.client.api.ODataClient;
 import org.apache.olingo.client.api.communication.response.ODataRetrieveResponse;
@@ -94,6 +96,14 @@ public class BaseOlingo4Test extends AbstractODataTest {
         // workaround the no serviceUri problem.
         //
         Olingo4AppEndpointConfiguration configuration = new Olingo4AppEndpointConfiguration();
+
+        //
+        // Override the ACCEPT header since it does not take account of the odata.metadata parameter
+        //
+        Map<String, String> httpHeaders = new HashMap<>();
+        httpHeaders.put(HttpHeaders.ACCEPT, "application/json;odata.metadata=full,application/xml,*/*");
+        configuration.setHttpHeaders(httpHeaders);
+
         configuration.setServiceUri(defaultTestServer.servicePlainUri());
 
         //
@@ -125,8 +135,6 @@ public class BaseOlingo4Test extends AbstractODataTest {
         main.addRouteBuilder(new MyRouteBuilder(camelURI));
 
         try {
-            main.start();
-
             ClientEntitySet olEntitySet = null;
             ODataRetrieveResponse<ClientEntitySet> response = null;
             try {
@@ -141,6 +149,8 @@ public class BaseOlingo4Test extends AbstractODataTest {
                     response.close();
                 }
             }
+
+            main.start();
 
             /*
              * Note:

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
@@ -76,7 +76,7 @@ public class ODataSerializerTest extends AbstractODataTest {
             .addSerializer(new ClientPrimitiveValueSerializer())
             .addSerializer(new ClientEnumValueSerializer())
             .addSerializer(new ClientCollectionValueSerializer())
-            .addSerializer(new ClientComplexValueSerializer(OBJECT_MAPPER));
+            .addSerializer(new ClientComplexValueSerializer());
         OBJECT_MAPPER.registerModule(module);
     }
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
@@ -39,6 +39,7 @@ public abstract class AbstractODataReadRouteTest extends AbstractODataRouteTest 
     protected static final String REF_SERVER_PEOPLE_DATA_3 = "ref-server-people-data-3.json";
     protected static final String REF_SERVER_PEOPLE_DATA_KLAX = "ref-server-data-klax.json";
     protected static final String REF_SERVER_PEOPLE_DATA_KLAX_LOC = "ref-server-data-klax-location.json";
+    protected static final String REF_SERVER_AIRPORT_DATA_1 = "ref-server-airport-data-1.json";
     protected static final String TEST_SERVER_DATA_EMPTY = "test-server-data-empty.json";
 
     private final boolean splitResult;

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -282,6 +282,30 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
     }
 
     @Test
+    public void testReferenceODataRouteIssue5151() throws Exception {
+        String resourcePath = "Airports";
+
+        context = new SpringCamelContext(applicationContext);
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(1);
+        result.setResultWaitTime(3600000L);
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testResult(result, 0, REF_SERVER_AIRPORT_DATA_1);
+    }
+
+    @Test
     public void testODataRouteWithSimpleQuery() throws Exception {
         String queryParams = "$filter=ID eq 1";
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataTest.java
@@ -95,4 +95,21 @@ public class ODataMetaDataTest extends AbstractODataTest {
         assertThat(meta.get().getPayload()).isInstanceOf(ODataMetadata.class);
     }
 
+    @Test
+    public void testMetaDataExtensionRetrievalOnceResourcePathSet() throws Exception {
+        ODataMetaDataExtension extension = new ODataMetaDataExtension(context);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SERVICE_URI, defaultTestServer.servicePlainUri());
+        parameters.put(RESOURCE_PATH, "Products");
+        Optional<MetaDataExtension.MetaData> meta = extension.meta(parameters);
+        assertThat(meta).isPresent();
+
+        Object payload = meta.get().getPayload();
+        assertThat(payload).isInstanceOf(ODataMetadata.class);
+        ODataMetadata odataMetadata = (ODataMetadata) payload;
+        assertThat(odataMetadata.getEntityNames().size()).isEqualTo(1);
+        assertThat(odataMetadata.getEntityNames().iterator().next()).isEqualTo(defaultTestServer.resourcePath());
+    }
+
 }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataServerConstants.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataServerConstants.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.odata.server;
+
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+import io.syndesis.common.util.StringConstants;
+
+public interface ODataServerConstants extends StringConstants {
+
+    // Service Namespace
+    String NAMESPACE = "OData.Demo";
+
+    // EDM Container
+    String CONTAINER_NAME = "Container";
+    FullQualifiedName CONTAINER = new FullQualifiedName(NAMESPACE, CONTAINER_NAME);
+
+    // Entity Types Names
+    String ET_PRODUCT_NAME = "Product";
+    FullQualifiedName ET_PRODUCT_FQN = new FullQualifiedName(NAMESPACE, ET_PRODUCT_NAME);
+
+    String ET_SPEC_NAME = "Specification";
+    FullQualifiedName ET_SPEC_FQN = new FullQualifiedName(NAMESPACE, ET_SPEC_NAME);
+
+    // Entity Set Names
+    String ES_PRODUCTS_NAME = "Products";
+
+    String PRODUCT_ID = "ID";
+    String PRODUCT_NAME = "Name";
+    String PRODUCT_DESCRIPTION = "Description";
+    String PRODUCT_SERIALS = "SerialNumbers";
+    String PRODUCT_SPEC = "Specification";
+
+    String SPEC_PRODUCT_TYPE = "ProductType";
+    String SPEC_DETAIL_1 = "Detail1";
+    String SPEC_DETAIL_2 = "Detail2";
+
+}

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEdmProvider.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEdmProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 import org.apache.olingo.commons.api.edm.provider.CsdlAbstractEdmProvider;
+import org.apache.olingo.commons.api.edm.provider.CsdlComplexType;
 import org.apache.olingo.commons.api.edm.provider.CsdlEntityContainer;
 import org.apache.olingo.commons.api.edm.provider.CsdlEntityContainerInfo;
 import org.apache.olingo.commons.api.edm.provider.CsdlEntitySet;
@@ -34,41 +35,51 @@ import org.apache.olingo.commons.api.edm.provider.CsdlSchema;
  * Taken from the tutorial:
  * https://olingo.apache.org/doc/odata4/tutorials/read/tutorial_read.html
  */
-public class ProductsEdmProvider extends CsdlAbstractEdmProvider {
+public class ProductsEdmProvider extends CsdlAbstractEdmProvider implements ODataServerConstants {
 
-    // Service Namespace
-    public static final String NAMESPACE = "OData.Demo";
+    @Override
+    public CsdlComplexType getComplexType(FullQualifiedName complexTypeName) {
+        if (complexTypeName.equals(ET_SPEC_FQN)) {
+            CsdlProperty type = new CsdlProperty().setName(SPEC_PRODUCT_TYPE)
+                .setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlProperty detail1 = new CsdlProperty().setName(SPEC_DETAIL_1)
+                .setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlProperty detail2 = new CsdlProperty().setName(SPEC_DETAIL_2)
+                .setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlComplexType complexType = new CsdlComplexType();
+            complexType.setName(ET_SPEC_NAME);
+            complexType.setProperties(Arrays.asList(type, detail1, detail2));
+            return complexType;
+        }
 
-    // EDM Container
-    public static final String CONTAINER_NAME = "Container";
-    public static final FullQualifiedName CONTAINER = new FullQualifiedName(NAMESPACE, CONTAINER_NAME);
-
-    // Entity Types Names
-    public static final String ET_PRODUCT_NAME = "Product";
-    public static final FullQualifiedName ET_PRODUCT_FQN = new FullQualifiedName(NAMESPACE, ET_PRODUCT_NAME);
-
-    // Entity Set Names
-    public static final String ES_PRODUCTS_NAME = "Products";
+        return null;
+    }
 
     @Override
     public CsdlEntityType getEntityType(FullQualifiedName entityTypeName) {
-
         // this method is called for one of the EntityTypes that are configured in the Schema
         if (entityTypeName.equals(ET_PRODUCT_FQN)) {
 
             //create EntityType properties
-            CsdlProperty id = new CsdlProperty().setName("ID").setType(EdmPrimitiveTypeKind.Int32.getFullQualifiedName());
-            CsdlProperty name = new CsdlProperty().setName("Name").setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
-            CsdlProperty description = new CsdlProperty().setName("Description").setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlProperty id = new CsdlProperty().setName(PRODUCT_ID).setType(EdmPrimitiveTypeKind.Int32.getFullQualifiedName());
+            CsdlProperty name = new CsdlProperty().setName(PRODUCT_NAME).setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlProperty description = new CsdlProperty().setName(PRODUCT_DESCRIPTION).setType(EdmPrimitiveTypeKind.String.getFullQualifiedName());
+            CsdlProperty serialNums = new CsdlProperty()
+                .setName(PRODUCT_SERIALS)
+                .setType(EdmPrimitiveTypeKind.String.getFullQualifiedName())
+                .setCollection(true);
+            CsdlProperty specification = new CsdlProperty()
+                .setName(PRODUCT_SPEC)
+                .setType(ET_SPEC_FQN);
 
             // create CsdlPropertyRef for Key element
             CsdlPropertyRef propertyRef = new CsdlPropertyRef();
-            propertyRef.setName("ID");
+            propertyRef.setName(PRODUCT_ID);
 
             // configure EntityType
             CsdlEntityType entityType = new CsdlEntityType();
             entityType.setName(ET_PRODUCT_NAME);
-            entityType.setProperties(Arrays.asList(id, name, description));
+            entityType.setProperties(Arrays.asList(id, name, description, serialNums, specification));
             entityType.setKey(Collections.singletonList(propertyRef));
 
             return entityType;
@@ -114,6 +125,10 @@ public class ProductsEdmProvider extends CsdlAbstractEdmProvider {
         // create Schema
         CsdlSchema schema = new CsdlSchema();
         schema.setNamespace(NAMESPACE);
+
+        List<CsdlComplexType> complexTypes = new ArrayList<CsdlComplexType>();
+        complexTypes.add(getComplexType(ET_SPEC_FQN));
+        schema.setComplexTypes(complexTypes);
 
         // add EntityTypes
         List<CsdlEntityType> entityTypes = new ArrayList<CsdlEntityType>();

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Storage.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Storage.java
@@ -20,6 +20,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.apache.olingo.commons.api.data.ComplexValue;
 import org.apache.olingo.commons.api.data.Entity;
 import org.apache.olingo.commons.api.data.EntityCollection;
 import org.apache.olingo.commons.api.data.Property;
@@ -27,21 +28,27 @@ import org.apache.olingo.commons.api.data.ValueType;
 import org.apache.olingo.commons.api.edm.EdmEntitySet;
 import org.apache.olingo.commons.api.edm.EdmEntityType;
 import org.apache.olingo.commons.api.edm.EdmKeyPropertyRef;
+import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.ex.ODataRuntimeException;
 import org.apache.olingo.commons.api.http.HttpMethod;
 import org.apache.olingo.commons.api.http.HttpStatusCode;
 import org.apache.olingo.server.api.ODataApplicationException;
 import org.apache.olingo.server.api.uri.UriParameter;
+import org.assertj.core.util.Arrays;
 
-public class Storage {
+public class Storage implements ODataServerConstants {
+
+    private static Object storageLock = new Object();
 
     private static Storage storage;
 
     private List<Entity> productList;
 
     public static Storage getInstance() {
-        if (storage == null) {
-            storage = new Storage();
+        synchronized(storageLock) {
+            if (storage == null) {
+                storage = new Storage();
+            }
         }
 
         return storage;
@@ -152,6 +159,14 @@ public class Storage {
         return requestedEntity;
     }
 
+    private URI createId(String entitySetName, Object id) {
+        try {
+            return new URI(entitySetName + OPEN_BRACKET + String.valueOf(id) + CLOSE_BRACKET);
+        } catch (URISyntaxException e) {
+            throw new ODataRuntimeException("Unable to create id for entity: " + entitySetName, e);
+        }
+    }
+
     private Entity createProduct(EdmEntityType edmEntityType, Entity entity) {
         // the ID of the newly created product entity is generated automatically
         int newId = 1;
@@ -159,14 +174,14 @@ public class Storage {
             newId++;
         }
 
-        Property idProperty = entity.getProperty("ID");
+        Property idProperty = entity.getProperty(PRODUCT_ID);
         if (idProperty != null) {
             idProperty.setValue(ValueType.PRIMITIVE, Integer.valueOf(newId));
         } else {
             // as of OData v4 spec, the key property can be omitted from the POST request body
-            entity.getProperties().add(new Property(null, "ID", ValueType.PRIMITIVE, newId));
+            entity.getProperties().add(new Property(null, PRODUCT_ID, ValueType.PRIMITIVE, newId));
         }
-        entity.setId(createId("Products", newId));
+        entity.setId(createId(ES_PRODUCTS_NAME, newId));
         this.productList.add(entity);
 
         return entity;
@@ -175,7 +190,7 @@ public class Storage {
 
     private boolean productIdExists(int id) {
         for (Entity entity : this.productList) {
-            Integer existingID = (Integer)entity.getProperty("ID").getValue();
+            Integer existingID = (Integer)entity.getProperty(PRODUCT_ID).getValue();
             if (existingID.intValue() == id) {
                 return true;
             }
@@ -244,38 +259,67 @@ public class Storage {
         return false;
     }
 
-    private void initSampleData() {
-        // add some sample product entities
-        final Entity e1 = new Entity()
-                .addProperty(new Property(null, "ID", ValueType.PRIMITIVE, 1))
-                .addProperty(new Property(null, "Name", ValueType.PRIMITIVE, "Notebook Basic 15"))
-                .addProperty(new Property(null, "Description", ValueType.PRIMITIVE,
-                        "Notebook Basic, 1.7GHz - 15 XGA - 1024MB DDR2 SDRAM - 40GB"));
-        e1.setId(createId("Products", 1));
-        productList.add(e1);
-
-        final Entity e2 = new Entity()
-                .addProperty(new Property(null, "ID", ValueType.PRIMITIVE, 2))
-                .addProperty(new Property(null, "Name", ValueType.PRIMITIVE, "1UMTS PDA"))
-                .addProperty(new Property(null, "Description", ValueType.PRIMITIVE,
-                        "Ultrafast 3G UMTS/HSDPA Pocket PC, supports GSM network"));
-        e2.setId(createId("Products", 2));
-        productList.add(e2);
-
-        final Entity e3 = new Entity()
-                .addProperty(new Property(null, "ID", ValueType.PRIMITIVE, 3))
-                .addProperty(new Property(null, "Name", ValueType.PRIMITIVE, "Ergo Screen"))
-                .addProperty(new Property(null, "Description", ValueType.PRIMITIVE,
-                        "19 Optimum Resolution 1024 x 768 @ 85Hz, resolution 1280 x 960"));
-        e3.setId(createId("Products", 3));
-        productList.add(e3);
+    private ComplexValue createSpec(String productType, String detail1, String detail2) {
+        ComplexValue complexValue = new ComplexValue();
+        List<Property> complexValueValue = complexValue.getValue();
+        complexValueValue.add(new Property(
+                                           EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                           SPEC_PRODUCT_TYPE, ValueType.PRIMITIVE, productType));
+        complexValueValue.add(new Property(
+                                           EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                           SPEC_DETAIL_1, ValueType.PRIMITIVE, detail1));
+        complexValueValue.add(new Property(
+                                           EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                           SPEC_DETAIL_2, ValueType.PRIMITIVE, detail2));
+        return complexValue;
     }
 
-    private URI createId(String entitySetName, Object id) {
-        try {
-            return new URI(entitySetName + "(" + String.valueOf(id) + ")");
-        } catch (URISyntaxException e) {
-            throw new ODataRuntimeException("Unable to create id for entity: " + entitySetName, e);
-        }
+    private Entity createEntity(int id, String name, String description, String[] serials, ComplexValue spec) {
+        Entity e = new Entity()
+            .addProperty(new Property(
+                                  EdmPrimitiveTypeKind.Int32.getFullQualifiedName().toString(),
+                                  PRODUCT_ID, ValueType.PRIMITIVE, id))
+            .addProperty(new Property(
+                                  EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                  PRODUCT_NAME, ValueType.PRIMITIVE, name))
+            .addProperty(new Property(
+                                  EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                  PRODUCT_DESCRIPTION, ValueType.PRIMITIVE, description))
+            .addProperty(new Property(
+                                  EdmPrimitiveTypeKind.String.getFullQualifiedName().toString(),
+                                  PRODUCT_SERIALS, ValueType.COLLECTION_PRIMITIVE, Arrays.asList(serials)))
+            .addProperty(new Property(
+                                  ET_SPEC_FQN.toString(),
+                                  PRODUCT_SPEC, ValueType.COMPLEX, spec));
+
+        e.setId(createId(ES_PRODUCTS_NAME, id));
+        return e;
+    }
+
+    private void initSampleData() {
+        // add some sample product entities
+        String[] e1Serials = {"ae8353484", "er5845474", "px376876"};
+        ComplexValue e1Spec = createSpec("Notebook", "CPU AMD Ryzen 3 2200U", "Dual-Core Cores");
+
+        productList.add(createEntity(1,
+                                 "Notebook Basic 15",
+                                 "Notebook Basic, 1.7GHz - 15 XGA - 1024MB DDR2 SDRAM - 40GB",
+                                 e1Serials, e1Spec));
+
+        String[] e2Serials = {"ae867484", "er586874", "px3429876"};
+        ComplexValue e2Spec = createSpec("Tablet", "Android OS", "Resolution - 1920 x 1200");
+
+        productList.add(createEntity(2,
+                                     "1UMTS PDA",
+                                     "Ultrafast 3G UMTS/HSDPA Pocket PC, supports GSM network",
+                                     e2Serials, e2Spec));
+
+        String[] e3Serials = {"ae949549", "er342367", "px230434"};
+        ComplexValue e3Spec = createSpec("Monitor", "Diagonal Size 22", "Aspect Ratio 16:9");
+
+        productList.add(createEntity(3,
+                                     "Ergo Screen",
+                                     "19 Optimum Resolution 1024 x 768 @ 85Hz, resolution 1280 x 960",
+                                     e3Serials, e3Spec));
     }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-airport-data-1.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-airport-data-1.json
@@ -1,0 +1,14 @@
+{
+  "Name":"San Francisco International Airport",
+  "IcaoCode":"KSFO",
+  "IataCode":"SFO",
+  "Location":{
+    "Address":"South McDonnell Road, San Francisco, CA 94128",
+    "Loc":"GEOGRAPHY'SRID=4326;Point(-122.374722222222 37.6188888888889)'",
+    "City":{
+      "Name":"San Francisco",
+      "CountryRegion":"United States",
+      "Region":"California"
+    }
+  }
+}

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax-location.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax-location.json
@@ -1,5 +1,9 @@
-[
-    "{Address:\"1 World Way, Los Angeles, CA, 90045\"}",
-    "{Loc:\"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'\"}",
-    "{City:[\"{Name:\\\"Los Angeles\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"California\\\"}\"]}"
-]
+{
+  "Address":"1 World Way, Los Angeles, CA, 90045",
+  "Loc":"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'",
+  "City":{
+    "Name":"Los Angeles",
+    "CountryRegion":"United States",
+    "Region":"California"
+  }
+}

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-data-klax.json
@@ -2,9 +2,13 @@
     "Name":"Los Angeles International Airport",
     "IcaoCode":"KLAX",
     "IataCode":"LAX",
-    "Location":[
-        "{Address:\"1 World Way, Los Angeles, CA, 90045\"}",
-        "{Loc:\"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'\"}",
-        "{City:[\"{Name:\\\"Los Angeles\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"California\\\"}\"]}"
-    ]
+    "Location":{
+        "Address":"1 World Way, Los Angeles, CA, 90045",
+        "Loc":"GEOGRAPHY'SRID=4326;Point(-118.408055555556 33.9425)'",
+        "City":{
+          "Name":"Los Angeles",
+          "CountryRegion":"United States",
+          "Region":"California"
+        }
+    }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1.json
@@ -3,22 +3,26 @@
   "FirstName": "Russell",
   "LastName": "Whyte",
   "MiddleName": "",
-  "Gender": "Male",
+  "Gender": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'Male'",
   "Age": "",
   "Emails": [
     "Russell@example.com",
     "Russell@contoso.com"
   ],
-  "FavoriteFeature": "Feature1",
+  "FavoriteFeature": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'Feature1'",
   "Features": [
-    "Feature1",
-    "Feature2"
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'Feature1'",
+    "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'Feature2'"
   ],
   "AddressInfo": [
-    [
-      "{Address:\"187 Suffolk Ln.\"}",
-      "{City:[\"{Name:\\\"Boise\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"ID\\\"}\"]}"
-    ]
+    {
+      "Address":"187 Suffolk Ln.",
+      "City":{
+        "Name":"Boise",
+        "CountryRegion":"United States",
+        "Region":"ID"
+      }
+    }
   ],
   "HomeAddress": "",
   "ResultCount": 20

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-2.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-2.json
@@ -3,18 +3,22 @@
   "FirstName": "Scott",
   "LastName": "Ketchum",
   "MiddleName": "",
-  "Gender": "Male",
+  "Gender": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'Male'",
   "Age": "",
   "Emails": [
     "Scott@example.com"
   ],
-  "FavoriteFeature": "Feature1",
+  "FavoriteFeature": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'Feature1'",
   "Features":[],
   "AddressInfo": [
-    [
-      "{Address:\"2817 Milton Dr.\"}",
-      "{City:[\"{Name:\\\"Albuquerque\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"NM\\\"}\"]}"
-    ]
+    {
+      "Address":"2817 Milton Dr.",
+      "City":{
+        "Name":"Albuquerque",
+        "CountryRegion":"United States",
+        "Region":"NM"
+      }
+    }
   ],
   "HomeAddress": "",
   "ResultCount": 20

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-3.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-3.json
@@ -3,19 +3,23 @@
   "FirstName": "Ronald",
   "LastName": "Mundy",
   "MiddleName": "",
-  "Gender": "Male",
+  "Gender": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender'Male'",
   "Age": "",
   "Emails": [
     "Ronald@example.com",
     "Ronald@contoso.com"
   ],
-  "FavoriteFeature": "Feature1",
+  "FavoriteFeature": "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Feature'Feature1'",
   "Features": [],
   "AddressInfo": [
-    [
-      "{Address:\"187 Suffolk Ln.\"}",
-      "{City:[\"{Name:\\\"Boise\\\"}\",\"{CountryRegion:\\\"United States\\\"}\",\"{Region:\\\"ID\\\"}\"]}"
-    ]
+    {
+      "Address":"187 Suffolk Ln.",
+      "City":{
+        "Name":"Boise",
+        "CountryRegion":"United States",
+        "Region":"ID"
+      }
+    }
   ],
   "HomeAddress": "",
   "ResultCount": 20

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1-with-count.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1-with-count.json
@@ -2,5 +2,11 @@
     "ID": 1,
     "Name": "Notebook Basic 15",
     "Description": "Notebook Basic, 1.7GHz - 15 XGA - 1024MB DDR2 SDRAM - 40GB",
+    "SerialNumbers": ["ae8353484","er5845474","px376876"],
+    "Specification":{
+      "ProductType":"Notebook",
+      "Detail1":"CPU AMD Ryzen 3 2200U",
+      "Detail2":"Dual-Core Cores"
+    },
     "ResultCount": 3
  }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1.json
@@ -1,5 +1,12 @@
 {
     "ID": 1,
     "Name": "Notebook Basic 15",
-    "Description": "Notebook Basic, 1.7GHz - 15 XGA - 1024MB DDR2 SDRAM - 40GB"
+    "Description": "Notebook Basic, 1.7GHz - 15 XGA - 1024MB DDR2 SDRAM - 40GB",
+    "SerialNumbers": ["ae8353484","er5845474","px376876"],
+    "Specification":{
+      "ProductType":"Notebook",
+      "Detail1":"CPU AMD Ryzen 3 2200U",
+      "Detail2":"Dual-Core Cores"
+    }
+  }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-2-with-count.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-2-with-count.json
@@ -2,5 +2,11 @@
     "ID": 2,
     "Name": "1UMTS PDA",
     "Description": "Ultrafast 3G UMTS/HSDPA Pocket PC, supports GSM network",
+    "SerialNumbers":["ae867484","er586874","px3429876"],
+    "Specification":{
+      "ProductType":"Tablet",
+      "Detail1":"Android OS",
+      "Detail2":"Resolution - 1920 x 1200"
+    },
     "ResultCount": 3
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-2.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-2.json
@@ -1,5 +1,11 @@
 {
     "ID": 2,
     "Name": "1UMTS PDA",
-    "Description": "Ultrafast 3G UMTS/HSDPA Pocket PC, supports GSM network"
+    "Description": "Ultrafast 3G UMTS/HSDPA Pocket PC, supports GSM network",
+    "SerialNumbers":["ae867484","er586874","px3429876"],
+    "Specification":{
+      "ProductType":"Tablet",
+      "Detail1":"Android OS",
+      "Detail2":"Resolution - 1920 x 1200"
+    }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-3-with-count.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-3-with-count.json
@@ -2,5 +2,11 @@
     "ID": 3,
     "Name": "Ergo Screen",
     "Description": "19 Optimum Resolution 1024 x 768 @ 85Hz, resolution 1280 x 960",
+    "SerialNumbers":["ae949549","er342367","px230434"],
+    "Specification":{
+      "ProductType":"Monitor",
+      "Detail1":"Diagonal Size 22",
+      "Detail2":"Aspect Ratio 16:9"
+    },
     "ResultCount": 3
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-3.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-3.json
@@ -1,5 +1,11 @@
 {
     "ID": 3,
     "Name": "Ergo Screen",
-    "Description": "19 Optimum Resolution 1024 x 768 @ 85Hz, resolution 1280 x 960"
+    "Description": "19 Optimum Resolution 1024 x 768 @ 85Hz, resolution 1280 x 960",
+    "SerialNumbers":["ae949549","er342367","px230434"],
+    "Specification":{
+      "ProductType":"Monitor",
+      "Detail1":"Diagonal Size 22",
+      "Detail2":"Aspect Ratio 16:9"
+    }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/test-complex.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/test-complex.json
@@ -1,7 +1,7 @@
 {
-  "testComplex": [
-      "{test1:\"test1\"}",
-      "{test2:\"test2\"}",
-      "{test3:\"test3\"}"
-  ]
+  "testComplex": {
+      "test1":"test1",
+      "test2":"test2",
+      "test3":"test3"
+  }
 }


### PR DESCRIPTION
* ODataComponent
 * Support returning full odata metadata by overriding the http ACCEPT
   header

* ClientComplexValueSerializer
 * Correct implementation to return correctly formatted json object and
   sub-objects

* EdmTypeConvertor
* OdataDataMetadata
 * Extends to generate property metadata for property objects of complex
   types

* ODataMetadataRetrieval
 * Extend the json schema returned by the output datashape to allow for
   complex types

* Updates test suite to provide complex types & values in test server and
  tests to check accordingly.