### PR TITLE
chore: Enhance google-sheets meta data with custom column names

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.connector.sheets;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.services.sheets.v4.Sheets;
+import org.apache.camel.component.google.sheets.BatchGoogleSheetsClientFactory;
+import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
+import org.apache.camel.util.ObjectHelper;
+
+/**
+ * @author Christoph Deppisch
+ */
+public final class GoogleSheetsConnectorHelper {
+
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
+
+    /**
+     * Prevent instantiation of utility class.
+     */
+    private GoogleSheetsConnectorHelper() {
+        super();
+    }
+
+    /**
+     * Create Google sheets client factory with given root URL and server certificate.
+     * @param rootUrl
+     * @param serverCertificate
+     * @param validateCertificates
+     * @return
+     * @throws GeneralSecurityException
+     * @throws IOException
+     */
+    public static GoogleSheetsClientFactory createClientFactory(String rootUrl, String serverCertificate, boolean validateCertificates) throws GeneralSecurityException, IOException {
+        NetHttpTransport.Builder transport = new NetHttpTransport.Builder();
+
+        if (validateCertificates && ObjectHelper.isNotEmpty(serverCertificate)) {
+            byte [] decoded = Base64.getDecoder().decode(serverCertificate.replaceAll(BEGIN_CERT, "")
+                    .replaceAll(END_CERT, ""));
+            transport.trustCertificatesFromStream(new ByteArrayInputStream(decoded));
+        } else {
+            transport.doNotValidateCertificate();
+        }
+
+        return new BatchGoogleSheetsClientFactory(transport.build()) {
+            @Override
+            protected void configure(Sheets.Builder clientBuilder) {
+                clientBuilder.setRootUrl(rootUrl);
+            }
+        };
+    }
+
+    /**
+     * Create client from given client factory using properties or default values.
+     * @param clientFactory
+     * @param properties
+     * @return
+     */
+    public static Sheets makeClient(GoogleSheetsClientFactory clientFactory, Map<String, Object> properties) {
+        final String clientId = Optional.ofNullable(properties.get("clientId"))
+                                        .map(Object::toString)
+                                        .orElse(null);
+
+        final String clientSecret = Optional.ofNullable(properties.get("clientSecret"))
+                                        .map(Object::toString)
+                                        .orElse(null);
+
+        final String applicationName = Optional.ofNullable(properties.get("applicationName"))
+                                        .map(Object::toString)
+                                        .orElse(null);
+
+        return clientFactory.makeClient(clientId, clientSecret, applicationName,
+                                properties.getOrDefault("refreshToken", "").toString(),
+                                properties.getOrDefault("accessToken", "").toString());
+    }
+}

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
@@ -16,19 +16,33 @@
 
 package io.syndesis.connector.sheets.meta;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
 import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
 import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.GoogleSheetsConnectorHelper;
 import io.syndesis.connector.sheets.model.CellCoordinate;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
+import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
 import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christoph Deppisch
  */
 public final class GoogleSheetsMetaDataHelper {
 
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleSheetsMetaDataHelper.class);
     private static final String JSON_SCHEMA_ORG_SCHEMA = "http://json-schema.org/schema#";
 
     /**
@@ -38,11 +52,11 @@ public final class GoogleSheetsMetaDataHelper {
         super();
     }
 
-    public static JsonSchema createSchema(String range, String majorDimension) {
-        return createSchema(range, majorDimension, false);
+    public static JsonSchema createSchema(String range, String majorDimension, String ... columnNames) {
+        return createSchema(range, majorDimension, false, columnNames);
     }
 
-    public static JsonSchema createSchema(String range, String majorDimension, boolean split) {
+    public static JsonSchema createSchema(String range, String majorDimension, boolean split, String ... columnNames) {
         ObjectSchema spec = new ObjectSchema();
 
         spec.setTitle("VALUE_RANGE");
@@ -50,7 +64,7 @@ public final class GoogleSheetsMetaDataHelper {
 
         RangeCoordinate coordinate = RangeCoordinate.fromRange(range);
         if (ObjectHelper.equal(RangeCoordinate.DIMENSION_ROWS, majorDimension)) {
-            createSchemaFromRowDimension(spec, coordinate);
+            createSchemaFromRowDimension(spec, coordinate, columnNames);
         } else if (ObjectHelper.equal(RangeCoordinate.DIMENSION_COLUMNS, majorDimension)) {
             createSchemaFromColumnDimension(spec, coordinate);
         }
@@ -66,16 +80,57 @@ public final class GoogleSheetsMetaDataHelper {
         }
     }
 
+    public static String fetchHeaderRow(String spreadsheetId, String range, String headerRow, Map<String, Object> properties) {
+        RangeCoordinate rangeCoordinate = RangeCoordinate.fromRange(range);
+        StringBuilder rangeBuilder = new StringBuilder();
+
+        if (range.contains("!")) {
+            rangeBuilder.append(range, 0, range.indexOf('!') + 1);
+        }
+
+        rangeBuilder.append(CellCoordinate.getColumnName(rangeCoordinate.getColumnStartIndex()))
+                    .append(headerRow)
+                    .append(':')
+                    .append(CellCoordinate.getColumnName(rangeCoordinate.getColumnEndIndex()))
+                    .append(headerRow);
+
+        final String rootUrl = properties.getOrDefault("rootUrl", Sheets.DEFAULT_ROOT_URL).toString();
+
+        final boolean validateCertificates = Optional.ofNullable(properties.get("validateCertificates"))
+                                                .map(Object::toString)
+                                                .map(Boolean::valueOf)
+                                                .orElse(false);
+
+        final String serverCertificate = properties.getOrDefault("serverCertificate", "").toString();
+
+        try {
+            final GoogleSheetsClientFactory clientFactory = GoogleSheetsConnectorHelper.createClientFactory(rootUrl, serverCertificate, validateCertificates);
+            Sheets client = GoogleSheetsConnectorHelper.makeClient(clientFactory, properties);
+
+            ValueRange valueRange = client.spreadsheets().values().get(spreadsheetId, rangeBuilder.toString()).execute();
+            if (ObjectHelper.isNotEmpty(valueRange.getValues())) {
+                StringJoiner joiner = new StringJoiner(",");
+                valueRange.getValues().get(0).stream().map(Object::toString).forEach(joiner::add);
+                return joiner.toString();
+            }
+        } catch (IOException | GeneralSecurityException e) {
+            LOG.warn(String.format("Failed to fetch header row %s from spreadsheet %s", rangeBuilder.toString(), spreadsheetId), e);
+        }
+
+        return rangeCoordinate.getColumnNames();
+    }
+
     /**
      * Create dynamic json schema from row dimension. If split only a single object "ROW" holding 1-n column values is
      * created. Otherwise each row results in a separate object with 1-n column values as property.
      *
      * @param spec
      * @param coordinate
+     * @param columnNames
      */
-    private static void createSchemaFromRowDimension(ObjectSchema spec, RangeCoordinate coordinate) {
+    private static void createSchemaFromRowDimension(ObjectSchema spec, RangeCoordinate coordinate, String ... columnNames) {
         for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
-            spec.putProperty(CellCoordinate.getColumnName(i), new JsonSchemaFactory().stringSchema());
+            spec.putProperty(CellCoordinate.getColumnName(i, coordinate.getColumnStartIndex(), columnNames), new JsonSchemaFactory().stringSchema());
         }
     }
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
@@ -16,15 +16,59 @@
 
 package io.syndesis.connector.sheets.meta;
 
+import java.util.Arrays;
+
 /**
  * @author Christoph Deppisch
  */
 public class GoogleValueRangeMetaData {
 
+    private String spreadsheetId;
+    private String headerRow;
+    private String[] columnNames = new String[0];
     private String range;
     private String majorDimension;
 
     private boolean split;
+
+    public String getSpreadsheetId() {
+        return spreadsheetId;
+    }
+
+    /**
+     * Specifies the spreadsheetId.
+     *
+     * @param spreadsheetId
+     */
+    public void setSpreadsheetId(String spreadsheetId) {
+        this.spreadsheetId = spreadsheetId;
+    }
+
+    public String[] getColumnNames() {
+        return Arrays.copyOf(columnNames, columnNames.length);
+    }
+
+    /**
+     * Specifies the columnNames.
+     *
+     * @param columnNames
+     */
+    public void setColumnNames(String ... columnNames) {
+        this.columnNames = Arrays.copyOf(columnNames, columnNames.length);
+    }
+
+    public String getHeaderRow() {
+        return headerRow;
+    }
+
+    /**
+     * Specifies the headerRow.
+     *
+     * @param headerRow
+     */
+    public void setHeaderRow(String headerRow) {
+        this.headerRow = headerRow;
+    }
 
     public String getRange() {
         return range;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/CellCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/CellCoordinate.java
@@ -112,7 +112,7 @@ public class CellCoordinate {
     }
 
     /**
-     * Evaluates column name in A1 notation based on column index. Index 0 will be "A" and index 25 will be "Z". Method also supports
+     * Evaluates column name in A1 notation based on the column index. Index 0 will be "A" and index 25 will be "Z". Method also supports
      * name overflow where index 26 will be "AA" and index 51 will be "AZ" and so on.
      *
      * @param columnIndex
@@ -130,12 +130,43 @@ public class CellCoordinate {
         }
 
         if (overflowIndex >= 0) {
-            columnName.append(String.valueOf(alphabet.toCharArray()[overflowIndex]));
+            columnName.append(alphabet.toCharArray()[overflowIndex]);
         }
 
-        columnName.append(String.valueOf(alphabet.toCharArray()[index]));
+        columnName.append(alphabet.toCharArray()[index]);
 
         return columnName.toString();
+    }
+
+    /**
+     * Special getter for column name where user is able to give set of user defined column names. When given column index is resolvable via custom names
+     * the custom column name is returned otherwise the evaluated default column name is returned.
+     *
+     * @param columnIndex
+     * @param columnStartIndex
+     * @param columnNames
+     * @return
+     */
+    public static String getColumnName(int columnIndex, int columnStartIndex, String ... columnNames) {
+        String columnName = getColumnName(columnIndex);
+
+        int index;
+        if (columnStartIndex > 0) {
+            index = columnIndex % columnStartIndex;
+        } else {
+            index = columnIndex;
+        }
+
+        if (index < columnNames.length) {
+            String name = columnNames[index];
+            if (columnName.equals(name)) {
+                return columnName;
+            } else {
+                return name;
+            }
+        }
+
+        return columnName;
     }
 
     public int getRowIndex() {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
@@ -16,6 +16,8 @@
 
 package io.syndesis.connector.sheets.model;
 
+import java.util.StringJoiner;
+
 /**
  * @author Christoph Deppisch
  */
@@ -81,6 +83,18 @@ public final class RangeCoordinate extends CellCoordinate {
         } else {
             return range;
         }
+    }
+
+    /**
+     * Get all names of columns included in this range.
+     * @return
+     */
+    public String getColumnNames() {
+        StringJoiner delimitedList = new StringJoiner(",");
+        for (int i = columnStartIndex; i < columnEndIndex; i++) {
+            delimitedList.add(CellCoordinate.getColumnName(i));
+        }
+        return delimitedList.toString();
     }
 
     public int getRowStartIndex() {

--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -210,6 +210,19 @@
                 "secret": false,
                 "type": "string"
               },
+              "headerRow": {
+                "deprecated": false,
+                "displayName": "Header row number",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Enter the row number that represents the headers. These values are used as column names.",
+                "order": "4",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
               "spreadsheetId": {
                 "deprecated": false,
                 "displayName": "SpreadsheetId",
@@ -246,6 +259,25 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
+                "order": "5",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Specify optional columnname mappings.",
+            "name": "Column name mappings",
+            "properties": {
+              "columnNames": {
+                "deprecated": false,
+                "displayName": "Column names",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
                 "required": false,
                 "secret": false,
@@ -319,6 +351,19 @@
                 "secret": false,
                 "type": "string"
               },
+              "headerRow": {
+                "deprecated": false,
+                "displayName": "Header row number",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Enter the row number that represents the headers. These values are used as column names.",
+                "order": "4",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
               "spreadsheetId": {
                 "deprecated": false,
                 "displayName": "SpreadsheetId",
@@ -355,6 +400,25 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "How to interpret input data.",
+                "order": "5",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Specify optional columnname mappings.",
+            "name": "Column name mappings",
+            "properties": {
+              "columnNames": {
+                "deprecated": false,
+                "displayName": "Column names",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
                 "required": false,
                 "secret": false,
@@ -400,7 +464,7 @@
                 "kind": "parameter",
                 "label": "consumer,scheduler",
                 "labelHint": "Time interval between polls for value changes.",
-                "order": "5",
+                "order": "6",
                 "required": false,
                 "secret": false,
                 "tags": [],
@@ -439,7 +503,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "Maximum number of values to return (value of '0' meaning results are unbounded).",
-                "order": "6",
+                "order": "7",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -454,6 +518,19 @@
                 "label": "producer",
                 "labelHint": "Value range in a spreadsheet to obtain.",
                 "order": "2",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "headerRow": {
+                "deprecated": false,
+                "displayName": "Header row number",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Enter the row number that represents the headers. These values are used as column names.",
+                "order": "4",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -477,7 +554,7 @@
                 "kind": "parameter",
                 "label": "producer",
                 "labelHint": "When enabled value range is split into multiple results where each result represents a single row or column.",
-                "order": "4",
+                "order": "5",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -491,6 +568,25 @@
                 "label": "producer",
                 "labelHint": "The spreadsheet identifier.",
                 "order": "1",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Specify column names.",
+            "name": "Column name mappings",
+            "properties": {
+              "columnNames": {
+                "deprecated": false,
+                "displayName": "Column names",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Comma delimited list of names that describe the columns.",
+                "order": "4",
                 "required": false,
                 "secret": false,
                 "type": "string"
@@ -860,7 +956,7 @@
           "when": [
             {
               "id": "validateCertificates",
-              "value": "false"
+              "value": "true"
             }
           ]
         }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
@@ -49,27 +49,31 @@ public class GoogleSheetsMetadataAdapterTest {
     private final String majorDimension;
     private final String expectedJson;
     private final boolean split;
+    private final String columnNames;
 
-    public GoogleSheetsMetadataAdapterTest(String range, String actionId, String majorDimension, String expectedJson, boolean split) {
+    public GoogleSheetsMetadataAdapterTest(String range, String actionId, String majorDimension, String expectedJson, boolean split, String columnNames) {
         this.range = range;
         this.actionId = actionId;
         this.majorDimension = majorDimension;
         this.expectedJson = expectedJson;
         this.split = split;
+        this.columnNames = columnNames;
     }
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "A1:D1", "io.syndesis:sheets-get-values-connector", "", "/meta/get_rows_metadata.json", false },
-                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_split_metadata.json", true },
-                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_metadata.json", false },
-                { "A1:C5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_split_metadata.json", true },
-                { "A1:A5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_metadata.json", false },
-                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/update_rows_metadata.json", false },
-                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/update_columns_metadata.json", false },
-                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/append_rows_metadata.json", false },
-                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/append_columns_metadata.json", false }
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", "", "/meta/get_rows_metadata.json", false, "A,B,C,D" },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_split_metadata.json", true, "A,B,C,D" },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/get_rows_metadata.json", false, "A,B,C,D" },
+                { "A1:C5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_split_metadata.json", true, "A,B,C" },
+                { "A1:A5", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/get_columns_metadata.json", false, "A" },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/update_rows_metadata.json", false, "A,B,C" },
+                { "A5:C5", "io.syndesis:sheets-update-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/update_columns_metadata.json", false, "A,B,C" },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/append_rows_metadata.json", false, "A,B,C,D,E,F,G" },
+                { "A1:G3", "io.syndesis:sheets-append-values-connector", RangeCoordinate.DIMENSION_COLUMNS, "/meta/append_columns_metadata.json", false, "A,B,C,D,E,F,G" },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/column_names_metadata.json", false, "Col_A,Col_B,Col_C,Col_D" },
+                { "A1:D1", "io.syndesis:sheets-get-values-connector", RangeCoordinate.DIMENSION_ROWS, "/meta/column_names_split_metadata.json", true, "Col_A,Col_B,Col_C,Col_D" }
         });
     }
 
@@ -85,6 +89,10 @@ public class GoogleSheetsMetadataAdapterTest {
 
         if (split) {
             parameters.put("splitResults", true);
+        }
+
+        if (ObjectHelper.isNotEmpty(columnNames)) {
+            parameters.put("columnNames", columnNames);
         }
 
         parameters.put("range", range);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.connector.sheets;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
+import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
+import org.apache.camel.impl.DefaultExchange;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+@RunWith(Parameterized.class)
+public class GoogleSheetsNamedColumnsTest extends AbstractGoogleSheetsCustomizerTestSupport {
+
+    private final String range;
+    private final String columnNames;
+    private final List<List<Object>> values;
+    private final List<String> model;
+
+    public GoogleSheetsNamedColumnsTest(String range, List<List<Object>> values, List<String> model, String columnNames) {
+        this.range = range;
+        this.values = values;
+        this.model = model;
+        this.columnNames = columnNames;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "A1:A3", Arrays.asList(Collections.singletonList("a1"), Collections.singletonList("a2"), Collections.singletonList("a3")),
+                        Arrays.asList("{\"spreadsheetId\":\"%s\", \"col_a\":\"a1\"}", "{\"spreadsheetId\":\"%s\", \"col_a\":\"a2\"}", "{\"spreadsheetId\":\"%s\", \"col_a\":\"a3\"}"), "col_a"},
+                { "A1:B2", Arrays.asList(Arrays.asList("a1", "b1"), Arrays.asList("a2", "b2")),
+                        Arrays.asList("{\"spreadsheetId\":\"%s\", \"col_a\":\"a1\", \"col_b\":\"b1\"}", "{\"spreadsheetId\":\"%s\", \"col_a\":\"a2\",\"col_b\":\"b2\"}"), "col_a,col_b"},
+                { "A1:D1", Collections.singletonList(Arrays.asList("a1", "b1", "c1", "d1")),
+                        Collections.singletonList("{\"spreadsheetId\":\"%s\", \"col_a\":\"a1\", \"col_b\":\"b1\", \"col_c\":\"c1\", \"col_d\":\"d1\"}"), "col_a,col_b,col_c,col_d"},
+                { "A1:D1", Collections.singletonList(Arrays.asList("a1", "b1", "c1", "d1")),
+                        Collections.singletonList("{\"spreadsheetId\":\"%s\", \"col_a\":\"a1\", \"col_b\":\"b1\", \"C\":\"c1\", \"D\":\"d1\"}"), "col_a,col_b"},
+                { "E1:G1", Collections.singletonList(Arrays.asList("e1", "f1", "g1")),
+                        Collections.singletonList("{\"spreadsheetId\":\"%s\", \"col_e\":\"e1\", \"col_f\":\"f1\", \"G\":\"g1\"}"), "col_e,col_f"}
+        });
+    }
+
+    @Test
+    public void testGetValuesCustomizer() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("spreadsheetId", getSpreadsheetId());
+        options.put("range", range);
+        options.put("columnNames", columnNames);
+        options.put("splitResults", false);
+
+        GoogleSheetsGetValuesCustomizer customizer = new GoogleSheetsGetValuesCustomizer();
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        ValueRange valueRange = new ValueRange();
+        valueRange.setRange(range);
+        valueRange.setMajorDimension(RangeCoordinate.DIMENSION_ROWS);
+        valueRange.setValues(values);
+
+        inbound.getIn().setBody(valueRange);
+        getComponent().getBeforeConsumer().process(inbound);
+
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
+        Assert.assertEquals("get", options.get("methodName"));
+
+        @SuppressWarnings("unchecked")
+        List<String> body = inbound.getIn().getBody(List.class);
+        Assert.assertEquals(model.size(), body.size());
+        Iterator<String> modelIterator = body.iterator();
+        for (String expected : model) {
+            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+        }
+    }
+
+    @Test
+    public void testUpdateValuesCustomizer() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("columnNames", columnNames);
+        options.put("range", range);
+
+        GoogleSheetsUpdateValuesCustomizer customizer = new GoogleSheetsUpdateValuesCustomizer();
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+        inbound.getIn().setBody(model);
+
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assertions.assertThat(inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE)).isEqualTo(range);
+        Assertions.assertThat(inbound.getIn().getHeader(GoogleSheetsStreamConstants.MAJOR_DIMENSION)).isEqualTo(RangeCoordinate.DIMENSION_ROWS);
+
+        ValueRange valueRange = (ValueRange) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "values");
+        Assertions.assertThat(valueRange.getValues()).hasSize(values.size());
+
+        for (List<Object> rowValues : values) {
+            Assertions.assertThat(valueRange.getValues()).contains(rowValues);
+        }
+    }
+
+}

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
@@ -69,5 +69,14 @@ public class CellCoordinateTest {
     @Test
     public void testGetColumnName() {
         Assert.assertEquals(columnName, CellCoordinate.getColumnName(columnIndexCheck));
+
+        String[] names = new String[columnIndexCheck];
+        Arrays.fill(names, "Foo");
+        Assert.assertEquals(columnName, CellCoordinate.getColumnName(columnIndexCheck, 0, names));
+
+        names = new String[columnIndexCheck + 1];
+        Arrays.fill(names, "Foo");
+        Assert.assertEquals("Foo", CellCoordinate.getColumnName(columnIndexCheck, 0, names));
+        Assert.assertEquals("Foo", CellCoordinate.getColumnName(columnIndexCheck, columnIndexCheck, names));
     }
 }

--- a/app/connector/google-sheets/src/test/resources/meta/column_names_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/column_names_metadata.json
@@ -1,0 +1,16 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:D1]",
+    "metadata": {
+      "variant": "collection"
+    },
+    "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"Col_A\":{\"type\":\"string\",\"required\":true},\"Col_B\":{\"type\":\"string\",\"required\":true},\"Col_C\":{\"type\":\"string\",\"required\":true},\"Col_D\":{\"type\":\"string\",\"required\":true}}}}"
+  }
+}

--- a/app/connector/google-sheets/src/test/resources/meta/column_names_split_metadata.json
+++ b/app/connector/google-sheets/src/test/resources/meta/column_names_split_metadata.json
@@ -1,0 +1,16 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "VALUE_RANGE_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "json-schema",
+    "type" : "VALUE_RANGE_PARAM_OUT",
+    "name" : "ValueRange Result",
+    "description" : "Results of range [A1:D1]",
+    "metadata": {
+      "variant": "element"
+    },
+    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"VALUE_RANGE\",\"properties\":{\"spreadsheetId\":{\"type\":\"string\",\"required\":true},\"Col_A\":{\"type\":\"string\",\"required\":true},\"Col_B\":{\"type\":\"string\",\"required\":true},\"Col_C\":{\"type\":\"string\",\"required\":true},\"Col_D\":{\"type\":\"string\",\"required\":true}}}"
+  }
+}

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/PropertyPair.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/PropertyPair.java
@@ -23,6 +23,10 @@ public final class PropertyPair {
 
     private final String value;
 
+    public PropertyPair(final String value) {
+        this(value, value);
+    }
+
     public PropertyPair(final String value, final String displayValue) {
         this.value = value;
         this.displayValue = displayValue;


### PR DESCRIPTION
This PR adds a meta data lookup for Google Sheets connector in order to provide custom column names. By default column names are simply named with their column letter (A,B,C,D). With the meta data lookup you can fetch a header row that contains custom column names. You have to specify the row number of the header row.

<img width="691" alt="Bildschirmfoto 2019-04-12 um 19 56 41" src="https://user-images.githubusercontent.com/195264/56057240-9df68a80-5d5e-11e9-88a9-9b9fe63e91d9.png">

Next property definition step fetches the column names.

<img width="694" alt="Bildschirmfoto 2019-04-12 um 19 56 59" src="https://user-images.githubusercontent.com/195264/56057288-bbc3ef80-5d5e-11e9-8bf1-f75530f9b8dc.png">

So you can use those names in data mapper which is more comfortable than just using A,B,C,D. See following source document using the custom column names vs. the target using the default column names.

<img width="691" alt="Bildschirmfoto 2019-04-12 um 20 02 43" src="https://user-images.githubusercontent.com/195264/56057316-d1d1b000-5d5e-11e9-9073-1d82cb46dfca.png">

Users can also skip fetching the header row and customize the names manually or just use the default names.