### PR TITLE
Faux addons feature in the operator

### DIFF
--- a/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
+++ b/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
@@ -20,6 +20,7 @@ type SyndesisSpec struct {
 	Components           ComponentsSpec  `json:"components,omitempty"`
 	OpenShiftConsoleUrl  string          `json:"openShiftConsoleUrl,omitempty"`
 	SarNamespace         string          `json:"sarNamespace,omitempty"`
+	Addons               AddonsSpec      `json:"addons,omitempty"`
 }
 
 // SyndesisStatus defines the observed state of Syndesis
@@ -93,6 +94,12 @@ type VolumeOnlyResources struct {
 type ServerFeatures struct {
 	ExposeVia3Scale bool `json:"exposeVia3Scale,omitempty"`
 }
+
+type AddonsSpec map[string]Parameters
+
+type Parameters []Parameter
+
+type Parameter map[string]string
 
 // =============================================================================
 

--- a/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
+++ b/install/operator/pkg/apis/syndesis/v1alpha1/syndesis_types.go
@@ -37,61 +37,61 @@ type SyndesisStatus struct {
 // =============================================================================
 
 type IntegrationSpec struct {
-        Limit              *int `json:"limit,omitempty"`
-        StateCheckInterval *int `json:"stateCheckInterval,omitempty"`
+	Limit              *int `json:"limit,omitempty"`
+	StateCheckInterval *int `json:"stateCheckInterval,omitempty"`
 }
 
 type ComponentsSpec struct {
-        Db         DbConfiguration         `json:"db,omitempty"`
-        Prometheus PrometheusConfiguration `json:"prometheus,omitempty"`
-        Grafana    GrafanaConfiguration    `json:"grafana,omitempty"`
-        Server     ServerConfiguration     `json:"server,omitempty"`
-        Meta       MetaConfiguration       `json:"meta,omitempty"`
-        Upgrade    UpgradeConfiguration    `json:"upgrade,omitempty"`
+	Db         DbConfiguration         `json:"db,omitempty"`
+	Prometheus PrometheusConfiguration `json:"prometheus,omitempty"`
+	Grafana    GrafanaConfiguration    `json:"grafana,omitempty"`
+	Server     ServerConfiguration     `json:"server,omitempty"`
+	Meta       MetaConfiguration       `json:"meta,omitempty"`
+	Upgrade    UpgradeConfiguration    `json:"upgrade,omitempty"`
 }
 
 type DbConfiguration struct {
-        Resources            ResourcesWithVolume `json:"resources,omitempty"`
-        User                 string              `json:"user,omitempty"`
-        Database             string              `json:"database,omitempty"`
-        ImageStreamNamespace string              `json:"imageStreamNamespace,omitempty"`
+	Resources            ResourcesWithVolume `json:"resources,omitempty"`
+	User                 string              `json:"user,omitempty"`
+	Database             string              `json:"database,omitempty"`
+	ImageStreamNamespace string              `json:"imageStreamNamespace,omitempty"`
 }
 type PrometheusConfiguration struct {
-        Resources ResourcesWithVolume `json:"resources,omitempty"`
+	Resources ResourcesWithVolume `json:"resources,omitempty"`
 }
 
 type GrafanaConfiguration struct {
-        Resources Resources `json:"resources,omitempty"`
+	Resources Resources `json:"resources,omitempty"`
 }
 
 type ServerConfiguration struct {
-        Resources Resources      `json:"resources,omitempty"`
-        Features  ServerFeatures `json:"features,omitempty"`
+	Resources Resources      `json:"resources,omitempty"`
+	Features  ServerFeatures `json:"features,omitempty"`
 }
 
 type MetaConfiguration struct {
-        Resources ResourcesWithVolume `json:"resources,omitempty"`
+	Resources ResourcesWithVolume `json:"resources,omitempty"`
 }
 
 type UpgradeConfiguration struct {
-        Resources VolumeOnlyResources `json:"resources,omitempty"`
+	Resources VolumeOnlyResources `json:"resources,omitempty"`
 }
 
 type Resources struct {
-        v1.ResourceRequirements `json:",inline,omitempty"`
+	v1.ResourceRequirements `json:",inline,omitempty"`
 }
 
 type ResourcesWithVolume struct {
-        v1.ResourceRequirements `json:",inline,omitempty"`
-        VolumeCapacity          string `json:"volumeCapacity,omitempty"`
+	v1.ResourceRequirements `json:",inline,omitempty"`
+	VolumeCapacity          string `json:"volumeCapacity,omitempty"`
 }
 
 type VolumeOnlyResources struct {
-        VolumeCapacity string `json:"volumeCapacity,omitempty"`
+	VolumeCapacity string `json:"volumeCapacity,omitempty"`
 }
 
 type ServerFeatures struct {
-        ExposeVia3Scale bool `json:"exposeVia3Scale,omitempty"`
+	ExposeVia3Scale bool `json:"exposeVia3Scale,omitempty"`
 }
 
 // =============================================================================
@@ -99,30 +99,29 @@ type ServerFeatures struct {
 type SyndesisPhase string
 
 const (
-        SyndesisPhaseMissing               SyndesisPhase = ""
-        SyndesisPhaseInstalling            SyndesisPhase = "Installing"
-        SyndesisPhaseUpgradingLegacy       SyndesisPhase = "UpgradingLegacy"
-        SyndesisPhaseStarting              SyndesisPhase = "Starting"
-        SyndesisPhaseStartupFailed         SyndesisPhase = "StartupFailed"
-        SyndesisPhaseInstalled             SyndesisPhase = "Installed"
-        SyndesisPhaseNotInstalled          SyndesisPhase = "NotInstalled"
-        SyndesisPhaseUpgrading             SyndesisPhase = "Upgrading"
-        SyndesisPhaseUpgradeFailureBackoff SyndesisPhase = "UpgradeFailureBackoff"
-        SyndesisPhaseUpgradeFailed         SyndesisPhase = "UpgradeFailed"
+	SyndesisPhaseMissing               SyndesisPhase = ""
+	SyndesisPhaseInstalling            SyndesisPhase = "Installing"
+	SyndesisPhaseUpgradingLegacy       SyndesisPhase = "UpgradingLegacy"
+	SyndesisPhaseStarting              SyndesisPhase = "Starting"
+	SyndesisPhaseStartupFailed         SyndesisPhase = "StartupFailed"
+	SyndesisPhaseInstalled             SyndesisPhase = "Installed"
+	SyndesisPhaseNotInstalled          SyndesisPhase = "NotInstalled"
+	SyndesisPhaseUpgrading             SyndesisPhase = "Upgrading"
+	SyndesisPhaseUpgradeFailureBackoff SyndesisPhase = "UpgradeFailureBackoff"
+	SyndesisPhaseUpgradeFailed         SyndesisPhase = "UpgradeFailed"
 )
 
 type SyndesisStatusReason string
 
 const (
-        SyndesisStatusReasonMissing                SyndesisStatusReason = ""
-        SyndesisStatusReasonDuplicate              SyndesisStatusReason = "Duplicate"
-        SyndesisStatusReasonDeploymentNotReady     SyndesisStatusReason = "DeploymentNotReady"
-        SyndesisStatusReasonUpgradePodFailed       SyndesisStatusReason = "UpgradePodFailed"
-        SyndesisStatusReasonTooManyUpgradeAttempts SyndesisStatusReason = "TooManyUpgradeAttempts"
+	SyndesisStatusReasonMissing                SyndesisStatusReason = ""
+	SyndesisStatusReasonDuplicate              SyndesisStatusReason = "Duplicate"
+	SyndesisStatusReasonDeploymentNotReady     SyndesisStatusReason = "DeploymentNotReady"
+	SyndesisStatusReasonUpgradePodFailed       SyndesisStatusReason = "UpgradePodFailed"
+	SyndesisStatusReasonTooManyUpgradeAttempts SyndesisStatusReason = "TooManyUpgradeAttempts"
 )
 
 // =============================================================================
-
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/install/operator/pkg/openshift/template/templateprocessor.go
+++ b/install/operator/pkg/openshift/template/templateprocessor.go
@@ -60,6 +60,8 @@ func (p *TemplateProcessor) Process(sourceTemplate *v1template.Template, paramet
 		return nil, err
 	}
 
+	log.V(4).Info("Template with parameters", "template", resource)
+
 	result := p.restClient.
 		Post().
 		Namespace(p.namespace).

--- a/install/operator/pkg/openshift/template/templateprocessor.go
+++ b/install/operator/pkg/openshift/template/templateprocessor.go
@@ -17,7 +17,7 @@ var log = logf.Log.WithName("template")
 type TemplateProcessor struct {
 	namespace  string
 	restClient *rest.RESTClient
-	scheme *runtime.Scheme
+	scheme     *runtime.Scheme
 }
 
 func NewTemplateProcessor(scheme *runtime.Scheme, namespace string) (*TemplateProcessor, error) {
@@ -48,7 +48,7 @@ func NewTemplateProcessor(scheme *runtime.Scheme, namespace string) (*TemplatePr
 	return &TemplateProcessor{
 		namespace:  namespace,
 		restClient: restClient,
-		scheme: scheme,
+		scheme:     scheme,
 	}, nil
 }
 
@@ -84,7 +84,7 @@ func (p *TemplateProcessor) Process(sourceTemplate *v1template.Template, paramet
 	if v1Temp, ok := templ.(*v1template.Template); ok {
 		return v1Temp.Objects, nil
 	}
-	log.Error(nil,"Wrong type returned by the server", "template", templ)
+	log.Error(nil, "Wrong type returned by the server", "template", templ)
 	return nil, errors.New("wrong type returned by the server")
 }
 

--- a/install/operator/pkg/syndesis/action/action.go
+++ b/install/operator/pkg/syndesis/action/action.go
@@ -24,11 +24,10 @@ type Client struct {
 }
 
 type baseAction struct {
-	log logr.Logger
+	log    logr.Logger
 	client client.Client
 	scheme *runtime.Scheme
-	api kubernetes.Interface
-
+	api    kubernetes.Interface
 }
 
 var actionLog = logf.Log.WithName("action")

--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -73,9 +73,16 @@ func (a *installAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis
 		syndesis.Spec.RouteHostName = "dummy"
 	}
 
-	list, err := syndesistemplate.GetInstallResourcesAsRuntimeObjects(a.scheme, syndesis, syndesistemplate.InstallParams{
+	params := syndesistemplate.InstallParams{
 		OAuthClientSecret: token,
-	})
+	}
+
+	if _, ok := syndesis.Spec.Addons["komodo"]; ok {
+		a.log.Info("Addon enabled", "addon", "komodo")
+		params.DataVirtEnabled = true
+	}
+
+	list, err := syndesistemplate.GetInstallResourcesAsRuntimeObjects(a.scheme, syndesis, params)
 	if err != nil {
 		return err
 	}
@@ -97,9 +104,7 @@ func (a *installAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis
 		}
 
 		// Recreate the list of resources to inject the route hostname
-		list, err = syndesistemplate.GetInstallResourcesAsRuntimeObjects(a.scheme, syndesis, syndesistemplate.InstallParams{
-			OAuthClientSecret: token,
-		})
+		list, err = syndesistemplate.GetInstallResourcesAsRuntimeObjects(a.scheme, syndesis, params)
 	}
 
 	// Link the image secret to service accounts

--- a/install/operator/pkg/syndesis/action/upgrade.go
+++ b/install/operator/pkg/syndesis/action/upgrade.go
@@ -37,7 +37,7 @@ type upgradeAction struct {
 
 func newUpgradeAction(mgr manager.Manager, api kubernetes.Interface) SyndesisOperatorAction {
 	return &upgradeAction{
-		newBaseAction(mgr,api, "upgrade"),
+		newBaseAction(mgr, api, "upgrade"),
 		"",
 	}
 }
@@ -245,7 +245,7 @@ func (a *upgradeAction) findUpgradePod(resources []runtime.Object) (*v1.Pod, err
 	return nil, errors.New("upgrade pod not found")
 }
 
-func (a *upgradeAction) getUpgradePodFromNamespace(ctx context.Context,  podTemplate *v1.Pod, syndesis *v1alpha1.Syndesis) (*v1.Pod, error) {
+func (a *upgradeAction) getUpgradePodFromNamespace(ctx context.Context, podTemplate *v1.Pod, syndesis *v1alpha1.Syndesis) (*v1.Pod, error) {
 	pod := v1.Pod{}
 	key := client.ObjectKey{
 		Namespace: syndesis.Namespace,

--- a/install/operator/pkg/syndesis/action/upgradebackoff.go
+++ b/install/operator/pkg/syndesis/action/upgradebackoff.go
@@ -23,7 +23,7 @@ type upgradeBackoffAction struct {
 
 func newUpgradeBackoffAction(mgr manager.Manager, api kubernetes.Interface) SyndesisOperatorAction {
 	return &upgradeBackoffAction{
-		newBaseAction(mgr,api,"upgrade-backoff"),
+		newBaseAction(mgr, api, "upgrade-backoff"),
 		"",
 	}
 }

--- a/install/operator/pkg/syndesis/action/upgradelegacy.go
+++ b/install/operator/pkg/syndesis/action/upgradelegacy.go
@@ -21,7 +21,7 @@ type upgradeLegacyAction struct {
 
 func newUpgradeLegacyAction(mgr manager.Manager, api kubernetes.Interface) SyndesisOperatorAction {
 	return &upgradeLegacyAction{
-		newBaseAction(mgr, api,"upgrade-legacy"),
+		newBaseAction(mgr, api, "upgrade-legacy"),
 	}
 }
 

--- a/install/operator/pkg/syndesis/configuration/util.go
+++ b/install/operator/pkg/syndesis/configuration/util.go
@@ -17,7 +17,7 @@ func getBool(config map[string]string, key SyndesisEnvVar) (bool, bool) {
 	if v, ok := config[string(key)]; ok {
 		boolValue, err := strconv.ParseBool(v)
 		if err != nil {
-			log.Info( " property has not a bool value", "key",string(key), "value", v)
+			log.Info(" property has not a bool value", "key", string(key), "value", v)
 			return false, false
 		}
 		return boolValue, true
@@ -29,7 +29,7 @@ func getInt(config map[string]string, key SyndesisEnvVar) (int, bool) {
 	if v, ok := config[string(key)]; ok {
 		intValue, err := strconv.Atoi(v)
 		if err != nil {
-			log.Info( " property has not a int value", "key", string(key), "value", v)
+			log.Info(" property has not a int value", "key", string(key), "value", v)
 			return 0, false
 		}
 		return intValue, true

--- a/install/operator/pkg/syndesis/legacy/controller.go
+++ b/install/operator/pkg/syndesis/legacy/controller.go
@@ -11,7 +11,6 @@ import (
 	"time"
 )
 
-
 var log = logf.Log.WithName("legacy")
 
 const (
@@ -48,7 +47,7 @@ func (c *LegacyController) verifyAndCreate(ctx context.Context, client client.Cl
 				return
 			case <-time.After(retryInterval):
 				if err := c.doVerifyAndCreate(ctx, client); err != nil {
-					log.Error(err,"Unable to check Syndesis legacy installations (will retry again)")
+					log.Error(err, "Unable to check Syndesis legacy installations (will retry again)")
 				} else {
 					return
 				}
@@ -86,7 +85,7 @@ func (c *LegacyController) doVerifyAndCreate(ctx context.Context, cl client.Clie
 
 		configuration.SetConfigurationFromEnvVars(config, &synd)
 
-		log.Info("Creating a new Syndesis resource from legacy installation", "namespace",c.namespace)
+		log.Info("Creating a new Syndesis resource from legacy installation", "namespace", c.namespace)
 		return cl.Create(ctx, &synd)
 	} else {
 		log.Info("No legacy Syndesis installations detected", "namespace", c.namespace)

--- a/install/operator/pkg/util/resources.go
+++ b/install/operator/pkg/util/resources.go
@@ -15,12 +15,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-
 var log = logf.Log.WithName("resources")
 
 func NewObjectKey(name string, namespace string) client.ObjectKey {
 	return client.ObjectKey{
-		Name: name,
+		Name:      name,
 		Namespace: namespace,
 	}
 }
@@ -55,8 +54,7 @@ func LoadRawResourceFromYaml(data string) (runtime.Object, error) {
 	}, nil
 }
 
-
-func LoadResourceFromYaml(scheme *runtime.Scheme,  source []byte) (runtime.Object, error) {
+func LoadResourceFromYaml(scheme *runtime.Scheme, source []byte) (runtime.Object, error) {
 	jsonSource, err := yaml.ToJSON(source)
 	if err != nil {
 		return nil, err
@@ -70,7 +68,7 @@ func LoadResourceFromYaml(scheme *runtime.Scheme,  source []byte) (runtime.Objec
 }
 
 // RuntimeObjectFromUnstructured converts an unstructured to a runtime object
-func RuntimeObjectFromUnstructured(scheme *runtime.Scheme,u *unstructured.Unstructured) (runtime.Object, error) {
+func RuntimeObjectFromUnstructured(scheme *runtime.Scheme, u *unstructured.Unstructured) (runtime.Object, error) {
 	gvk := u.GroupVersionKind()
 	codecs := serializer.NewCodecFactory(scheme)
 	decoder := codecs.UniversalDecoder(gvk.GroupVersion())

--- a/install/operator/pkg/util/resources_test.go
+++ b/install/operator/pkg/util/resources_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 )
 
-
 func init() {
 	scheme = runtime.NewScheme()
 	if err := appsv1.AddToScheme(scheme); err != nil {
@@ -18,7 +17,7 @@ func init() {
 var scheme *runtime.Scheme
 
 func TestLoadResources(t *testing.T) {
-	object, err := LoadResourceFromFile(scheme,"../../test/resources/dep.json")
+	object, err := LoadResourceFromFile(scheme, "../../test/resources/dep.json")
 	assert.Nil(t, err)
 
 	assert.NotNil(t, object)
@@ -28,7 +27,7 @@ func TestLoadResources(t *testing.T) {
 }
 
 func TestLoadYamlResources(t *testing.T) {
-	object, err := LoadResourceFromFile(scheme,"../../test/resources/dep.yml")
+	object, err := LoadResourceFromFile(scheme, "../../test/resources/dep.yml")
 	assert.Nil(t, err)
 
 	assert.NotNil(t, object)


### PR DESCRIPTION
It was simple to implement this, thought now I'm faced with an issue and would like some help, so halp!

When I create a Syndesis object like:

```yaml
apiVersion: "syndesis.io/v1alpha1"
kind: "Syndesis"
metadata:
  name: "example"
spec:
  addons:
    komodo:
```

I get this lovely error:
```
"level":"error","ts":1558512713.3689954,"logger":"controller","msg":"Error reconciling","action":"*action.installAction","phase":"Installing","error":"failed to decode json data with gvk(apps.openshift.io/v1, Kind=DeploymentConfig): v1.DeploymentConfig.Spec: v1.DeploymentConfigSpec.Replicas: readUint32: unexpected character: \ufffd, error found in #10 byte of ...|eplicas\":\"1\",\"select|..., bigger context ...|ure\"},\"name\":\"komodo-server\"},\"spec\":{\"replicas\":\"1\",\"selector\":{\"app\":\"syndesis\",\"syndesis.io/app\":|...","stacktrace":"github.com/syndesisio/syndesis/install/operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/syndesisio/syndesis/install/operator/pkg/controller/syndesis.(*ReconcileSyndesis).Reconcile\n\t/go/src/github.com/syndesisio/syndesis/install/operator/pkg/controller/syndesis/syndesis_controller.go:122\ngithub.com/syndesisio/syndesis/install/operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:213\ngithub.com/syndesisio/syndesis/install/operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/syndesisio/syndesis/install/operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

So there's a `\ufffd` ([replacement char](https://en.wikipedia.org/wiki/Specials_(Unicode_block))) somewhere around `"replicas": "1"`, or here in the template:

https://github.com/syndesisio/syndesis/blob/57c352e39cb99b8610d9e092a95bed38a1297170/install/syndesis.yml#L2019

I see no issues when installing via template and specifying the `DATAVIRT_ENABLED` parameter as `"1"` or `"0"`.

Any ideas anyone?