### PR TITLE
chore: #5181 UI uses backend bulk operation for step descriptor lookup

### DIFF
--- a/app/ui/src/app/core/providers/integration-support-provider.service.ts
+++ b/app/ui/src/app/core/providers/integration-support-provider.service.ts
@@ -17,8 +17,7 @@ import {
   PUBLISHED,
   IntegrationStatusDetail,
   ContinuousDeliveryEnvironment,
-  DescriptorRequest,
-  ActionDescriptor,
+  Step
 } from '@syndesis/ui/platform';
 import { EventsService } from '@syndesis/ui/store';
 import { HttpHeaders } from '@angular/common/http';
@@ -222,12 +221,11 @@ export class IntegrationSupportProviderService extends IntegrationSupportService
       .get();
   }
 
-  getStepDescriptor(
-    kind: string,
-    dataShapes: DescriptorRequest
-  ): Observable<ActionDescriptor> {
+  getStepDescriptors(
+    steps: Step[]
+  ): Observable<Step[]> {
     return this.apiHttpService
-      .setEndpointUrl(integrationEndpoints.getStepDescriptor, { kind })
-      .post(dataShapes);
+      .setEndpointUrl(integrationEndpoints.getStepDescriptors)
+      .post(steps);
   }
 }

--- a/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/action-configure/action-configure.component.ts
@@ -162,7 +162,6 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
                 this.currentFlowService.events.emit({
                   kind: INTEGRATION_SET_DESCRIPTOR,
                   position: this.position,
-                  skipReconcile: true,
                   descriptor,
                   onSave: () => {
                     /* All done... */
@@ -230,7 +229,6 @@ export class IntegrationConfigureActionComponent implements OnInit, OnDestroy {
         this.currentFlowService.events.emit({
           kind: INTEGRATION_SET_DESCRIPTOR,
           position: this.position,
-          skipReconcile: true,
           descriptor,
           onSave: () => {
             this.initialize(position, page, descriptor);

--- a/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -326,7 +326,6 @@ export class DataMapperHostComponent implements OnInit, OnDestroy {
       kind: INTEGRATION_SET_ACTION,
       position: this.position,
       stepKind: 'mapper',
-      skipReconcile: true,
       action: {
         actionType: 'step',
         descriptor: {

--- a/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -99,7 +99,6 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
         this.currentFlowService.events.emit({
           kind: INTEGRATION_SET_METADATA,
           position: this.position,
-          skipReconcile: true,
           metadata: { configured: 'true' },
           onSave: () => {
             this.router.navigate(['save-or-add-step'], {

--- a/app/ui/src/app/platform/types/integration/integration-support.service.ts
+++ b/app/ui/src/app/platform/types/integration/integration-support.service.ts
@@ -11,8 +11,7 @@ import {
   IntegrationStatus,
   IntegrationStatusDetail,
   ContinuousDeliveryEnvironment,
-  DescriptorRequest,
-  ActionDescriptor,
+  Step
 } from '@syndesis/ui/platform';
 
 @Injectable()
@@ -121,8 +120,7 @@ export abstract class IntegrationSupportService {
 
   abstract getEnvironments(): Observable<string[]>;
 
-  abstract getStepDescriptor(
-    kind: string,
-    dataShapes: DescriptorRequest
-  ): Observable<ActionDescriptor>;
+  abstract getStepDescriptors(
+    steps: Step[]
+  ): Observable<Step[]>;
 }

--- a/app/ui/src/app/platform/types/integration/integration.api.ts
+++ b/app/ui/src/app/platform/types/integration/integration.api.ts
@@ -11,7 +11,7 @@ export const integrationEndpoints: Endpoints = {
   metadata: '/connections/{connectionId}/actions/{actionId}',
   // TODO should this go into the integration service
   filterOptions: '/integrations/filters/options',
-  getStepDescriptor: '/steps/{kind}/descriptor',
+  getStepDescriptors: '/steps/descriptor',
 
   overviews: '/integration-support/overviews',
   overview: '/integrations/{id}/overview',

--- a/app/ui/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui/src/app/platform/types/integration/integration.models.ts
@@ -10,7 +10,6 @@ import {
   StringMap,
   WithId,
 } from '@syndesis/ui/platform';
-import { DataShape } from '../platform.models';
 
 export class Step implements BaseEntity {
   id?: string;
@@ -231,11 +230,6 @@ export interface ContinuousDeliveryEnvironment {
   lastTaggedAt: number;
   lastExportedat: number;
   lastImportedAt: number;
-}
-
-export interface DescriptorRequest {
-  inputShape: DataShape;
-  outputShape: DataShape;
 }
 
 export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';


### PR DESCRIPTION
Use new bulk operation for step descriptor lookup and optimize reconcile calls when integration changes.

The reconcile call is only executed when a step changes its meta data (which is only the case when a step is edited and changes its configured properties and its meta data) and when a step is removed. When reconcile is called the UI uses a bulk operation on server backend to send all steps and receive all steps with maybe adapted data shapes in one single operation.