### PR TITLE
#5181 Removed fetch metadata calls from reconcile cycles

### DIFF
--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -162,6 +162,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
                 this.currentFlowService.events.emit({
                   kind: INTEGRATION_SET_DESCRIPTOR,
                   position: this.position,
+                  skipReconcile: true,
                   descriptor,
                   onSave: () => {
                     /* All done... */
@@ -229,6 +230,7 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
         this.currentFlowService.events.emit({
           kind: INTEGRATION_SET_DESCRIPTOR,
           position: this.position,
+          skipReconcile: true,
           descriptor,
           onSave: () => {
             this.initialize(position, page, descriptor);

--- a/app/ui/src/app/integration/edit-page/edit-page.models.ts
+++ b/app/ui/src/app/integration/edit-page/edit-page.models.ts
@@ -21,7 +21,7 @@ export interface IndexedStep {
   index: number;
 }
 
-// Mucking with the intergration actions
+// Mucking with the integration actions
 export const INTEGRATION_UPDATED = 'integration-updated';
 export const INTEGRATION_INSERT_STEP = 'integration-insert-step';
 export const INTEGRATION_INSERT_DATAMAPPER = 'integration-insert-datamapper';

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -99,6 +99,7 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
         this.currentFlowService.events.emit({
           kind: INTEGRATION_SET_METADATA,
           position: this.position,
+          skipReconcile: true,
           metadata: { configured: 'true' },
           onSave: () => {
             this.router.navigate(['save-or-add-step'], {


### PR DESCRIPTION
This PR optimizes the number of requests to the backend regarding step meta data lookups.

In my opinion we can remove the fetch meta data calls from reconcile cycles completely. These calls are done explicitly for the currently selected step when going through the process of setting the configured properties for the step.

Fetch meta data calls for current step: 

https://github.com/syndesisio/syndesis/blob/b5d006c58b60f6df5b0430a912fadb375affa09f/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts#L159

and

https://github.com/syndesisio/syndesis/blob/b5d006c58b60f6df5b0430a912fadb375affa09f/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts#L223

I think these two calls (made only for the current selected step) are sufficient and we do not have to call the meta data lookup for other steps during reconcile.

When all configured properties are set on the current step `INTEGRATION_SET_METADATA` event is fired and this is the place in my eyes to go through all the steps to update the step *descriptors* in reconcile as now steps have changed. So I added the reconcile to this event handler.

I will now move on to provide a bulk operation on the backend for updating the step descriptors of all steps so we do not have to visit each step during reconcile.

@gashcrumb what do you think?