### PR TITLE
fix: #5430 Servicenow connector meta data retrieval adapter lookup

### DIFF
--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
@@ -35,7 +35,7 @@ import org.apache.camel.component.extension.MetaDataExtension;
 import org.apache.camel.component.servicenow.ServiceNowConstants;
 import org.apache.camel.util.ObjectHelper;
 
-final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieval {
+public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieval {
 
     /**
      * TODO: use local extension, remove when switching to camel 2.22.x


### PR DESCRIPTION
MetadataRetrieval class needs to be public so factory finder mechanism can find and instantiate it in ConnectorEndpoint