### PR TITLE
chore: Use simple text field for single value property suggestion on meta lookup

### DIFF
--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -15,15 +15,16 @@
  */
 package io.syndesis.server.endpoint.v1.handler.connection;
 
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
+import com.netflix.hystrix.HystrixExecutable;
+import com.netflix.hystrix.HystrixInvokableInfo;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -36,12 +37,8 @@ import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.endpoint.v1.dto.MetaData;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
-
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import com.netflix.hystrix.HystrixExecutable;
-import com.netflix.hystrix.HystrixInvokableInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -176,7 +173,7 @@ public class ConnectionActionHandlerTest {
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
             .replaceConfigurationProperty("sObjectName",
-                c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")))
+                c -> c.defaultValue("Contact"))
             .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("ID", "Contact ID")))
             .replaceConfigurationProperty("sObjectIdName", c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Email", "Email")))

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
@@ -96,7 +96,7 @@ public class DynamicActionSalesforceITCase extends BaseITCase {
 
     private final ConfigurationProperty contactSalesforceObjectName = new ConfigurationProperty.Builder()
         .createFrom(_DEFAULT_SALESFORCE_OBJECT_NAME)
-        .addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")).build();
+        .defaultValue("Contact").build();
 
     private final ConfigurationProperty suggestedSalesforceIdNames = new ConfigurationProperty.Builder()
         .createFrom(_DEFAULT_SALESFORCE_IDENTIFIER)


### PR DESCRIPTION
The meta data lookup for connection actions uses enums as property suggestions. This is even when only one single value has been added as property suggestion.

This PR changes the meta data lookup to only set the default value for the property when a single suggestion value is provided by the meta data retrieval. This has the effect to render a normal text field in the UI forms instead of having a single element drop down.

This way you can add a simple default value for a property as meta data lookup result based on a single value property suggestion. 