### PR TITLE
Related to #5194: add marker for camel k resources

### DIFF
--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -263,7 +263,7 @@
         maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         integrationStateCheckInterval: ${INTEGRATION_STATE_CHECK_INTERVAL}
-# Access to Camel-K resources
+# START:CAMEL-K
 - kind: Role
   apiVersion: rbac.authorization.k8s.io/v1beta1
   metadata:
@@ -295,3 +295,4 @@
     kind: Role
     name: camel-k
     apiGroup: rbac.authorization.k8s.io
+# END:CAMEL-K

--- a/install/generator/04-todo-example.yml.mustache
+++ b/install/generator/04-todo-example.yml.mustache
@@ -134,7 +134,6 @@
             ports:
               - containerPort: 8080
                 name: http
-            resources: {}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
         dnsPolicy: ClusterFirst

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1287,7 +1287,7 @@ objects:
       # See the License for the specific language governing permissions and
       # limitations under the License.
       #
-
+      
       startDelaySecs: 5
       ssl: false
       blacklistObjectNames: ["java.lang:*"]
@@ -1399,8 +1399,8 @@ objects:
               context: $1
               type: context
           type: GAUGE
-
-
+      
+      
       # Route level
         - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1498,7 +1498,7 @@ objects:
               route: $2
               type: routes
           type: GAUGE
-
+      
       # Processor level
         - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1596,7 +1596,7 @@ objects:
               processor: $2
               type: processors
           type: COUNTER
-
+      
       # Consumers
         - pattern: 'org.apache.camel<context=([^,]+), type=consumers, name=([^,]+)><>InflightExchanges'
           name: org.apache.camel.InflightExchanges
@@ -1606,7 +1606,7 @@ objects:
               consumer: $2
               type: consumers
           type: GAUGE
-
+      
       # Services
         - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MaxDuration'
           name: org.apache.camel.MaxDuration
@@ -1827,7 +1827,7 @@ objects:
               type: $2
               service: $3
               port: $4
-
+      
 
 - apiVersion: v1
   kind: ConfigMap
@@ -1895,7 +1895,7 @@ objects:
         maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         integrationStateCheckInterval: ${INTEGRATION_STATE_CHECK_INTERVAL}
-# Access to Camel-K resources
+# START:CAMEL-K
 - kind: Role
   apiVersion: rbac.authorization.k8s.io/v1beta1
   metadata:
@@ -1927,6 +1927,7 @@ objects:
     kind: Role
     name: camel-k
     apiGroup: rbac.authorization.k8s.io
+# END:CAMEL-K
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
@heiko-braun if we're going to rebuild syndesis, we may add some markers so we can automatically remove the camel k stuff from the openshift online templates.