### PR TITLE
Support for API key authentication in custom API client connectors

### DIFF
--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import io.syndesis.connector.rest.swagger.auth.basic.Basic;
 import io.syndesis.connector.rest.swagger.auth.oauth.OAuth;
+import io.syndesis.connector.rest.swagger.auth.parameter.Parameter;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -38,16 +39,20 @@ public class AuthenticationCustomizer implements ComponentProxyCustomizer {
 
             final CamelContext context = component.getCamelContext();
             final Configuration configuration = new Configuration(this, context, options);
-            component.setConfiguration(configuration);
 
-            if (authenticationType == AuthenticationType.oauth2) {
+            switch (authenticationType) {
+            case oauth2:
                 OAuth.setup(component, configuration);
-            } else if (authenticationType == AuthenticationType.basic) {
+                break;
+            case basic:
                 Basic.setup(component, configuration);
-            } else {
+                break;
+            case parameter:
+                Parameter.setup(component, configuration);
+                break;
+            default:
                 throw new IllegalStateException("Unsupported authentication type: " + authenticationType);
             }
-
         });
     }
 

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationType.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationType.java
@@ -16,5 +16,5 @@
 package io.syndesis.connector.rest.swagger;
 
 public enum AuthenticationType {
-    basic, none, oauth2
+    basic, none, oauth2, parameter
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/RequestCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/RequestCustomizer.java
@@ -23,7 +23,6 @@ import io.syndesis.common.model.OutputDataShapeAware;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import io.syndesis.integration.component.proxy.Processors;
-import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
 
 import org.apache.camel.CamelContext;
 
@@ -40,16 +39,7 @@ public final class RequestCustomizer implements ComponentProxyCustomizer, InputD
         final CamelContext camelContext = component.getCamelContext();
 
         if (!camelContext.getComponentNames().contains(DELEGATE_COMPONENT_NAME)) {
-            // HttpComponent::createProducer will ignore any
-            // HttpHeaderFilterStrategy set on the component/endpoint and set
-            // it's own HttpRestHeaderFilterStrategy which cannot be influenced
-            // in any way, here we're getting the reference to the endpoint
-            // that's created in the createProducer and modifying the configured
-            // DefaultHeaderFilterStrategy with the configuration from our
-            // global HeaderFilterStrategy. This way we can filter out any HTTP
-            // headers we do not wish to receive or send via HTTP (such as
-            // Syndesis.*)
-            final WithSyndesisHeaderFilterStrategy delegate = new WithSyndesisHeaderFilterStrategy(new SyndesisHeaderStrategy());
+            final SyndesisRestSwaggerComponent delegate = new SyndesisRestSwaggerComponent();
             camelContext.addComponent(DELEGATE_COMPONENT_NAME, delegate);
         }
 

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerProxyComponent.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SwaggerProxyComponent.java
@@ -23,8 +23,6 @@ import org.apache.camel.Endpoint;
 
 public final class SwaggerProxyComponent extends ComponentProxyComponent {
 
-    private Configuration configuration;
-
     private Function<Endpoint, Endpoint> endpointOverride = Function.identity();
 
     public SwaggerProxyComponent(final String componentId, final String componentScheme) {
@@ -35,13 +33,6 @@ public final class SwaggerProxyComponent extends ComponentProxyComponent {
     public Endpoint createEndpoint(final String uri) throws Exception {
         final Endpoint endpoint = super.createEndpoint(uri);
 
-        if (configuration == null) {
-            // AuthenticationCustomizer did not invoke setConfiguration
-            // meaning we don't need to wrap the endpoint as no
-            // authentication is to be performed
-            return endpoint;
-        }
-
         return endpointOverride.apply(endpoint);
     }
 
@@ -49,7 +40,4 @@ public final class SwaggerProxyComponent extends ComponentProxyComponent {
         this.endpointOverride = endpointOverride;
     }
 
-    public void setConfiguration(final Configuration configuration) {
-        this.configuration = configuration;
-    }
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SyndesisRestSwaggerComponent.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SyndesisRestSwaggerComponent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Producer;
+import org.apache.camel.component.http4.HttpComponent;
+import org.apache.camel.component.http4.HttpProducer;
+import org.apache.camel.spi.RestConfiguration;
+
+public final class SyndesisRestSwaggerComponent extends HttpComponent {
+
+    private static final List<Consumer<HttpProducer>> CUSTOMIZERS = new ArrayList<>(3);
+
+    static {
+        CUSTOMIZERS.add(new WithSyndesisHeaderFilterStrategy());
+    }
+
+    @Override
+    @SuppressWarnings("PMD.ExcessiveParameterList") // overriden method
+    public Producer createProducer(final CamelContext camelContext, final String host, final String verb, final String basePath, final String uriTemplate,
+        final String queryParameters, final String consumes, final String produces, final RestConfiguration configuration, final Map<String, Object> parameters)
+        throws Exception {
+
+        final HttpProducer producer = (HttpProducer) super.createProducer(camelContext, host, verb, basePath, uriTemplate, queryParameters, consumes, produces,
+            configuration, parameters);
+
+        for (final Consumer<HttpProducer> customizer : CUSTOMIZERS) {
+            customizer.accept(producer);
+        }
+
+        return producer;
+    }
+}

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHeader.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHeader.java
@@ -15,10 +15,25 @@
  */
 package io.syndesis.connector.rest.swagger.auth;
 
-public final class SetAuthorizationHeader extends SetHttpHeader {
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
 
-    public SetAuthorizationHeader(final String authorizationHeaderValue) {
-        super("Authorization", authorizationHeaderValue);
+public class SetHeader implements Processor {
+
+    final String headerName;
+
+    final String headerValue;
+
+    public SetHeader(final String headerName, final String headerValue) {
+        this.headerName = headerName;
+        this.headerValue = headerValue;
+    }
+
+    @Override
+    public void process(final Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+        in.setHeader(headerName, headerValue);
     }
 
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeader.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeader.java
@@ -15,10 +15,21 @@
  */
 package io.syndesis.connector.rest.swagger.auth;
 
-public final class SetAuthorizationHeader extends SetHttpHeader {
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
 
-    public SetAuthorizationHeader(final String authorizationHeaderValue) {
-        super("Authorization", authorizationHeaderValue);
+import org.apache.camel.Exchange;
+
+public class SetHttpHeader extends SetHeader {
+
+    public SetHttpHeader(final String headerName, final String headerValue) {
+        super(headerName, headerValue);
+    }
+
+    @Override
+    public void process(final Exchange exchange) throws Exception {
+        super.process(exchange);
+
+        SyndesisHeaderStrategy.whitelist(exchange, headerName);
     }
 
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuth.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuth.java
@@ -38,7 +38,7 @@ public final class OAuth {
             Processors.addBeforeProducer(component, new OAuthRefreshTokenProcessor(state, configuration));
 
             final OAuthRefreshTokenOnFailProcessor refreshOnFailure = new OAuthRefreshTokenOnFailProcessor(state, configuration);
-            component.overrideEndpoint(e -> new OAuthRefreshingEndpoint(component, e, refreshOnFailure));
+            component.overrideEndpoint(endpoint -> new OAuthRefreshingEndpoint(component, endpoint, refreshOnFailure));
         } else {
             final String authorizationHeaderValue = "Bearer " + configuration.stringOption("accessToken");
             Processors.addBeforeProducer(component, new SetAuthorizationHeader(authorizationHeaderValue));

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/parameter/Parameter.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/parameter/Parameter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger.auth.parameter;
+
+import io.syndesis.connector.rest.swagger.Configuration;
+import io.syndesis.connector.rest.swagger.SwaggerProxyComponent;
+import io.syndesis.connector.rest.swagger.auth.SetHeader;
+import io.syndesis.connector.rest.swagger.auth.SetHttpHeader;
+import io.syndesis.integration.component.proxy.Processors;
+
+public final class Parameter {
+
+    public enum Placement {
+        header, query
+    }
+
+    private Parameter() {
+        // utility class
+    }
+
+    public static void setup(final SwaggerProxyComponent component, final Configuration configuration) {
+        final String authParameterName = configuration.stringOption("authenticationParameterName");
+        final String authParameterValue = configuration.stringOption("authenticationParameterValue");
+        final String authParameterPlacement = configuration.stringOption("authenticationParameterPlacement");
+
+        if ("header".equals(authParameterPlacement)) {
+            Processors.addBeforeProducer(component, new SetHttpHeader(authParameterName, authParameterValue));
+        } else if ("query".equals(authParameterPlacement)) {
+            Processors.addBeforeProducer(component, new SetHeader(authParameterName, authParameterValue));
+        }
+
+    }
+
+}

--- a/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
+++ b/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
@@ -49,6 +49,40 @@
       "javaType": "java.lang.Long",
       "type": "hidden"
     },
+    "authenticationParameterName": {
+      "description": "Name of the API key parameter",
+      "displayName": "API key parameter name",
+      "javaType": "java.lang.String",
+      "order": 2,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterPlacement": {
+      "displayName": "Placement of the API key parameter",
+      "enum": [
+        {
+          "label": "header",
+          "value": "header"
+        },
+        {
+          "label": "query",
+          "value": "query"
+        }
+      ],
+      "javaType": "java.lang.String",
+      "order": 4,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterValue": {
+      "description": "Value of the API key authentication parameter",
+      "displayName": "API key",
+      "javaType": "java.lang.String",
+      "order": 3,
+      "required": true,
+      "secret": true,
+      "type": "string"
+    },
     "authenticationType": {
       "displayName": "Authentication type",
       "enum": [
@@ -63,6 +97,10 @@
         {
           "label": "oauth2",
           "value": "oauth2"
+        },
+        {
+          "label": "parameter",
+          "value": "parameter"
         }
       ],
       "javaType": "java.lang.String",
@@ -70,7 +108,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "authorizationEndpoint": {
       "description": "URL for the start of the OAuth flow",

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
@@ -28,6 +28,7 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.util.Json;
+import io.syndesis.connector.rest.swagger.auth.parameter.Parameter.Placement;
 
 import org.apache.camel.CamelContext;
 import org.junit.Test;
@@ -64,10 +65,35 @@ public class DescriptorTest {
                 .javaType("java.lang.Long")
                 .type("hidden")
                 .build())
+            .putProperty("authenticationParameterName", new ConfigurationProperty.Builder()
+                .description("Name of the API key parameter")
+                .displayName("API key parameter name")
+                .javaType("java.lang.String")
+                .order(2)
+                .required(true)
+                .type("hidden")
+                .build())
+            .putProperty("authenticationParameterPlacement", new ConfigurationProperty.Builder()
+                .displayName("Placement of the API key parameter")
+                .addAllEnum(Stream.of(Placement.values()).map(p -> new PropertyValue.Builder().label(p.toString()).value(p.toString()).build())::iterator)
+                .javaType("java.lang.String")
+                .order(4)
+                .required(true)
+                .type("hidden")
+                .build())
+            .putProperty("authenticationParameterValue", new ConfigurationProperty.Builder()
+                .description("Value of the API key authentication parameter")
+                .displayName("API key")
+                .javaType("java.lang.String")
+                .order(3)
+                .required(true)
+                .secret(true)
+                .type("string")
+                .build())
             .putProperty("authenticationType", new ConfigurationProperty.Builder()
                 .displayName("Authentication type")
                 .addTag("authentication-type")
-                .type("string")
+                .type("hidden")
                 .javaType("java.lang.String")
                 .order(1)
                 .addAllEnum(Stream.of(AuthenticationType.values())

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetAuthorizationHeaderTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetAuthorizationHeaderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger.auth;
+
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SetAuthorizationHeaderTest {
+
+    @Test
+    public void shouldSetHeaderAndWhitelist() throws Exception {
+        final Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        new SetAuthorizationHeader("value").process(exchange);
+
+        assertThat(exchange.getIn().getHeader("Authorization")).isEqualTo("value");
+        assertThat(SyndesisHeaderStrategy.isWhitelisted(exchange, "Authorization")).isTrue();
+    }
+
+}

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeaderTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeaderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger.auth;
+
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SetHttpHeaderTest {
+
+    @Test
+    public void shouldSetHeaderAndWhitelist() throws Exception {
+        final Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        new SetHttpHeader("name", "value").process(exchange);
+
+        assertThat(exchange.getIn().getHeader("name")).isEqualTo("value");
+        assertThat(SyndesisHeaderStrategy.isWhitelisted(exchange, "name")).isTrue();
+    }
+
+}

--- a/app/connector/rest-swagger/src/test/resources/petstore.json
+++ b/app/connector/rest-swagger/src/test/resources/petstore.json
@@ -184,6 +184,58 @@
         ]
       }
     },
+    "/secured/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "apiKeyFindPetsByStatus",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ],
+              "default": "available"
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "api_key_query": []
+          }
+        ]
+      }
+    },
     "/pet/findByTags": {
       "get": {
         "tags": [
@@ -736,6 +788,31 @@
         }
       }
     },
+    "/secured/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "apiKeyLogoutUser",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "security": [
+          {
+            "api_key_query": []
+          }
+        ]
+      }
+    },
     "/user/{username}": {
       "get": {
         "tags": [
@@ -855,6 +932,11 @@
       "type": "apiKey",
       "name": "api_key",
       "in": "header"
+    },
+    "api_key_query": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "query"
     }
   },
   "definitions": {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/SyndesisHeaderStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/SyndesisHeaderStrategy.java
@@ -23,6 +23,8 @@ import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 
 public final class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
 
+    public static final SyndesisHeaderStrategy INSTANCE = new SyndesisHeaderStrategy();
+
     public static final String WHITELISTED_HEADERS = "syndesis-whitelisted-headers";
 
     /**
@@ -33,13 +35,17 @@ public final class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
      */
     @Override
     public boolean applyFilterToCamelHeaders(final String headerName, final Object headerValue, final Exchange exchange) {
-        final Collection<String> whitelisted = whitelisted(exchange);
-
-        if (whitelisted != null && whitelisted.contains(headerName)) {
+        if (isWhitelisted(exchange, headerName)) {
             return false; // allow the header
         }
 
         return super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
+    }
+
+    public static boolean isWhitelisted(final Exchange exchange, String headerName) {
+        final Collection<String> whitelisted = whitelisted(exchange);
+
+        return whitelisted != null && whitelisted.contains(headerName);
     }
 
     @Override

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGenerator.java
@@ -162,7 +162,7 @@ abstract class BaseSwaggerConnectorGenerator extends ConnectorGenerator {
         final Map<String, String> alreadyConfiguredProperties = builder.build().getConfiguredProperties();
 
         connectorTemplate.getConnectorProperties().forEach((propertyName, template) -> {
-            final Optional<ConfigurationProperty> maybeProperty = PropertyGenerators.createProperty(propertyName, swagger, template);
+            final Optional<ConfigurationProperty> maybeProperty = PropertyGenerators.createProperty(propertyName, swagger, template, connectorSettings);
 
             maybeProperty.ifPresent(property -> {
                 builder.putProperty(propertyName, property);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypes.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypes.java
@@ -23,7 +23,7 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 
 @SuppressWarnings("ImmutableEnumChecker")
 enum SupportedAuthenticationTypes {
-    basic("HTTP Basic Authentication"), oauth2("OAuth 2.0");
+    apiKey("API Key"), basic("HTTP Basic Authentication"), oauth2("OAuth 2.0");
 
     static final Set<String> SUPPORTED = Arrays.stream(SupportedAuthenticationTypes.values()).map(SupportedAuthenticationTypes::name)
         .collect(Collectors.toSet());

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SyndesisSwaggerValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SyndesisSwaggerValidationRules.java
@@ -49,7 +49,7 @@ import io.syndesis.server.api.generator.APIValidationContext;
  */
 public final class SyndesisSwaggerValidationRules implements Function<SwaggerModelInfo, SwaggerModelInfo> {
 
-    private static final Set<String> SUPPORTED_CONSUMED_AUTH_TYPES = new HashSet<>(Arrays.asList("basic", "oauth2"));
+    private static final Set<String> SUPPORTED_CONSUMED_AUTH_TYPES = new HashSet<>(Arrays.asList("apiKey", "basic", "oauth2"));
 
     private final List<Function<SwaggerModelInfo, SwaggerModelInfo>> rules = new ArrayList<>();
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
@@ -53,7 +53,6 @@ public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
         assertThatCode(() -> JsonRecordSupport.validateKey(sanitized)).doesNotThrowAnyException();
     }
 
-
     @Test
     public void testThatAllSwaggerFilesAreValid() throws IOException {
         final String[] specifications = {"/swagger/concur.swagger.json", "/swagger/petstore.swagger.json",
@@ -114,6 +113,6 @@ public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
         final SwaggerModelInfo info = SwaggerHelper.parse(specification, APIValidationContext.CONSUMED_API);
 
         assertThat(info.getErrors()).isEmpty();
-        assertThat(info.getWarnings()).hasSize(3);
+        assertThat(info.getWarnings()).hasSize(2);
     }
 }

--- a/app/server/api-generator/src/test/resources/swagger/basic_auth.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/basic_auth.unified_connector.json
@@ -77,7 +77,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/complex_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/complex_xml.unified_connector.json
@@ -83,7 +83,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/damage_service.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/damage_service.unified_connector.json
@@ -135,7 +135,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/kie-server.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/kie-server.unified_connector.json
@@ -6961,7 +6961,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/machine_history.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/machine_history.unified_connector.json
@@ -135,7 +135,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
@@ -605,7 +605,6 @@
   ],
   "componentScheme": "rest-swagger",
   "configuredProperties": {
-    "authenticationType": "oauth2",
     "authorizationEndpoint": "http://petstore.swagger.io/oauth/dialog",
     "basePath": "/v2",
     "host": "http://petstore.swagger.io",
@@ -669,13 +668,42 @@
       "secret": false,
       "type": "hidden"
     },
+    "authenticationParameterName": {
+      "defaultValue": "api_key",
+      "description": "Name of the API key parameter",
+      "displayName": "API key parameter name",
+      "javaType": "java.lang.String",
+      "order": 2,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterPlacement": {
+      "defaultValue": "header",
+      "displayName": "Placement of the API key parameter",
+      "javaType": "java.lang.String",
+      "order": 4,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterValue": {
+      "description": "Value of the API key authentication parameter",
+      "displayName": "API key",
+      "javaType": "java.lang.String",
+      "order": 3,
+      "required": true,
+      "secret": true,
+      "type": "string"
+    },
     "authenticationType": {
       "componentProperty": true,
-      "defaultValue": "oauth2",
       "deprecated": false,
       "description": "Type of authentication used to connect to the API",
       "displayName": "Authentication Type",
       "enum": [
+        {
+          "label": "API Key",
+          "value": "apiKey"
+        },
         {
           "label": "OAuth 2.0",
           "value": "oauth2"
@@ -691,7 +719,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "authorizationEndpoint": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
@@ -599,7 +599,6 @@
   ],
   "componentScheme": "rest-swagger",
   "configuredProperties": {
-    "authenticationType": "oauth2",
     "authorizationEndpoint": "http://petstore.swagger.io/oauth/dialog",
     "basePath": "/v2",
     "componentName": "connector-rest-swagger-http4",
@@ -665,13 +664,42 @@
       "secret": false,
       "type": "hidden"
     },
+    "authenticationParameterName": {
+      "defaultValue": "api_key",
+      "description": "Name of the API key parameter",
+      "displayName": "API key parameter name",
+      "javaType": "java.lang.String",
+      "order": 2,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterPlacement": {
+      "defaultValue": "header",
+      "displayName": "Placement of the API key parameter",
+      "javaType": "java.lang.String",
+      "order": 4,
+      "required": true,
+      "type": "hidden"
+    },
+    "authenticationParameterValue": {
+      "description": "Value of the API key authentication parameter",
+      "displayName": "API key",
+      "javaType": "java.lang.String",
+      "order": 3,
+      "required": true,
+      "secret": true,
+      "type": "string"
+    },
     "authenticationType": {
       "componentProperty": true,
-      "defaultValue": "oauth2",
       "deprecated": false,
       "description": "Type of authentication used to connect to the API",
       "displayName": "Authentication Type",
       "enum": [
+        {
+          "label": "API Key",
+          "value": "apiKey"
+        },
         {
           "label": "OAuth 2.0",
           "value": "oauth2"
@@ -687,7 +715,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "authorizationEndpoint": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
@@ -4771,7 +4771,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "authorizationEndpoint": {
       "componentProperty": true,

--- a/app/server/api-generator/src/test/resources/swagger/todo.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/todo.unified_connector.json
@@ -220,7 +220,7 @@
       "tags": [
         "authentication-type"
       ],
-      "type": "string"
+      "type": "hidden"
     },
     "basePath": {
       "componentProperty": true,

--- a/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
+++ b/app/server/dao/src/main/resources/io/syndesis/server/dao/deployment.json
@@ -123,6 +123,40 @@
           "secret": false,
           "type": "hidden"
         },
+        "authenticationParameterName": {
+          "description": "Name of the API key parameter",
+          "displayName": "API key parameter name",
+          "javaType": "java.lang.String",
+          "order": 2,
+          "required": true,
+          "type": "hidden"
+        },
+        "authenticationParameterPlacement": {
+          "displayName": "Placement of the API key parameter",
+          "enum": [
+            {
+              "label": "header",
+              "value": "header"
+            },
+            {
+              "label": "query",
+              "value": "query"
+            }
+          ],
+          "javaType": "java.lang.String",
+          "order": 4,
+          "required": true,
+          "type": "hidden"
+        },
+        "authenticationParameterValue": {
+          "description": "Value of the API key authentication parameter",
+          "displayName": "API key",
+          "javaType": "java.lang.String",
+          "order": 3,
+          "required": true,
+          "secret": true,
+          "type": "string"
+        },
         "authenticationType": {
           "componentProperty": true,
           "deprecated": false,
@@ -138,7 +172,7 @@
           "tags": [
             "authentication-type"
           ],
-          "type": "string"
+          "type": "hidden"
         },
         "authorizationEndpoint": {
           "componentProperty": true,


### PR DESCRIPTION
This adds API key authentication to the API client connector (`rest-swagger`) and to the API client generator (`server-api-generator`). Submitted to solicit feedback.

This there are two tests that should fail until we have a Camel build that includes [CAMEL-13192](https://issues.apache.org/jira/browse/CAMEL-13192).

Here's a gif:

![Peek 2019-05-08 15-23](https://user-images.githubusercontent.com/1306050/57378733-adbe8e80-71a5-11e9-9176-8a564c5bc6c1.gif)

Fixes #3629