### PR TITLE
fix: DATAVIRT_ENABLED parameter use in sydesis.yml

### DIFF
--- a/install/generator/04-teiid-komodo-server.yml.mustache
+++ b/install/generator/04-teiid-komodo-server.yml.mustache
@@ -27,7 +27,7 @@
       syndesis.io/component: komodo-server
     name: komodo-server
   spec:
-    replicas: ${DATAVIRT_ENABLED}
+    replicas: {{=(( ))=}}${{DATAVIRT_ENABLED}}((={{ }}=))
     selector:
       app: syndesis
       syndesis.io/app: syndesis

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -2016,7 +2016,7 @@ objects:
       syndesis.io/component: komodo-server
     name: komodo-server
   spec:
-    replicas: ${DATAVIRT_ENABLED}
+    replicas: ${{DATAVIRT_ENABLED}}
     selector:
       app: syndesis
       syndesis.io/app: syndesis


### PR DESCRIPTION
This fixes the inclusion of DATAVIRT_ENABLED template parameter in the syndesis.yml template. The value needs to be inserted as a number and using double curly braces (`${{DATAVIRT_ENABLED}}`) makes sure that this is done.

For mustache template the delimiter needs to be changed so `{{...}}` is not interpreted so it's first changed to `((..))` and later changed back to `{{..}}`.

Fixes #5442

Thanks @astefanutti for the fix for this :+1: 