### PR TITLE
 chore: use SCLs Nginx base image 

### DIFF
--- a/app/ui-angular/docker/Dockerfile
+++ b/app/ui-angular/docker/Dockerfile
@@ -1,6 +1,4 @@
-FROM docker.io/centos:7
-
-ENV NGINX_VERSION 1.13.4-1.el7
+FROM ${docker-base-image}
 
 # This refers to the files copied by assembly configuration in pom.xml
 # Change this to e.g. "dist" if running the dockerfile from top-level e.g.
@@ -8,53 +6,26 @@ ENV NGINX_VERSION 1.13.4-1.el7
 ARG SRC_DIR="maven/dist"
 ARG CONTEXT_DIR="."
 
-LABEL name="nginxinc/nginx" \
+LABEL name="syndesis/ui" \
       maintainer="Syndesis Authors <syndesis@googlegroups.com>" \
-      vendor="NGINX Inc." \
-      version="${NGINX_VERSION}" \
-      release="1" \
-      summary="NGINX" \
-      description="nginx will do ....."
-### Required labels above - recommended below
-LABEL url="https://www.nginx.com/" \
-      io.k8s.display-name="NGINX" \
-      io.openshift.expose-services="http:8080" \
-      io.openshift.tags="nginx,nginxinc"
+      summary="Presentation layer for Syndesis" \
+      description="Presentation layer for Syndesis - a flexible, customizable, cloud-hosted platform that provides core integration capabilities as a service." \
+      url="https://syndesis.io/" \
+      io.k8s.display-name="Syndesis" \
+      io.k8s.description="Presentation layer for Syndesis - a flexible, customizable, cloud-hosted platform that provides core integration capabilities as a service." \
+      io.openshift.tags="syndesis,integration"
 
-ADD ${CONTEXT_DIR}/nginx.repo /etc/yum.repos.d/nginx.repo
-
-RUN curl -sO http://nginx.org/keys/nginx_signing.key && \
-    rpm --import ./nginx_signing.key && \
-    yum -y install --setopt=tsflags=nodocs nginx-${NGINX_VERSION}.ngx && \
-    rm -f ./nginx_signing.key && \
-    yum clean all
-
-# forward request and error logs to docker log collector
-# - Change pid file location & remove nginx user & change port to 8080
-# - modify perms for non-root runtime
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log && \
-    sed -i 's/\/var\/run\/nginx.pid/\/var\/cache\/nginx\/nginx.pid/g' /etc/nginx/nginx.conf && \
-    sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf && \
-    rm -f /etc/nginx/conf.d/default.conf && \
-    chown -R 998 /var/cache/nginx /etc/nginx && \
-    chmod -R g=u /var/cache/nginx /etc/nginx
-
-
+USER root
 # Copy licenses
 RUN mkdir -p /opt/ipaas/licenses
 COPY licenses /opt/ipaas/licenses
-
-#VOLUME ["/var/cache/nginx"]
+USER default
 
 EXPOSE 8080 8443
 
-# Add symbolic link to config.json to avoid mounting issues
-RUN ln -sf /usr/share/nginx/html/config/config.json /usr/share/nginx/html/config.json
+COPY ${CONTEXT_DIR}/nginx-syndesis.conf /tmp/src/nginx-default-cfg/
+COPY ${SRC_DIR} /tmp/src/
 
-USER 998
+RUN $STI_SCRIPTS_PATH/assemble
 
-CMD ["nginx", "-g", "daemon off;"]
-
-COPY ${CONTEXT_DIR}/nginx-syndesis.conf /etc/nginx/conf.d
-COPY ${SRC_DIR} /usr/share/nginx/html
+CMD ["/bin/sh", "-c", "$STI_SCRIPTS_PATH/run"]

--- a/app/ui-angular/docker/nginx-syndesis.conf
+++ b/app/ui-angular/docker/nginx-syndesis.conf
@@ -1,40 +1,36 @@
-server {
-    listen       8080;
-    server_name  localhost;
+gzip         on;
+gzip_disable "msie6";
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_buffers 16 8k;
+gzip_http_version 1.1;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
 
-    gzip         on;
-    gzip_disable "msie6";
-    gzip_vary on;
-    gzip_proxied any;
-    gzip_comp_level 6;
-    gzip_buffers 16 8k;
-    gzip_http_version 1.1;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
+location = / {
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
+    try_files /index.html =200;
+}
 
-    root         /usr/share/nginx/html;
+location = /config.json {
+    root /opt/app-root/src/config;
+}
 
-    location = / {
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-        try_files /index.html =200;
+location ~ /.+ {
+    try_files $uri $uri/ /index.html;
+}
+
+location = /logout {
+    set $cookie "";
+    if ($http_syndesis_xsrf_token = "awesome") {
+        set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
     }
-
-    location ~ /.+ {
-        try_files $uri $uri/ /index.html;
-    }
-
-    location = /logout {
-        set $cookie "";
-        if ($http_syndesis_xsrf_token = "awesome") {
-            set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
-        }
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-        add_header Set-Cookie $cookie always;
-        default_type "text/html; charset=ISO-8859-1";
-        alias /usr/share/nginx/html/logout.html;
-    }
-
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
+    add_header Set-Cookie $cookie always;
+    default_type "text/html; charset=ISO-8859-1";
+    alias /opt/app-root/src/logout.html;
 }

--- a/app/ui-angular/docker/nginx.repo
+++ b/app/ui-angular/docker/nginx.repo
@@ -1,5 +1,0 @@
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/mainline/rhel/7/$basearch/
-gpgcheck=1
-enabled=1

--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -35,6 +35,7 @@
     <yarn-install-args />
     <yarn-verbose />
     <npm-verbose />
+    <docker-base-image>centos/nginx-114-centos7</docker-base-image>
   </properties>
 
   <build>

--- a/app/ui-react/docker/Dockerfile
+++ b/app/ui-react/docker/Dockerfile
@@ -1,6 +1,4 @@
-FROM docker.io/centos:7
-
-ENV NGINX_VERSION 1.13.4-1.el7
+FROM ${docker-base-image}
 
 # This refers to the files copied by assembly configuration in pom.xml
 # Change this to e.g. "dist" if running the dockerfile from top-level e.g.
@@ -8,53 +6,26 @@ ENV NGINX_VERSION 1.13.4-1.el7
 ARG SRC_DIR="maven/syndesis/build"
 ARG CONTEXT_DIR="."
 
-LABEL name="nginxinc/nginx" \
+LABEL name="syndesis/ui" \
       maintainer="Syndesis Authors <syndesis@googlegroups.com>" \
-      vendor="NGINX Inc." \
-      version="${NGINX_VERSION}" \
-      release="1" \
-      summary="NGINX" \
-      description="nginx will do ....."
-### Required labels above - recommended below
-LABEL url="https://www.nginx.com/" \
-      io.k8s.display-name="NGINX" \
-      io.openshift.expose-services="http:8080" \
-      io.openshift.tags="nginx,nginxinc"
+      summary="Presentation layer for Syndesis" \
+      description="Presentation layer for Syndesis - a flexible, customizable, cloud-hosted platform that provides core integration capabilities as a service." \
+      url="https://syndesis.io/" \
+      io.k8s.display-name="Syndesis" \
+      io.k8s.description="Presentation layer for Syndesis - a flexible, customizable, cloud-hosted platform that provides core integration capabilities as a service." \
+      io.openshift.tags="syndesis,integration"
 
-ADD ${CONTEXT_DIR}/nginx.repo /etc/yum.repos.d/nginx.repo
-
-RUN curl -sO http://nginx.org/keys/nginx_signing.key && \
-    rpm --import ./nginx_signing.key && \
-    yum -y install --setopt=tsflags=nodocs nginx-${NGINX_VERSION}.ngx && \
-    rm -f ./nginx_signing.key && \
-    yum clean all
-
-# forward request and error logs to docker log collector
-# - Change pid file location & remove nginx user & change port to 8080
-# - modify perms for non-root runtime
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log && \
-    sed -i 's/\/var\/run\/nginx.pid/\/var\/cache\/nginx\/nginx.pid/g' /etc/nginx/nginx.conf && \
-    sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf && \
-    rm -f /etc/nginx/conf.d/default.conf && \
-    chown -R 998 /var/cache/nginx /etc/nginx && \
-    chmod -R g=u /var/cache/nginx /etc/nginx
-
-
+USER root
 # Copy licenses
-#RUN mkdir -p /opt/ipaas/licenses
-#COPY licenses /opt/ipaas/licenses
-
-#VOLUME ["/var/cache/nginx"]
+RUN mkdir -p /opt/ipaas/licenses
+COPY licenses /opt/ipaas/licenses
+USER default
 
 EXPOSE 8080 8443
 
-# Add symbolic link to config.json to avoid mounting issues
-RUN ln -sf /usr/share/nginx/html/config/config.json /usr/share/nginx/html/config.json
+COPY ${CONTEXT_DIR}/nginx-syndesis.conf /tmp/src/nginx-default-cfg/
+COPY ${SRC_DIR} /tmp/src/
 
-USER 998
+RUN $STI_SCRIPTS_PATH/assemble
 
-CMD ["nginx", "-g", "daemon off;"]
-
-COPY ${CONTEXT_DIR}/nginx-syndesis.conf /etc/nginx/conf.d
-COPY ${SRC_DIR} /usr/share/nginx/html
+CMD ["/bin/sh", "-c", "$STI_SCRIPTS_PATH/run"]

--- a/app/ui-react/docker/nginx-syndesis.conf
+++ b/app/ui-react/docker/nginx-syndesis.conf
@@ -1,40 +1,36 @@
-server {
-    listen       8080;
-    server_name  localhost;
+gzip         on;
+gzip_disable "msie6";
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_buffers 16 8k;
+gzip_http_version 1.1;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
 
-    gzip         on;
-    gzip_disable "msie6";
-    gzip_vary on;
-    gzip_proxied any;
-    gzip_comp_level 6;
-    gzip_buffers 16 8k;
-    gzip_http_version 1.1;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
+location = / {
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
+    try_files /index.html =200;
+}
 
-    root         /usr/share/nginx/html;
+location = /config.json {
+    root /opt/app-root/src/config;
+}
 
-    location = / {
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-        try_files /index.html =200;
+location ~ /.+ {
+    try_files $uri $uri/ /index.html;
+}
+
+location = /logout {
+    set $cookie "";
+    if ($http_syndesis_xsrf_token = "awesome") {
+        set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
     }
-
-    location ~ /.+ {
-        try_files $uri $uri/ /index.html;
-    }
-
-    location = /logout {
-        set $cookie "";
-        if ($http_syndesis_xsrf_token = "awesome") {
-            set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
-        }
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-        add_header Set-Cookie $cookie always;
-        default_type "text/html; charset=ISO-8859-1";
-        alias /usr/share/nginx/html/logout.html;
-    }
-
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    add_header Pragma "no-cache" always;
+    add_header Expires "0" always;
+    add_header Set-Cookie $cookie always;
+    default_type "text/html; charset=ISO-8859-1";
+    alias /opt/app-root/src/logout.html;
 }

--- a/app/ui-react/docker/nginx.repo
+++ b/app/ui-react/docker/nginx.repo
@@ -1,5 +1,0 @@
-[nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/mainline/rhel/7/$basearch/
-gpgcheck=1
-enabled=1

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -35,6 +35,7 @@
     <yarn-install-args />
     <yarn-verbose />
     <npm-verbose />
+    <docker-base-image>centos/nginx-114-centos7</docker-base-image>
   </properties>
 
   <build>

--- a/install/generator/03-syndesis-ui.yml.mustache
+++ b/install/generator/03-syndesis-ui.yml.mustache
@@ -74,7 +74,7 @@
           ports:
           - containerPort: 8080
           volumeMounts:
-          - mountPath: /usr/share/nginx/html/config
+          - mountPath: /opt/app-root/src/config
             name: config-volume
           # Set to burstable with a low memory footprint to start (50 Mi)
           resources:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -454,7 +454,7 @@ objects:
           ports:
           - containerPort: 8080
           volumeMounts:
-          - mountPath: /usr/share/nginx/html/config
+          - mountPath: /opt/app-root/src/config
             name: config-volume
           # Set to burstable with a low memory footprint to start (50 Mi)
           resources:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1354,7 +1354,6 @@ objects:
       # See the License for the specific language governing permissions and
       # limitations under the License.
       #
-
       startDelaySecs: 5
       ssl: false
       blacklistObjectNames: ["java.lang:*"]
@@ -1466,7 +1465,6 @@ objects:
               context: $1
               type: context
           type: GAUGE
-
       # Route level
         - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1564,7 +1562,6 @@ objects:
               route: $2
               type: routes
           type: GAUGE
-
       # Processor level
         - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1662,7 +1659,6 @@ objects:
               processor: $2
               type: processors
           type: COUNTER
-
       # Consumers
         - pattern: 'org.apache.camel<context=([^,]+), type=consumers, name=([^,]+)><>InflightExchanges'
           name: org.apache.camel.InflightExchanges
@@ -1672,7 +1668,6 @@ objects:
               consumer: $2
               type: consumers
           type: GAUGE
-
       # Services
         - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MaxDuration'
           name: org.apache.camel.MaxDuration
@@ -1893,7 +1888,6 @@ objects:
               type: $2
               service: $3
               port: $4
-
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
**HEADS UP** @syndesisio/ui-api @cunningt @djcoleman @orpiske

Switches the use of the Syndesis UI Docker base image from CentOS and Nginx installed from nginx.org RPM repository to SCLs Nginx[1].

Since SCLs Nginx is a S2I builder image the Dockerfile was modified to copy the distribution files and configuration to `/tmp/src` and run `assemble` as an S2I build would do.

`docker.base-image` Maven property can be used to change to a different SCLs Nginx base image (say `rhscl/nginx-114-rhel7` for RHEL 7 based base image).

[1] https://github.com/sclorg/nginx-container/blob/master/1.14/README.md