### PR TITLE
ENTESB-9863 Upgrade jackson-databind version to 2.8.11.3 in integration-bom

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -30,6 +30,7 @@
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <camel.version>2.21.0.fuse-740001</camel.version>
     <atlasmap.version>1.39.6</atlasmap.version>
+    <jackson.databind.version>2.8.11.3</jackson.databind.version>
   </properties>
 
     <!-- Metadata need to publish to central -->
@@ -342,6 +343,11 @@
         <groupId>io.syndesis.connector</groupId>
         <artifactId>connector-box</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.databind.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
spring-boot-dependencies brings in an old version of jackson-databind, we should make sure it brings in 2.8.11.3