### PR TITLE
Fix #5193 Add choice step handler representing content based router

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/choice/FlowOption.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/choice/FlowOption.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.choice;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.common.model.expression.RuleBase;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = FlowOption.Builder.class)
+public interface FlowOption extends RuleBase {
+
+    /**
+     * Matching condition expression in form of simple language expression. More powerful way
+     * of specifying the condition for this mapping. But user has to know bits of the simple language.
+     */
+    String getCondition();
+
+    /**
+     * Flow that this mapping is pointing to. Usually a flow identifier.
+     */
+    String getFlow();
+
+    @Override
+    String getPath();
+
+    @Override
+    String getOp();
+
+    @Override
+    String getValue();
+
+    /**
+     * Get the final condition expression for this mapping either directly referencing the condition or building a
+     * simple expression from given path, operator and value.
+     */
+    default String getConditionExpression() {
+        if (getCondition() != null) {
+            return getCondition();
+        }
+
+        return String.format("%s %s '%s'",
+                convertPathToSimple(),
+                getOp(),
+                getValue());
+    }
+
+    class Builder extends ImmutableFlowOption.Builder { }
+}

--- a/app/common/model/src/main/java/io/syndesis/common/model/expression/RuleBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/expression/RuleBase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.common.model.expression;
+
+/**
+ * @author Christoph Deppisch
+ */
+public interface RuleBase {
+
+    /**
+     * Path expression within the message on which to evaluate on. Can be part of header, body, properties
+     * The path is a simple dot notation to the property to evaluate.
+     */
+    String getPath();
+
+    /**
+     * Operator to use for the expression. The value comes from meta data obtained by the UI in
+     * a separate call. Example: "contains"
+     */
+    String getOp();
+
+    /**
+     * Value used by operator to decide whether the expression applies
+     */
+    String getValue();
+
+    default String convertPathToSimple() {
+        return String.format("${body.%s}", getPath());
+    }
+
+}

--- a/app/common/model/src/main/java/io/syndesis/common/model/filter/FilterRule.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/filter/FilterRule.java
@@ -16,6 +16,7 @@
 package io.syndesis.common.model.filter;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.common.model.expression.RuleBase;
 import org.immutables.value.Value;
 
 /**
@@ -23,25 +24,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @JsonDeserialize(builder = FilterRule.Builder.class)
-public interface FilterRule {
-
-    /**
-     *  Path expression within the message on which to filter. Can be part of header, body, properties
-     * The path is a simple dot notation to the property to filter.
-     */
-    String getPath();
-
-    /**
-     * Operator to use for the filter. The value comes from meta dara obtained by the UI in
-     * a separate call. Example: "contains"
-     */
-    String getOp();
-
-    /**
-     * Value used by operator to decide whether the filter applies
-     *
-     */
-    String getValue();
+public interface FilterRule extends RuleBase {
 
     /**
      * Get the simple filter expression for this rule
@@ -51,10 +34,6 @@ public interface FilterRule {
                              convertPathToSimple(),
                              getOp(),
                              getValue());
-    }
-
-    default String convertPathToSimple() {
-        return String.format("${body.%s}",getPath());
     }
 
     class Builder extends ImmutableFilterRule.Builder { }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/StepKind.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/StepKind.java
@@ -22,6 +22,7 @@ public enum StepKind {
     ruleFilter,
     extension,
     mapper,
+    choice,
     split,
     aggregate,
     log,

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.handlers;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.syndesis.common.model.choice.FlowOption;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.Json;
+import io.syndesis.integration.runtime.IntegrationRouteBuilder;
+import io.syndesis.integration.runtime.IntegrationStepHandler;
+import io.syndesis.integration.runtime.util.JsonSimplePredicate;
+import org.apache.camel.CamelContext;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.Predicate;
+import org.apache.camel.model.ChoiceDefinition;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.util.ObjectHelper;
+
+public class ChoiceStepHandler implements IntegrationStepHandler {
+
+    @Override
+    public boolean canHandle(Step step) {
+        return StepKind.choice == step.getStepKind();
+    }
+
+    @SuppressWarnings({"PMD.AvoidReassigningParameters", "PMD.AvoidDeeplyNestedIfStmts"})
+    @Override
+    public Optional<ProcessorDefinition<?>> handle(Step step, ProcessorDefinition<?> route, IntegrationRouteBuilder builder, String flowIndex, String stepIndex) {
+        ObjectHelper.notNull(route, "route");
+
+        String routingScheme = step.getConfiguredProperties().getOrDefault("routingScheme", "direct");
+        String defaultFlow = step.getConfiguredProperties().get("default");
+        List<FlowOption> flows = extractFlows(step.getConfiguredProperties().get("flows"));
+
+        if (!flows.isEmpty()) {
+            ChoiceDefinition choice = route.choice();
+
+            for (FlowOption flowOption : flows) {
+                choice.when(getPredicate(flowOption.getConditionExpression(), builder.getContext()))
+                        .to(getEndpointUri(routingScheme, flowOption.getFlow()))
+                        .end();
+            }
+
+            if (ObjectHelper.isNotEmpty(defaultFlow)) {
+                choice.otherwise()
+                        .to(getEndpointUri(routingScheme, defaultFlow))
+                        .end();
+            } else if (step.getId().isPresent()) {
+                choice.otherwise()
+                        .log(LoggingLevel.INFO, (String) null, step.getId().get(), getNoContentBasedRouteLogMessage())
+                        .end();
+            } else {
+                choice.otherwise()
+                        .log(LoggingLevel.INFO, getNoContentBasedRouteLogMessage())
+                        .end();
+            }
+
+            route = choice.end();
+        }
+
+        return Optional.of(route);
+    }
+
+    private Predicate getPredicate(String conditionExpression, CamelContext context) {
+        return new JsonSimplePredicate(conditionExpression, context);
+    }
+
+    private String getNoContentBasedRouteLogMessage() {
+        return "Message Context: [${in.headers}] Body: [${bean:bodyLogger}] No content based route for message";
+    }
+
+    // *******************************
+    // Helpers
+    // *******************************
+
+    /**
+     * Construct flow endpoint uri using given scheme and flow identifier. By default constructed uri is
+     * using "scheme:flowId" pattern.
+     *
+     * @param routingScheme
+     * @param flowId
+     * @return
+     */
+    private String getEndpointUri(String routingScheme, String flowId) {
+        return routingScheme + ":" + flowId;
+    }
+
+    private List<FlowOption> extractFlows(String flowMappings) {
+        try {
+            if (flowMappings == null || flowMappings.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            return Json.reader().forType(new TypeReference<List<FlowOption>>(){}).readValue(flowMappings);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format("Failed to read flow mappings %s: %s", flowMappings, e.getMessage()),e);
+        }
+    }
+}

--- a/app/integration/runtime/src/main/resources/META-INF/services/io.syndesis.integration.runtime.IntegrationStepHandler
+++ b/app/integration/runtime/src/main/resources/META-INF/services/io.syndesis.integration.runtime.IntegrationStepHandler
@@ -4,6 +4,7 @@ io.syndesis.integration.runtime.handlers.DataMapperStepHandler
 io.syndesis.integration.runtime.handlers.EndpointStepHandler
 io.syndesis.integration.runtime.handlers.ExpressionFilterStepHandler
 io.syndesis.integration.runtime.handlers.ExtensionStepHandler
+io.syndesis.integration.runtime.handlers.ChoiceStepHandler
 io.syndesis.integration.runtime.handlers.HeadersStepHandler
 io.syndesis.integration.runtime.handlers.LogStepHandler
 io.syndesis.integration.runtime.handlers.RuleFilterStepHandler

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.KeyGenerator;
+import io.syndesis.integration.runtime.IntegrationTestSupport;
+import io.syndesis.integration.runtime.logging.ActivityTracker;
+import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
+import io.syndesis.integration.runtime.logging.BodyLogger;
+import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
+import io.syndesis.integration.runtime.util.JsonSupport;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+public class ChoiceStepHandlerTest extends IntegrationTestSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChoiceStepHandlerTest.class);
+
+    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+
+    @Before
+    public void setupMocks() {
+        reset(activityTracker);
+        doAnswer(invocation -> {
+            LOGGER.info(JsonSupport.toJsonObject(invocation.getArguments()));
+            return null;
+        }).when(activityTracker).track(any());
+    }
+
+    @Test
+    public void testChoiceStep() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
+                new Step.Builder()
+                    .id("flow-step")
+                    .stepKind(StepKind.endpoint)
+                    .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                            .componentScheme("direct")
+                            .putConfiguredProperty("name", "flow")
+                            .build())
+                        .build())
+                    .build(),
+                new Step.Builder()
+                    .id("choice-step")
+                    .stepKind(StepKind.choice)
+                    .putConfiguredProperty("flows", "[" +
+                                        "{\"condition\": \"${body} contains 'Hello'\", \"flow\": \"hello-flow\"}," +
+                                        "{\"condition\": \"${body} contains 'Bye'\", \"flow\": \"bye-flow\"}" +
+                                    "]")
+                    .build(),
+                new Step.Builder()
+                    .id("mock-step")
+                    .stepKind(StepKind.endpoint)
+                    .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                            .componentScheme("mock")
+                            .putConfiguredProperty("name", "result")
+                            .build())
+                        .build())
+                    .build()
+            );
+
+            final RouteBuilder helloRoute = new RouteBuilder() {
+                @Override
+                public void configure() throws Exception {
+                    from("direct:hello-flow")
+                            .to("mock:hello");
+                }
+            };
+
+            final RouteBuilder byeRoute = new RouteBuilder() {
+                @Override
+                public void configure() throws Exception {
+                    from("direct:bye-flow")
+                            .to("mock:bye");
+                }
+            };
+
+            // Set up the camel context
+            context.setUuidGenerator(KeyGenerator::createKey);
+            context.addLogListener(new IntegrationLoggingListener(activityTracker));
+            context.addInterceptStrategy(new ActivityTrackingInterceptStrategy(activityTracker));
+            context.addRoutes(helloRoute);
+            context.addRoutes(byeRoute);
+            context.addRoutes(integrationRoute);
+
+            SimpleRegistry beanRegistry = new SimpleRegistry();
+            beanRegistry.put("bodyLogger", new BodyLogger.Default());
+            context.setRegistry(beanRegistry);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:result", MockEndpoint.class);
+            final MockEndpoint helloResult = context.getEndpoint("mock:hello", MockEndpoint.class);
+            final MockEndpoint byeResult = context.getEndpoint("mock:bye", MockEndpoint.class);
+
+            final List<String> messages = Arrays.asList("Hello Camel!", "Bye Camel!", "And Now for Something Completely Different");
+
+            result.expectedBodiesReceived(messages);
+            helloResult.expectedBodiesReceived("Hello Camel!");
+            byeResult.expectedBodiesReceived("Bye Camel!");
+
+            for (String message : messages) {
+                template.sendBody("direct:flow", message);
+            }
+
+            result.assertIsSatisfied();
+            helloResult.assertIsSatisfied();
+            byeResult.assertIsSatisfied();
+
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("begin"));
+            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("done"), eq("failed"), eq(false));
+            verify(activityTracker).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("message"), endsWith("No content based route for message"));
+
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testChoiceStepWithDefaultFlow() throws Exception {
+        final CamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
+                    new Step.Builder()
+                            .id("flow-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("direct")
+                                            .putConfiguredProperty("name", "flow")
+                                            .build())
+                                    .build())
+                            .build(),
+                    new Step.Builder()
+                            .id("choice-step")
+                            .stepKind(StepKind.choice)
+                            .putConfiguredProperty("routingScheme", "mock")
+                            .putConfiguredProperty("default", "default-flow")
+                            .putConfiguredProperty("flows", "[" +
+                                    "{\"condition\": \"${body} contains 'Hello'\", \"flow\": \"hello-flow\"}," +
+                                    "{\"condition\": \"${body} contains 'Bye'\", \"flow\": \"bye-flow\"}" +
+                                    "]")
+                            .build(),
+                    new Step.Builder()
+                            .id("mock-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("mock")
+                                            .putConfiguredProperty("name", "result")
+                                            .build())
+                                    .build())
+                            .build()
+            );
+
+            // Set up the camel context
+            context.setUuidGenerator(KeyGenerator::createKey);
+            context.addLogListener(new IntegrationLoggingListener(activityTracker));
+            context.addInterceptStrategy(new ActivityTrackingInterceptStrategy(activityTracker));
+            context.addRoutes(integrationRoute);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:result", MockEndpoint.class);
+            final MockEndpoint defaultResult = context.getEndpoint("mock:default-flow", MockEndpoint.class);
+            final MockEndpoint helloResult = context.getEndpoint("mock:hello-flow", MockEndpoint.class);
+            final MockEndpoint byeResult = context.getEndpoint("mock:bye-flow", MockEndpoint.class);
+
+            final List<String> messages = Arrays.asList("Hello Camel!", "Bye Camel!", "And Now for Something Completely Different");
+
+            result.expectedBodiesReceived(messages);
+            defaultResult.expectedBodiesReceived("And Now for Something Completely Different");
+            helloResult.expectedBodiesReceived("Hello Camel!");
+            byeResult.expectedBodiesReceived("Bye Camel!");
+
+            for (String message : messages) {
+                template.sendBody("direct:flow", message);
+            }
+
+            result.assertIsSatisfied();
+            helloResult.assertIsSatisfied();
+            byeResult.assertIsSatisfied();
+
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("begin"));
+            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("done"), eq("failed"), eq(false));
+
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testChoiceStepWithRuleBasedConditions() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
+                    new Step.Builder()
+                            .id("flow-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("direct")
+                                            .putConfiguredProperty("name", "flow")
+                                            .build())
+                                    .build())
+                            .build(),
+                    new Step.Builder()
+                            .id("choice-step")
+                            .stepKind(StepKind.choice)
+                            .putConfiguredProperty("routingScheme", "mock")
+                            .putConfiguredProperty("flows", "[" +
+                                        "{\"path\": \"text\", \"op\": \"contains\", \"value\": \"Hello\", \"flow\": \"hello-flow\"}," +
+                                        "{\"path\": \"text\", \"op\": \"contains\", \"value\": \"Bye\", \"flow\": \"bye-flow\"}" +
+                                    "]")
+                            .build(),
+                    new Step.Builder()
+                            .id("mock-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("mock")
+                                            .putConfiguredProperty("name", "result")
+                                            .build())
+                                    .build())
+                            .build()
+            );
+
+            // Set up the camel context
+            context.setUuidGenerator(KeyGenerator::createKey);
+            context.addLogListener(new IntegrationLoggingListener(activityTracker));
+            context.addInterceptStrategy(new ActivityTrackingInterceptStrategy(activityTracker));
+            context.addRoutes(integrationRoute);
+
+            SimpleRegistry beanRegistry = new SimpleRegistry();
+            beanRegistry.put("bodyLogger", new BodyLogger.Default());
+            context.setRegistry(beanRegistry);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:result", MockEndpoint.class);
+            final MockEndpoint helloResult = context.getEndpoint("mock:hello-flow", MockEndpoint.class);
+            final MockEndpoint byeResult = context.getEndpoint("mock:bye-flow", MockEndpoint.class);
+
+            final List<String> messages = Arrays.asList("{\"text\": \"Hello Camel!\"}", "{\"text\": \"Bye Camel!\"}", "{\"text\": \"And Now for Something Completely Different\"}");
+
+            result.expectedBodiesReceived(messages);
+            helloResult.expectedBodiesReceived("{\"text\": \"Hello Camel!\"}");
+            byeResult.expectedBodiesReceived("{\"text\": \"Bye Camel!\"}");
+
+            for (String message : messages) {
+                template.sendBody("direct:flow", message);
+            }
+
+            result.assertIsSatisfied();
+            helloResult.assertIsSatisfied();
+            byeResult.assertIsSatisfied();
+
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("begin"));
+            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("done"), eq("failed"), eq(false));
+            verify(activityTracker).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("message"), endsWith("No content based route for message"));
+
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testChoiceStepNoConfiguredFlows() throws Exception {
+        final CamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
+                    new Step.Builder()
+                            .id("flow-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("direct")
+                                            .putConfiguredProperty("name", "flow")
+                                            .build())
+                                    .build())
+                            .build(),
+                    new Step.Builder()
+                            .id("choice-step")
+                            .stepKind(StepKind.choice)
+                            .build(),
+                    new Step.Builder()
+                            .id("mock-step")
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("mock")
+                                            .putConfiguredProperty("name", "result")
+                                            .build())
+                                    .build())
+                            .build()
+            );
+
+            // Set up the camel context
+            context.setUuidGenerator(KeyGenerator::createKey);
+            context.addLogListener(new IntegrationLoggingListener(activityTracker));
+            context.addInterceptStrategy(new ActivityTrackingInterceptStrategy(activityTracker));
+            context.addRoutes(integrationRoute);
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:result", MockEndpoint.class);
+
+            final List<String> messages = Arrays.asList("Hello Camel!", "Bye Camel!", "And Now for Something Completely Different");
+
+            result.expectedBodiesReceived(messages);
+
+            for (String message : messages) {
+                template.sendBody("direct:flow", message);
+            }
+
+            result.assertIsSatisfied();
+
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("begin"));
+            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("status"), eq("done"), eq("failed"), eq(false));
+
+        } finally {
+            context.stop();
+        }
+    }
+}


### PR DESCRIPTION
Integration runtime is able to handle content based router step with Camel choice-when-otherwise EIP.

The CBR step is configured with a condition expression and a flow identifier. The choice delegates to flows based on "direct:flowId" endpoint URI. The condition expression can be a simple language expression (like in advanced filter e.g. `${body} contains 'Hello'`) or a rule based expression using the properties path, operator and value (like in basic filter).

In case a default flow is configured on the step the otherwise branch in the choice delegates to this flow by default. When no default flow is configured a simple log message is done stating that no contend based route did actually match for the message. This log message is using the same pattern as the log step and should be printed to the activity log.