### PR TITLE
fix(server): instead of `operation-NNN` use random UUID

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -301,7 +302,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
     protected String requireUniqueOperationId(final String preferredOperationId, final Set<String> alreadyUsedOperationIds) {
         String baseId = preferredOperationId;
         if (baseId == null) {
-            baseId = "operation";
+            baseId = UUID.randomUUID().toString();
         }
         // Sanitize for using it in direct
         baseId = baseId.replaceAll("[^A-Za-z0-9-_]", "");

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerUnifiedShapeConnectorGenerator.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.server.api.generator.swagger;
 
+import java.util.function.Supplier;
+
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.syndesis.common.model.DataShape;
@@ -25,11 +27,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public final class SwaggerUnifiedShapeConnectorGenerator extends BaseSwaggerConnectorGenerator {
 
-    private final DataShapeGenerator dataShapeGenerator;
+    private final DataShapeGenerator dataShapeGenerator = new UnifiedDataShapeGenerator();
 
     public SwaggerUnifiedShapeConnectorGenerator(final Connector restSwaggerConnector) {
         super(restSwaggerConnector);
-        dataShapeGenerator = new UnifiedDataShapeGenerator();
+    }
+
+    SwaggerUnifiedShapeConnectorGenerator(final Connector restSwaggerConnector, final Supplier<String> operationIdGenerator) {
+        super(restSwaggerConnector, operationIdGenerator);
     }
 
     @Override

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SwaggerUnifiedShapeGeneratorExampleTests.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SwaggerUnifiedShapeGeneratorExampleTests.java
@@ -18,6 +18,7 @@ package io.syndesis.server.api.generator.swagger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.util.Json;
@@ -57,7 +58,8 @@ public class SwaggerUnifiedShapeGeneratorExampleTests extends BaseSwaggerGenerat
         try (InputStream stream = SwaggerUnifiedShapeGeneratorExampleTests.class.getResourceAsStream("/META-INF/syndesis/connector/rest-swagger.json")) {
             final Connector restSwagger = Json.readFromStream(stream, Connector.class);
 
-            return new SwaggerUnifiedShapeConnectorGenerator(restSwagger);
+            final AtomicInteger cnt = new AtomicInteger();
+            return new SwaggerUnifiedShapeConnectorGenerator(restSwagger, () -> "operation-" + cnt.getAndIncrement());
         } catch (final IOException e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
When editing the OpenAPI document it is possible that the current operation ID algorithm of using the base of `operation-` and adding the monolithically increasing number (`operation-NNN`) will generate the same operation ID of a removed operation and in doing so inheriting that flow.

This uses random UUID instead so that two identical operation IDs cannot be generated.

Fixes #5310