### PR TITLE
[fix] Avoid duplicate activity log entries

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
@@ -58,15 +58,18 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
                 return target;
             }
 
-            return new EventProcessor(target);
+            return new EventProcessor(target, stepId);
         }
 
         return target;
     }
 
     private class EventProcessor extends DelegateAsyncProcessor {
-        EventProcessor(Processor processor) {
+        private final String stepId;
+
+        EventProcessor(Processor processor, String stepId) {
             super(processor);
+            this.stepId = stepId;
         }
 
         @Override
@@ -78,12 +81,11 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
 
             return super.process(exchange, doneSync -> {
                 final String activityId =  ActivityTracker.getActivityId(exchange);
-                final String stepId = in.getHeader(IntegrationLoggingConstants.STEP_ID, String.class);
 
                 if (activityId != null) {
                     tracker.track(
                         "exchange", activityId,
-                        "step", stepId != null ? stepId : "none",
+                        "step", stepId,
                         "id", trackerId,
                         "duration", System.nanoTime() - createdAt,
                         "failure", failure(exchange)

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
@@ -57,6 +57,10 @@ import static org.mockito.Mockito.verify;
 public class ChoiceStepHandlerTest extends IntegrationTestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChoiceStepHandlerTest.class);
 
+    private static final String START_STEP = "start-step";
+    private static final String CHOICE_STEP = "choice-step";
+    private static final String MOCK_STEP = "mock-step";
+
     private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
@@ -81,7 +85,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
-                    .id("flow-step")
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -91,7 +95,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
-                    .id("choice-step")
+                    .id(CHOICE_STEP)
                     .stepKind(StepKind.choice)
                     .putConfiguredProperty("flows", "[" +
                                         "{\"condition\": \"${body} contains 'Hello'\", \"flow\": \"hello-flow\"}," +
@@ -99,7 +103,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     "]")
                     .build(),
                 new Step.Builder()
-                    .id("mock-step")
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -162,10 +166,10 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
             byeResult.assertIsSatisfied();
 
             verify(activityTracker, times(3)).startTracking(any(Exchange.class));
-            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(CHOICE_STEP, 3);
+            verifyActivityStepTracking(MOCK_STEP, 3);
+            verifyNoMatchingConditionTracking(1);
             verify(activityTracker, times(3)).finishTracking(any(Exchange.class));
-            verify(activityTracker).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("message"), endsWith("No matching condition for message"));
-
         } finally {
             context.stop();
         }
@@ -178,7 +182,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
-                            .id("flow-step")
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -188,7 +192,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
-                            .id("choice-step")
+                            .id(CHOICE_STEP)
                             .stepKind(StepKind.choice)
                             .putConfiguredProperty("routingScheme", "mock")
                             .putConfiguredProperty("default", "default-flow")
@@ -198,7 +202,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     "]")
                             .build(),
                     new Step.Builder()
-                            .id("mock-step")
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -241,7 +245,8 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
             byeResult.assertIsSatisfied();
 
             verify(activityTracker, times(3)).startTracking(any(Exchange.class));
-            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(CHOICE_STEP, 3);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker, times(3)).finishTracking(any(Exchange.class));
 
         } finally {
@@ -256,7 +261,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
-                            .id("flow-step")
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -266,7 +271,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
-                            .id("choice-step")
+                            .id(CHOICE_STEP)
                             .stepKind(StepKind.choice)
                             .putConfiguredProperty("routingScheme", "mock")
                             .putConfiguredProperty("flows", "[" +
@@ -275,7 +280,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     "]")
                             .build(),
                     new Step.Builder()
-                            .id("mock-step")
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -320,9 +325,10 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
             byeResult.assertIsSatisfied();
 
             verify(activityTracker, times(3)).startTracking(any(Exchange.class));
-            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(CHOICE_STEP, 3);
+            verifyActivityStepTracking(MOCK_STEP, 3);
+            verifyNoMatchingConditionTracking(1);
             verify(activityTracker, times(3)).finishTracking(any(Exchange.class));
-            verify(activityTracker).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("message"), endsWith("No matching condition for message"));
 
         } finally {
             context.stop();
@@ -336,7 +342,7 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder integrationRoute = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
-                            .id("flow-step")
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -346,11 +352,11 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
-                            .id("choice-step")
+                            .id(CHOICE_STEP)
                             .stepKind(StepKind.choice)
                             .build(),
                     new Step.Builder()
-                            .id("mock-step")
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -385,11 +391,20 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(3)).startTracking(any(Exchange.class));
-            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(CHOICE_STEP, 3);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker, times(3)).finishTracking(any(Exchange.class));
 
         } finally {
             context.stop();
         }
+    }
+
+    private void verifyActivityStepTracking(String stepId, int times) {
+        verify(activityTracker, times(times)).track(eq("exchange"), anyString(), eq("step"), eq(stepId), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+    }
+
+    private void verifyNoMatchingConditionTracking(int times) {
+        verify(activityTracker, times(times)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("message"), endsWith("No matching condition for message"));
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/FilterStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/FilterStepHandlerTest.java
@@ -61,6 +61,10 @@ import static org.mockito.Mockito.verify;
 public class FilterStepHandlerTest extends IntegrationTestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterStepHandlerTest.class);
 
+    private static final String START_STEP = "start-step";
+    private static final String FILTER_STEP = "filter-step";
+    private static final String MOCK_STEP = "mock-step";
+
     private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
@@ -85,6 +89,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -94,10 +99,12 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(FILTER_STEP)
                     .stepKind(StepKind.expressionFilter)
                     .putConfiguredProperty("filter", "${body} contains 'number'")
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -136,7 +143,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -150,6 +158,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -159,10 +168,12 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
+                            .id(FILTER_STEP)
                             .stepKind(StepKind.expressionFilter)
                             .putConfiguredProperty("filter", "${body.name} == 'James'")
                             .build(),
                     new Step.Builder()
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -201,7 +212,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -215,6 +227,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -224,10 +237,12 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
+                            .id(FILTER_STEP)
                             .stepKind(StepKind.expressionFilter)
                             .putConfiguredProperty("filter", "${body.size()} > 0 && ${body[0].name} == 'James'")
                             .build(),
                     new Step.Builder()
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -267,7 +282,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(4)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -296,6 +312,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -305,12 +322,14 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(FILTER_STEP)
                     .stepKind(StepKind.ruleFilter)
                     .putConfiguredProperty("type", "rule")
                     .putConfiguredProperty("predicate", "OR")
                     .putConfiguredProperty("rules", "[{\"path\":\"name\",\"op\":\"==\",\"value\":\"James\"}, {\"path\":\"name\",\"op\":\"==\",\"value\":\"Roland\"}]")
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -349,7 +368,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(5)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -363,6 +383,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -372,12 +393,14 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(FILTER_STEP)
                     .stepKind(StepKind.ruleFilter)
                     .putConfiguredProperty("type", "rule")
                     .putConfiguredProperty("predicate", "OR")
                     .putConfiguredProperty("rules", "[{\"path\":\"user.name\",\"op\":\"==\",\"value\":\"James\"}, {\"path\":\"user.name\",\"op\":\"==\",\"value\":\"Roland\"}]")
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -416,7 +439,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(5)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -430,6 +454,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -439,12 +464,14 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
+                            .id(FILTER_STEP)
                             .stepKind(StepKind.ruleFilter)
                             .putConfiguredProperty("type", "rule")
                             .putConfiguredProperty("predicate", "AND")
                             .putConfiguredProperty("rules", "[{\"path\":\"size()\",\"op\":\"==\",\"value\":\"2\"}, {\"path\":\"[0].user.name\",\"op\":\"==\",\"value\":\"James\"}, {\"path\":\"[1].user.name\",\"op\":\"==\",\"value\":\"Roland\"}]")
                             .build(),
                     new Step.Builder()
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -486,7 +513,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(6)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -500,6 +528,7 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -509,12 +538,14 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(FILTER_STEP)
                     .stepKind(StepKind.ruleFilter)
                     .putConfiguredProperty("type", "rule")
                     .putConfiguredProperty("predicate", "OR")
                     .putConfiguredProperty("rules", "[{\"path\":\"name\",\"op\":\"==\",\"value\":\"James\"}, {\"path\":\"name\",\"op\":\"==\",\"value\":\"Roland\"}]")
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -553,7 +584,8 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker, times(allMessages.size())).startTracking(any(Exchange.class));
-            verify(activityTracker, times(5)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(MOCK_STEP, matchingMessages.size());
+            verifyActivityStepTracking(FILTER_STEP, allMessages.size());
             verify(activityTracker, times(allMessages.size())).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -578,6 +610,10 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
 
     private String buildUserJsonArray(String ... names) {
         return "[" + buildUserJson(names) + "]";
+    }
+
+    private void verifyActivityStepTracking(String stepId, int times) {
+        verify(activityTracker, times(times)).track(eq("exchange"), anyString(), eq("step"), eq(stepId), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
     }
 
     // ***************************

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerTest.java
@@ -61,6 +61,10 @@ import static org.mockito.Mockito.verify;
 public class SplitStepHandlerTest extends IntegrationTestSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(SplitStepHandlerTest.class);
 
+    private static final String START_STEP = "start-step";
+    private static final String SPLIT_STEP = "split-step";
+    private static final String MOCK_STEP = "mock-step";
+
     private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
@@ -85,6 +89,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -94,9 +99,11 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(SPLIT_STEP)
                     .stepKind(StepKind.split)
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -129,7 +136,8 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -143,6 +151,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                 new Step.Builder()
+                    .id(START_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -152,11 +161,13 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                         .build())
                     .build(),
                 new Step.Builder()
+                    .id(SPLIT_STEP)
                     .stepKind(StepKind.split)
                     .putConfiguredProperty("language", "tokenize")
                     .putConfiguredProperty("expression", "|")
                     .build(),
                 new Step.Builder()
+                    .id(MOCK_STEP)
                     .stepKind(StepKind.endpoint)
                     .action(new ConnectorAction.Builder()
                         .descriptor(new ConnectorDescriptor.Builder()
@@ -189,7 +200,8 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker).startTracking(any(Exchange.class));
-            verify(activityTracker, times(5)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 5);
             verify(activityTracker).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -203,6 +215,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                        .id(START_STEP)
                         .stepKind(StepKind.endpoint)
                         .action(new ConnectorAction.Builder()
                             .descriptor(new ConnectorDescriptor.Builder()
@@ -212,9 +225,11 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                             .build())
                         .build(),
                     new Step.Builder()
+                        .id(SPLIT_STEP)
                         .stepKind(StepKind.split)
                         .build(),
                     new Step.Builder()
+                        .id(MOCK_STEP)
                         .stepKind(StepKind.endpoint)
                         .action(new ConnectorAction.Builder()
                             .descriptor(new ConnectorDescriptor.Builder()
@@ -248,7 +263,8 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -262,6 +278,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                        .id(START_STEP)
                         .stepKind(StepKind.endpoint)
                         .action(new ConnectorAction.Builder()
                             .descriptor(new ConnectorDescriptor.Builder()
@@ -271,9 +288,11 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                             .build())
                         .build(),
                     new Step.Builder()
+                        .id(SPLIT_STEP)
                         .stepKind(StepKind.split)
                         .build(),
                     new Step.Builder()
+                        .id(MOCK_STEP)
                         .stepKind(StepKind.endpoint)
                         .action(new ConnectorAction.Builder()
                             .descriptor(new ConnectorDescriptor.Builder()
@@ -307,7 +326,8 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
@@ -321,6 +341,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         try {
             final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
                     new Step.Builder()
+                            .id(START_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -330,6 +351,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
+                            .id(SPLIT_STEP)
                             .stepKind(StepKind.split)
                             .action(new StepAction.Builder()
                                     .descriptor(new StepDescriptor.Builder()
@@ -362,6 +384,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
                                     .build())
                             .build(),
                     new Step.Builder()
+                            .id(MOCK_STEP)
                             .stepKind(StepKind.endpoint)
                             .action(new ConnectorAction.Builder()
                                     .descriptor(new ConnectorDescriptor.Builder()
@@ -405,10 +428,15 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
             result.assertIsSatisfied();
 
             verify(activityTracker).startTracking(any(Exchange.class));
-            verify(activityTracker, times(3)).track(eq("exchange"), anyString(), eq("step"), anyString(), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 3);
             verify(activityTracker).finishTracking(any(Exchange.class));
         } finally {
             context.stop();
         }
+    }
+
+    private void verifyActivityStepTracking(String stepId, int times) {
+        verify(activityTracker, times(times)).track(eq("exchange"), anyString(), eq("step"), eq(stepId), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingTest.java
@@ -83,7 +83,8 @@ public class ActivityLoggingTest extends AbstractActivityLoggingTest {
         assertEquals("false", findActivityEvent(x -> "done".equals(x.status)).failed);
 
         // There should be 1 log activity
-        assertEquals(1, findActivityEvents(x -> "log".equals(x.step)).size());
+        assertEquals(1, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isEmpty(x.duration)).size());
+        assertEquals(1, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isNotEmpty(x.duration)).size());
         assertEquals("hi", findActivityEvent(x -> "log".equals(x.step)).message);
 
         // There should be step activity tracking events
@@ -109,7 +110,8 @@ public class ActivityLoggingTest extends AbstractActivityLoggingTest {
         assertEquals("true", findActivityEvent(x -> "done".equals(x.status)).failed);
 
         // There should be 1 log activity
-        assertEquals(1, findActivityEvents(x -> "log".equals(x.step)).size());
+        assertEquals(1, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isEmpty(x.duration)).size());
+        assertEquals(1, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isNotEmpty(x.duration)).size());
         assertEquals("hi", findActivityEvent(x -> "log".equals(x.step)).message);
 
         // There should be step activity tracking events

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingWithSplitTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingWithSplitTest.java
@@ -87,7 +87,8 @@ public class ActivityLoggingWithSplitTest extends AbstractActivityLoggingTest {
         assertEquals("false", findActivityEvent(x -> "done".equals(x.status)).failed);
 
         // There should be log activities
-        assertEquals(2, findActivityEvents(x -> "log".equals(x.step)).size());
+        assertEquals(2, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isEmpty(x.duration)).size());
+        assertEquals(2, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isNotEmpty(x.duration)).size());
         assertEquals("hi", findActivityEvent(x -> "log".equals(x.step)).message);
 
         // There should be step activity tracking events
@@ -113,7 +114,8 @@ public class ActivityLoggingWithSplitTest extends AbstractActivityLoggingTest {
         assertEquals("true", findActivityEvent(x -> "done".equals(x.status)).failed);
 
         // There should be log activities
-        assertEquals(2, findActivityEvents(x -> "log".equals(x.step)).size());
+        assertEquals(2, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isEmpty(x.duration)).size());
+        assertEquals(2, findActivityEvents(x -> "log".equals(x.step) && ObjectHelper.isNotEmpty(x.duration)).size());
         assertEquals("hi", findActivityEvent(x -> "log".equals(x.step)).message);
 
         // There should be step activity tracking events


### PR DESCRIPTION
Ref #5213 
Fixes #4181 

As soon as the integration route uses blocks like `filter`, `choice` the activity logging is not working as expected. We see duplicate step activity entries and inconsistent activities as reported in #4181 

This PR fixes that activity logging by not reading the step id from exchange header anymore ([ActivityTrackingInterceptStrategy](https://github.com/syndesisio/syndesis/blob/13a5c8e8afe7de7042952707cd21d6293321cc21/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java)). The stepId header is overwritten by nested steps that live inside blocks like filter and choice and this is why the logs get inconsistent. 

Instead use the static step id that the surrounding pipeline was created with. This ensures that the async callback (executed when the pipeline is done) always uses the proper step id when doing the activity logging.