### PR TITLE
feat(4986): Adds a generic email connector - IMAP(s)/POP3(s)/SMTP(s)

### DIFF
--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.syndesis.connector</groupId>
+    <artifactId>connector-parent</artifactId>
+    <version>1.7-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>connector-email</artifactId>
+  <name>Connector :: EMail</name>
+  <packaging>jar</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-mail</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-jdk5</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.11.3</version>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.syndesis.integration</groupId>
+      <artifactId>integration-component-proxy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>connector-support-verifier</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mail</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
+
+    <!-- test -->
+    <dependency>
+      <groupId>io.syndesis.integration</groupId>
+      <artifactId>integration-runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail</artifactId>
+      <version>1.5.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <delimiters>
+            <delimiter>@</delimiter>
+          </delimiters>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.syndesis.connector</groupId>
+        <artifactId>connector-support-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>inspections</id>
+            <goals>
+              <goal>generate-connector-inspections</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/EMailConstants.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/EMailConstants.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email;
+
+import java.util.Locale;
+import io.syndesis.common.util.StringConstants;
+
+public interface EMailConstants extends StringConstants {
+
+    String PROTOCOL = "protocol";
+
+    String SECURE = "secure";
+
+    String HOST = "host";
+
+    String PORT = "port";
+
+    String USER = "username";
+
+    String PASSWORD = "password";
+
+    String SSL_CONTEXT_PARAMETERS = "sslContextParameters";
+
+    String SERVER_CERTIFICATE = "serverCertificate";
+
+    String UNSEEN_ONLY = "unseenOnly";
+
+    String TO_PLAIN_TEXT = "plainText";
+
+    String MAX_MESSAGES = "maxMessagesPerPoll";
+
+    String CONSUMER = "consumer";
+
+    String DELAY = "delay";
+
+    String MAIL_SUBJECT = "subject";
+
+    String MAIL_FROM = "from";
+
+    String MAIL_TO = "to";
+
+    String MAIL_CC = "cc";
+
+    String MAIL_BCC = "bcc";
+
+    String MAIL_TEXT = "text";
+
+    String PRIORITY = "priority";
+
+    /**
+     * Content types of email
+     */
+    String TEXT_HTML = "text/html";
+    String TEXT_PLAIN = "text/plain";
+
+    enum Protocols {
+        IMAP, IMAPS,
+        POP3, POP3S,
+        SMTP, SMTPS;
+
+        public static Protocols getValueOf(String name) {
+            for (Protocols method : Protocols.values()) {
+                if (method.name().equalsIgnoreCase(name)) {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        public String id() {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+
+        public boolean isSSL() {
+            return name().endsWith("S");
+        }
+
+        public boolean isReceiver() {
+            return ! isProducer();
+        }
+
+        public boolean isProducer() {
+            return this.equals(SMTP) || this.equals(SMTPS);
+        }
+
+        public String componentSchema() {
+            return "email" + HYPHEN + (isReceiver() ? "receive" : "send");
+        }
+    }
+
+    enum EMailFunction {
+        READ,
+        SEND;
+
+        public String id() {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+
+        public String connectorId() {
+            return "email" + HYPHEN + id() + HYPHEN + "connector";
+        }
+    }
+
+    enum Priorities {
+        INPUT_VALUES("inputValues"),
+        CONSUMED_DATA("consumedData");
+
+        private final String id;
+
+        Priorities(String id) {
+            this.id = id;
+        }
+
+        public static Priorities getValueOf(String name) {
+            if (name == null) {
+                return CONSUMED_DATA;
+            }
+
+            for (Priorities priority : Priorities.values()) {
+                if (priority.id.equalsIgnoreCase(name)) {
+                    return priority;
+                }
+            }
+
+            return CONSUMED_DATA;
+        }
+
+        @Override
+        public String toString() {
+            return id;
+        }
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/EMailUtil.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/EMailUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.jsse.KeyManagersParameters;
+import org.apache.camel.util.jsse.KeyStoreParameters;
+import org.apache.camel.util.jsse.SSLContextParameters;
+import org.apache.camel.util.jsse.TrustManagersParameters;
+import io.syndesis.connector.support.util.KeyStoreHelper;
+
+public class EMailUtil implements EMailConstants {
+
+    private static boolean isSSL(String protocol) {
+        if (ObjectHelper.isEmpty(protocol)) {
+            return false;
+        }
+
+        Protocols p = Protocols.getValueOf(protocol);
+        return p != null && p.isSSL();
+    }
+
+    private static KeyStore createKeyStore(Map<String, Object> options)
+        throws KeyStoreException, NoSuchAlgorithmException, CertificateException, FileNotFoundException, IOException {
+        String certContent = (String) options.get(SERVER_CERTIFICATE);
+        return KeyStoreHelper.createKeyStoreWithCustomCertificate("mail", certContent);
+    }
+
+    public static SSLContextParameters createSSLContextParameters(Map<String, Object> options) {
+        String protocol = (String) options.get(PROTOCOL);
+        if (! isSSL(protocol)) {
+            return null;
+        }
+
+        KeyStoreParameters keystoreParams = new KeyStoreParameters() {
+            @Override
+            public KeyStore createKeyStore() throws GeneralSecurityException, IOException {
+                try {
+                    return EMailUtil.createKeyStore(options);
+                } catch (Exception e) {
+                    throw new GeneralSecurityException(e);
+                }
+            }
+        };
+
+        KeyManagersParameters keyManagersParams = new KeyManagersParameters();
+        keyManagersParams.setKeyStore(keystoreParams);
+
+        TrustManagersParameters trustManagersParams = new TrustManagersParameters();
+        trustManagersParams.setKeyStore(keystoreParams);
+
+        SSLContextParameters sslContextParameters = new SSLContextParameters();
+        sslContextParameters.setKeyManagers(keyManagersParams);
+        sslContextParameters.setTrustManagers(trustManagersParams);
+        return sslContextParameters;
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.camel.Component;
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.mail.MailComponent;
+import org.apache.camel.component.mail.MailConfiguration;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.jsse.SSLContextParameters;
+import io.syndesis.connector.email.EMailConstants;
+import io.syndesis.connector.email.EMailUtil;
+import io.syndesis.connector.support.util.PropertyBuilder;
+import io.syndesis.integration.component.proxy.ComponentDefinition;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+
+public final class EMailComponent extends ComponentProxyComponent implements EMailConstants {
+
+    /**
+     * These fields are populated using reflection by the HandlerCustomizer class.
+     *
+     * The values are resolved then the appropriate setter called, while the original
+     * key/value pairs are removed from the options map.
+     *
+     * Note:
+     * Should a property be secret then its raw value is the property placeholder and
+     * the resolving process converts it accordingly hence the importance of doing it
+     * this way rather than using the options map directly.
+     */
+    private String protocol;
+    private boolean secure;
+    private String host;
+    private int port = -1;
+    private String username;
+    private String password;
+    private String serverCertificate;
+    private boolean unseenOnly;
+
+    // Consumer properties
+    private long delay = -1;
+    private int maxResults = 5;
+
+    EMailComponent(String componentId, String componentScheme) {
+        super(componentId, componentScheme);
+    }
+
+    public String getProtocol() {
+        //
+        // Will convert, for example,  imap to imaps
+        // if the protocol has been specified as secure
+        //
+        if (isSecure() && (protocol != null && !protocol.endsWith("s"))) {
+            return protocol + "s";
+        }
+
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getServerCertificate() {
+        return serverCertificate;
+    }
+
+    public void setServerCertificate(String serverCertificate) {
+        this.serverCertificate = serverCertificate;
+    }
+
+    public boolean isUnseenOnly() {
+        return unseenOnly;
+    }
+
+    public void setUnseenOnly(boolean unseenOnly) {
+        this.unseenOnly = unseenOnly;
+    }
+
+    public long getDelay() {
+        return delay;
+    }
+
+    public void setDelay(long delay) {
+        this.delay = delay;
+    }
+
+    public int getMaxResults() {
+        return maxResults;
+    }
+
+    public void setMaxResults(int maxResults) {
+        this.maxResults = maxResults;
+    }
+
+    private Map<String, Object> bundleOptions() {
+        PropertyBuilder<Object> builder = new PropertyBuilder<Object>();
+        return builder
+            .propertyIfNotNull(PROTOCOL, getProtocol())
+            .propertyIfNotNull(HOST, getHost())
+            .propertyIfNotNull(PORT, getPort())
+            .propertyIfNotNull(USER, getUsername())
+            .propertyIfNotNull(PASSWORD, getPassword())
+            .propertyIfNotNull(SERVER_CERTIFICATE, getServerCertificate())
+            .propertyIfNotNull(UNSEEN_ONLY, isUnseenOnly())
+            .propertyIfNotNull(MAX_MESSAGES, getMaxResults())
+            .build();
+    }
+
+    @Override
+    protected ComponentDefinition getDefinition() {
+        try {
+            /*
+             * The definition set on construction is the placeholder 'email'
+             * so find the underlying defintion based on the specified protocol
+             */
+            return ComponentDefinition.forScheme(getCatalog(), getProtocol());
+        } catch (IOException ex) {
+            throw ObjectHelper.wrapRuntimeCamelException(ex);
+        }
+    }
+
+    @SuppressWarnings("PMD")
+    @Override
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+        MailComponent component = new MailComponent(getCamelContext());
+        MailConfiguration configuration = new MailConfiguration(getCamelContext());
+
+        if (getProtocol() == null) {
+            throw new IllegalStateException("No protocol specified for email component");
+        }
+
+        configuration.setProtocol(getProtocol());
+        configuration.setHost(getHost());
+        configuration.setPort(getPort());
+        configuration.setUsername(getUsername());
+        configuration.setPassword(getPassword());
+        configuration.setUnseen(isUnseenOnly());
+
+        Map<String, Object> resolvedOptions = bundleOptions();
+        SSLContextParameters sslContextParameters = EMailUtil.createSSLContextParameters(resolvedOptions);
+        if (sslContextParameters != null) {
+            configuration.setSslContextParameters(sslContextParameters);
+        }
+
+        configuration.setFetchSize(getMaxResults());
+
+        // Decode mime headers like the subject from Quoted-Printable encoding to normal text
+        configuration.setMimeDecodeHeaders(true);
+
+        component.setConfiguration(configuration);
+        return Optional.of(component);
+    }
+
+    @Override
+    protected Endpoint createDelegateEndpoint(
+                                              ComponentDefinition definition, String scheme, Map<String, String> options)
+                                              throws Exception {
+
+        Endpoint endpoint = super.createDelegateEndpoint(getDefinition(), scheme, options);
+
+        Protocols protocol = Protocols.getValueOf(getProtocol())    ;
+        if (protocol.isReceiver()) { // only receivers are consumers
+            /**
+             * Need to apply these consumer properties after the creation
+             */
+            Map<String, Object> properties = new HashMap<>();
+
+            if (getDelay() > -1) {
+                properties.put(CONSUMER + DOT + DELAY, Long.toString(getDelay()));
+            }
+
+            if (! properties.isEmpty()) {
+                endpoint.configureProperties(properties);
+            }
+        }
+
+        return endpoint;
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponentFactory.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponentFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.component;
+
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyFactory;
+
+public class EMailComponentFactory implements ComponentProxyFactory {
+
+    @Override
+    public ComponentProxyComponent newInstance(String componentId, String componentScheme) {
+        return new EMailComponent(componentId, componentScheme);
+    }
+
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailReceiveCustomizer.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailReceiveCustomizer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.customizer;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.mail.BodyPart;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.internet.MimeMultipart;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.util.ObjectHelper;
+import org.jsoup.Jsoup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.syndesis.connector.email.EMailConstants;
+import io.syndesis.connector.email.model.EMailMessageModel;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
+public class EMailReceiveCustomizer implements ComponentProxyCustomizer, CamelContextAware, EMailConstants {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EMailReceiveCustomizer.class);
+
+    private CamelContext camelContext;
+
+    @Override
+    public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        component.setBeforeConsumer(this::beforeConsumer);
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return this.camelContext;
+    }
+
+    private void beforeConsumer(Exchange exchange) {
+
+        final Message in = exchange.getIn();
+        final EMailMessageModel mail = new EMailMessageModel();
+
+        if (ObjectHelper.isNotEmpty(in.getBody())) {
+            textFromMessage(in, mail);
+        }
+        if (ObjectHelper.isNotEmpty(in.getHeader(MAIL_SUBJECT))) {
+            mail.setSubject(in.getHeader(MAIL_SUBJECT, String.class));
+        }
+        if (ObjectHelper.isNotEmpty(in.getHeader(MAIL_FROM))) {
+            mail.setFrom(in.getHeader(MAIL_FROM, String.class));
+        }
+        if (ObjectHelper.isNotEmpty(in.getHeader(MAIL_TO))) {
+            mail.setTo(in.getHeader(MAIL_TO, String.class));
+        }
+        if (ObjectHelper.isNotEmpty(in.getHeader(MAIL_CC))) {
+            mail.setCc(in.getHeader(MAIL_CC, String.class));
+        }
+        if (ObjectHelper.isNotEmpty(in.getHeader(MAIL_BCC))) {
+            mail.setBcc(in.getHeader(MAIL_BCC, String.class));
+        }
+        exchange.getIn().setBody(mail);
+    }
+
+    private String getPlainTextFromMultipart(Multipart multipart)  throws MessagingException, IOException{
+        StringBuilder result = new StringBuilder();
+        int count = multipart.getCount();
+        for (int i = 0; i < count; i++) {
+            BodyPart bodyPart = multipart.getBodyPart(i);
+            if (bodyPart.isMimeType(TEXT_PLAIN)) {
+                result.append(NEW_LINE)
+                            .append(bodyPart.getContent());
+                break; // without break same text appears twice
+            } else if (bodyPart.isMimeType(TEXT_HTML)) {
+                result.append(NEW_LINE)
+                            .append(Jsoup.parse((String) bodyPart.getContent()).text());
+            } else if (bodyPart.isMimeType("application/pgp-encrypted")) {
+                //
+                // Body is encrypted so flag as such to enable easy understanding for users
+                //
+                result.append(NEW_LINE)
+                            .append("<pgp encrypted text>")
+                            .append(NEW_LINE)
+                            .append(bodyPart.getContent().toString());
+            } else if (bodyPart.getContent() instanceof MimeMultipart){
+                result.append(NEW_LINE)
+                            .append(getPlainTextFromMultipart((MimeMultipart) bodyPart.getContent()));
+            }
+        }
+        return result.toString();
+    }
+
+    private void textFromMessage(Message camelMessage, EMailMessageModel model) {
+        Object content = camelMessage.getBody();
+
+        if (content instanceof String) {
+            content = content.toString().trim();
+        } else if (content instanceof Multipart) {
+            try {
+                Multipart multipart = (Multipart) content;
+                content = getPlainTextFromMultipart(multipart);
+            } catch (Exception ex) {
+                String errorMsg = "Failed to extract text from email message";
+                LOG.error(errorMsg, ex);
+
+                content = errorMsg;
+            }
+        }
+
+        model.setContent(content);
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.customizer;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.mail.MessagingException;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.util.ObjectHelper;
+import io.syndesis.connector.email.EMailConstants;
+import io.syndesis.connector.email.model.EMailMessageModel;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
+public class EMailSendCustomizer implements ComponentProxyCustomizer, EMailConstants {
+
+    private String from;
+    private String to;
+    private String subject;
+    private String text;
+    private String bcc;
+    private String cc;
+    private Priorities priority;
+
+    @Override
+    public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        setApiMethod(options);
+        component.setBeforeProducer(this::beforeProducer);
+    }
+
+    private void setApiMethod(Map<String, Object> options) {
+        from = (String) options.get(MAIL_FROM);
+        to = (String) options.get(MAIL_TO);
+        subject = (String) options.get(MAIL_SUBJECT);
+        text = (String) options.get(MAIL_TEXT);
+        cc = (String) options.get(MAIL_CC);
+        bcc = (String) options.get(MAIL_BCC);
+
+        //
+        // Will return injected data if not set
+        //
+        priority = Priorities.getValueOf((String) options.get(PRIORITY));
+    }
+
+    private Object updateMail(String inputValue, Object dataValue) {
+        if (ObjectHelper.isEmpty(inputValue)) {
+            // Input value is empty so return data value
+            return dataValue;
+        }
+
+        if (ObjectHelper.isEmpty(dataValue)) {
+            // Data value is empty so return input value (which is not empty)
+            return inputValue;
+        }
+
+        if (Priorities.INPUT_VALUES.equals(priority)) {
+            // Input values are given priority so don't update
+            return inputValue;
+        }
+
+        // Otherwise return the data value
+        return dataValue;
+    }
+
+    private void beforeProducer(Exchange exchange) throws MessagingException, IOException {
+        final Message in = exchange.getIn();
+        final EMailMessageModel mail = in.getBody(EMailMessageModel.class);
+        if (mail == null) {
+            return;
+        }
+
+        in.setHeader(MAIL_FROM, updateMail(from, mail.getFrom()));
+        in.setHeader(MAIL_TO, updateMail(to, mail.getTo()));
+        in.setHeader(MAIL_CC, updateMail(cc, mail.getCc()));
+        in.setHeader(MAIL_BCC, updateMail(bcc, mail.getBcc()));
+        in.setHeader(MAIL_SUBJECT, updateMail(subject, mail.getSubject()));
+
+        in.setBody(updateMail(text, mail.getContent()));
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetaDataExtension.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetaDataExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.meta;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
+import org.apache.camel.component.extension.metadata.DefaultMetaData;
+import io.syndesis.connector.email.EMailConstants;
+
+public class EMailMetaDataExtension extends AbstractMetaDataExtension implements EMailConstants {
+
+    EMailMetaDataExtension(CamelContext context) {
+        super(context);
+    }
+
+    @Override
+    public Optional<MetaData> meta(Map<String, Object> parameters) {
+        //
+        // Method called twice.
+        // 1) After selection of the type of integration request
+        // 2) After the user has inputed settings and the wizard step is completing
+        //
+        EMailMetadata emailMetadata = buildMetadata(parameters);
+        return Optional.of(new DefaultMetaData(null, null, emailMetadata));
+    }
+
+    private EMailMetadata buildMetadata(Map<String, Object> parameters) {
+        String protocolId = Optional.ofNullable(parameters.get(PROTOCOL))
+            .map(Object::toString)
+            .orElse(null);
+
+        Protocols protocol = Protocols.getValueOf(protocolId);
+        if (protocol == null) {
+            throw new IllegalStateException("Email connector protocol cannot be identified");
+        }
+
+        EMailMetadata emailMetadata = new EMailMetadata();
+        emailMetadata.setProtocol(protocol);
+        return emailMetadata;
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetaDataRetrieval.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetaDataRetrieval.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.meta;
+
+import java.util.Map;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import io.syndesis.connector.email.EMailConstants;
+import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+
+public class EMailMetaDataRetrieval extends ComponentMetadataRetrieval implements EMailConstants {
+
+    @Override
+    protected MetaDataExtension resolveMetaDataExtension(CamelContext context, Class<? extends MetaDataExtension> metaDataExtensionClass, String componentId, String actionId) {
+        return new EMailMetaDataExtension(context);
+    }
+
+    @SuppressWarnings({"PMD"})
+    @Override
+    protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
+        EMailMetadata emailMetadata = (EMailMetadata) metadata.getPayload();
+
+        //
+        // The camel-mail component has 6 different connectors and they
+        // are named according to the protocol of the mail server,
+        // ie. imap(s), pop3(s), smtp(s)
+        //
+        Protocols protocol = emailMetadata.getProtocol();
+
+        if (actionId.endsWith(EMailFunction.READ.connectorId())) {
+            //
+            // Read action NOT applicable to SMTP connectors
+            //
+            if (protocol.isProducer()) {
+                String msg = "The protocol for the selection connection is set to '" + protocol.id() +
+                    "'. This is not appropriate for a consuming email connector. Please amend the connector and try again.";
+                throw new IllegalStateException(msg);
+            }
+        } else if(actionId.endsWith(EMailFunction.SEND.connectorId())) {
+            //
+            // Send action is only applicable to SMTP connectors
+            //
+            if (protocol.isReceiver()) {
+                String msg = "The protocol of the selected connection is set to '" + protocol.id() +
+                    "'. Only 'smtp' is appropriate for a producing email connector. Please amend the connector and try again.";
+                throw new IllegalStateException(msg);
+            }
+        }
+
+        return SyndesisMetadata.EMPTY;
+    }
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetadata.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/meta/EMailMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.meta;
+
+import io.syndesis.connector.email.EMailConstants;
+
+public class EMailMetadata implements EMailConstants {
+
+    private Protocols protocol;
+
+    public Protocols getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(Protocols protocol) {
+        this.protocol = protocol;
+    }
+
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/model/EMailMessageModel.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/model/EMailMessageModel.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.model;
+
+import io.syndesis.connector.email.EMailConstants;
+
+public class EMailMessageModel implements EMailConstants{
+
+    private String subject;
+    private String from;
+    private String to;
+    private String cc;
+    private String bcc;
+
+    //
+    // Can be a MimeMultiPart for ensuring consistent
+    // data integrity is maintained rather than reducing
+    // content to just plain text.
+    //
+    private Object content;
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getFrom() {
+        return this.from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getCc() {
+        return cc;
+    }
+
+    public void setCc(String cc) {
+        this.cc = cc;
+    }
+
+    public String getBcc() {
+        return bcc;
+    }
+
+    public void setBcc(String bcc) {
+        this.bcc = bcc;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    public void setContent(Object content) {
+        this.content = content;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((bcc == null) ? 0 : bcc.hashCode());
+        result = prime * result + ((cc == null) ? 0 : cc.hashCode());
+        result = prime * result + ((subject == null) ? 0 : subject.hashCode());
+        result = prime * result + ((content == null) ? 0 : content.hashCode());
+        result = prime * result + ((to == null) ? 0 : to.hashCode());
+        result = prime * result + ((from == null) ? 0 : from.hashCode());
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings("PMD")
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (! (obj instanceof EMailMessageModel)) {
+            return false;
+        }
+
+        EMailMessageModel other = (EMailMessageModel) obj;
+        if (bcc == null) {
+            if (other.bcc != null) {
+                return false;
+            }
+        } else if (!bcc.equals(other.bcc)) {
+            return false;
+        }
+
+        if (cc == null) {
+            if (other.cc != null) {
+                return false;
+            }
+        } else if (!cc.equals(other.cc)) {
+            return false;
+        }
+
+        if (subject == null) {
+            if (other.subject != null) {
+                return false;
+            }
+        } else if (!subject.equals(other.subject)) {
+            return false;
+        }
+
+        if (content == null) {
+            if (other.content != null) {
+                return false;
+            }
+        } else if (!content.equals(other.content)) {
+            return false;
+        }
+
+        if (from == null) {
+            if (other.from != null) {
+                return false;
+            }
+        } else if (!from.equals(other.from)) {
+            return false;
+        }
+
+        if (to == null) {
+            if (other.to != null) {
+                return false;
+            }
+        } else if (!to.equals(other.to)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "EMailMessageModel [subject=" + subject + ", from=" + from + ", to=" + to + ", cc=" + cc + ", bcc=" + bcc
+               + ", content=" + content + "]";
+    }
+
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/EMailVerifier.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/EMailVerifier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.verifier;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.ComponentVerifierExtension;
+
+import io.syndesis.connector.support.verifier.api.ComponentVerifier;
+
+public class EMailVerifier extends ComponentVerifier {
+
+    public EMailVerifier() {
+        super("email", EMailVerifierExtension.class);
+    }
+
+    @Override
+    protected ComponentVerifierExtension resolveComponentVerifierExtension(CamelContext context, String scheme) {
+        return new EMailVerifierExtension(scheme, context);
+    }
+
+}

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/EMailVerifierExtension.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/EMailVerifierExtension.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.verifier;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import javax.mail.Session;
+import javax.mail.Store;
+import javax.mail.Transport;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
+import org.apache.camel.component.extension.verifier.ResultBuilder;
+import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
+import org.apache.camel.component.extension.verifier.ResultErrorHelper;
+import org.apache.camel.component.mail.JavaMailSender;
+import org.apache.camel.component.mail.MailConfiguration;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.jsse.SSLContextParameters;
+import io.syndesis.connector.email.EMailConstants;
+import io.syndesis.connector.email.EMailUtil;
+
+public class EMailVerifierExtension extends DefaultComponentVerifierExtension implements EMailConstants {
+
+    protected EMailVerifierExtension(String defaultScheme, CamelContext context) {
+        super(defaultScheme, context);
+    }
+
+
+    // *********************************
+    // Parameters validation
+    // *********************************
+
+    @Override
+    protected Result verifyParameters(Map<String, Object> parameters) {
+
+        ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.PARAMETERS)
+            .error(ResultErrorHelper.requiresOption(PROTOCOL, parameters))
+            .error(ResultErrorHelper.requiresOption(HOST, parameters))
+            .error(ResultErrorHelper.requiresOption(PORT, parameters))
+            .error(ResultErrorHelper.requiresOption(USER, parameters))
+            .error(ResultErrorHelper.requiresOption(PASSWORD, parameters));
+
+        return builder.build();
+    }
+
+    // *********************************
+    // Connectivity validation
+    // *********************************
+
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    protected Result verifyConnectivity(Map<String, Object> parameters) {
+        ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY);
+
+        try {
+            secureProtocol(parameters);
+
+            //
+            // setProperties will strip parameters key/values so if anything else wants to read
+            // them then they must be read first.
+            //
+            SSLContextParameters sslContextParameters = EMailUtil.createSSLContextParameters(parameters);
+            parameters.put(SSL_CONTEXT_PARAMETERS, sslContextParameters);
+            MailConfiguration configuration = setProperties(new MailConfiguration(), parameters);
+
+            JavaMailSender sender = createJavaMailSender(configuration);
+            Session session = sender.getSession();
+
+            Protocols protocol = Protocols.getValueOf(configuration.getProtocol());
+            if (protocol.isReceiver()) {
+                Store store = session.getStore(configuration.getProtocol());
+                try {
+                    store.connect(configuration.getHost(), configuration.getPort(),
+                                      configuration.getUsername(), configuration.getPassword());
+                } finally {
+                    if (store.isConnected()) {
+                        store.close();
+                    }
+                }
+            } else if (protocol.isProducer()) {
+                Transport transport = session.getTransport(protocol.id());
+                try {
+                    transport.connect(configuration.getHost(), configuration.getPort(),
+                                  configuration.getUsername(), configuration.getPassword());
+                } finally {
+                    if (transport.isConnected()) {
+                        transport.close();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            ResultErrorBuilder errorBuilder = ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION, e.getMessage())
+                .detail("mail_exception_message", e.getMessage()).detail(VerificationError.ExceptionAttribute.EXCEPTION_CLASS, e.getClass().getName())
+                .detail(VerificationError.ExceptionAttribute.EXCEPTION_INSTANCE, e);
+
+            builder.error(errorBuilder.build());
+        }
+
+        return builder.build();
+    }
+
+
+    private void secureProtocol(Map<String, Object> parameters) {
+        String protocol = (String) parameters.get(PROTOCOL);
+        if (ObjectHelper.isEmpty(protocol)) {
+            return;
+        }
+
+        String secure = (String) parameters.get(SECURE);
+        if (ObjectHelper.isEmpty(secure) || protocol.endsWith("s")) {
+            return;
+        }
+
+        parameters.put(PROTOCOL, protocol + "s");
+    }
+
+
+    private JavaMailSender createJavaMailSender(MailConfiguration configuration)
+        throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Method method = MailConfiguration.class.getDeclaredMethod("createJavaMailSender");
+        method.setAccessible(true);
+        return (JavaMailSender) method.invoke(configuration);
+    }
+}

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-receive.json
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-receive.json
@@ -1,0 +1,221 @@
+{
+  "actions": [
+    {
+      "actionType": "connector",
+      "description": "Obtain messages from the email account that this connection is authorized to access.",
+      "descriptor": {
+        "connectorCustomizers": [
+          "io.syndesis.connector.email.customizer.EMailReceiveCustomizer"
+        ],
+        "connectorFactory": "io.syndesis.connector.email.component.EMailComponentFactory",
+        "inputDataShape": {
+          "kind": "none"
+        },
+        "outputDataShape": {
+          "kind": "java",
+          "name": "EmailMessage",
+          "type": "io.syndesis.connector.email.model.EMailMessageModel"
+        },
+        "propertyDefinitionSteps": [
+          {
+            "description": "Specify the emails that you want to obtain.",
+            "name": "Obtain Messages from Email",
+            "properties": {
+              "unseenOnly": {
+                "componentProperty": false,
+                "defaultValue": false,
+                "deprecated": false,
+                "displayName": "Unseen Only",
+                "group": "common",
+                "javaType": "boolean",
+                "kind": "parameter",
+                "label": "consumer",
+                "labelHint": "If true, only fetch unseen messages.",
+                "order": "1",
+                "required": false,
+                "secret": false,
+                "tags": [],
+                "type": "boolean"
+              },
+              "delay": {
+                "componentProperty": false,
+                "defaultValue": 5000,
+                "deprecated": false,
+                "displayName": "Delay",
+                "group": "scheduler",
+                "javaType": "long",
+                "kind": "parameter",
+                "label": "consumer,scheduler",
+                "labelHint": "Time interval between polls for emails.",
+                "order": "2",
+                "required": false,
+                "secret": false,
+                "tags": [],
+                "type": "duration"
+              },
+              "maxResults": {
+                "defaultValue": "5",
+                "deprecated": false,
+                "displayName": "Maximum Emails",
+                "group": "consumer",
+                "javaType": "int",
+                "kind": "parameter",
+                "label": "consumer",
+                "labelHint": "Maximum number of emails to return (use -1 to fetch all of them).",
+                "order": "3",
+                "required": false,
+                "secret": false,
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "id": "io.syndesis:email-read-connector",
+      "name": "Receive Email",
+      "pattern": "From",
+      "tags": [
+        "dynamic"
+      ]
+    }
+  ],
+  "componentScheme": "email-receive",
+  "configuredProperties": {},
+  "dependencies": [
+    {
+      "id": "@project.groupId@:@project.artifactId@:@project.version@",
+      "type": "MAVEN"
+    }
+  ],
+  "description": "Receive email messages from an imap or pop3 account.",
+  "icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaWQ9IkxheWVyXzEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUwIDUwOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTAgNTAiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0I3QzVGRDt9Cgkuc3Qxe2ZpbGw6IzlBQURGRDt9Cgkuc3Qye2ZpbGw6I0ZGRkZGRjt9Cgkuc3Qze2ZpbGw6IzM5NTVEMTt9Cgkuc3Q0e2ZpbGw6IzQ0NjZGQjt9Cgkuc3Q1e2ZpbGw6I0FBQkFGRDt9Cgkuc3Q2e2ZpbGw6Izc5OEZGRTt9Cgkuc3Q3e2ZpbGw6IzZCQjVGQjt9Cgkuc3Q4e2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAgICA7fQoJLnN0OXtmaWxsOiMxQjJBNEY7fQoJLnN0MTB7ZmlsbDp1cmwoIyk7fQoJLnN0MTF7ZmlsbDojMzg0RTg1O30KCS5zdDEye2ZpbGw6IzJFNDI3Nzt9Cgkuc3QxM3tmaWxsOiNEOURERjY7fQoJLnN0MTR7ZmlsbDojNTM1RDg4O30KCS5zdDE1e2ZpbGw6IzJCM0M2Nzt9Cgkuc3QxNntmaWxsOiM4RkNDRkY7fQoJLnN0MTd7ZmlsbDojOENBMUZEO30KCS5zdDE4e29wYWNpdHk6MC4zO30KCS5zdDE5e29wYWNpdHk6MC4zO2ZpbGw6IzQ0NjZGQjt9Cgkuc3QyMHtvcGFjaXR5OjAuMjt9Cjwvc3R5bGU+PGc+PGc+PGc+PGc+PHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSI0Mi44OTksMS42NDk3MSA0Mi45NzYxNiwyOC44NjU4MyA4LjE2MzQ4LDQ4Ljk2NTg0IDguMDg2MzIsMjEuNzQ5NzIgICAgICIvPjwvZz48Zz48cG9seWdvbiBjbGFzcz0ic3QxIiBwb2ludHM9IjQyLjg5MjA2LDEuNjUzNjIgNDEuODM2OCwxLjAzNDE2IDcuMDIzODQsMjEuMTI3MTkgNy4xMDQ3Nyw0OC4zNDMyNCA4LjE2MzQ3LDQ4Ljk2NDY3ICAgICAgIDguMDg2MzEsMjEuNzQ5NTkgICAgICIvPjwvZz48Zz48ZyBjbGFzcz0ic3Q4Ij48Zz48cG9seWdvbiBjbGFzcz0ic3Q1IiBwb2ludHM9IjI1LjQ4NDIyLDIyLjMyODY3IDQyLjk3NjE2LDI4Ljg2NTgzIDguMTYzNDgsNDguOTY1ODQgICAgICAgIi8+PC9nPjxnPjxwb2x5Z29uIGNsYXNzPSJzdDE3IiBwb2ludHM9IjI1LjQ3NzYyLDIwLjAwMDE3IDQyLjk3NjE2LDI4Ljg2NTgzIDI1LjQ4NDIyLDIyLjMyODY3IDguMTYzNDgsNDguOTY1ODQgNDIuOTM3NTgsMjguODY1ODMgICAgICAgICA4LjE2MzQ4LDQ4Ljk2NTg0ICAgICAgICIvPjwvZz48L2c+PC9nPjxnPjxnPjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iNDIuODk5LDEuNjQ5NzEgMjUuNTc4MjcsMjguMjg2OTIgOC4wODYzMiwyMS43NDk3MiAgICAgICIvPjwvZz48Zz48cG9seWdvbiBjbGFzcz0ic3Q1IiBwb2ludHM9IjQyLjg5OSwxLjY0OTcxIDI1LjU4NDIxLDMwLjM4MjU1IDguMDg2MzIsMjEuNzQ5NzIgMjUuNTc4MjcsMjguMjg2OTIgICAgICAiLz48L2c+PC9nPjwvZz48Zz48Zz48cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMzEuNzE0ODMsMi4xNzg2NmMtMS4zMTY4OS0wLjc3MDIxLTMuMTU1NDQtMC42NzA3My01LjE2NzkyLDAuNDk2OTQgICAgICBjLTQuMDAwMSwyLjMzNTQ5LTcuMjMwMTQsNy45MDA4Ny03LjIwNTI3LDEyLjUyMjExYzAsMi4yODU5LDAuNzk1MDgsMy45MDA3NywyLjExMTk2LDQuNjQ2MjZsLTEuMTI5MDctMC42NTY2MSAgICAgIGMtMS4zMTY3NC0wLjc0NTQ5LTIuMTExODEtMi4zNjAzNi0yLjExMTgxLTQuNjQ2MTFjLTAuMDI0ODctNC42MjEzOSwzLjIwNTAyLTEwLjE4Njc3LDcuMjA1MTItMTIuNTIyMjYgICAgICBjMi4wMzczNi0xLjE0MjgsMy44NTExOC0xLjI2NzE1LDUuMTY3OTItMC40OTY5NEwzMS43MTQ4MywyLjE3ODY2eiIvPjwvZz48Zz48Zz48ZWxsaXBzZSBjbGFzcz0ic3Q0IiBjeD0iMjYuNTgxMTUiIGN5PSIxMS4wMTI3NyIgcng9IjEwLjIxODk5IiByeT0iNS45MTkxMiIgdHJhbnNmb3JtPSJtYXRyaXgoMC41MDI0NSAtMC44NjQ2MSAwLjg2NDYxIDAuNTAyNDUgMy43MDM3MiAyOC40NjE2KSIvPjwvZz48Zz48Zz48cGF0aCBjbGFzcz0ic3QyIiBkPSJNMjcuMTM2Nyw2Ljk3NjQxYzEuODU1OTItMS4wNzE1MiwzLjA5OTU1LTAuMTgyNzksMy4xMDUxNSwxLjc5MjI5ICAgICAgICBjMC4wMDQ5OSwxLjc2MTYyLTAuODY3MiwzLjE3MDI2LTEuNjkxNDUsMy42NDYxNGMtMC41NTE5MSwwLjMxODY0LTAuODY2OTksMC4wNTgzOS0wLjg5NzE4LTAuMzk5NTVsLTAuMDAwMjItMC4wNzY2OCAgICAgICAgYy0wLjM0MjksMC43NjI2MS0wLjkzMTQ2LDEuNTMyMTMtMS41NTkxMiwxLjg5NDUxYy0wLjkxNDQzLDAuNTI3OTUtMS41MDYzMywwLjEyMjM2LTEuNTA5NDMtMC45NzE5MSAgICAgICAgYy0wLjAwNDQ1LTEuNTcwOTUsMS4xNDI2Ny0zLjQ5OTUzLDIuMzAwNTktNC4xNjgwNmMwLjYzODQ4LTAuMzY4NjMsMS4wNzI0Ny0wLjIyMjY5LDEuMjYxNDIsMC4xNTM5N2wwLjEyNjA3LTAuNzc0NDQgICAgICAgIGwwLjY2NzM0LTAuMzg1MjlsLTAuNTUwNDQsMy4zODM4N2MtMC4wMTA2NCwwLjA3MjU3LTAuMDIxMTcsMC4xODAzNy0wLjAyMDk4LDAuMjQ4NzYgICAgICAgIGMwLjAwMTA2LDAuMzczMDUsMC4yMDkwOCwwLjQ2Njc2LDAuNDY1MTksMC4zMTg5YzAuMzgyMzctMC4yMjA3NiwxLjA2ODE0LTEuMTEyODMsMS4wNjM3Mi0yLjY3MTM0ICAgICAgICBjLTAuMDA1MjUtMS44NTI4MS0xLjExODI4LTIuNTU1MzctMi43OTAyMy0xLjU5MDA3Yy0xLjkwNDYyLDEuMDk5NjMtMy41MjA1OCwzLjk2NzMzLTMuNTE0Niw2LjA3OTIgICAgICAgIGMwLjAwNTEyLDEuODA1MTMsMS4xODg2MSwyLjUxMjcsMi44MTkwOCwxLjU3MTM1YzAuNjk4LTAuNDAyOTksMS4yOTYxLTAuOTk1MzQsMS44MjUyNy0xLjY4Njk3bDAuMTc3NTksMC4xOTIyNCAgICAgICAgYy0wLjYwODM0LDAuODAzNzctMS4zMTQ2MiwxLjQ3MTAzLTIuMDQxNDgsMS44OTA2OGMtMS43ODczOCwxLjAzMTk1LTMuMTE3NDMsMC4yNDkxNi0zLjEyMzA5LTEuNzQ4NzIgICAgICAgIEMyMy4yNDI5OCwxMS4yMzgwNiwyNS4wOTMyLDguMTU2MjIsMjcuMTM2Nyw2Ljk3NjQxeiBNMjcuNzQ4NTIsMTEuMjI1NDFsMC4yODA1Mi0xLjczMzQgICAgICAgIGMtMC4xMDc0MS0wLjI4ODgyLTAuNDMzNC0wLjU3NTk4LTEuMDE0MTctMC4yNDA2OGMtMC45ODExNywwLjU2NjQ4LTEuNzI0ODQsMi4wNjA3Ni0xLjcyMTc0LDMuMTU1MDQgICAgICAgIGMwLjAwMjA1LDAuNzIzMywwLjM2NjA4LDEuMDQ0NTUsMS4wMDQ1NiwwLjY3NTkzQzI2Ljk2NTAzLDEyLjY5NzAxLDI3LjQ2NDksMTEuODY0NTMsMjcuNzQ4NTIsMTEuMjI1NDEiLz48L2c+PC9nPjwvZz48L2c+PC9nPjwvZz48L3N2Zz4=",
+  "id": "email-receive",
+  "name": "Receive Email (imap or pop3)",
+  "metadata": {
+    "tech-preview": true
+  },
+  "properties": {
+    "protocol": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Protocol",
+      "enum": [
+        {
+          "label": "imap",
+          "value": "imap"
+        },
+        {
+          "label": "pop3",
+          "value": "pop3"
+        }
+      ],
+      "defaultValue": "imap",
+      "group": "common",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "labelHint": "The type of the email server, ie. imap or pop3",
+      "order": "1",
+      "required": true,
+      "secret": false,
+      "type": "string"
+    },
+    "host": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "The hostname of the email server.",
+      "displayName": "Email Host Name",
+      "group": "common",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common",
+      "order": "2",
+      "required": true,
+      "secret": false,
+      "type": "string"
+    },
+    "port": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "The port of the email server.",
+      "displayName": "Email Server Port Number",
+      "group": "common",
+      "javaType": "java.lang.Integer",
+      "kind": "parameter",
+      "label": "common",
+      "order": "3",
+      "required": true,
+      "secret": false,
+      "type": "integer"
+    },
+    "username": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "User Name",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "labelHint": "Specify a user name for authentication of the email service url, if required.",
+      "order": "4",
+      "required": false,
+      "secret": false,
+      "type": "string"
+    },
+    "password": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Password",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "labelHint": "Specify a password for authentication of the email service, if required.",
+      "order": "5",
+      "required": false,
+      "secret": true,
+      "type": "string"
+    },
+    "secure": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Secure (SSL)",
+      "group": "security",
+      "javaType": "java.lang.boolean",
+      "kind": "parameter",
+      "label": "security",
+      "labelHint": "Specify whether this is an ssl enabled connection",
+      "order": "6",
+      "required": false,
+      "secret": false,
+      "type": "boolean"
+    },
+    "serverCertificate": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "If the SSL email server is internal and possesses a self-signed certificate then enable SSL by adding the certificate here.",
+      "displayName": "Server Certificate",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "order": "7",
+      "relation": [
+        {
+          "action": "ENABLE",
+          "when": [
+            {
+              "id": "secure",
+              "value": "true"
+            }
+          ]
+        }
+      ],
+      "required": false,
+      "secret": false,
+      "type": "textarea"
+    }
+  },
+  "tags": [
+    "verifier"
+  ]
+}

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-send.json
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-send.json
@@ -1,0 +1,266 @@
+{
+  "actions": [
+    {
+      "actionType": "connector",
+      "description": "Send messages to the email account that this connection is authorized to access.",
+      "descriptor": {
+        "connectorCustomizers": [
+          "io.syndesis.connector.email.customizer.EMailSendCustomizer"
+        ],
+        "connectorFactory": "io.syndesis.connector.email.component.EMailComponentFactory",
+        "inputDataShape": {
+          "kind": "java",
+          "name": "EmailMessage",
+          "type": "io.syndesis.connector.email.model.EMailMessageModel"
+        },
+        "outputDataShape": {
+          "kind": "none"
+        },
+        "propertyDefinitionSteps": [
+          {
+            "description": "Specify the emails that you want to obtain.",
+            "name": "Send messages to Email",
+            "properties": {
+              "bcc": {
+                "deprecated": false,
+                "displayName": "Email bcc",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "One or more comma-separated email addresses to send a blind copy of the email to.",
+                "order": "6",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "cc": {
+                "deprecated": false,
+                "displayName": "Email cc",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "One or more comma-separated email addresses to send a copy of the email to.",
+                "order": "5",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "from": {
+                "deprecated": false,
+                "displayName": "Email from",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Email address of the sender (must be valid email address to avoid sender verification failure)",
+                "order": "2",
+                "required": true,
+                "secret": false,
+                "type": "string"
+              },
+              "priority": {
+                "deprecated": false,
+                "displayName": "Parameter Priority",
+                "enum": [
+                  {
+                    "label": "Input Values",
+                    "value": "inputValues"
+                  },
+                  {
+                    "label": "Consumed Data",
+                    "value": "consumedData"
+                  }
+                ],
+                "defaultValue": "injectedData",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Whether the input values above or the consumed data gets priority in being applied to the generated emails",
+                "order": "7",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "subject": {
+                "deprecated": false,
+                "displayName": "Email subject",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The text to insert in the subject line of the email.",
+                "order": "3",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "text": {
+                "deprecated": false,
+                "displayName": "Email text",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The email message that you want to send.",
+                "order": "4",
+                "required": false,
+                "secret": false,
+                "type": "textarea"
+              },
+              "to": {
+                "deprecated": false,
+                "displayName": "Email to",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "One or more comma-separated email addresses to send the email to.",
+                "order": "1",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "id": "io.syndesis:email-send-connector",
+      "name": "Send Email",
+      "pattern": "To",
+      "tags": [
+        "dynamic"
+      ]
+    }
+  ],
+  "componentScheme": "email-send",
+  "configuredProperties": {
+    "protocol": "smtp"
+  },
+  "dependencies": [
+    {
+      "id": "@project.groupId@:@project.artifactId@:@project.version@",
+      "type": "MAVEN"
+    }
+  ],
+  "description": "Send email messages.",
+  "icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaWQ9IkxheWVyXzEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUwIDUwOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTAgNTAiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0I3QzVGRDt9Cgkuc3Qxe2ZpbGw6IzlBQURGRDt9Cgkuc3Qye2ZpbGw6I0ZGRkZGRjt9Cgkuc3Qze2ZpbGw6IzM5NTVEMTt9Cgkuc3Q0e2ZpbGw6IzQ0NjZGQjt9Cgkuc3Q1e2ZpbGw6I0FBQkFGRDt9Cgkuc3Q2e2ZpbGw6Izc5OEZGRTt9Cgkuc3Q3e2ZpbGw6IzZCQjVGQjt9Cgkuc3Q4e2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAgICA7fQoJLnN0OXtmaWxsOiMxQjJBNEY7fQoJLnN0MTB7ZmlsbDp1cmwoIyk7fQoJLnN0MTF7ZmlsbDojMzg0RTg1O30KCS5zdDEye2ZpbGw6IzJFNDI3Nzt9Cgkuc3QxM3tmaWxsOiNEOURERjY7fQoJLnN0MTR7ZmlsbDojNTM1RDg4O30KCS5zdDE1e2ZpbGw6IzJCM0M2Nzt9Cgkuc3QxNntmaWxsOiM4RkNDRkY7fQoJLnN0MTd7ZmlsbDojOENBMUZEO30KCS5zdDE4e29wYWNpdHk6MC4zO30KCS5zdDE5e29wYWNpdHk6MC4zO2ZpbGw6IzQ0NjZGQjt9Cgkuc3QyMHtvcGFjaXR5OjAuMjt9Cjwvc3R5bGU+PGc+PGc+PGc+PGc+PHBvbHlnb24gY2xhc3M9InN0MCIgcG9pbnRzPSI0Mi44OTksMS42NDk3MSA0Mi45NzYxNiwyOC44NjU4MyA4LjE2MzQ4LDQ4Ljk2NTg0IDguMDg2MzIsMjEuNzQ5NzIgICAgICIvPjwvZz48Zz48cG9seWdvbiBjbGFzcz0ic3QxIiBwb2ludHM9IjQyLjg5MjA2LDEuNjUzNjIgNDEuODM2OCwxLjAzNDE2IDcuMDIzODQsMjEuMTI3MTkgNy4xMDQ3Nyw0OC4zNDMyNCA4LjE2MzQ3LDQ4Ljk2NDY3ICAgICAgIDguMDg2MzEsMjEuNzQ5NTkgICAgICIvPjwvZz48Zz48ZyBjbGFzcz0ic3Q4Ij48Zz48cG9seWdvbiBjbGFzcz0ic3Q1IiBwb2ludHM9IjI1LjQ4NDIyLDIyLjMyODY3IDQyLjk3NjE2LDI4Ljg2NTgzIDguMTYzNDgsNDguOTY1ODQgICAgICAgIi8+PC9nPjxnPjxwb2x5Z29uIGNsYXNzPSJzdDE3IiBwb2ludHM9IjI1LjQ3NzYyLDIwLjAwMDE3IDQyLjk3NjE2LDI4Ljg2NTgzIDI1LjQ4NDIyLDIyLjMyODY3IDguMTYzNDgsNDguOTY1ODQgNDIuOTM3NTgsMjguODY1ODMgICAgICAgICA4LjE2MzQ4LDQ4Ljk2NTg0ICAgICAgICIvPjwvZz48L2c+PC9nPjxnPjxnPjxwb2x5Z29uIGNsYXNzPSJzdDAiIHBvaW50cz0iNDIuODk5LDEuNjQ5NzEgMjUuNTc4MjcsMjguMjg2OTIgOC4wODYzMiwyMS43NDk3MiAgICAgICIvPjwvZz48Zz48cG9seWdvbiBjbGFzcz0ic3Q1IiBwb2ludHM9IjQyLjg5OSwxLjY0OTcxIDI1LjU4NDIxLDMwLjM4MjU1IDguMDg2MzIsMjEuNzQ5NzIgMjUuNTc4MjcsMjguMjg2OTIgICAgICAiLz48L2c+PC9nPjwvZz48Zz48Zz48cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMzEuNzE0ODMsMi4xNzg2NmMtMS4zMTY4OS0wLjc3MDIxLTMuMTU1NDQtMC42NzA3My01LjE2NzkyLDAuNDk2OTQgICAgICBjLTQuMDAwMSwyLjMzNTQ5LTcuMjMwMTQsNy45MDA4Ny03LjIwNTI3LDEyLjUyMjExYzAsMi4yODU5LDAuNzk1MDgsMy45MDA3NywyLjExMTk2LDQuNjQ2MjZsLTEuMTI5MDctMC42NTY2MSAgICAgIGMtMS4zMTY3NC0wLjc0NTQ5LTIuMTExODEtMi4zNjAzNi0yLjExMTgxLTQuNjQ2MTFjLTAuMDI0ODctNC42MjEzOSwzLjIwNTAyLTEwLjE4Njc3LDcuMjA1MTItMTIuNTIyMjYgICAgICBjMi4wMzczNi0xLjE0MjgsMy44NTExOC0xLjI2NzE1LDUuMTY3OTItMC40OTY5NEwzMS43MTQ4MywyLjE3ODY2eiIvPjwvZz48Zz48Zz48ZWxsaXBzZSBjbGFzcz0ic3Q0IiBjeD0iMjYuNTgxMTUiIGN5PSIxMS4wMTI3NyIgcng9IjEwLjIxODk5IiByeT0iNS45MTkxMiIgdHJhbnNmb3JtPSJtYXRyaXgoMC41MDI0NSAtMC44NjQ2MSAwLjg2NDYxIDAuNTAyNDUgMy43MDM3MiAyOC40NjE2KSIvPjwvZz48Zz48Zz48cGF0aCBjbGFzcz0ic3QyIiBkPSJNMjcuMTM2Nyw2Ljk3NjQxYzEuODU1OTItMS4wNzE1MiwzLjA5OTU1LTAuMTgyNzksMy4xMDUxNSwxLjc5MjI5ICAgICAgICBjMC4wMDQ5OSwxLjc2MTYyLTAuODY3MiwzLjE3MDI2LTEuNjkxNDUsMy42NDYxNGMtMC41NTE5MSwwLjMxODY0LTAuODY2OTksMC4wNTgzOS0wLjg5NzE4LTAuMzk5NTVsLTAuMDAwMjItMC4wNzY2OCAgICAgICAgYy0wLjM0MjksMC43NjI2MS0wLjkzMTQ2LDEuNTMyMTMtMS41NTkxMiwxLjg5NDUxYy0wLjkxNDQzLDAuNTI3OTUtMS41MDYzMywwLjEyMjM2LTEuNTA5NDMtMC45NzE5MSAgICAgICAgYy0wLjAwNDQ1LTEuNTcwOTUsMS4xNDI2Ny0zLjQ5OTUzLDIuMzAwNTktNC4xNjgwNmMwLjYzODQ4LTAuMzY4NjMsMS4wNzI0Ny0wLjIyMjY5LDEuMjYxNDIsMC4xNTM5N2wwLjEyNjA3LTAuNzc0NDQgICAgICAgIGwwLjY2NzM0LTAuMzg1MjlsLTAuNTUwNDQsMy4zODM4N2MtMC4wMTA2NCwwLjA3MjU3LTAuMDIxMTcsMC4xODAzNy0wLjAyMDk4LDAuMjQ4NzYgICAgICAgIGMwLjAwMTA2LDAuMzczMDUsMC4yMDkwOCwwLjQ2Njc2LDAuNDY1MTksMC4zMTg5YzAuMzgyMzctMC4yMjA3NiwxLjA2ODE0LTEuMTEyODMsMS4wNjM3Mi0yLjY3MTM0ICAgICAgICBjLTAuMDA1MjUtMS44NTI4MS0xLjExODI4LTIuNTU1MzctMi43OTAyMy0xLjU5MDA3Yy0xLjkwNDYyLDEuMDk5NjMtMy41MjA1OCwzLjk2NzMzLTMuNTE0Niw2LjA3OTIgICAgICAgIGMwLjAwNTEyLDEuODA1MTMsMS4xODg2MSwyLjUxMjcsMi44MTkwOCwxLjU3MTM1YzAuNjk4LTAuNDAyOTksMS4yOTYxLTAuOTk1MzQsMS44MjUyNy0xLjY4Njk3bDAuMTc3NTksMC4xOTIyNCAgICAgICAgYy0wLjYwODM0LDAuODAzNzctMS4zMTQ2MiwxLjQ3MTAzLTIuMDQxNDgsMS44OTA2OGMtMS43ODczOCwxLjAzMTk1LTMuMTE3NDMsMC4yNDkxNi0zLjEyMzA5LTEuNzQ4NzIgICAgICAgIEMyMy4yNDI5OCwxMS4yMzgwNiwyNS4wOTMyLDguMTU2MjIsMjcuMTM2Nyw2Ljk3NjQxeiBNMjcuNzQ4NTIsMTEuMjI1NDFsMC4yODA1Mi0xLjczMzQgICAgICAgIGMtMC4xMDc0MS0wLjI4ODgyLTAuNDMzNC0wLjU3NTk4LTEuMDE0MTctMC4yNDA2OGMtMC45ODExNywwLjU2NjQ4LTEuNzI0ODQsMi4wNjA3Ni0xLjcyMTc0LDMuMTU1MDQgICAgICAgIGMwLjAwMjA1LDAuNzIzMywwLjM2NjA4LDEuMDQ0NTUsMS4wMDQ1NiwwLjY3NTkzQzI2Ljk2NTAzLDEyLjY5NzAxLDI3LjQ2NDksMTEuODY0NTMsMjcuNzQ4NTIsMTEuMjI1NDEiLz48L2c+PC9nPjwvZz48L2c+PC9nPjwvZz48L3N2Zz4=",
+  "id": "email-send",
+  "name": "Send Email (smtp)",
+  "metadata": {
+    "tech-preview": true
+  },
+  "properties": {
+    "protocol": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Protocol",
+      "group": "common",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "required": true,
+      "secret": false,
+      "type": "hidden"
+    },
+    "host": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "The hostname of the email server.",
+      "displayName": "Email Host Name",
+      "group": "common",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common",
+      "order": "2",
+      "required": true,
+      "secret": false,
+      "type": "string"
+    },
+    "port": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "The port of the email server.",
+      "displayName": "Email Server Port Number",
+      "group": "common",
+      "javaType": "java.lang.Integer",
+      "kind": "parameter",
+      "label": "common",
+      "order": "3",
+      "required": true,
+      "secret": false,
+      "type": "integer"
+    },
+    "username": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "User Name",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "labelHint": "Specify a user name for authentication of the email service url, if required.",
+      "order": "4",
+      "required": false,
+      "secret": false,
+      "type": "string"
+    },
+    "password": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Password",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "labelHint": "Specify a password for authentication of the email service, if required.",
+      "order": "5",
+      "required": false,
+      "secret": true,
+      "type": "string"
+    },
+    "secure": {
+      "componentProperty": true,
+      "deprecated": false,
+      "displayName": "Secure (SSL)",
+      "group": "security",
+      "javaType": "java.lang.boolean",
+      "kind": "parameter",
+      "label": "security",
+      "labelHint": "Specify whether this is an imaps (ssl enabled) connection",
+      "order": "6",
+      "required": false,
+      "secret": false,
+      "type": "boolean"
+    },
+    "serverCertificate": {
+      "componentProperty": true,
+      "deprecated": false,
+      "description": "If the SSL email server is internal and possesses a self-signed certificate then enable SSL by adding the certificate here.",
+      "displayName": "Server Certificate",
+      "group": "security",
+      "javaType": "java.lang.String",
+      "kind": "parameter",
+      "label": "common,security",
+      "order": "7",
+      "relation": [
+        {
+          "action": "ENABLE",
+          "when": [
+            {
+              "id": "secure",
+              "value": "true"
+            }
+          ]
+        }
+      ],
+      "required": false,
+      "secret": false,
+      "type": "textarea"
+    }
+  },
+  "tags": [
+    "verifier"
+  ]
+}

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/meta/email-receive
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/meta/email-receive
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class=io.syndesis.connector.email.meta.EMailMetaDataRetrieval

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/meta/email-send
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/meta/email-send
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class=io.syndesis.connector.email.meta.EMailMetaDataRetrieval

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/verifier/email-receive
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/verifier/email-receive
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class=io.syndesis.connector.email.verifier.EMailVerifier

--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/verifier/email-send
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/verifier/email-send
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class=io.syndesis.connector.email.verifier.EMailVerifier

--- a/app/connector/email/src/main/resources/org/apache/camel/catalog/components/email-receive.json
+++ b/app/connector/email/src/main/resources/org/apache/camel/catalog/components/email-receive.json
@@ -1,0 +1,23 @@
+{
+ "component": {
+    "kind": "component",
+    "scheme": "email-receive",
+    "alternativeSchemes": "imap,imaps,pop3,pop3s",
+    "syntax": "emailR:host:port",
+    "alternativeSyntax": "emailR:username:password@host:port",
+    "title": "EMAIL RECEIVE",
+    "description": "To receive emails using imap/pop3 protocols.",
+    "label": "email (receive)",
+    "deprecated": false,
+    "deprecationNote": "",
+    "async": false,
+    "consumerOnly": true,
+    "producerOnly": false,
+    "lenientProperties": false,
+    "javaType": "io.syndesis.connector.email.component.EMailComponent",
+    "firstVersion": "1.0.0",
+    "groupId": "io.syndesis.connector",
+    "artifactId": "connector-email",
+    "version": "1.7"
+  }
+}

--- a/app/connector/email/src/main/resources/org/apache/camel/catalog/components/email-send.json
+++ b/app/connector/email/src/main/resources/org/apache/camel/catalog/components/email-send.json
@@ -1,0 +1,23 @@
+{
+ "component": {
+    "kind": "component",
+    "scheme": "email-send",
+    "alternativeSchemes": "smtp,smtps",
+    "syntax": "emailS:host:port",
+    "alternativeSyntax": "emailS:username:password@host:port",
+    "title": "EMAIL SEND",
+    "description": "To send emails using smtp protocol.",
+    "label": "email (send)",
+    "deprecated": false,
+    "deprecationNote": "",
+    "async": false,
+    "consumerOnly": false,
+    "producerOnly": true,
+    "lenientProperties": false,
+    "javaType": "io.syndesis.connector.email.component.EMailComponent",
+    "firstVersion": "1.0.0",
+    "groupId": "io.syndesis.connector",
+    "artifactId": "connector-email",
+    "version": "1.7"
+  }
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEMailTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEMailTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.properties.DefaultPropertiesParser;
+import org.apache.camel.component.properties.PropertiesComponent;
+import org.apache.camel.component.properties.PropertiesParser;
+import org.apache.camel.spring.SpringCamelContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertyResolver;
+import io.syndesis.connector.email.server.EMailTestServer;
+import io.syndesis.connector.email.server.EMailTestServer.Options;
+
+public abstract class AbstractEMailTest implements EMailConstants {
+
+    protected static final String TEST_HOST_NAME = "localhost";
+    protected static final String TEST_USER_NAME = "bob" + AT + TEST_HOST_NAME;
+    protected static final String TEST_PASSWORD = "MyReallySecurePassword";
+
+    protected static final int MOCK_TIMEOUT_MILLISECONDS = 60000;
+
+    private static Options[] serverTypes = {
+            Options.IMAP,
+            Options.IMAPS,
+            Options.POP3,
+            Options.POP3S,
+            Options.SMTP,
+            Options.SMTPS
+            };
+
+    private static Map<Options, EMailTestServer> mailServers = new HashMap<>();
+
+    @Configuration
+    public static class TestConfiguration {
+        @Bean
+        public PropertiesParser propertiesParser(PropertyResolver propertyResolver) {
+            return new DefaultPropertiesParser() {
+                @Override
+                public String parseProperty(String key, String value, Properties properties) {
+                    return propertyResolver.getProperty(key);
+                }
+            };
+        }
+
+        @Bean(destroyMethod = "")
+        public PropertiesComponent properties(PropertiesParser parser) {
+            PropertiesComponent pc = new PropertiesComponent();
+            pc.setPropertiesParser(parser);
+            return pc;
+        }
+    }
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    protected CamelContext context;
+
+
+    @BeforeClass
+    public static void scaffold() throws Exception {
+        for (Options option : serverTypes) {
+            if (! mailServers.containsKey(option)) {
+                EMailTestServer server = new EMailTestServer(TEST_HOST_NAME, option);
+                server.createUser(TEST_USER_NAME, TEST_PASSWORD);
+                refresh(server);
+                server.start();
+                mailServers.put(option, server);
+            }
+        }
+    }
+
+    protected static void refresh(EMailTestServer server) throws Exception {
+        if (server == null) {
+            return;
+        }
+
+        server.clear();
+        if (! server.isSmtp()) {
+            server.generateMail(TEST_USER_NAME, TEST_PASSWORD);
+        }
+    }
+
+    @Before
+    public void setup() {
+        context = createCamelContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (context != null) {
+            context.stop();
+            context = null;
+        }
+    }
+
+    /**
+     * Creates a camel context complete with a properties component that handles
+     * lookups of secret values such as passwords. Fetches the values from external
+     * properties file.
+     *
+     * @return CamelContext
+     */
+    protected CamelContext createCamelContext() {
+            CamelContext ctx = new SpringCamelContext(applicationContext);
+            ctx.disableJMX();
+            PropertiesComponent pc = new PropertiesComponent("classpath:mail-test-options.properties");
+            ctx.addComponent("properties", pc);
+            return ctx;
+        }
+
+    protected static EMailTestServer server(Options option) {
+        return mailServers.get(option);
+    }
+
+    protected static EMailTestServer imapServer() {
+        return server(Options.IMAP);
+    }
+
+    protected static EMailTestServer imapsServer() {
+        return server(Options.IMAPS);
+    }
+
+    protected static EMailTestServer pop3Server() {
+        return server(Options.POP3);
+    }
+
+    protected static EMailTestServer pop3sServer() {
+        return server(Options.POP3S);
+    }
+
+    protected static EMailTestServer smtpServer() {
+        return server(Options.SMTP);
+    }
+
+    protected static EMailTestServer smtpsServer() {
+        return server(Options.SMTPS);
+    }
+
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadRouteTest.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.camel.Endpoint;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mail.MailEndpoint;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.util.SuppressFBWarnings;
+import io.syndesis.connector.email.AbstractEMailRouteTest;
+import io.syndesis.connector.email.component.EMailComponentFactory;
+import io.syndesis.connector.email.customizer.EMailReceiveCustomizer;
+import io.syndesis.connector.email.model.EMailMessageModel;
+import io.syndesis.connector.email.server.EMailTestServer;
+import io.syndesis.connector.support.util.PropertyBuilder;
+
+@DirtiesContext
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    classes = {
+        EMailReadRouteTest.TestConfiguration.class
+    },
+    properties = {
+        "spring.main.banner-mode = off",
+        "logging.level.io.syndesis.integration.runtime = DEBUG"
+    }
+)
+@TestExecutionListeners(
+    listeners = {
+        DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class
+    }
+)
+@SuppressFBWarnings
+public class EMailReadRouteTest extends AbstractEMailRouteTest {
+
+    private EMailTestServer server;
+
+    public EMailReadRouteTest() throws Exception {
+        super();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        refresh(server);
+    }
+
+    @Override
+    protected ConnectorAction createConnectorAction(Map<String, String> configuredProperties) throws Exception {
+        ConnectorAction emailAction = new ConnectorAction.Builder()
+            .description("Read email from the server")
+             .id("io.syndesis:email-receive-connector")
+             .name("Read Email")
+             .descriptor(new ConnectorDescriptor.Builder()
+                        .addConnectorCustomizer(EMailReceiveCustomizer.class.getName())
+                        .connectorFactory(EMailComponentFactory.class.getName())
+                        .outputDataShape(new DataShape.Builder()
+                                         .kind(DataShapeKinds.JAVA)
+                                         .type(EMailMessageModel.class.getCanonicalName())
+                                         .build())
+                        .putAllConfiguredProperties(configuredProperties)
+                        .build())
+            .build();
+        return emailAction;
+    }
+
+    @Test
+    public void testImapEMailRoute() throws Exception {
+        server = imapServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        List<EMailMessageModel> emails = server.getEmails();
+        for (int i = 0; i < emails.size(); ++i) {
+            testResult(result, i, emails.get(i));
+        }
+    }
+
+    @Test
+    public void testImapEMailRouteWrongPassword() throws Exception {
+        server = imapServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(SECURE, Boolean.toString(true))
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, "ReallyWrongPassword"));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+
+        //
+        // No messages returned due to wrong password
+        //
+        result.setAssertPeriod(2000L);
+        result.setMinimumExpectedMessageCount(0);
+
+        context.start();
+        result.assertIsSatisfied();
+    }
+
+    @Test
+    public void testPop3EMailRoute() throws Exception {
+        server = pop3Server();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.POP3.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        List<EMailMessageModel> emails = server.getEmails();
+        for (int i = 0; i < emails.size(); ++i) {
+            testResult(result, i, emails.get(i));
+        }
+    }
+
+    @Test
+    public void testImapsEMailRoute() throws Exception {
+        server = imapsServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(SECURE, Boolean.toString(true))
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD)
+                                                               .property(SERVER_CERTIFICATE, server.getCertificate()));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        List<EMailMessageModel> emails = server.getEmails();
+        for (int i = 0; i < emails.size(); ++i) {
+            testResult(result, i, emails.get(i));
+        }
+    }
+
+    @Test
+    public void testPop3sEMailRoute() throws Exception {
+        server = pop3sServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.POP3.id())
+                                                               .property(SECURE, Boolean.toString(true))
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD)
+                                                               .property(SERVER_CERTIFICATE, server.getCertificate()));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        List<EMailMessageModel> emails = server.getEmails();
+        for (int i = 0; i < emails.size(); ++i) {
+            testResult(result, i, emails.get(i));
+        }
+    }
+
+    @Test
+    public void testImapEMailRouteUnseenMailsOnly() throws Exception {
+        server = imapServer();
+        int emailCount = server.getEmailCount();
+        int unseenCount = 2;
+
+        //
+        // Read all emails except unseenCount
+        //
+        int readCount = emailCount - unseenCount;
+        server.readEmails(readCount);
+
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        PropertyBuilder<String> configuredProperties = new PropertyBuilder<>();
+        configuredProperties.property(UNSEEN_ONLY, Boolean.toString(true));
+        Step mailStep = createEMailStep(mailConnector, configuredProperties.build());
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setResultWaitTime(10000L);
+        result.setExpectedMessageCount(unseenCount);
+
+        context.start();
+
+        assertSatisfied(result);
+
+        assertEquals(unseenCount, result.getExchanges().size());
+        for (int i = readCount; i < emailCount; ++i) {
+            testResult(result, (i - readCount), server.getEmails().get(i));
+        }
+    }
+
+    @Test
+    public void testImapEMailRouteMaxEmails() throws Exception {
+        int filteredTotal = 2;
+        server = imapServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        PropertyBuilder<String> configuredProperties = new PropertyBuilder<>();
+        configuredProperties.property(MAX_MESSAGES, Integer.toString(filteredTotal));
+        Step mailStep = createEMailStep(mailConnector, configuredProperties.build());
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setExpectedMessageCount(filteredTotal);
+
+        context.start();
+
+        assertSatisfied(result);
+
+        assertEquals(filteredTotal, result.getExchanges().size());
+        for (int i = 0; i < filteredTotal; ++i) {
+            testResult(result, i, server.getEmails().get(i));
+        }
+    }
+
+    @Test
+    public void testImapRouteWithConsumerDelayProperties() throws Exception {
+        String delayValue = "1000";
+
+        server = imapServer();
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        PropertyBuilder<String> configuredProperties = new PropertyBuilder<>();
+        configuredProperties.property(DELAY, delayValue);
+        Step mailStep = createEMailStep(mailConnector, configuredProperties.build());
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        List<EMailMessageModel> emails = server.getEmails();
+        for (int i = 0; i < emails.size(); ++i) {
+            testResult(result, i, emails.get(i));
+        }
+
+        Collection<Endpoint> endpoints = context.getEndpoints();
+        MailEndpoint mailEndpoint = null;
+        for (Endpoint endpoint : endpoints) {
+            if (endpoint instanceof MailEndpoint) {
+                mailEndpoint = (MailEndpoint) endpoint;
+            }
+        }
+        assertNotNull(mailEndpoint);
+
+        Map<String, Object> consumerProperties = mailEndpoint.getConsumerProperties();
+        assertNotNull(consumerProperties);
+        assertTrue(consumerProperties.size() > 0);
+        assertEquals(delayValue, consumerProperties.get(DELAY));
+    }
+
+    /**
+     * Receive will parse and strip the html from the message
+     * and just leave the plain text.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testImapMessageHTMLToPlainText() throws Exception {
+        server = imapServer();
+        server.clear();
+
+        String plainText = "Hi, how are you?";
+        String body = "<html><body>Hi, <i>how are you?</i></body></html>";
+
+        server.createMultipartMessage(TEST_USER_NAME, TEST_PASSWORD, "Ben1@test.com",
+                                                                       "An HTML Message", TEXT_HTML, body);
+        assertEquals(1, server.getEmailCount());
+
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.IMAP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        PropertyBuilder<String> configuredProperties = new PropertyBuilder<>();
+        configuredProperties.property(TO_PLAIN_TEXT, Boolean.toString(true));
+        Step mailStep = createEMailStep(mailConnector, configuredProperties.build());
+        Integration mailIntegration = createIntegration(mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(server.getEmailCount());
+
+        context.start();
+
+        assertSatisfied(result);
+
+        EMailMessageModel model = extractModelFromExchgMsg(result, 0);
+        assertThat(model.getContent()).isInstanceOf(String.class);
+        assertEquals(plainText, model.getContent().toString().trim());
+    }
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/meta/EMailMetaDataTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/meta/EMailMetaDataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.junit.Before;
+import org.junit.Test;
+import io.syndesis.connector.email.AbstractEMailTest;
+import io.syndesis.connector.email.server.EMailTestServer;
+
+public class EMailMetaDataTest extends AbstractEMailTest {
+
+    @Before
+    public void emailSetup() throws Exception {
+        super.setup();
+        context.start();
+    }
+
+    @Test
+    public void testMetaDataExtensionRetrieval() throws Exception {
+        EMailTestServer server = imapServer();
+        EMailMetaDataExtension extension = new EMailMetaDataExtension(context);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(PROTOCOL, server.getProtocol());
+        parameters.put(HOST, server.getHost());
+        parameters.put(PORT, Integer.toString(server.getPort()));
+        parameters.put(USER, TEST_USER_NAME);
+        parameters.put(PASSWORD, TEST_PASSWORD);
+
+        Optional<MetaDataExtension.MetaData> meta = extension.meta(parameters);
+        assertThat(meta).isPresent();
+
+        Object payload = meta.get().getPayload();
+        assertThat(payload).isInstanceOf(EMailMetadata.class);
+        assertThat(((EMailMetadata) payload).getProtocol()).isEqualTo(Protocols.getValueOf(server.getProtocol()));
+    }
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/producer/EMailSendRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/producer/EMailSendRouteTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.producer;
+
+import static org.junit.Assert.assertEquals;
+import java.util.List;
+import java.util.Map;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.direct.DirectEndpoint;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.SuppressFBWarnings;
+import io.syndesis.connector.email.AbstractEMailRouteTest;
+import io.syndesis.connector.email.component.EMailComponentFactory;
+import io.syndesis.connector.email.customizer.EMailSendCustomizer;
+import io.syndesis.connector.email.model.EMailMessageModel;
+import io.syndesis.connector.email.server.EMailTestServer;
+import io.syndesis.connector.support.util.PropertyBuilder;
+
+
+@DirtiesContext
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    classes = {
+        EMailSendRouteTest.TestConfiguration.class
+    },
+    properties = {
+        "spring.main.banner-mode = off",
+        "logging.level.io.syndesis.integration.runtime = DEBUG"
+    }
+)
+@TestExecutionListeners(
+    listeners = {
+        DependencyInjectionTestExecutionListener.class,
+        DirtiesContextTestExecutionListener.class
+    }
+)
+@SuppressFBWarnings
+public class EMailSendRouteTest extends AbstractEMailRouteTest {
+
+    private static EMailTestServer server;
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        //
+        // Clear smtp server
+        //
+        refresh(server);
+    }
+
+    public EMailSendRouteTest() throws Exception {
+        super();
+    }
+
+    @Override
+    protected ConnectorAction createConnectorAction(Map<String, String> configuredProperties) throws Exception {
+        ConnectorAction emailAction = new ConnectorAction.Builder()
+        .description("Send email to another server")
+         .id("io.syndesis:email-send-connector")
+         .name("Send Email")
+         .descriptor(new ConnectorDescriptor.Builder()
+                    .addConnectorCustomizer(EMailSendCustomizer.class.getName())
+                    .connectorFactory(EMailComponentFactory.class.getName())
+                    .inputDataShape(new DataShape.Builder()
+                                     .kind(DataShapeKinds.JAVA)
+                                     .type(EMailMessageModel.class.getCanonicalName())
+                                     .build())
+                    .putAllConfiguredProperties(configuredProperties)
+                    .build())
+        .build();
+        return emailAction;
+    }
+
+    private Step createDirectStep() {
+        Step directStep = new Step.Builder()
+            .stepKind(StepKind.endpoint)
+            .action(new ConnectorAction.Builder()
+                    .descriptor(new ConnectorDescriptor.Builder()
+                                .componentScheme("direct")
+                                .putConfiguredProperty("name", "start")
+                                .build())
+                    .build())
+            .build();
+        return directStep;
+    }
+
+    @Test
+    public void testSmtpSenderRoute() throws Exception {
+        server = smtpServer();
+
+        Step directStep = createDirectStep();
+
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.SMTP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(directStep, mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setExpectedMessageCount(1);
+
+        DirectEndpoint directEndpoint = context.getEndpoint("direct://start", DirectEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+
+        context.start();
+
+        EMailMessageModel msgModel = new EMailMessageModel();
+        msgModel.setSubject("Test Email 1");
+        msgModel.setFrom(TEST_USER_NAME);
+        msgModel.setTo(TEST_USER_NAME);
+        msgModel.setContent("Hello, I am sending emails to myself again!\r\n");
+
+        template.sendBody(directEndpoint, msgModel);
+
+        result.assertIsSatisfied();
+
+        List<EMailMessageModel> emails = server.getEmails();
+        assertEquals(1, emails.size());
+        assertEquals(msgModel, emails.get(0));
+    }
+
+    @Test
+    public void testSmtpsSenderRoute() throws Exception {
+        server = smtpsServer();
+
+        Step directStep = createDirectStep();
+
+        //
+        // Even though protocol is set to 'smtp', it will be changed to 'smtps'
+        // by the EMailComponent due to secure being true
+        //
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.SMTP.id())
+                                                               .property(SECURE, Boolean.toString(true))
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD)
+                                                               .property(SERVER_CERTIFICATE, server.getCertificate()));
+
+        Step mailStep = createEMailStep(mailConnector);
+        Integration mailIntegration = createIntegration(directStep, mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setExpectedMessageCount(1);
+
+        DirectEndpoint directEndpoint = context.getEndpoint("direct://start", DirectEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+
+        context.start();
+
+        EMailMessageModel msgModel = new EMailMessageModel();
+        msgModel.setSubject("Test Email 1");
+        msgModel.setFrom(TEST_USER_NAME);
+        msgModel.setTo(TEST_USER_NAME);
+        msgModel.setContent("Hello, I am sending emails to myself again!\r\n");
+
+        template.sendBody(directEndpoint, msgModel);
+
+        result.assertIsSatisfied();
+
+        List<EMailMessageModel> emails = server.getEmails();
+        assertEquals(1, emails.size());
+        assertEquals(msgModel, emails.get(0));
+    }
+
+    @Test
+    public void testPriorityOfValuesInjectedData() throws Exception {
+        server = smtpServer();
+
+        Step directStep = createDirectStep();
+
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.SMTP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        EMailMessageModel injectedDataModel = new EMailMessageModel();
+        injectedDataModel.setSubject("Injected Data Email 1");
+        injectedDataModel.setFrom(TEST_USER_NAME);
+        injectedDataModel.setTo(TEST_USER_NAME);
+        injectedDataModel.setContent("Hello, this is an email from injected data!\r\n");
+
+        String inputValueSubject = "Input Values Email 1";
+        String inputValueText = "Hello, this is an email using inputted values!";
+
+        PropertyBuilder<String> builder = new PropertyBuilder<>();
+        builder.property(PRIORITY, Priorities.CONSUMED_DATA.toString());
+        builder.property(MAIL_SUBJECT, inputValueSubject);
+        builder.property(MAIL_TEXT, inputValueText);
+
+        Step mailStep = createEMailStep(mailConnector, builder.build());
+        Integration mailIntegration = createIntegration(directStep, mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setExpectedMessageCount(1);
+
+        DirectEndpoint directEndpoint = context.getEndpoint("direct://start", DirectEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+
+        context.start();
+
+        //
+        // Sending through injected data model as if consumed from another connection
+        //
+        template.sendBody(directEndpoint, injectedDataModel);
+
+        result.assertIsSatisfied();
+
+        List<EMailMessageModel> emails = server.getEmails();
+        assertEquals(1, emails.size());
+
+        //
+        // The email is consistent with the injected data and has overridden
+        // the values set by the inputted values
+        //
+        assertEquals(injectedDataModel, emails.get(0));
+    }
+
+    @Test
+    public void testPriorityOfValuesInputtedValues() throws Exception {
+        server = smtpServer();
+
+        Step directStep = createDirectStep();
+
+        Connector mailConnector = createEMailConnector(componentScheme(server),
+                                                       new PropertyBuilder<String>()
+                                                               .property(PROTOCOL, Protocols.SMTP.id())
+                                                               .property(HOST, server.getHost())
+                                                               .property(PORT, Integer.toString(server.getPort()))
+                                                               .property(USER, TEST_USER_NAME)
+                                                               .property(PASSWORD, TEST_PASSWORD));
+
+        EMailMessageModel injectedDataModel = new EMailMessageModel();
+        injectedDataModel.setSubject("Injected Data Email 1");
+        injectedDataModel.setFrom(TEST_USER_NAME);
+        injectedDataModel.setTo(TEST_USER_NAME);
+        injectedDataModel.setContent("Hello, this is an email from injected data!\r\n");
+
+        String inputValueSubject = "Input Values Email 1";
+        String inputValueText = "Hello, this is an email using inputted values!\r\n";
+
+        //
+        // Change the integration's priority to prefer input values if present
+        //
+        PropertyBuilder<String> builder = new PropertyBuilder<>();
+        builder.property(PRIORITY, Priorities.INPUT_VALUES.toString());
+        builder.property(MAIL_SUBJECT, inputValueSubject);
+        builder.property(MAIL_TEXT, inputValueText);
+
+        Step mailStep = createEMailStep(mailConnector, builder.build());
+        Integration mailIntegration = createIntegration(directStep, mailStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(mailIntegration);
+        context.addRoutes(routes);
+
+        MockEndpoint result = initMockEndpoint();
+        result.setExpectedMessageCount(1);
+
+        DirectEndpoint directEndpoint = context.getEndpoint("direct://start", DirectEndpoint.class);
+        ProducerTemplate template = context.createProducerTemplate();
+
+        context.start();
+
+        //
+        // Sending through injected data model as if consumed from another connection
+        //
+        template.sendBody(directEndpoint, injectedDataModel);
+
+        result.assertIsSatisfied();
+
+        List<EMailMessageModel> emails = server.getEmails();
+        assertEquals(1, emails.size());
+
+        //
+        // The email looks like injectedData but retains
+        // the subject & text specified by the input values
+        //
+        EMailMessageModel expectedModel = new EMailMessageModel();
+        expectedModel.setSubject(inputValueSubject);
+        expectedModel.setFrom(injectedDataModel.getFrom());
+        expectedModel.setTo(injectedDataModel.getTo());
+        expectedModel.setContent(inputValueText);
+
+        assertEquals(expectedModel, emails.get(0));
+    }
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/server/EMailTestServer.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/server/EMailTestServer.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.server;
+
+import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import javax.mail.Flags.Flag;
+import javax.mail.Message.RecipientType;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import org.apache.commons.codec.binary.Base64;
+import com.icegreen.greenmail.server.AbstractServer;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.DummySSLServerSocketFactory;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import io.syndesis.common.util.StringConstants;
+import io.syndesis.connector.email.model.EMailMessageModel;
+
+public class EMailTestServer implements StringConstants {
+
+    public enum Options {
+        IMAP, IMAPS,
+        POP3, POP3S,
+        SMTP, SMTPS
+    }
+
+    private List<Options> optionsList;
+
+    private GreenMail greenMail;
+
+    private AbstractServer server;
+
+    public EMailTestServer(Options... options) {
+        this(null, options);
+    }
+
+    public EMailTestServer(String hostName, Options... options) {
+        this.optionsList = Arrays.asList(options);
+
+        if (optionsList.contains(Options.IMAP)) {
+            initServer(hostName, ServerSetupTest.IMAP, () -> greenMail.getImap());
+        } else if (optionsList.contains(Options.IMAPS)) {
+            initServer(hostName, ServerSetupTest.IMAPS, () -> greenMail.getImaps());
+        } else if (optionsList.contains(Options.POP3)) {
+            initServer(hostName, ServerSetupTest.POP3, () -> greenMail.getPop3());
+        } else if (optionsList.contains(Options.POP3S)) {
+            initServer(hostName, ServerSetupTest.POP3S, () -> greenMail.getPop3s());
+        } else if (optionsList.contains(Options.SMTP)) {
+            initServer(hostName, ServerSetupTest.SMTP, () -> greenMail.getSmtp());
+        } else if (optionsList.contains(Options.SMTPS)) {
+            initServer(hostName, ServerSetupTest.SMTPS, () -> greenMail.getSmtps());
+        } else {
+            throw new UnsupportedOperationException("Server must be either IMAP(S), POP3(S) or SMTP(S)");
+        }
+    }
+
+    private void initServer(String hostName, ServerSetup type, Supplier<AbstractServer> supplier) {
+        if (hostName != null) {
+            greenMail = new GreenMail(type.createCopy(hostName));
+        } else {
+            greenMail = new GreenMail(type);
+        }
+
+        server = supplier.get();
+    }
+
+    public void start() {
+        if (greenMail == null) {
+            throw new IllegalStateException();
+        }
+
+        greenMail.start();
+    }
+
+    public void clear() throws Exception {
+        greenMail.purgeEmailFromAllMailboxes();
+    }
+
+    public void stop() {
+        if (greenMail == null) {
+            return;
+        }
+
+        greenMail.stop();
+    }
+
+    public String getHost() {
+        return server.getServerSetup().getBindAddress();
+    }
+
+    public int getPort() {
+        return server.getPort();
+    }
+
+    public String getProtocol() {
+        return server.getProtocol();
+    }
+
+    public void createUser(String username, String password) {
+        greenMail.setUser(username, password);
+    }
+
+    protected static String convertToPem(Certificate cert) throws CertificateEncodingException {
+        Base64 encoder = new Base64(64);
+        String cert_begin = "-----BEGIN CERTIFICATE-----\n";
+        String end_cert = "-----END CERTIFICATE-----";
+
+        byte[] derCert = cert.getEncoded();
+        String pemCertPre = new String(encoder.encode(derCert), Charset.defaultCharset());
+        String pemCert = cert_begin + pemCertPre + end_cert;
+        return pemCert;
+    }
+
+    public String getCertificate() throws KeyStoreException, CertificateEncodingException {
+        KeyStore keyStore = new DummySSLServerSocketFactory().getKeyStore();
+        Certificate certificate = keyStore.getCertificate("greenmail");
+        return convertToPem(certificate);
+    }
+
+    private MimeMessage createTextMessage(String to, String from, String subject, String body) {
+        return GreenMailUtil.createTextEmail(to, from, subject, body, server.getServerSetup());
+    }
+
+    public void createMultipartMessage(String user, String password, String from, String subject,
+                                                                       String contentType, Object body) throws Exception {
+        GreenMailUser greenUser = greenMail.setUser(user, password);
+        MimeMultipart multiPart = new MimeMultipart();
+        MimeBodyPart textPart = new MimeBodyPart();
+        multiPart.addBodyPart(textPart);
+        textPart.setContent(body, contentType);
+
+        Session session = GreenMailUtil.getSession(server.getServerSetup());
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setRecipients(Message.RecipientType.TO, greenUser.getEmail());
+        mimeMessage.setFrom(from);
+        mimeMessage.setSubject(subject);
+        mimeMessage.setContent(multiPart, "multipart/mixed");
+        greenUser.deliver(mimeMessage);
+    }
+
+    public void generateMail(String user, String password) {
+        for (int i = 1; i <= 5; ++i) {
+            // Use random content to avoid potential residual lingering problems
+            String subject = GreenMailUtil.random();
+            String body = GreenMailUtil.random();
+            GreenMailUser greenUser = greenMail.setUser(user, password);
+            MimeMessage message = createTextMessage(greenUser.getEmail(), "Ben" + i + "@test.com", subject, body); // Construct message
+            greenUser.deliver(message);
+        }
+
+        assertEquals(5, greenMail.getReceivedMessages().length);
+    }
+
+    public int getEmailCount() {
+        return greenMail.getReceivedMessages().length;
+    }
+
+    private EMailMessageModel createMessageModel(MimeMessage msg) throws MessagingException, IOException {
+        EMailMessageModel model = new EMailMessageModel();
+        model.setFrom(msg.getFrom()[0].toString());
+        model.setTo(msg.getRecipients(RecipientType.TO)[0].toString());
+        model.setSubject(msg.getSubject());
+        model.setContent(msg.getContent());
+        return model;
+    }
+
+    public List<EMailMessageModel> readEmails(int number) throws Exception {
+        List<EMailMessageModel> models = new ArrayList<>();
+        MimeMessage[] msgs = greenMail.getReceivedMessages();
+        for (int i = 0; i < number; ++i) {
+            if (i > msgs.length) {
+                break;
+            }
+
+            MimeMessage msg = msgs[i];
+            msg.setFlag(Flag.SEEN, true);
+            models.add(createMessageModel(msg));
+        }
+
+        return models;
+    }
+
+    public List<EMailMessageModel> getEmails() throws Exception {
+        List<EMailMessageModel> models = new ArrayList<>();
+        for (MimeMessage msg : greenMail.getReceivedMessages()) {
+            models.add(createMessageModel(msg));
+        }
+
+        return models;
+    }
+
+    public boolean isSmtp() {
+        return server.getProtocol().equalsIgnoreCase("smtp") ||
+            server.getProtocol().equalsIgnoreCase("smtps");
+    }
+}

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.email.verifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import io.syndesis.connector.email.AbstractEMailTest;
+import io.syndesis.connector.support.verifier.api.Verifier;
+import io.syndesis.connector.support.verifier.api.VerifierResponse;
+
+public class EMailVerifierTest extends AbstractEMailTest {
+
+    public EMailVerifierTest() throws Exception {
+        super();
+    }
+
+    @Test
+    public void testVerifyWithServer() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(PROTOCOL, "imap");
+        parameters.put(HOST, imapServer().getHost());
+        parameters.put(PORT, imapServer().getPort());
+        parameters.put(USER, TEST_USER_NAME);
+        parameters.put(PASSWORD, TEST_PASSWORD);
+
+        Verifier verifier = new EMailVerifier();
+        List<VerifierResponse> responses = verifier.verify(context, "email", parameters);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.PARAMETERS);
+        assertThat(responses).allMatch(response -> response.getStatus() == Verifier.Status.OK);
+    }
+
+    @Test
+    public void testVerifyWithSSLServer() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(PROTOCOL, "imap");
+        parameters.put(SECURE, Boolean.toString(true));
+        parameters.put(HOST, imapsServer().getHost());
+        parameters.put(PORT, imapsServer().getPort());
+        parameters.put(USER, TEST_USER_NAME);
+        parameters.put(PASSWORD, TEST_PASSWORD);
+        parameters.put(SERVER_CERTIFICATE, imapsServer().getCertificate());
+
+        Verifier verifier = new EMailVerifier();
+        List<VerifierResponse> responses = verifier.verify(context, "email", parameters);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
+        assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.PARAMETERS);
+        assertThat(responses).allMatch(response -> response.getStatus() == Verifier.Status.OK);
+    }
+}

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -81,6 +81,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.syndesis.common</groupId>
       <artifactId>common-model</artifactId>
     </dependency>

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -29,7 +29,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import io.syndesis.connector.odata.ODataConstants;
 import io.syndesis.connector.odata.ODataUtil;
-import io.syndesis.connector.odata.PropertyBuilder;
+import io.syndesis.connector.support.util.PropertyBuilder;
 import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -49,6 +49,7 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.odata.server.ODataTestServer;
 import io.syndesis.connector.odata.server.ODataTestServer.Options;
+import io.syndesis.connector.support.util.PropertyBuilder;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 
 public abstract class AbstractODataTest implements ODataConstants {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
@@ -22,9 +22,9 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.connector.odata.AbstractODataRouteTest;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.customizer.ODataReadCustomizer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 public abstract class AbstractODataReadRouteTest extends AbstractODataRouteTest {
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -39,8 +39,8 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.server.ODataTestServer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -39,8 +39,8 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.server.ODataTestServer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
@@ -42,10 +42,10 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.odata.AbstractODataRouteTest;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.consumer.ODataReadRouteSplitResultsTest;
 import io.syndesis.connector.odata.customizer.ODataCreateCustomizer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
@@ -42,10 +42,10 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.odata.AbstractODataRouteTest;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.consumer.ODataReadRouteSplitResultsTest;
 import io.syndesis.connector.odata.customizer.ODataDeleteCustomizer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -48,10 +48,10 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.odata.AbstractODataRouteTest;
-import io.syndesis.connector.odata.PropertyBuilder;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.consumer.ODataReadRouteSplitResultsTest;
 import io.syndesis.connector.odata.customizer.ODataPatchCustomizer;
+import io.syndesis.connector.support.util.PropertyBuilder;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)

--- a/app/connector/pom.xml
+++ b/app/connector/pom.xml
@@ -50,6 +50,7 @@
     <module>aws-sqs</module>
     <module>box</module>
     <module>dropbox</module>
+    <module>email</module>
     <module>ftp</module>
     <module>fhir</module>
     <module>gmail</module>

--- a/app/connector/support/catalog/pom.xml
+++ b/app/connector/support/catalog/pom.xml
@@ -185,6 +185,11 @@
       <artifactId>connector-rest-swagger</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>connector-email</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/CertificateUtil.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/CertificateUtil.java
@@ -16,7 +16,11 @@
 package io.syndesis.connector.support.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -80,5 +84,17 @@ public final class CertificateUtil {
             // insert newline after header
             return certificate.replace("-----BEGIN CERTIFICATE-----", "-----BEGIN CERTIFICATE-----\n");
         }
+    }
+
+    /**
+     * @return the built-in java runtime's default keystore
+     * @throws FileNotFoundException
+     */
+    public static InputStream defaultKeyStore() throws FileNotFoundException {
+        return new FileInputStream(
+                                          System.getProperties()
+                                                .getProperty("java.home") + File.separator
+                                              + "lib" + File.separator + "security" + File.separator
+                                              + "cacerts");
     }
 }

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/PropertyBuilder.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/PropertyBuilder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.connector.odata;
+package io.syndesis.connector.support.util;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/app/integration/bom-camel-k/pom.xml
+++ b/app/integration/bom-camel-k/pom.xml
@@ -354,6 +354,11 @@
         <artifactId>connector-flow</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.syndesis.connector</groupId>
+        <artifactId>connector-email</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -359,6 +359,11 @@
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.databind.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.syndesis.connector</groupId>
+        <artifactId>connector-email</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
 import org.apache.camel.Endpoint;
@@ -119,6 +118,15 @@ public class ComponentProxyComponent extends DefaultComponent {
         }
     }
 
+    /**
+     * Allows the definition to be overridden if required by specific components
+     *
+     * @return definition
+     */
+    protected ComponentDefinition getDefinition() {
+        return definition;
+    }
+
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
@@ -130,6 +138,7 @@ public class ComponentProxyComponent extends DefaultComponent {
         // create the uri of the base component, DO NOT log the computed delegate
         final Map<String, String> endpointOptions = buildEndpointOptions(remaining, options);
         final String endpointScheme = componentSchemeAlias.orElse(componentScheme);
+        ComponentDefinition definition = getDefinition();
         final Endpoint delegate = createDelegateEndpoint(definition, endpointScheme, endpointOptions);
 
         LOGGER.info("Connector resolved: {} -> {}", URISupport.sanitizeUri(uri), URISupport.sanitizeUri(delegate.getEndpointUri()));
@@ -162,6 +171,7 @@ public class ComponentProxyComponent extends DefaultComponent {
         this.remainingOptions.clear();
         this.remainingOptions.putAll(this.configuredOptions);
 
+        ComponentDefinition definition = getDefinition();
         Optional<Component> component = createDelegateComponent(definition, this.remainingOptions);
         if (component.isPresent()) {
 
@@ -359,7 +369,7 @@ public class ComponentProxyComponent extends DefaultComponent {
         // Extract options from options that are supposed to be set at the endpoint
         // level, those options can be overridden and extended using by the query
         // parameters.
-        Collection<String> endpointProperties = definition.getEndpointProperties().keySet();
+        Collection<String> endpointProperties =getDefinition().getEndpointProperties().keySet();
         for (String key : endpointProperties) {
             Object val = options.get(key);
             if (val != null) {

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -376,6 +376,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-email</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <!-- Needed by Guava at compile time -->
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1482,6 +1482,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.syndesis.connector</groupId>
+        <artifactId>connector-email</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- ============================================== -->
 
       <dependency>

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
@@ -319,7 +319,7 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
                             dataManager.update(dbConnection);
                         }
 
-                        if (connection.getId().isPresent()) {
+                        if (connection.getId().isPresent() && ! integration.isDeleted()) {
                             //
                             // Compare the connection in the draft integration's step
                             // with the connection from the data manager and log the


### PR DESCRIPTION
* Since camel-mail divides up component into 3 component-defn, a proxy
  'email' defn is used for the sake of avoiding duplication.

* 2 connection types - Receive:IMAP/POP3 (Consumer) & Send:SMTP (Producer)

* Connection types have 'secure' option for enabling SSL

* EMailComponent
 * Handles fetch component defn based on protocol from underlying camel-mail
 * Create MailConfiguration based on connection configuration

* EMailReceiveCustomizer
 * Converts MimeMessage into EMailMessageModel
 * Parses email text to ensure it's semi-readable (maybe further work
   required if requested)

* EMailSendCustomizer
 * Configures email for sending
 * Allows for either input-parameters or consumed-data to be preferred
   choice for certain fields. Example, useful for overwriting From-field
   with single email address

* EMailMetaData[...]
 * Serves primarily as checks that the connection being offered for mail
   transport is the correct one for the route being configured

* EMailMessageModel
 * Differs from GMail connector model by including a FROM field which needs
   to be valid email address rather than default camel@localhost
  * SMTP servers have domain checking validation that ensures FROM is not
    spoofed.

* catalog/.../email-[receive|send]/.json
 * Catalog placeholder definitions required for valid 'email' component defn
   but are superseded by the real protocol-based component defns in
   EMailComponent

* ComponentProxyComponent
 * Makes definition getter protected so sub-classes can override it; allows
   for EMailComponent to delegate defn to protocol-defined versions.

* Lots n lots of tests!
 * EMailTestServer using Greenmail

* OData refactoring
 * Moves PropertyBuilder to connector-support/util
 * Moves general certificate functions to connector-support/util