### PR TITLE
user doc: Remove incorrect config options for AMQP request/response

### DIFF
--- a/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
+++ b/doc/connecting/topics/p_adding-amqp-connection-middle.adoc
@@ -34,6 +34,12 @@ you specify and receive a response. To configure this action:
 .. In the *Destination Name* field, enter the name of the queue or topic 
 to send messages to. 
 .. For the *Destination Type*, accept *Queue* or select *Topic*.
+
+
+.. In the *Durable Subscription ID* field, to allow connections to 
+close and reopen without missing messages, enter the durable
+subscription ID. The destination type must be a topic. 
+
 .. In the *Message Selector* field, if you want to receive only responses 
 that satisfy a particular condition, enter a filter expression. 
 +
@@ -47,17 +53,6 @@ The message selector in the following example selects any message that has a
 The message consumer receives only those messages whose headers and 
 properties match the message selector expression. A message selector cannot select messages on 
 the basis of the content of the message body.
-
-
-.. In the *Named Reply To* field, enter the name of
-a queue or topic. The destination sends its response
-to this queue or topic. 
-.. Select *Persistent* to guarantee message delivery even if
-a connection fails.  
-.. In the *Response Time Out* field, specify the number of milliseconds that this 
-connection waits for a 
-response message before throwing a runtime exception. 
-The default is 5000 milliseconds (5 seconds).
 
 . Click *Next* to specify the action's input and output type. 
 


### PR DESCRIPTION
Per FUSEDOC-3159, in the doc for the AMQP connector, when the user selects the Request Response Using Messages action, I removed the content for these fields:

- Named Reply To 
- Persistent checkbox
- Response Time Out

And I added content for this field:

- Durable Subscription ID