### PR TITLE
Add a proxy profile for doing yarn build behind a firewall, add repository.xml

### DIFF
--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -155,6 +155,43 @@
 
   <profiles>
     <profile>
+      <id>addrepository</id>
+      <activation>
+        <property>
+          <name>addrepository</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/repository.xml</descriptor>
+              </descriptors>
+            </configuration>
+            <executions>
+              <execution>
+                <id>make-repository-assembly</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <configuration>
+              <!-- TODO: re-enable -->
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>image</id>
       <activation>
         <property>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -180,14 +180,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <configuration>
-              <!-- TODO: re-enable -->
-              <skip>true</skip>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/app/s2i/src/main/assembly/repository.xml
+++ b/app/s2i/src/main/assembly/repository.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+  <id>m2</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <outputDirectory>./</outputDirectory>
+      <directory>target/generated-sources/docker/</directory>
+      <includes>
+        <include>m2/**</include>
+        <include>settings.xml</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -72,6 +72,7 @@
     "ng2-file-upload": "1.3.0",
     "ngx-bootstrap": "3.1.4",
     "ngx-chips": "1.9.8",
+    "node-sass": "^4.9.0",
     "oai-ts-commands": "0.2.59",
     "oai-ts-core": "0.2.33",
     "patternfly": "3.59.0",

--- a/app/ui/pom.xml
+++ b/app/ui/pom.xml
@@ -31,88 +31,11 @@
 
   <name>UI</name>
 
+  <properties>
+      <npmRegistryURL2></npmRegistryURL2>
+  </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-            </configuration>
-          </execution>
-          <execution>
-            <id>install yarn</id>
-            <goals>
-              <goal>install-node-and-yarn</goal>
-            </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-              <yarnVersion>${yarn.version}</yarnVersion>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn install</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>install --no-progress --force</arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn cache dir</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>cache dir</arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn ng lint</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>lint</arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn ng test</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>test:ci</arguments>
-              <skip>${skipTests}</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn cleanup</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>cleanup</arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>yarn ng build</id>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>build:ci</arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -124,6 +47,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
+              <tarLongFileMode>posix</tarLongFileMode>
               <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
               <descriptors>
                 <descriptor>src/assembly/unix-dist.xml</descriptor>
@@ -164,6 +88,256 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>noproxy</id>
+      <activation>
+          <property>
+              <name>!proxy</name>
+          </property>
+      </activation>
+      <build>
+          <plugins>
+            <plugin>
+              <groupId>com.github.eirslett</groupId>
+              <artifactId>frontend-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>install node and npm</id>
+                  <goals>
+                    <goal>install-node-and-npm</goal>
+                  </goals>
+                  <configuration>
+                    <nodeVersion>${node.version}</nodeVersion>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>install yarn</id>
+                  <goals>
+                    <goal>install-node-and-yarn</goal>
+                  </goals>
+                  <configuration>
+                    <nodeVersion>${node.version}</nodeVersion>
+                    <yarnVersion>${yarn.version}</yarnVersion>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn install</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>install --no-progress --force</arguments>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn cache dir</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>cache dir</arguments>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn ng lint</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>lint</arguments>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn ng test</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>test:ci</arguments>
+                    <skip>${skipTests}</skip>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn cleanup</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>cleanup</arguments>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>yarn ng build</id>
+                  <goals>
+                    <goal>yarn</goal>
+                  </goals>
+                  <configuration>
+                    <arguments>build:ci</arguments>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+              </plugins>
+          </build>
+      </profile>
+      <profile>
+          <id>proxy</id>
+          <activation>
+              <property>
+                  <name>proxy</name>
+              </property>
+          </activation>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin-version}</version>
+                <executions>
+                  <execution>
+                    <id>install node and npm</id>
+                    <goals>
+                      <goal>install-node-and-npm</goal>
+                    </goals>
+                    <configuration>
+                      <nodeVersion>${node.version}</nodeVersion>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>install yarn</id>
+                    <goals>
+                      <goal>install-node-and-yarn</goal>
+                    </goals>
+                    <configuration>
+                      <nodeVersion>${node.version}</nodeVersion>
+                      <yarnVersion>${yarn.version}</yarnVersion>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>set https proxy</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set https-proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>set http proxy</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>set maxconn</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set maxsockets 30</arguments>
+                    </configuration>
+                  </execution>
+        <execution>
+                    <id>npm set registry</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set registry ${npmRegistryURL2}</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn set registry</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set registry ${npmRegistryURL2}</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn set no-strict ssl</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set strict-ssl false</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn set sass binary url</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>config set sass-binary-site ${sass-binary-site}</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>install node-sass</id>
+                    <goals>
+                      <goal>npm</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>install --global-style node-sass@4.9.0 --loglevel=silly --max-sockets=30 --fetch-retry-mintimeout=60000 --fetch-retries=10</arguments>
+                    </configuration>
+                  </execution>
+        <execution>
+                    <id>yarn install</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>install --verbose  --force  --network-concurrency=30 --child-concurrency=1 --no-progress --pure-lockfile --network-timeout=100000</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn cache dir</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>cache dir</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn ng test</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>test:ci</arguments>
+                      <skip>${skipTests}</skip>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn cleanup</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                      <arguments>cleanup</arguments>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>yarn ng build</id>
+                    <goals>
+                      <goal>yarn</goal>
+                    </goals>
+                    <configuration>
+                        <arguments>build:ci</arguments>
+                        <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+              <!-- End Prod fixes -->
+            </plugins>
+          </build>
+      </profile>
     <profile>
       <id>flash</id>
       <build>

--- a/app/ui/pom.xml
+++ b/app/ui/pom.xml
@@ -32,8 +32,11 @@
   <name>UI</name>
 
   <properties>
-      <npmRegistryURL2></npmRegistryURL2>
+    <yarn-install-args />
+    <yarn-verbose />
+    <npm-verbose />
   </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -84,260 +87,263 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>${node.version}</nodeVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>install yarn</id>
+            <goals>
+              <goal>install-node-and-yarn</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>${node.version}</nodeVersion>
+              <yarnVersion>${yarn.version}</yarnVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn install</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>install --force --no-progress --frozen-lockfile ${yarn-install-args} ${yarn-verbose}</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn ng lint</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>lint</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn ng test</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>test:ci</arguments>
+              <skip>${skipTests}</skip>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn cleanup</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>cleanup</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn ng build</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>build:ci</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
     <profile>
-      <id>noproxy</id>
+      <id>with-proxy</id>
       <activation>
-          <property>
-              <name>!proxy</name>
-          </property>
+        <property>
+          <name>proxy-server</name>
+        </property>
+      </activation>
+      <properties>
+        <yarn-install-args>--network-concurrency=30 --child-concurrency=1 --network-timeout=100000</yarn-install-args>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>require-proxy-properties</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireProperty>
+                      <property>proxy-user</property>
+                    </requireProperty>
+                    <requireProperty>
+                      <property>proxy-password</property>
+                    </requireProperty>
+                    <requireProperty>
+                      <property>proxy-port</property>
+                    </requireProperty>
+                  </rules>
+                  <fail>true</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>set https proxy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set https-proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set http proxy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>set maxconn</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set maxsockets 30</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>with-custom-registry</id>
+      <activation>
+        <property>
+          <name>custom-registry</name>
+        </property>
       </activation>
       <build>
-          <plugins>
-            <plugin>
-              <groupId>com.github.eirslett</groupId>
-              <artifactId>frontend-maven-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>install node and npm</id>
-                  <goals>
-                    <goal>install-node-and-npm</goal>
-                  </goals>
-                  <configuration>
-                    <nodeVersion>${node.version}</nodeVersion>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>install yarn</id>
-                  <goals>
-                    <goal>install-node-and-yarn</goal>
-                  </goals>
-                  <configuration>
-                    <nodeVersion>${node.version}</nodeVersion>
-                    <yarnVersion>${yarn.version}</yarnVersion>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn install</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>install --no-progress --force</arguments>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn cache dir</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>cache dir</arguments>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn ng lint</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>lint</arguments>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn ng test</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>test:ci</arguments>
-                    <skip>${skipTests}</skip>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn cleanup</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>cleanup</arguments>
-                  </configuration>
-                </execution>
-                <execution>
-                  <id>yarn ng build</id>
-                  <goals>
-                    <goal>yarn</goal>
-                  </goals>
-                  <configuration>
-                    <arguments>build:ci</arguments>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-              </plugins>
-          </build>
-      </profile>
-      <profile>
-          <id>proxy</id>
-          <activation>
-              <property>
-                  <name>proxy</name>
-              </property>
-          </activation>
-          <build>
-            <plugins>
-              <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>${frontend-maven-plugin-version}</version>
-                <executions>
-                  <execution>
-                    <id>install node and npm</id>
-                    <goals>
-                      <goal>install-node-and-npm</goal>
-                    </goals>
-                    <configuration>
-                      <nodeVersion>${node.version}</nodeVersion>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>install yarn</id>
-                    <goals>
-                      <goal>install-node-and-yarn</goal>
-                    </goals>
-                    <configuration>
-                      <nodeVersion>${node.version}</nodeVersion>
-                      <yarnVersion>${yarn.version}</yarnVersion>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>set https proxy</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set https-proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>set http proxy</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>set maxconn</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set maxsockets 30</arguments>
-                    </configuration>
-                  </execution>
-        <execution>
-                    <id>npm set registry</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set registry ${npmRegistryURL2}</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn set registry</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set registry ${npmRegistryURL2}</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn set no-strict ssl</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set strict-ssl false</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn set sass binary url</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>config set sass-binary-site ${sass-binary-site}</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>install node-sass</id>
-                    <goals>
-                      <goal>npm</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>install --global-style node-sass@4.9.0 --loglevel=silly --max-sockets=30 --fetch-retry-mintimeout=60000 --fetch-retries=10</arguments>
-                    </configuration>
-                  </execution>
-        <execution>
-                    <id>yarn install</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>install --verbose  --force  --network-concurrency=30 --child-concurrency=1 --no-progress --pure-lockfile --network-timeout=100000</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn cache dir</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>cache dir</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn ng test</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>test:ci</arguments>
-                      <skip>${skipTests}</skip>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn cleanup</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                      <arguments>cleanup</arguments>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>yarn ng build</id>
-                    <goals>
-                      <goal>yarn</goal>
-                    </goals>
-                    <configuration>
-                        <arguments>build:ci</arguments>
-                        <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
-                    </configuration>
-                  </execution>
-                </executions>
-              </plugin>
-              <!-- End Prod fixes -->
-            </plugins>
-          </build>
-      </profile>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>set registry</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set registry ${custom-registry}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn set registry</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set registry ${custom-registry}</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>insecure</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>yarn set no-strict ssl</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set strict-ssl false</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>rebuild-saas</id>
+      <activation>
+        <property>
+          <name>sass-binary-site</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>yarn set sass binary url</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set sass-binary-site ${sass-binary-site}</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>install node-sass</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>install --global-style node-sass@4.9.0 ${npm-verbose} --max-sockets=30 --fetch-retry-mintimeout=60000 --fetch-retries=10</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>verbose</id>
+      <properties>
+        <yarn-verbose>--verbose</yarn-verbose>
+        <npm-verbose>--loglevel=silly</npm-verbose>
+      </properties>
+    </profile>
     <profile>
       <id>flash</id>
       <build>
@@ -409,7 +415,7 @@
               <!-- Important here, otherwise fmp silently ignores the build config -->
               <skipBuildPom>false</skipBuildPom>
               <verbose>true</verbose>
-              <!-- Only when running in openshift: -->
+                <!-- Only when running in openshift: -->
               <buildStrategy>docker</buildStrategy>
               <images>
                 <image>


### PR DESCRIPTION
We need the ability to be able to run the yarn build through a proxy.    I've added two profiles, proxy and noproxy, to app/ui/pom.xml.      

Have also added a profile to app/s2i for the inclusion of a necessary repository.xml and the license plugin.