### PR TITLE
fix(5330): Moves the todo app to addons directory

### DIFF
--- a/install/addons/syndesis-db-dashboard.yml
+++ b/install/addons/syndesis-db-dashboard.yml
@@ -6,6 +6,7 @@ metadata:
     app: syndesis
     syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
+    syndesis.io/addon: db-dashboard
 spec:
   name: syndesis-db.json
   json: |

--- a/install/addons/syndesis-db-prometheus-rule.yml
+++ b/install/addons/syndesis-db-prometheus-rule.yml
@@ -5,6 +5,7 @@ metadata:
     app: syndesis
     syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
+    syndesis.io/addon: db-prometheus-rule
     prometheus: application-monitoring
     role: alert-rules
     monitoring-key: middleware

--- a/install/addons/syndesis-db-servicemonitor.yml
+++ b/install/addons/syndesis-db-servicemonitor.yml
@@ -6,6 +6,7 @@ metadata:
     syndesis.io/app: syndesis
     syndesis.io/component: syndesis-db-metrics
     syndesis.io/type: infrastructure
+    syndesis.io/addon: db-service-monitor
     monitoring-key: middleware
     application-monitoring: "true"
   name: syndesis-db-metrics

--- a/install/addons/syndesis-jvm-dashboard.yml
+++ b/install/addons/syndesis-jvm-dashboard.yml
@@ -6,6 +6,7 @@ metadata:
     app: syndesis
     syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
+    syndesis.io/addon: jvm-dashboard
 spec:
   name: syndesis-jvm.json
   json: |

--- a/install/addons/syndesis-meta-servicemonitor.yml
+++ b/install/addons/syndesis-meta-servicemonitor.yml
@@ -6,6 +6,7 @@ metadata:
     syndesis.io/app: syndesis
     syndesis.io/component: syndesis-meta
     syndesis.io/type: infrastructure
+    syndesis.io/addon: meta-service-monitor
     monitoring-key: middleware
     application-monitoring: "true"
   name: syndesis-meta

--- a/install/addons/syndesis-rest-api-dashboard.yml
+++ b/install/addons/syndesis-rest-api-dashboard.yml
@@ -6,6 +6,7 @@ metadata:
     app: syndesis
     syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
+    syndesis.io/addon: rest-api-dashboard
 spec:
   name: syndesis-rest-api.json
   json: |

--- a/install/addons/syndesis-rest-api-prometheus-rule.yml
+++ b/install/addons/syndesis-rest-api-prometheus-rule.yml
@@ -5,6 +5,7 @@ metadata:
     app: syndesis
     syndesis.io/app: syndesis
     syndesis.io/type: infrastructure
+    syndesis.io/addon: rest-api-prometheus-rule
     prometheus: application-monitoring
     role: alert-rules
     monitoring-key: middleware

--- a/install/addons/syndesis-sampledb-1-config.yml
+++ b/install/addons/syndesis-sampledb-1-config.yml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: syndesis
+    syndesis.io/type: infrastructure
+    syndesis.io/component: syndesis-db
+    syndesis.io/addon: db-sampledb
+  name: syndesis-sampledb-config
+data:
+  add-sample-db.sh: |
+    #!/bin/bash
+    until bash -c "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"; do
+      echo "Waiting for Postgres server..."
+      sleep 1
+    done
+    echo "***** creating sampledb"
+    psql <<EOF
+      CREATE DATABASE sampledb;
+      CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
+      GRANT ALL PRIVILEGES ON DATABASE sampledb to sampledb;
+    EOF
+    psql -d sampledb -U sampledb <<'EOF'
+      CREATE TABLE IF NOT EXISTS contact (first_name VARCHAR, last_name VARCHAR, company VARCHAR, lead_source VARCHAR, create_date DATE);
+      INSERT INTO contact VALUES ('Joe','Jackson','Red Hat','db',current_timestamp);
+      CREATE TABLE IF NOT EXISTS todo (id SERIAL PRIMARY KEY, task VARCHAR, completed INTEGER);
+      CREATE OR REPLACE FUNCTION add_lead(
+        first_and_last_name varchar,
+        company varchar,
+        phone varchar,
+        email varchar,
+        lead_source varchar,
+        lead_status varchar,
+        rating varchar)
+
+        RETURNS void
+        LANGUAGE 'plpgsql'
+
+      AS $BODY$
+      DECLARE
+        task varchar;
+      BEGIN
+        task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from ' || lead_source, '. Rating: ' || rating, '.');
+        insert into todo(task,completed) VALUES (task,0);
+      END;
+      $BODY$;
+
+      CREATE OR REPLACE FUNCTION create_lead(
+        OUT first_name text,
+        OUT last_name text,
+        OUT company text,
+        OUT lead_source text)
+        RETURNS SETOF record
+        AS
+        $$
+          SELECT first_name, last_name, company, lead_source
+          FROM contact;
+        $$
+         LANGUAGE 'sql' VOLATILE;
+    EOF
+
+    echo "***** sampledb created"
+  postStart.sh: |
+    #!/bin/bash
+    /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1

--- a/install/addons/syndesis-sampledb-2-deploy.yml
+++ b/install/addons/syndesis-sampledb-2-deploy.yml
@@ -1,0 +1,146 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: syndesis-db
+  labels:
+    app: syndesis
+    syndesis.io/app: syndesis
+    syndesis.io/type: infrastructure
+    syndesis.io/component: syndesis-db
+    syndesis.io/addon: db-sampledb
+spec:
+  replicas: 1
+  selector:
+    app: syndesis
+    syndesis.io/app: syndesis
+    syndesis.io/component: syndesis-db
+  strategy:
+    type: Recreate
+    resources:
+      limits:
+        memory: "256Mi"
+      requests:
+        memory: "20Mi"
+  template:
+    metadata:
+      labels:
+        app: syndesis
+        syndesis.io/app: syndesis
+        syndesis.io/component: syndesis-db
+    spec:
+      serviceAccountName: syndesis-default
+      containers:
+      - capabilities: {}
+        env:
+        - name: POSTGRESQL_USER
+          value: ${POSTGRESQL_USER}
+        - name: POSTGRESQL_PASSWORD
+          value: ${POSTGRESQL_PASSWORD}
+        - name: POSTGRESQL_DATABASE
+          value: ${POSTGRESQL_DATABASE}
+        - name: POSTGRESQL_SAMPLEDB_PASSWORD
+          value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+        image: ' '
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - /var/lib/pgsql/sampledb/postStart.sh
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 5432
+        name: postgresql
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
+          initialDelaySeconds: 5
+        # DB QoS class is "Guaranteed" (requests == limits)
+        # Note: On OSO there is no Guaranteed class, its always burstable
+        resources:
+          limits:
+            memory: ${POSTGRESQL_MEMORY_LIMIT}
+          requests:
+            memory: ${POSTGRESQL_MEMORY_LIMIT}
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: syndesis-db-data
+        - mountPath: /var/lib/pgsql/sampledb
+          name: syndesis-sampledb-config
+        - mountPath: /opt/app-root/src/postgresql-cfg/
+          name: syndesis-db-conf
+      - capabilities: {}
+        env:
+        - name: DATA_SOURCE_NAME
+          value: postgresql://${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@localhost:5432/syndesis?sslmode=disable
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /etc/postgres/exporter/queries.yaml
+        image: ' '
+
+        imagePullPolicy: IfNotPresent
+        name: syndesis-db-metrics
+        livenessProbe:
+          failureThreshold: 5
+          tcpSocket:
+            port: 9187
+          initialDelaySeconds: 60
+        readinessProbe:
+          failureThreshold: 5
+          tcpSocket:
+            port: 9187
+          initialDelaySeconds: 30
+        ports:
+        - containerPort: 9187
+          name: metrics
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/postgres/exporter
+          name: syndesis-db-metrics-config
+      volumes:
+      - name: syndesis-db-metrics-config
+        configMap:
+          name: syndesis-db-metrics-config
+      - name: syndesis-db-data
+        persistentVolumeClaim:
+          claimName: syndesis-db
+      - configMap:
+          defaultMode: 511
+          name: syndesis-sampledb-config
+        name: syndesis-sampledb-config
+      - configMap:
+          name: syndesis-db-conf
+        name: syndesis-db-conf
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - postgresql
+      from:
+        kind: ImageStreamTag
+        name: postgresql:9.5
+        namespace: ${POSTGRESQL_IMAGE_STREAM_NAMESPACE}
+    type: ImageChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - syndesis-db-metrics
+      from:
+        kind: ImageStreamTag
+        name: postgres_exporter:v0.4.7
+        namespace: ${IMAGE_STREAM_NAMESPACE}
+    type: ImageChange

--- a/install/addons/syndesis-server-servicemonitor.yml
+++ b/install/addons/syndesis-server-servicemonitor.yml
@@ -6,6 +6,7 @@ metadata:
     syndesis.io/app: syndesis
     syndesis.io/component: syndesis-server
     syndesis.io/type: infrastructure
+    syndesis.io/addon: server-service-monitor
     monitoring-key: middleware
     application-monitoring: "true"
   name: syndesis-server

--- a/install/addons/syndesis-todo-1-service.yml
+++ b/install/addons/syndesis-todo-1-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/component: todo
+    syndesis.io/addon: todo
+  name: todo
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/component: todo

--- a/install/addons/syndesis-todo-2-route.yml
+++ b/install/addons/syndesis-todo-2-route.yml
@@ -1,0 +1,21 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/component: todo
+    syndesis.io/addon: todo
+  name: todo
+spec:
+  host: todo-${ROUTE_HOSTNAME}
+  path: /
+  port:
+    targetPort: 8080
+  tls:
+    insecureEdgeTerminationPolicy: Allow
+    termination: edge
+  to:
+    kind: Service
+    name: todo
+    weight: 100

--- a/install/addons/syndesis-todo-3-imagestream.yml
+++ b/install/addons/syndesis-todo-3-imagestream.yml
@@ -1,0 +1,15 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/addon: todo
+  name: todo
+spec:
+  lookupPolicy:
+    local: false
+status:
+  tags:
+    - items:
+      tag: latest

--- a/install/addons/syndesis-todo-4-build.yml
+++ b/install/addons/syndesis-todo-4-build.yml
@@ -1,0 +1,31 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/addon: todo
+  name: todo
+spec:
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    git:
+      uri: 'https://github.com/syndesisio/todo-example.git'
+    type: Git
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'todo:latest'
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: 'php:7.0'
+        namespace: openshift
+    type: Source
+  triggers:
+    - type: ConfigChange
+    - imageChange:
+      type: ImageChange

--- a/install/addons/syndesis-todo-5-deploy.yml
+++ b/install/addons/syndesis-todo-5-deploy.yml
@@ -1,0 +1,70 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/addon: todo
+  name: todo
+spec:
+  replicas: 1
+  selector:
+    app: syndesis
+    syndesis.io/app: todo
+    syndesis.io/component: todo
+  strategy:
+    resources:
+      limits:
+        memory: "256Mi"
+      requests:
+        memory: "20Mi"
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
+      creationTimestamp: null
+      labels:
+        app: syndesis
+        syndesis.io/app: todo
+        syndesis.io/component: todo
+    spec:
+      containers:
+        - env:
+            - name: TODO_DB_SERVER
+              value: syndesis-db
+            - name: TODO_DB_NAME
+              value: sampledb
+            - name: TODO_DB_USER
+              value: sampledb
+            - name: TODO_DB_PASS
+              value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
+          imagePullPolicy: Always
+          name: todo
+          image: ' '
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 256Mi
+          ports:
+            - containerPort: 8080
+              name: http
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - todo
+        from:
+          kind: ImageStreamTag
+          name: todo:latest
+      type: ImageChange

--- a/install/operator/cmd/syndesis-operator/main.go
+++ b/install/operator/cmd/syndesis-operator/main.go
@@ -41,7 +41,7 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 
 	configuration.TemplateLocation = flag.String("template", "/conf/syndesis-template.yml", "Path to template used for installation")
-	configuration.AddonsDirLocation = flag.String("addons", "", "Path to the addons directory used for installation")
+	configuration.AddonsDirLocation = flag.String("addons", "/conf/addons", "Path to the addons directory used for installation")
 	configuration.Registry = flag.String("registry", "docker.io", "Registry to use for loading images like the upgrade pod")
 
 	flag.Parse()

--- a/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
+++ b/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
@@ -20,6 +20,7 @@ type SyndesisSpec struct {
 	Components           ComponentsSpec  `json:"components,omitempty"`
 	OpenShiftConsoleUrl  string          `json:"openShiftConsoleUrl,omitempty"`
 	SarNamespace         string          `json:"sarNamespace,omitempty"`
+	Addons               string          `json:"addons,omitempty"`
 }
 
 // SyndesisStatus defines the observed state of Syndesis
@@ -37,61 +38,63 @@ type SyndesisStatus struct {
 // =============================================================================
 
 type IntegrationSpec struct {
-        Limit              *int `json:"limit,omitempty"`
-        StateCheckInterval *int `json:"stateCheckInterval,omitempty"`
+	Limit              *int `json:"limit,omitempty"`
+	StateCheckInterval *int `json:"stateCheckInterval,omitempty"`
 }
 
 type ComponentsSpec struct {
-        Db         DbConfiguration         `json:"db,omitempty"`
-        Prometheus PrometheusConfiguration `json:"prometheus,omitempty"`
-        Grafana    GrafanaConfiguration    `json:"grafana,omitempty"`
-        Server     ServerConfiguration     `json:"server,omitempty"`
-        Meta       MetaConfiguration       `json:"meta,omitempty"`
-        Upgrade    UpgradeConfiguration    `json:"upgrade,omitempty"`
+	Db         DbConfiguration         `json:"db,omitempty"`
+	Prometheus PrometheusConfiguration `json:"prometheus,omitempty"`
+	Grafana    GrafanaConfiguration    `json:"grafana,omitempty"`
+	Server     ServerConfiguration     `json:"server,omitempty"`
+	Meta       MetaConfiguration       `json:"meta,omitempty"`
+	Upgrade    UpgradeConfiguration    `json:"upgrade,omitempty"`
 }
 
 type DbConfiguration struct {
-        Resources            ResourcesWithVolume `json:"resources,omitempty"`
-        User                 string              `json:"user,omitempty"`
-        Database             string              `json:"database,omitempty"`
-        ImageStreamNamespace string              `json:"imageStreamNamespace,omitempty"`
+	Resources            ResourcesWithVolume `json:"resources,omitempty"`
+	User                 string              `json:"user,omitempty"`
+	Password             string              `json:"password,omitempty"`
+	Database             string              `json:"database,omitempty"`
+	ImageStreamNamespace string              `json:"imageStreamNamespace,omitempty"`
+	SampleDbPassword     string              `json:"SampleDbPassword,omitempty"`
 }
 type PrometheusConfiguration struct {
-        Resources ResourcesWithVolume `json:"resources,omitempty"`
+	Resources ResourcesWithVolume `json:"resources,omitempty"`
 }
 
 type GrafanaConfiguration struct {
-        Resources Resources `json:"resources,omitempty"`
+	Resources Resources `json:"resources,omitempty"`
 }
 
 type ServerConfiguration struct {
-        Resources Resources      `json:"resources,omitempty"`
-        Features  ServerFeatures `json:"features,omitempty"`
+	Resources Resources      `json:"resources,omitempty"`
+	Features  ServerFeatures `json:"features,omitempty"`
 }
 
 type MetaConfiguration struct {
-        Resources ResourcesWithVolume `json:"resources,omitempty"`
+	Resources ResourcesWithVolume `json:"resources,omitempty"`
 }
 
 type UpgradeConfiguration struct {
-        Resources VolumeOnlyResources `json:"resources,omitempty"`
+	Resources VolumeOnlyResources `json:"resources,omitempty"`
 }
 
 type Resources struct {
-        v1.ResourceRequirements `json:",inline,omitempty"`
+	v1.ResourceRequirements `json:",inline,omitempty"`
 }
 
 type ResourcesWithVolume struct {
-        v1.ResourceRequirements `json:",inline,omitempty"`
-        VolumeCapacity          string `json:"volumeCapacity,omitempty"`
+	v1.ResourceRequirements `json:",inline,omitempty"`
+	VolumeCapacity          string `json:"volumeCapacity,omitempty"`
 }
 
 type VolumeOnlyResources struct {
-        VolumeCapacity string `json:"volumeCapacity,omitempty"`
+	VolumeCapacity string `json:"volumeCapacity,omitempty"`
 }
 
 type ServerFeatures struct {
-        ExposeVia3Scale bool `json:"exposeVia3Scale,omitempty"`
+	ExposeVia3Scale bool `json:"exposeVia3Scale,omitempty"`
 }
 
 // =============================================================================
@@ -99,30 +102,29 @@ type ServerFeatures struct {
 type SyndesisPhase string
 
 const (
-        SyndesisPhaseMissing               SyndesisPhase = ""
-        SyndesisPhaseInstalling            SyndesisPhase = "Installing"
-        SyndesisPhaseUpgradingLegacy       SyndesisPhase = "UpgradingLegacy"
-        SyndesisPhaseStarting              SyndesisPhase = "Starting"
-        SyndesisPhaseStartupFailed         SyndesisPhase = "StartupFailed"
-        SyndesisPhaseInstalled             SyndesisPhase = "Installed"
-        SyndesisPhaseNotInstalled          SyndesisPhase = "NotInstalled"
-        SyndesisPhaseUpgrading             SyndesisPhase = "Upgrading"
-        SyndesisPhaseUpgradeFailureBackoff SyndesisPhase = "UpgradeFailureBackoff"
-        SyndesisPhaseUpgradeFailed         SyndesisPhase = "UpgradeFailed"
+	SyndesisPhaseMissing               SyndesisPhase = ""
+	SyndesisPhaseInstalling            SyndesisPhase = "Installing"
+	SyndesisPhaseUpgradingLegacy       SyndesisPhase = "UpgradingLegacy"
+	SyndesisPhaseStarting              SyndesisPhase = "Starting"
+	SyndesisPhaseStartupFailed         SyndesisPhase = "StartupFailed"
+	SyndesisPhaseInstalled             SyndesisPhase = "Installed"
+	SyndesisPhaseNotInstalled          SyndesisPhase = "NotInstalled"
+	SyndesisPhaseUpgrading             SyndesisPhase = "Upgrading"
+	SyndesisPhaseUpgradeFailureBackoff SyndesisPhase = "UpgradeFailureBackoff"
+	SyndesisPhaseUpgradeFailed         SyndesisPhase = "UpgradeFailed"
 )
 
 type SyndesisStatusReason string
 
 const (
-        SyndesisStatusReasonMissing                SyndesisStatusReason = ""
-        SyndesisStatusReasonDuplicate              SyndesisStatusReason = "Duplicate"
-        SyndesisStatusReasonDeploymentNotReady     SyndesisStatusReason = "DeploymentNotReady"
-        SyndesisStatusReasonUpgradePodFailed       SyndesisStatusReason = "UpgradePodFailed"
-        SyndesisStatusReasonTooManyUpgradeAttempts SyndesisStatusReason = "TooManyUpgradeAttempts"
+	SyndesisStatusReasonMissing                SyndesisStatusReason = ""
+	SyndesisStatusReasonDuplicate              SyndesisStatusReason = "Duplicate"
+	SyndesisStatusReasonDeploymentNotReady     SyndesisStatusReason = "DeploymentNotReady"
+	SyndesisStatusReasonUpgradePodFailed       SyndesisStatusReason = "UpgradePodFailed"
+	SyndesisStatusReasonTooManyUpgradeAttempts SyndesisStatusReason = "TooManyUpgradeAttempts"
 )
 
 // =============================================================================
-
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/install/operator/pkg/syndesis/addons/install.go
+++ b/install/operator/pkg/syndesis/addons/install.go
@@ -3,14 +3,55 @@ package addons
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1alpha1"
 	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
 	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 )
 
-func GetAddonsResources(addonsDir string) ([]*unstructured.Unstructured, error) {
+func loadAndProcessFile(path string, syndesis *v1alpha1.Syndesis) (*unstructured.Unstructured, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	//
+	// Loop through the available EnvVars & if there are values the substitute them in the content
+	// Effectively plugs the EnvVars into the addons before being returned as Unstructured objects
+	//
+	content := string(data)
+	config := configuration.GetEnvVars(syndesis)
+	for k, v := range config {
+		content = strings.Replace(content, strings.Join([]string{"${", k, "}"}, ""), v, -1)
+	}
+
+	data = []byte(content)
+	data, err = util.JsonIfYaml(data, path)
+	if err != nil {
+		return nil, err
+	}
+
+	uo, err := util.LoadUnstructuredObject(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return uo, nil
+}
+
+func GetAddonID(addon *unstructured.Unstructured) string {
+	labels := addon.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	return labels["syndesis.io/addon"]
+}
+
+func GetAddonsResources(addonsDir string, syndesis *v1alpha1.Syndesis) ([]*unstructured.Unstructured, error) {
 	files, err := ioutil.ReadDir(addonsDir)
 	if err != nil {
 		return nil, err
@@ -23,7 +64,7 @@ func GetAddonsResources(addonsDir string) ([]*unstructured.Unstructured, error) 
 			continue
 		}
 
-		addon, err := util.LoadUnstructuredObjectFromFile(filepath.Join(*configuration.AddonsDirLocation, f.Name()))
+		addon, err := loadAndProcessFile(filepath.Join(addonsDir, f.Name()), syndesis)
 		if err != nil {
 			return nil, err
 		}

--- a/install/operator/pkg/syndesis/addons/install_test.go
+++ b/install/operator/pkg/syndesis/addons/install_test.go
@@ -1,0 +1,44 @@
+package addons
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetAddonResources(t *testing.T) {
+	syndesis := v1alpha1.Syndesis{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.SyndesisSpec{
+			ImageStreamNamespace: "is",
+			RouteHostName:        "myhost",
+			Components: v1alpha1.ComponentsSpec{
+				Db: v1alpha1.DbConfiguration{
+					ImageStreamNamespace: "dbis",
+					Database:             "db",
+					User:                 "user",
+					SampleDbPassword:     "password",
+				},
+			},
+		},
+	}
+
+	addons, err := GetAddonsResources("../../../../addons", &syndesis)
+	assert.NoError(t, err)
+
+	foundHost := false
+	for _, addon := range addons {
+		host, f, _ := unstructured.NestedString(addon.UnstructuredContent(), "spec", "host")
+		if f {
+			foundHost = true
+			assert.Equal(t, "todo-myhost", host)
+		}
+	}
+
+	assert.True(t, foundHost)
+}

--- a/install/operator/pkg/syndesis/configuration/configuration_test.go
+++ b/install/operator/pkg/syndesis/configuration/configuration_test.go
@@ -17,10 +17,17 @@ func TestStandardConfig(t *testing.T) {
 	}
 
 	config := GetEnvVars(&syndesis)
-	assert.Len(t, config, 3)
+	assert.Len(t, config, 5)
 	assert.Contains(t, config, string(EnvOpenshiftProject))
 	assert.Contains(t, config, string(EnvSarNamespace))
 	assert.Contains(t, config, string(EnvExposeVia3Scale))
+
+	assert.Contains(t, config, string(EnvImageStreamNamespace))
+	assert.Equal(t, "", config[string(EnvImageStreamNamespace)])
+
+	// Should contain default value of sampledb password
+	assert.Contains(t, config, string(EnvPostgresqlSampleDbPassword))
+	assert.Equal(t, DEFAULT_POSTGRESQL_SAMPLEDB_PASSWORD, config[string(EnvPostgresqlSampleDbPassword)])
 }
 
 func TestSpecificConfig(t *testing.T) {
@@ -28,6 +35,7 @@ func TestSpecificConfig(t *testing.T) {
 	deploy := false
 	limit := 2
 	stateCheckInterval := 120
+	addons := "db-sampledb,todo"
 	syndesis := v1alpha1.Syndesis{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "ns",
@@ -42,11 +50,13 @@ func TestSpecificConfig(t *testing.T) {
 			RouteHostName:      "myhost",
 			Registry:           "registry",
 			DeployIntegrations: &deploy,
+			Addons:             addons,
 			Components: v1alpha1.ComponentsSpec{
 				Db: v1alpha1.DbConfiguration{
 					ImageStreamNamespace: "dbis",
 					Database:             "db",
 					User:                 "user",
+					SampleDbPassword:     "password",
 					Resources: v1alpha1.ResourcesWithVolume{
 						ResourceRequirements: v12.ResourceRequirements{
 							Limits: v12.ResourceList{
@@ -107,6 +117,7 @@ func TestSpecificConfig(t *testing.T) {
 	assert.Equal(t, "user", config[string(EnvPostgresqlUser)])
 	assert.Equal(t, "1Gi", config[string(EnvPostgresqlMemoryLimit)])
 	assert.Equal(t, "2Gi", config[string(EnvPostgresqlVolumeCapacity)])
+	assert.Equal(t, "password", config[string(EnvPostgresqlSampleDbPassword)])
 
 	assert.Equal(t, "3Gi", config[string(EnvServerMemoryLimit)])
 	assert.Equal(t, "false", config[string(EnvExposeVia3Scale)])
@@ -116,4 +127,6 @@ func TestSpecificConfig(t *testing.T) {
 
 	assert.Equal(t, "6Gi", config[string(EnvPrometheusMemoryLimit)])
 	assert.Equal(t, "7Gi", config[string(EnvPrometheusVolumeCapacity)])
+
+	assert.Equal(t, addons, config[string(EnvAddons)])
 }

--- a/install/operator/pkg/syndesis/template/install.go
+++ b/install/operator/pkg/syndesis/template/install.go
@@ -47,5 +47,5 @@ func GetInstallResources(scheme *runtime.Scheme, syndesis *v1alpha1.Syndesis, pa
 	config := configuration.GetEnvVars(syndesis)
 	config[string(configuration.EnvOpenshiftOauthClientSecret)] = params.OAuthClientSecret
 
-	return processor.Process(templ, config)
+	return processor.Process(templ, config, syndesis)
 }

--- a/install/operator/pkg/syndesis/template/upgrade.go
+++ b/install/operator/pkg/syndesis/template/upgrade.go
@@ -38,7 +38,7 @@ func GetUpgradeResources(scheme *runtime.Scheme, syndesis *v1alpha1.Syndesis, pa
 	paramMap[string(configuration.EnvOpenshiftOauthClientSecret)] = params.OAuthClientSecret
 	paramMap[string(configuration.EnvUpgradeRegistry)] = *params.UpgradeRegistry
 
-	return processor.Process(upgrateTempl, paramMap)
+	return processor.Process(upgrateTempl, paramMap, syndesis)
 }
 
 func findUpgradeTemplate(scheme *runtime.Scheme, list []runtime.RawExtension) (*templatev1.Template, error) {

--- a/install/operator/pkg/util/resources.go
+++ b/install/operator/pkg/util/resources.go
@@ -15,12 +15,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-
 var log = logf.Log.WithName("resources")
 
 func NewObjectKey(name string, namespace string) client.ObjectKey {
 	return client.ObjectKey{
-		Name: name,
+		Name:      name,
 		Namespace: namespace,
 	}
 }
@@ -31,7 +30,7 @@ func LoadResourceFromFile(scheme *runtime.Scheme, path string) (runtime.Object, 
 		return nil, err
 	}
 
-	data, err = jsonIfYaml(data, path)
+	data, err = JsonIfYaml(data, path)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +54,7 @@ func LoadRawResourceFromYaml(data string) (runtime.Object, error) {
 	}, nil
 }
 
-
-func LoadResourceFromYaml(scheme *runtime.Scheme,  source []byte) (runtime.Object, error) {
+func LoadResourceFromYaml(scheme *runtime.Scheme, source []byte) (runtime.Object, error) {
 	jsonSource, err := yaml.ToJSON(source)
 	if err != nil {
 		return nil, err
@@ -70,7 +68,7 @@ func LoadResourceFromYaml(scheme *runtime.Scheme,  source []byte) (runtime.Objec
 }
 
 // RuntimeObjectFromUnstructured converts an unstructured to a runtime object
-func RuntimeObjectFromUnstructured(scheme *runtime.Scheme,u *unstructured.Unstructured) (runtime.Object, error) {
+func RuntimeObjectFromUnstructured(scheme *runtime.Scheme, u *unstructured.Unstructured) (runtime.Object, error) {
 	gvk := u.GroupVersionKind()
 	codecs := serializer.NewCodecFactory(scheme)
 	decoder := codecs.UniversalDecoder(gvk.GroupVersion())
@@ -86,25 +84,6 @@ func RuntimeObjectFromUnstructured(scheme *runtime.Scheme,u *unstructured.Unstru
 	return ro, nil
 }
 
-func LoadUnstructuredObjectFromFile(path string) (*unstructured.Unstructured, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err = jsonIfYaml(data, path)
-	if err != nil {
-		return nil, err
-	}
-
-	uo, err := LoadUnstructuredObject(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return uo, nil
-}
-
 func LoadUnstructuredObject(data []byte) (*unstructured.Unstructured, error) {
 	var uo unstructured.Unstructured
 	if err := json.Unmarshal(data, &uo.Object); err != nil {
@@ -113,7 +92,7 @@ func LoadUnstructuredObject(data []byte) (*unstructured.Unstructured, error) {
 	return &uo, nil
 }
 
-func jsonIfYaml(source []byte, filename string) ([]byte, error) {
+func JsonIfYaml(source []byte, filename string) ([]byte, error) {
 	if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 		return yaml.ToJSON(source)
 	}

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -70,12 +70,6 @@ parameters:
   name: POSTGRESQL_VOLUME_CAPACITY
   required: true
   value: 1Gi
-- description: Password for the PostgreSQL sampledb user.
-  displayName: PostgreSQL SampleDB Connection Password
-  from: '[a-zA-Z0-9]{16}'
-  generate: expression
-  name: POSTGRESQL_SAMPLEDB_PASSWORD
-  required: true
 - description: Enables test-support endpoint on backend API
   displayName: Test Support Enabled
   name: TEST_SUPPORT_ENABLED
@@ -335,7 +329,6 @@ objects:
       POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}
       POSTGRESQL_DATABASE=${POSTGRESQL_DATABASE}
       POSTGRESQL_VOLUME_CAPACITY=${POSTGRESQL_VOLUME_CAPACITY}
-      POSTGRESQL_SAMPLEDB_PASSWORD=${POSTGRESQL_SAMPLEDB_PASSWORD}
       TEST_SUPPORT_ENABLED=${TEST_SUPPORT_ENABLED}
       DEMO_DATA_ENABLED=${DEMO_DATA_ENABLED}
       SYNDESIS_REGISTRY=${SYNDESIS_REGISTRY}
@@ -516,72 +509,6 @@ objects:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
       syndesis.io/component: syndesis-db
-    name: syndesis-sampledb-config
-  data:
-    add-sample-db.sh: |
-      #!/bin/bash
-      until bash -c "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"; do
-        echo "Waiting for Postgres server..."
-        sleep 1
-      done
-      echo "***** creating sampledb"
-      psql <<EOF
-        CREATE DATABASE sampledb;
-        CREATE USER sampledb WITH PASSWORD '$POSTGRESQL_SAMPLEDB_PASSWORD';
-        GRANT ALL PRIVILEGES ON DATABASE sampledb to sampledb;
-      EOF
-      psql -d sampledb -U sampledb <<'EOF'
-        CREATE TABLE IF NOT EXISTS contact (first_name VARCHAR, last_name VARCHAR, company VARCHAR, lead_source VARCHAR, create_date DATE);
-        INSERT INTO contact VALUES ('Joe','Jackson','Red Hat','db',current_timestamp);
-        CREATE TABLE IF NOT EXISTS todo (id SERIAL PRIMARY KEY, task VARCHAR, completed INTEGER);
-        CREATE OR REPLACE FUNCTION add_lead(
-          first_and_last_name varchar,
-          company varchar,
-          phone varchar,
-          email varchar,
-          lead_source varchar,
-          lead_status varchar,
-          rating varchar)
-
-          RETURNS void
-          LANGUAGE 'plpgsql'
-
-        AS $BODY$
-        DECLARE
-          task varchar;
-        BEGIN
-          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from ' || lead_source, '. Rating: ' || rating, '.');
-          insert into todo(task,completed) VALUES (task,0);
-        END;
-        $BODY$;
-
-        CREATE OR REPLACE FUNCTION create_lead(
-          OUT first_name text,
-          OUT last_name text,
-          OUT company text,
-          OUT lead_source text)
-          RETURNS SETOF record
-          AS
-          $$
-            SELECT first_name, last_name, company, lead_source
-            FROM contact;
-          $$
-           LANGUAGE 'sql' VOLATILE;
-      EOF
-
-      echo "***** sampledb created"
-    postStart.sh: |
-      #!/bin/bash
-      /var/lib/pgsql/sampledb/add-sample-db.sh &>  /proc/1/fd/1
-
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-db
     name: syndesis-db-conf
   data:
     syndesis-postgresql.conf: |
@@ -676,17 +603,8 @@ objects:
             value: ${POSTGRESQL_PASSWORD}
           - name: POSTGRESQL_DATABASE
             value: ${POSTGRESQL_DATABASE}
-          - name: POSTGRESQL_SAMPLEDB_PASSWORD
-            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           image: ' '
           imagePullPolicy: IfNotPresent
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                - /bin/sh
-                - -c
-                - /var/lib/pgsql/sampledb/postStart.sh
           livenessProbe:
             initialDelaySeconds: 60
             tcpSocket:
@@ -713,8 +631,6 @@ objects:
           volumeMounts:
           - mountPath: /var/lib/pgsql/data
             name: syndesis-db-data
-          - mountPath: /var/lib/pgsql/sampledb
-            name: syndesis-sampledb-config
           - mountPath: /opt/app-root/src/postgresql-cfg/
             name: syndesis-db-conf
         - capabilities: {}
@@ -755,10 +671,6 @@ objects:
         - name: syndesis-db-data
           persistentVolumeClaim:
             claimName: syndesis-db
-        - configMap:
-            defaultMode: 511
-            name: syndesis-sampledb-config
-          name: syndesis-sampledb-config
         - configMap:
             name: syndesis-db-conf
           name: syndesis-db-conf
@@ -1278,7 +1190,7 @@ objects:
       # See the License for the specific language governing permissions and
       # limitations under the License.
       #
-      
+
       startDelaySecs: 5
       ssl: false
       blacklistObjectNames: ["java.lang:*"]
@@ -1390,8 +1302,8 @@ objects:
               context: $1
               type: context
           type: GAUGE
-      
-      
+
+
       # Route level
         - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1489,7 +1401,7 @@ objects:
               route: $2
               type: routes
           type: GAUGE
-      
+
       # Processor level
         - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesCompleted'
           name: org.apache.camel.ExchangesCompleted
@@ -1587,7 +1499,7 @@ objects:
               processor: $2
               type: processors
           type: COUNTER
-      
+
       # Consumers
         - pattern: 'org.apache.camel<context=([^,]+), type=consumers, name=([^,]+)><>InflightExchanges'
           name: org.apache.camel.InflightExchanges
@@ -1597,7 +1509,7 @@ objects:
               consumer: $2
               type: consumers
           type: GAUGE
-      
+
       # Services
         - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MaxDuration'
           name: org.apache.camel.MaxDuration
@@ -1818,7 +1730,7 @@ objects:
               type: $2
               service: $3
               port: $4
-      
+
 
 - apiVersion: v1
   kind: ConfigMap
@@ -1919,160 +1831,6 @@ objects:
     name: camel-k
     apiGroup: rbac.authorization.k8s.io
 # END:CAMEL-K
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: todo
-      syndesis.io/component: todo
-    name: todo
-  spec:
-    ports:
-    - port: 8080
-      protocol: TCP
-      targetPort: 8080
-    selector:
-      app: syndesis
-      syndesis.io/app: todo
-      syndesis.io/component: todo
-
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: todo
-      syndesis.io/component: todo
-    name: todo
-  spec:
-    host: todo-${ROUTE_HOSTNAME}
-    path: /
-    port:
-      targetPort: 8080
-    tls:
-      insecureEdgeTerminationPolicy: Allow
-      termination: edge
-    to:
-      kind: Service
-      name: todo
-      weight: 100
-
-- apiVersion: image.openshift.io/v1
-  kind: ImageStream
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: todo
-    name: todo
-  spec:
-    lookupPolicy:
-      local: false
-  status:
-    tags:
-      - items:
-        tag: latest
-
-- apiVersion: build.openshift.io/v1
-  kind: BuildConfig
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: todo
-    name: todo
-  spec:
-    postCommit: {}
-    resources: {}
-    runPolicy: Serial
-    source:
-      git:
-        uri: 'https://github.com/syndesisio/todo-example.git'
-      type: Git
-    output:
-      to:
-        kind: ImageStreamTag
-        name: 'todo:latest'
-    strategy:
-      sourceStrategy:
-        from:
-          kind: ImageStreamTag
-          name: 'php:7.0'
-          namespace: openshift
-      type: Source
-    triggers:
-      - type: ConfigChange
-      - imageChange:
-        type: ImageChange
-
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: syndesis
-      syndesis.io/app: todo
-    name: todo
-  spec:
-    replicas: 1
-    selector:
-      app: syndesis
-      syndesis.io/app: todo
-      syndesis.io/component: todo
-    strategy:
-      resources:
-        limits:
-          memory: "256Mi"
-        requests:
-          memory: "20Mi"
-      type: Recreate
-    template:
-      metadata:
-        annotations:
-          openshift.io/container.todo.image.entrypoint: '["container-entrypoint","/bin/sh","-c","$STI_SCRIPTS_PATH/usage"]'
-        creationTimestamp: null
-        labels:
-          app: syndesis
-          syndesis.io/app: todo
-          syndesis.io/component: todo
-      spec:
-        containers:
-          - env:
-              - name: TODO_DB_SERVER
-                value: syndesis-db
-              - name: TODO_DB_NAME
-                value: sampledb
-              - name: TODO_DB_USER
-                value: sampledb
-              - name: TODO_DB_PASS
-                value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
-            imagePullPolicy: Always
-            name: todo
-            image: ' '
-            resources:
-              limits:
-                memory: 256Mi
-              requests:
-                memory: 256Mi
-            ports:
-              - containerPort: 8080
-                name: http
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        schedulerName: default-scheduler
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-    test: false
-    triggers:
-      - type: ConfigChange
-      - imageChangeParams:
-          automatic: true
-          containerNames:
-            - todo
-          from:
-            kind: ImageStreamTag
-            name: todo:latest
-        type: ImageChange
 - apiVersion: authorization.openshift.io/v1
   kind: RoleBinding
   metadata:

--- a/tools/bin/commands/install
+++ b/tools/bin/commands/install
@@ -29,6 +29,7 @@ cat <<"EOT"
 -o  --open                    Open Syndesis in browser when installation is ready (implies --watch)
 -y  --yes                     Assume 'yes' automatically when asking for deleting
                               a given project.
+    --addons <a1,a2,a3>       Additional addons to install (comma-separated list), ie. db-sampledb,todo
     --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
     --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
     --test-support            Allow test support endpoint for syndesis-server

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -161,6 +161,17 @@ EOT
         syndesis="${syndesis}${extra}"
     fi
 
+    local addons=$(readopt --addons)
+    if [ -n "$addons" ]; then
+        extra=$(cat <<EOT
+
+  addons: "$addons"
+EOT
+)
+
+        syndesis="${syndesis}${extra}"
+    fi
+
     local memory_server=$(readopt --memory-server)
     local memory_meta=$(readopt --memory-meta)
     if [ -n "$memory_server" ] || [ -n "$memory_meta" ]; then


### PR DESCRIPTION
* syndesis.yml
 * Strips out sampledb & todo & relocates them to install/addons

* .../commands/[install|util/openshift_funcs]
 * Adds a --addons switch that takes a comma-separated list of addons to
   install in addition to base syndesis components. At the moment this
   list would be "db-sampledb,todo"

* main.go
 * Adds in default of /conf/addons to turn on addons support

* syndesis_types.go
 * Adds additional fields to structs for extra environment variables, inc.
   Addons (which contains the preferred set of addons)

* templateprocessor.go
 * To fully support sampledb and todo moving to addons, the env vars from
   the syndesis template must be available. This is due to the sample-db
   being a full copy of the syndesis-db resource with the extra sample-db
   elements included.

* action/[install|upgrade].go
 * When installing addons:
  - Check their is some in the directory
  - Find the addon resources and get each addon ID
  - If addon ID is included in the list specified by --addons switch then
    install

* addon/install.go
 * Both sampledb & todo have env vars that must have values injected in
   them before the resource is loaded. The template has the templateprocessor
   that does the same. loadAndProcessFile() conducts a string replace over
   each file ensuring env vars are correctly substituted for their values
 * Since the metadata.name of each resource is not unique then it is
   essential that each resource has a managed ID that can be used to
   select it for install. The syndesis.io/addon label provides this. It
   doesn't need to be unique as all the todo resources have the same ID.

* configuration.go
 * Add in extra env vars required by addons, inc. addons