### PR TITLE
Cleanup operator logging

### DIFF
--- a/install/operator/Dockerfile
+++ b/install/operator/Dockerfile
@@ -12,4 +12,4 @@ ADD addons /conf/addons
 # Add the operator
 ADD syndesis-operator /usr/local/bin/syndesis-operator
 
-ENTRYPOINT [ "/usr/local/bin/syndesis-operator", "-template", "/conf/syndesis-template.yml" ]
+ENTRYPOINT [ "/usr/local/bin/syndesis-operator", "--template", "/conf/syndesis-template.yml" ]

--- a/install/operator/Gopkg.lock
+++ b/install/operator/Gopkg.lock
@@ -279,11 +279,12 @@
   version = "v3.9.0"
 
 [[projects]]
-  digest = "1:01be1fb7df4fa7362e8023d980a8424f93d7a4b6432b20db2e827efcd0672f7f"
+  digest = "1:016289e90df3b36fb52d9c84e683002e303485d1246815509ca5e46f5a294531"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sutil",
     "pkg/leader",
+    "pkg/log/zap",
     "version",
   ]
   pruneopts = "UT"
@@ -853,7 +854,9 @@
     "github.com/openshift/api/template/v1",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
+    "github.com/operator-framework/operator-sdk/pkg/log/zap",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/install/operator/cmd/syndesis-operator/main.go
+++ b/install/operator/cmd/syndesis-operator/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"github.com/syndesisio/syndesis/install/operator/pkg/openshift"
 	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
@@ -11,8 +10,10 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
+	"github.com/spf13/pflag"
 	"github.com/syndesisio/syndesis/install/operator/pkg/apis"
 	"github.com/syndesisio/syndesis/install/operator/pkg/controller"
 
@@ -33,18 +34,19 @@ func printVersion() {
 }
 
 func main() {
+	configuration.TemplateLocation = pflag.StringP("template", "t", "/conf/syndesis-template.yml", "Path to template used for installation")
+	configuration.AddonsDirLocation = pflag.StringP("addons", "a", "", "Path to the addons directory used for installation")
+	configuration.Registry = pflag.StringP("registry", "r", "docker.io", "Registry to use for loading images like the upgrade pod")
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
+	pflag.CommandLine.AddFlagSet(zap.FlagSet())
+	logf.SetLogger(zap.Logger())
 	logf.SetLogger(logf.ZapLogger(false))
 
-	configuration.TemplateLocation = flag.String("template", "/conf/syndesis-template.yml", "Path to template used for installation")
-	configuration.AddonsDirLocation = flag.String("addons", "", "Path to the addons directory used for installation")
-	configuration.Registry = flag.String("registry", "docker.io", "Registry to use for loading images like the upgrade pod")
-
-	flag.Parse()
+	pflag.Parse()
 
 	log.Info("Using template", "template", *configuration.TemplateLocation)
 	printVersion()

--- a/install/operator/pkg/controller/syndesis/syndesis_controller.go
+++ b/install/operator/pkg/controller/syndesis/syndesis_controller.go
@@ -3,9 +3,9 @@ package syndesis
 import (
 	"context"
 	"reflect"
-    "time"
+	"time"
 
-    "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -86,7 +86,7 @@ type ReconcileSyndesis struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileSyndesis) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling Syndesis")
+	reqLogger.V(2).Info("Reconciling Syndesis")
 
 	// Fetch the Syndesis syndesis
 	syndesis := &syndesisv1alpha1.Syndesis{}
@@ -115,9 +115,9 @@ func (r *ReconcileSyndesis) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	for _, a := range actions {
 		if a.CanExecute(syndesis) {
-			log.Info("Running action", "action", reflect.TypeOf(a))
+			log.V(2).Info("Running action", "action", reflect.TypeOf(a))
 			if err := a.Execute(ctx, syndesis); err != nil {
-				log.Error(err, "Error reconciling","action", reflect.TypeOf(a), "phase", syndesis.Status.Phase)
+				log.Error(err, "Error reconciling", "action", reflect.TypeOf(a), "phase", syndesis.Status.Phase)
 				return reconcile.Result{}, err
 			}
 		}
@@ -125,9 +125,9 @@ func (r *ReconcileSyndesis) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	// Requeuing because actions expect this behaviour
 	return reconcile.Result{
-	    Requeue: true,
-	    RequeueAfter: 15 * time.Second,
-    }, nil
+		Requeue:      true,
+		RequeueAfter: 15 * time.Second,
+	}, nil
 }
 
 func (r *ReconcileSyndesis) isLatestVersion(ctx context.Context, syndesis *syndesisv1alpha1.Syndesis) (bool, error) {

--- a/install/operator/pkg/syndesis/action/startup.go
+++ b/install/operator/pkg/syndesis/action/startup.go
@@ -31,7 +31,7 @@ func (a *startupAction) CanExecute(syndesis *v1alpha1.Syndesis) bool {
 
 func (a *startupAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis) error {
 
-	list := v1.DeploymentConfigList {
+	list := v1.DeploymentConfigList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DeploymentConfig",
 			APIVersion: "apps.openshift.io/v1",
@@ -54,7 +54,7 @@ func (a *startupAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis
 	var failedDeployment *string
 	for _, depl := range list.Items {
 		if depl.Spec.Replicas != depl.Status.ReadyReplicas {
-			a.log.Info("Not ready", "desired", depl.Spec.Replicas, "actual", depl.Status.ReadyReplicas, "deployment", depl.Name)
+			a.log.V(2).Info("Not ready", "desired", depl.Spec.Replicas, "actual", depl.Status.ReadyReplicas, "deployment", depl.Name)
 			ready = false
 		}
 		if depl.Spec.Replicas != depl.Status.Replicas && depl.Status.Replicas == 0 && !isProcessing(&depl) {
@@ -74,14 +74,14 @@ func (a *startupAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis
 		target.Status.Phase = v1alpha1.SyndesisPhaseStartupFailed
 		target.Status.Reason = v1alpha1.SyndesisStatusReasonDeploymentNotReady
 		target.Status.Description = "Some Syndesis deployments failed to startup within the allowed time frame"
-		a.log.Info("Startup failed for Syndesis resource. Deployment not ready", "name", syndesis.Name, "deployment", *failedDeployment)
+		a.log.V(2).Info("Startup failed for Syndesis resource. Deployment not ready", "name", syndesis.Name, "deployment", *failedDeployment)
 		return a.client.Update(ctx, target)
 	} else {
 		target := syndesis.DeepCopy()
 		target.Status.Phase = v1alpha1.SyndesisPhaseStarting
 		target.Status.Reason = v1alpha1.SyndesisStatusReasonMissing
 		target.Status.Description = ""
-		a.log.Info("Waiting for Syndesis resource to startup", "name", syndesis.Name)
+		a.log.V(2).Info("Waiting for Syndesis resource to startup", "name", syndesis.Name)
 		return a.client.Update(ctx, target)
 	}
 }


### PR DESCRIPTION
This is based on #5445 (so take a look at that first)

Right now the operator is logging several log lines per second during the reconciliation, this adds support for specifying log level via command line parameter.

**HEADSUP: the `-template` parameter was renamed to `--template` this is due to the use of `github.com/spf13/pflag` instead `flag` package.**

cc @cunningt @djcoleman @orpiske