### PR TITLE
feat: Add choice step meta data handler

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
@@ -20,22 +20,21 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.Dependency;
+import io.syndesis.common.model.Dependency.Type;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithConfiguredProperties;
 import io.syndesis.common.model.WithDependencies;
 import io.syndesis.common.model.WithId;
 import io.syndesis.common.model.WithMetadata;
-import io.syndesis.common.model.Dependency.Type;
 import io.syndesis.common.model.action.Action;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.extension.Extension;
-
 import org.immutables.value.Value;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
 @JsonDeserialize(builder = Step.Builder.class)
@@ -76,21 +75,31 @@ public interface Step extends WithId<Step>, WithConfiguredProperties, WithDepend
     }
 
     default Optional<DataShape> inputDataShape() {
-        return getAction().flatMap(a -> a.getInputDataShape());
+        return getAction().flatMap(Action::getInputDataShape);
     }
 
     default Optional<DataShape> outputDataShape() {
-        return getAction().flatMap(a -> a.getOutputDataShape());
+        return getAction().flatMap(Action::getOutputDataShape);
     }
 
     default Step updateInputDataShape(final Optional<DataShape> inputDataShape) {
-        return getAction().map(a -> builder().action(a.withInputDataShape(inputDataShape))).map(b -> b.build())
+        return getAction().map(a -> builder().action(a.withInputDataShape(inputDataShape))).map(ImmutableStep.Builder::build)
             .orElseThrow(() -> new IllegalStateException("Unable to update input data shape of non existing action"));
     }
 
     default Step updateOutputDataShape(final Optional<DataShape> outputDataShape) {
-        return getAction().map(a -> builder().action(a.withOutputDataShape(outputDataShape))).map(b -> b.build())
+        return getAction().map(a -> builder().action(a.withOutputDataShape(outputDataShape))).map(ImmutableStep.Builder::build)
             .orElseThrow(() -> new IllegalStateException("Unable to update output data shape of non existing action"));
+    }
+
+    default boolean hasInputDataShape() {
+        Optional<DataShape> maybeShape = inputDataShape();
+        return maybeShape.isPresent() && maybeShape.get().getKind() != DataShapeKinds.NONE;
+    }
+
+    default boolean hasOutputDataShape() {
+        Optional<DataShape> maybeShape = outputDataShape();
+        return maybeShape.isPresent() && maybeShape.get().getKind() != DataShapeKinds.NONE;
     }
 
     @JsonIgnore

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -52,11 +52,11 @@ class AggregateMetadataHandler implements StepMetadataHandler {
     @Override
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
         DataShape inputShape = StepMetadataHelper.getFirstWithInputShape(subsequentSteps)
-                                            .map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                            .flatMap(Step::inputDataShape)
                                             .orElse(StepMetadataHelper.NO_SHAPE);
 
         DataShape outputShape = StepMetadataHelper.getLastWithOutputShape(previousSteps)
-                                            .map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                            .flatMap(Step::outputDataShape)
                                             .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -51,16 +51,12 @@ class AggregateMetadataHandler implements StepMetadataHandler {
 
     @Override
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
-        DataShape inputShape = subsequentSteps.stream()
-                                            .filter(StepMetadataHelper::hasInputDataShape)
-                                            .findFirst()
-                                            .map(StepMetadataHelper::getInputDataShape)
+        DataShape inputShape = StepMetadataHelper.getFirstWithInputShape(subsequentSteps)
+                                            .map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
                                             .orElse(StepMetadataHelper.NO_SHAPE);
 
-        DataShape outputShape = previousSteps.stream()
-                                            .filter(StepMetadataHelper::hasOutputDataShape)
-                                            .reduce((first, second) -> second)
-                                            .map(StepMetadataHelper::getOutputDataShape)
+        DataShape outputShape = StepMetadataHelper.getLastWithOutputShape(previousSteps)
+                                            .map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
                                             .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
@@ -35,17 +35,14 @@ class ChoiceMetadataHandler implements StepMetadataHandler {
 
     @Override
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
-        DataShape inputShape = StepMetadataHelper.getFirstWithInputShape(subsequentSteps)
-                                                    .flatMap(Step::inputDataShape)
-                                                    .orElse(StepMetadataHelper.NO_SHAPE);
-
         DataShape outputShape = StepMetadataHelper.getLastWithOutputShape(previousSteps)
                                                     .flatMap(Step::outputDataShape)
                                                     .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()
-                        .inputShape(inputShape)
-                        .outputShape(outputShape)
+                        .inputShape(outputShape)
+                        .outputShape(step.outputDataShape()
+                                         .orElse(StepMetadataHelper.NO_SHAPE))
                         .build();
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.endpoint.v1.handler.meta;
+
+import java.util.List;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.connection.DynamicActionMetadata;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+
+/**
+ * @author Christoph Deppisch
+ */
+class ChoiceMetadataHandler implements StepMetadataHandler {
+
+    @Override
+    public boolean canHandle(StepKind kind) {
+        return StepKind.choice.equals(kind);
+    }
+
+    @Override
+    public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
+        DataShape inputShape = StepMetadataHelper.getFirstWithInputShape(subsequentSteps)
+                                                    .map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                                    .orElse(StepMetadataHelper.NO_SHAPE);
+
+        DataShape outputShape = StepMetadataHelper.getLastWithOutputShape(previousSteps)
+                                                    .map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                                    .orElse(StepMetadataHelper.NO_SHAPE);
+
+        return new DynamicActionMetadata.Builder()
+                        .inputShape(inputShape)
+                        .outputShape(outputShape)
+                        .build();
+    }
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
@@ -36,11 +36,11 @@ class ChoiceMetadataHandler implements StepMetadataHandler {
     @Override
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
         DataShape inputShape = StepMetadataHelper.getFirstWithInputShape(subsequentSteps)
-                                                    .map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                                    .flatMap(Step::inputDataShape)
                                                     .orElse(StepMetadataHelper.NO_SHAPE);
 
         DataShape outputShape = StepMetadataHelper.getLastWithOutputShape(previousSteps)
-                                                    .map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+                                                    .flatMap(Step::outputDataShape)
                                                     .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -51,10 +51,10 @@ class SplitMetadataHandler implements StepMetadataHandler {
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
         Optional<Step> previousStepWithDataShape = StepMetadataHelper.getFirstWithOutputShape(previousSteps);
 
-        DataShape inputShape = previousStepWithDataShape.map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+        DataShape inputShape = previousStepWithDataShape.flatMap(Step::inputDataShape)
                                                         .orElse(StepMetadataHelper.NO_SHAPE);
 
-        DataShape outputShape = previousStepWithDataShape.map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
+        DataShape outputShape = previousStepWithDataShape.flatMap(Step::outputDataShape)
                                                         .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -49,14 +49,12 @@ class SplitMetadataHandler implements StepMetadataHandler {
 
     @Override
     public DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
-        Optional<Step> previousStepWithDataShape = previousSteps.stream()
-                                                                .filter(StepMetadataHelper::hasOutputDataShape)
-                                                                .findFirst();
+        Optional<Step> previousStepWithDataShape = StepMetadataHelper.getFirstWithOutputShape(previousSteps);
 
-        DataShape inputShape = previousStepWithDataShape.map(StepMetadataHelper::getInputDataShape)
+        DataShape inputShape = previousStepWithDataShape.map(s -> s.inputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
                                                         .orElse(StepMetadataHelper.NO_SHAPE);
 
-        DataShape outputShape = previousStepWithDataShape.map(StepMetadataHelper::getOutputDataShape)
+        DataShape outputShape = previousStepWithDataShape.map(s -> s.outputDataShape().orElse(StepMetadataHelper.NO_SHAPE))
                                                         .orElse(StepMetadataHelper.NO_SHAPE);
 
         return new DynamicActionMetadata.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
@@ -50,7 +50,8 @@ import org.springframework.stereotype.Component;
 public class StepActionHandler extends BaseHandler {
 
     private final List<StepMetadataHandler> metadataHandlers = Arrays.asList(new SplitMetadataHandler(),
-                                                                             new AggregateMetadataHandler());
+                                                                             new AggregateMetadataHandler(),
+                                                                             new ChoiceMetadataHandler());
 
     public StepActionHandler(final DataManager dataMgr) {
         super(dataMgr);

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
@@ -32,7 +32,9 @@ interface StepMetadataHandler {
      * @param metadata
      * @return
      */
-    DynamicActionMetadata handle(DynamicActionMetadata metadata);
+    default DynamicActionMetadata handle(DynamicActionMetadata metadata) {
+        return metadata;
+    }
 
     /**
      * Determine if this handler can handle the specific step kind.

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.DataShapeMetaData;
-import io.syndesis.common.model.action.Action;
-import io.syndesis.common.model.action.ActionDescriptor;
 import io.syndesis.common.model.integration.Step;
 
 /**
@@ -44,12 +42,45 @@ final class StepMetadataHelper {
     }
 
     /**
+     * Finds first step in list that has a proper input data shape.
+     * @param steps list of steps to evaluate
+     * @return optional matching step
+     */
+    static Optional<Step> getFirstWithInputShape(List<Step> steps) {
+        return steps.stream()
+                .filter(Step::hasInputDataShape)
+                .findFirst();
+    }
+
+    /**
+     * Finds first step in list that has a proper output data shape.
+     * @param steps list of steps to evaluate
+     * @return optional matching step
+     */
+    static Optional<Step> getFirstWithOutputShape(List<Step> steps) {
+        return steps.stream()
+                .filter(Step::hasOutputDataShape)
+                .findFirst();
+    }
+
+    /**
+     * Finds last step in list that has a proper output data shape.
+     * @param steps list of steps to evaluate
+     * @return optional matching step
+     */
+    static Optional<Step> getLastWithOutputShape(List<Step> steps) {
+        return steps.stream()
+                .filter(Step::hasOutputDataShape)
+                .reduce((first, second) -> second);
+    }
+
+    /**
      * Extracts variants from given original data shape excluding the given variant. Includes the original data shape itself as variant to the list of extracted variants.
      * In case given original data shape and exclude variant happen to be equal just return original data shape itself as exclusive variant and set given variant meta data.
      * @param original the original data shape providing variants
      * @param variant variant to exclude from the original variants
      * @param variantMeta optional new meta data variant value in case original and exclude happen to be equal
-     * @return
+     * @return list of data shape variants
      */
     static List<DataShape> extractVariants(DataShape original, DataShape variant, String variantMeta) {
         if (original.equals(variant)) {
@@ -71,65 +102,5 @@ final class StepMetadataHelper {
 
             return variants;
         }
-    }
-
-    /**
-     * Evaluates input data shape on given step to be present and to not be of kind
-     * {@link DataShapeKinds#NONE}
-     * @param step
-     * @return
-     */
-    static boolean hasInputDataShape(Step step) {
-        return !getInputDataShape(step).getKind().equals(DataShapeKinds.NONE);
-    }
-
-    /**
-     * Evaluates output data shape on given step to be present and to not be of kind
-     * {@link DataShapeKinds#NONE}
-     * @param step
-     * @return
-     */
-    static boolean hasOutputDataShape(Step step) {
-        return !getOutputDataShape(step).getKind().equals(DataShapeKinds.NONE);
-    }
-
-    /**
-     * Safely get the input data shape of given step. If shape is not present this method returns
-     * a dummy data shape of kind {@link DataShapeKinds#NONE}.
-     * @param step
-     * @return
-     */
-    static DataShape getInputDataShape(Step step) {
-        Optional<Action> action = step.getAction();
-
-        if (action.isPresent()) {
-            ActionDescriptor descriptor = action.get().getDescriptor();
-            if (descriptor != null) {
-                Optional<DataShape> inputShape = descriptor.getInputDataShape();
-                return inputShape.orElse(NO_SHAPE);
-            }
-        }
-
-        return NO_SHAPE;
-    }
-
-    /**
-     * Safely get the output data shape of given step. If shape is not present this method returns
-     * a dummy data shape of kind {@link DataShapeKinds#NONE}.
-     * @param step
-     * @return
-     */
-    static DataShape getOutputDataShape(Step step) {
-        Optional<Action> action = step.getAction();
-
-        if (action.isPresent()) {
-            ActionDescriptor descriptor = action.get().getDescriptor();
-            if (descriptor != null) {
-                Optional<DataShape> outputShape = descriptor.getOutputDataShape();
-                return outputShape.orElse(NO_SHAPE);
-            }
-        }
-
-        return NO_SHAPE;
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.endpoint.v1.handler.meta;
+
+import java.util.Collections;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.DynamicActionMetadata;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ChoiceMetadataHandlerTest {
+
+    private ChoiceMetadataHandler metadataHandler = new ChoiceMetadataHandler();
+
+    private Step choiceStep = new Step.Builder()
+            .stepKind(StepKind.choice)
+            .build();
+
+    @Test
+    public void shouldCreateMetaDataFromSurroundingSteps() {
+        Step previousStep = new Step.Builder()
+                .stepKind(StepKind.endpoint)
+                .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                                .inputDataShape(StepMetadataHelper.NO_SHAPE)
+                                .outputDataShape(new DataShape.Builder()
+                                        .kind(DataShapeKinds.JSON_INSTANCE)
+                                        .specification("{}")
+                                        .description("previousOutput")
+                                        .addVariant(testShape("variant1"))
+                                        .addVariant(testShape("variant2"))
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        Step subsequentStep = new Step.Builder()
+                .stepKind(StepKind.endpoint)
+                .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                                .inputDataShape(new DataShape.Builder()
+                                        .kind(DataShapeKinds.JSON_INSTANCE)
+                                        .specification("{}")
+                                        .description("subsequentInput")
+                                        .addVariant(testShape("variant3"))
+                                        .addVariant(testShape("variant4"))
+                                        .build())
+                                .outputDataShape(StepMetadataHelper.NO_SHAPE)
+                                .build())
+                        .build())
+                .build();
+
+        DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
+
+        Assert.assertNotNull(metadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, metadata.inputShape().getKind());
+        Assert.assertEquals("subsequentInput", metadata.inputShape().getDescription());
+        Assert.assertEquals(2, metadata.inputShape().getVariants().size());
+        Assert.assertEquals("variant3", metadata.inputShape().getVariants().get(0).getMetadata().get("name"));
+        Assert.assertEquals("variant4", metadata.inputShape().getVariants().get(1).getMetadata().get("name"));
+
+        Assert.assertNotNull(metadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, metadata.outputShape().getKind());
+        Assert.assertEquals("previousOutput", metadata.outputShape().getDescription());
+        Assert.assertEquals(2, metadata.outputShape().getVariants().size());
+        Assert.assertEquals("variant1", metadata.outputShape().getVariants().get(0).getMetadata().get("name"));
+        Assert.assertEquals("variant2", metadata.outputShape().getVariants().get(1).getMetadata().get("name"));
+    }
+
+    @Test
+    public void shouldCreateMetaDataFromAnyShapes() {
+        Step previousStep = new Step.Builder()
+                .stepKind(StepKind.endpoint)
+                .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                                .inputDataShape(StepMetadataHelper.NO_SHAPE)
+                                .outputDataShape(StepMetadataHelper.ANY_SHAPE)
+                                .build())
+                        .build())
+                .build();
+
+        Step subsequentStep = new Step.Builder()
+                .stepKind(StepKind.endpoint)
+                .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                                .inputDataShape(StepMetadataHelper.ANY_SHAPE)
+                                .outputDataShape(StepMetadataHelper.NO_SHAPE)
+                                .build())
+                        .build())
+                .build();
+
+        DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
+
+        Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.inputShape());
+        Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.outputShape());
+    }
+
+    @Test
+    public void shouldCreateMetaDataFromEmptySurroundingSteps() {
+        DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.emptyList(), Collections.emptyList());
+
+        Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.inputShape());
+        Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.outputShape());
+    }
+
+    @Test
+    public void shouldPreserveGivenMetadata() {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(testShape("input"))
+                .outputShape(testShape("output"))
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+        Assert.assertEquals(metadata, enrichedMetadata);
+    }
+
+    private DataShape testShape(String name) {
+        return new DataShape.Builder()
+                .kind(DataShapeKinds.JSON_INSTANCE)
+                .description(name)
+                .specification("{}")
+                .putMetadata("name", name)
+                .build();
+    }
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
@@ -75,19 +75,15 @@ public class ChoiceMetadataHandlerTest {
 
         DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
 
+        Assert.assertNotNull(metadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.NONE, metadata.outputShape().getKind());
+
         Assert.assertNotNull(metadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, metadata.inputShape().getKind());
-        Assert.assertEquals("subsequentInput", metadata.inputShape().getDescription());
+        Assert.assertEquals("previousOutput", metadata.inputShape().getDescription());
         Assert.assertEquals(2, metadata.inputShape().getVariants().size());
-        Assert.assertEquals("variant3", metadata.inputShape().getVariants().get(0).getMetadata().get("name"));
-        Assert.assertEquals("variant4", metadata.inputShape().getVariants().get(1).getMetadata().get("name"));
-
-        Assert.assertNotNull(metadata.outputShape());
-        Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, metadata.outputShape().getKind());
-        Assert.assertEquals("previousOutput", metadata.outputShape().getDescription());
-        Assert.assertEquals(2, metadata.outputShape().getVariants().size());
-        Assert.assertEquals("variant1", metadata.outputShape().getVariants().get(0).getMetadata().get("name"));
-        Assert.assertEquals("variant2", metadata.outputShape().getVariants().get(1).getMetadata().get("name"));
+        Assert.assertEquals("variant1", metadata.inputShape().getVariants().get(0).getMetadata().get("name"));
+        Assert.assertEquals("variant2", metadata.inputShape().getVariants().get(1).getMetadata().get("name"));
     }
 
     @Test
@@ -115,7 +111,7 @@ public class ChoiceMetadataHandlerTest {
         DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
 
         Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.inputShape());
-        Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.outputShape());
+        Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.outputShape());
     }
 
     @Test


### PR DESCRIPTION
Content based router (=choice) step adapts input/output data shapes from previous and subsequent steps during step descriptor meta data lookup.

Also moved some utility methods to step model class

Belongs to #5193 