### PR TITLE
Fix 5223: [camel-k] support api client

### DIFF
--- a/app/integration/runtime-camelk/readme.adoc
+++ b/app/integration/runtime-camelk/readme.adoc
@@ -5,12 +5,13 @@ In order to use the Syndesis Camel-k runtime (i.e. this project) at the moment a
 == Running a Syndesis integrations in Camel-k
 
 * Place the Json format of your integrations in a file with `.syndesis` extension (a very simple example can be found at `src/test/resources/syndesis/integration/integration.syndesis`).
+* Import the syndesis specific camel version generated Camel-k catalog in ocp:
+  - `mvn org.apache.maven.plugins:maven-dependency-plugin:copy -Dartifact=io.syndesis.integration:integration-runtime-camelk:<syndesis_version>:yaml:catalog -DoutputDirectory=./`
+  - `oc apply -f ./integration-runtime-camelk-<syndesis_version>-catalog.yaml`
 * Have the Camel-K environment running somewhere (follow the instructions in https://github.com/apache/camel-k#installation[Camel-k readme], or use `-camel-k` option of `syndesis install` command) and `kamel` CLI in your path. It is IMPORTANT to run Camel-k install with the following options:
   - `--repository https://repository.jboss.org/nexus/content/groups/ea`
   - `--camel-version <camel.version>`
   - `--runtime-version <camel-k-runtime.version>`
-* Import the syndesis specific camel version generated Camel-k catalog in ocp:
-  - `oc create -f app/integration/runtime-camelk/target/camel-catalog-<camel.version>.yaml`
 * Create `target/dependencies` folder with all useful dependencies in a maven repo like structure with: `mvn clean install -Pdependency-prepare`
 * Get the pod id in which Camel-k operator is running: `oc get pod --selector=name=camel-k-operator -o jsonpath='{.items[*].metadata.name}'`.
 * Sync the dependencies folder with the local maven repo inside Camel-k operator container: `oc rsync ./target/dependencies/ <camel_k_operator_pod_id>:/tmp/artifacts/m2/`. This is needed to quickly have snapshot local artifacts available to the Camel-k operator.
@@ -19,3 +20,9 @@ In order to use the Syndesis Camel-k runtime (i.e. this project) at the moment a
 == Important note
 
 The dependencies gathered and synced with the Camel-k operator thanks to the steps above covers only very basic usecases. If more connector are used those needs to be imported separately.
+
+There is the option to run camel-k operator directly in you machine to better debug it and automatically use all your .m2 dependencies avoiding the need of generating `target/dependencies` folder. To do so, in the main camel-k project dir after have built it:
+
+* `mkdir /tmp/artifacts && ln -s ~/.m2/repository /tmp/artifacts/m2`
+* `export WATCH_NAMESPACE=<your_ocp_project>`
+* `./camel-k`


### PR DESCRIPTION
Updated camel-k-runtime to 0.3.2 (i.e. camel-k operator to 0.3.3).