### PR TITLE
fix(5108): Ensure trailing slashes are removed from odata base url

### DIFF
--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -151,6 +151,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataUtil.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataUtil.java
@@ -33,6 +33,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.Map;
+import java.util.Optional;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -41,6 +42,7 @@ import org.apache.camel.util.jsse.KeyManagersParameters;
 import org.apache.camel.util.jsse.KeyStoreParameters;
 import org.apache.camel.util.jsse.SSLContextParameters;
 import org.apache.camel.util.jsse.TrustManagersParameters;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -278,5 +280,18 @@ public class ODataUtil implements ODataConstants {
 
     public static HttpClientFactory newHttpFactory(Map<String, Object> options) {
         return new ODataHttpClientFactory(options);
+    }
+
+    /**
+     * Remove the slashes at the end of the given string
+     *
+     * @param path
+     * @return string sans slashes
+     */
+    public static String removeEndSlashes(String path) {
+        return Optional.ofNullable(path)
+            .filter(str -> str.length() != 0)
+            .map(str -> StringUtils.stripEnd(path, FORWARD_SLASH))
+            .orElse(path);
     }
 }

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -77,41 +77,33 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         return resourcePath;
     }
 
-
     public void setResourcePath(String resourcePath) {
         this.resourcePath = resourcePath;
     }
-
 
     public String getServiceUri() {
         return serviceUri;
     }
 
-
     public void setServiceUri(String serviceUri) {
-        this.serviceUri = serviceUri;
+        this.serviceUri = ODataUtil.removeEndSlashes(serviceUri);
     }
-
 
     public String getBasicUserName() {
         return basicUserName;
     }
 
-
     public void setBasicUserName(String basicUserName) {
         this.basicUserName = basicUserName;
     }
-
 
     public String getBasicPassword() {
         return basicPassword;
     }
 
-
     public void setBasicPassword(String basicPassword) {
         this.basicPassword = basicPassword;
     }
-
 
     public String getServerCertificate() {
         return serverCertificate;

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
@@ -77,12 +77,13 @@ public class ODataVerifierExtension extends DefaultComponentVerifierExtension im
         if (!builder.build().getErrors().isEmpty()) {
             return;
         }
-        final String serviceUrl = (String) parameters.get(SERVICE_URI);
+        String serviceUrl = (String) parameters.get(SERVICE_URI);
         LOGGER.debug("Validating OData connection to {}", serviceUrl);
 
         if (ObjectHelper.isNotEmpty(serviceUrl)) {
             try (CloseableHttpClient httpClient = ODataUtil.createHttpClient(parameters)) {
 
+                serviceUrl = ODataUtil.removeEndSlashes(serviceUrl);
                 HttpGet httpGet = new HttpGet(serviceUrl + METADATA_ENDPOINT);
                 CloseableHttpResponse response = httpClient.execute(httpGet);
                 if (response.getStatusLine().getStatusCode() == 401) {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -15,11 +15,12 @@
  */
 package io.syndesis.connector.odata.consumer;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import java.util.List;
 import java.util.Map;
+import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.component.olingo4.Olingo4Endpoint;
@@ -140,6 +141,50 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         testResult(result, 0, TEST_SERVER_DATA_1);
         testResult(result, 1, TEST_SERVER_DATA_2);
         testResult(result, 2, TEST_SERVER_DATA_3);
+    }
+
+    @Test
+    public void testEmptyServiceUri() throws Exception {
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>());
+
+        Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+
+        assertThatExceptionOfType(RuntimeCamelException.class)
+            .isThrownBy(() -> {
+                context.start();
+            })
+            .withMessageContaining("serviceUri is not set");
+    }
+
+    @Test
+    public void testEndSlashOnServiceUri() throws Exception {
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                                .property(SERVICE_URI, defaultTestServer.servicePlainUri() + FORWARD_SLASH));
+
+        Step odataStep = createODataStep(odataConnector, defaultTestServer.resourcePath());
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(defaultTestServer.getResultCount());
+
+        context.start();
+
+        result.assertIsSatisfied();
+        testResult(result, 0, TEST_SERVER_DATA_1);
+        testResult(result, 1, TEST_SERVER_DATA_2);
+        testResult(result, 2, TEST_SERVER_DATA_3);
+
+        Olingo4Endpoint olingo4Endpoint = context.getEndpoint(OLINGO4_READ_ENDPOINT, Olingo4Endpoint.class);
+        assertNotNull(olingo4Endpoint);
+        String endpointServiceURI = olingo4Endpoint.getConfiguration().getServiceUri();
+        assertEquals(defaultTestServer.servicePlainUri(), endpointServiceURI);
     }
 
     /**

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
@@ -76,6 +76,24 @@ public class ODataVerifierTest extends AbstractODataTest {
     }
 
     @Test
+    public void testVerifyWithServerWithEndSlashesServiceURI() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        StringBuilder builder = new StringBuilder(defaultTestServer.servicePlainUri());
+        for (int i = 0; i < 10; ++i) {
+            builder.append(FORWARD_SLASH);
+        }
+        parameters.put(SERVICE_URI, builder.toString());
+
+        Verifier verifier = new ODataVerifierAutoConfiguration().odataVerifier();
+        List<VerifierResponse> responses = verifier.verify(context, "odata", parameters);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.PARAMETERS);
+        assertThat(responses).allMatch(response -> response.getStatus() == Verifier.Status.OK);
+    }
+
+    @Test
     public void testVerifyWithBasicAuthenticatedServer() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(SERVICE_URI, authTestServer.servicePlainUri());


### PR DESCRIPTION
* ODataUtil
 * Function for removing slashes

* ODataComponent
 * Removes trailing slashes on setting of the base url

* ODataVerifierExtension
 * Removes trailing slashes before verifying the metadata url

* Tests for both code changes