### PR TITLE
refactor: rename parameter to apiKey

### DIFF
--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
@@ -17,9 +17,9 @@ package io.syndesis.connector.rest.swagger;
 
 import java.util.Map;
 
+import io.syndesis.connector.rest.swagger.auth.apikey.ApiKey;
 import io.syndesis.connector.rest.swagger.auth.basic.Basic;
 import io.syndesis.connector.rest.swagger.auth.oauth.OAuth;
-import io.syndesis.connector.rest.swagger.auth.parameter.Parameter;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -47,8 +47,8 @@ public class AuthenticationCustomizer implements ComponentProxyCustomizer {
             case basic:
                 Basic.setup(component, configuration);
                 break;
-            case parameter:
-                Parameter.setup(component, configuration);
+            case apiKey:
+                ApiKey.setup(component, configuration);
                 break;
             default:
                 throw new IllegalStateException("Unsupported authentication type: " + authenticationType);

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationType.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationType.java
@@ -16,5 +16,5 @@
 package io.syndesis.connector.rest.swagger;
 
 public enum AuthenticationType {
-    basic, none, oauth2, parameter
+    basic, none, oauth2, apiKey
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/apikey/ApiKey.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/apikey/ApiKey.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.connector.rest.swagger.auth.parameter;
+package io.syndesis.connector.rest.swagger.auth.apikey;
 
 import io.syndesis.connector.rest.swagger.Configuration;
 import io.syndesis.connector.rest.swagger.SwaggerProxyComponent;
@@ -21,13 +21,13 @@ import io.syndesis.connector.rest.swagger.auth.SetHeader;
 import io.syndesis.connector.rest.swagger.auth.SetHttpHeader;
 import io.syndesis.integration.component.proxy.Processors;
 
-public final class Parameter {
+public final class ApiKey {
 
     public enum Placement {
         header, query
     }
 
-    private Parameter() {
+    private ApiKey() {
         // utility class
     }
 

--- a/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
+++ b/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
@@ -99,8 +99,8 @@
           "value": "oauth2"
         },
         {
-          "label": "parameter",
-          "value": "parameter"
+          "label": "apiKey",
+          "value": "apiKey"
         }
       ],
       "javaType": "java.lang.String",

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
@@ -96,7 +96,7 @@ public class AuthenticationCustomizerTest {
         final AuthenticationCustomizer customizer = new AuthenticationCustomizer();
 
         final Map<String, Object> options = new HashMap<>();
-        options.put("authenticationType", AuthenticationType.parameter);
+        options.put("authenticationType", AuthenticationType.apiKey);
         options.put("authenticationParameterName", "apiKey");
         options.put("authenticationParameterValue", "{{key}}");
         options.put("authenticationParameterPlacement", "header");

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
@@ -28,7 +28,7 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.util.Json;
-import io.syndesis.connector.rest.swagger.auth.parameter.Parameter.Placement;
+import io.syndesis.connector.rest.swagger.auth.apikey.ApiKey.Placement;
 
 import org.apache.camel.CamelContext;
 import org.junit.Test;

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
@@ -342,7 +342,7 @@ public class RestSwaggerConnectorIntegrationTest {
     private Flow additionalQueryParameterAuthenticationFlow() {
         final Step queryParameterAuth = operation("apiKeyFindPetsByStatus", JSON_SCHEMA_SHAPE, NONE_SHAPE).builder()
             .connection(connection.builder()
-                .putConfiguredProperty("authenticationType", AuthenticationType.parameter.name())
+                .putConfiguredProperty("authenticationType", AuthenticationType.apiKey.name())
                 .putConfiguredProperty("authenticationParameterName", "api_key")
                 .putConfiguredProperty("authenticationParameterValue", "ENC:_key_")
                 .putConfiguredProperty("authenticationParameterPlacement", "query")
@@ -443,7 +443,7 @@ public class RestSwaggerConnectorIntegrationTest {
     private Flow headerAuthenticationFlow() {
         final Step headerParameterAuth = operation("logoutUser", NONE_SHAPE, NONE_SHAPE).builder()
             .connection(connection.builder()
-                .putConfiguredProperty("authenticationType", AuthenticationType.parameter.name())
+                .putConfiguredProperty("authenticationType", AuthenticationType.apiKey.name())
                 .putConfiguredProperty("authenticationParameterName", "apiKey")
                 .putConfiguredProperty("authenticationParameterValue", "ENC:_key_")
                 .putConfiguredProperty("authenticationParameterPlacement", "header")
@@ -530,7 +530,7 @@ public class RestSwaggerConnectorIntegrationTest {
     private Flow queryParameterAuthenticationFlow() {
         final Step queryParameterAuth = operation("apiKeyLogoutUser", NONE_SHAPE, NONE_SHAPE).builder()
             .connection(connection.builder()
-                .putConfiguredProperty("authenticationType", AuthenticationType.parameter.name())
+                .putConfiguredProperty("authenticationType", AuthenticationType.apiKey.name())
                 .putConfiguredProperty("authenticationParameterName", "api_key")
                 .putConfiguredProperty("authenticationParameterValue", "ENC:_key_")
                 .putConfiguredProperty("authenticationParameterPlacement", "query")


### PR DESCRIPTION
In a call a spade a spade decision, the `parameter` authentication method was renamed to `apiKey` to decrease the cognitive load and fix issues where the terminology clashes like in #5369.

Fixes #5369