### PR TITLE
fix: #5014 Unstable Google Sheets integration tests

### DIFF
--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/AbstractGoogleSheetsTestSupport.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/AbstractGoogleSheetsTestSupport.java
@@ -169,13 +169,8 @@ public class AbstractGoogleSheetsTestSupport extends CamelTestSupport {
         return spreadsheet;
     }
 
-    public Spreadsheet getSpreadsheetWithTestData() {
-        if (spreadsheet == null) {
-            createTestSpreadsheet();
-        }
-
+    public Spreadsheet applyTestData(Spreadsheet spreadsheet) {
         createTestData();
-
         return spreadsheet;
     }
 

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIntegrationTest.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/SheetsSpreadsheetsValuesIntegrationTest.java
@@ -164,11 +164,13 @@ public class SheetsSpreadsheetsValuesIntegrationTest extends AbstractGoogleSheet
                 .hasSheetTitle("TestData")
                 .andReturnSpreadsheet(spreadsheetId);
 
+        Spreadsheet testSheet = getSpreadsheet();
+
         assertThatGoogleApi(getGoogleApiTestServer())
                 .updateValuesRequest(spreadsheetId, TEST_SHEET + "!A1:B2", Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")))
                 .andReturnUpdateResponse();
 
-        Spreadsheet testSheet = getSpreadsheetWithTestData();
+        applyTestData(testSheet);
 
         assertThatGoogleApi(getGoogleApiTestServer())
                 .clearValuesRequest(testSheet.getSpreadsheetId(), TEST_SHEET + "!A1:B2")

--- a/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIntegrationTest.java
+++ b/app/connector/google-sheets/src/test/java/org/apache/camel/component/google/sheets/stream/SheetsStreamConsumerIntegrationTest.java
@@ -48,6 +48,8 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
                 .hasSheetTitle("TestData")
                 .andReturnSpreadsheet(spreadsheetId);
 
+        Spreadsheet testSheet = getSpreadsheet();
+
         List<List<Object>> data = Arrays.asList(
                 Arrays.asList("a1", "b1"),
                 Arrays.asList("a2", "b2")
@@ -57,7 +59,7 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
                 .updateValuesRequest(spreadsheetId, range, data)
                 .andReturnUpdateResponse();
 
-        Spreadsheet testSheet = getSpreadsheetWithTestData();
+        applyTestData(testSheet);
 
         assertThatGoogleApi(getGoogleApiTestServer())
                 .batchGetValuesRequest(testSheet.getSpreadsheetId(), range)
@@ -96,6 +98,8 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
                 .hasSheetTitle("TestData")
                 .andReturnSpreadsheet(spreadsheetId);
 
+        Spreadsheet testSheet = getSpreadsheet();
+
         List<List<Object>> data = Arrays.asList(
                 Arrays.asList("a1", "b1"),
                 Arrays.asList("a2", "b2")
@@ -105,7 +109,7 @@ public class SheetsStreamConsumerIntegrationTest extends AbstractGoogleSheetsStr
                 .updateValuesRequest(spreadsheetId, range, data)
                 .andReturnUpdateResponse();
 
-        Spreadsheet testSheet = getSpreadsheetWithTestData();
+        applyTestData(testSheet);
 
         assertThatGoogleApi(getGoogleApiTestServer())
                 .batchGetValuesRequest(testSheet.getSpreadsheetId(), range)


### PR DESCRIPTION
This PR separates test spreadsheet creation from pushing initial test data to the same spreadsheet. Before this was handled in parallel on the mocked test server and this caused some racing conditions. This could lead to messed up correlation ids on the test server and one of the operations did not get any response.