### PR TITLE
feat: UI is able to reorder conditional flows

### DIFF
--- a/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
+++ b/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
@@ -66,7 +66,7 @@
                       ])
                     "
                     >
-                      Go to main flow
+                      Go to primary flow
                     </button>
                   </li>
                   <li role="separator" class="divider"></li>
@@ -94,7 +94,7 @@
                 </ul>
               </div>
             </div>
-            <div *ngIf="!hideButtons" class="toolbar-pf-action-right">
+            <div *ngIf="!hideButtons && isPrimaryFlow(currentFlow)" class="toolbar-pf-action-right">
               <button
                 class="btn btn-default"
                 (click)="flowPageService.cancel()"
@@ -144,10 +144,28 @@
                 Publish
               </button>
             </div>
+            <div *ngIf="!hideButtons && isAlternateFlow(currentFlow)" class="toolbar-pf-action-right">
+              <button
+                class="btn btn-default"
+                [disabled]="
+                      flowPageService.saveInProgress ||
+                      flowPageService.publishInProgress
+                    "
+                (click)="
+                      save([
+                        '/integrations',
+                        currentFlowService.integration?.id,
+                        'edit'
+                      ])
+                    "
+              >
+                Back to primary flow
+              </button>
+            </div>
           </div>
         </div>
       </div>
-      <div class="row toolbar-pf toolbar-condensed" *ngIf="!isPrimaryFlow(currentFlow)">
+      <div class="row toolbar-pf toolbar-condensed" *ngIf="isAlternateFlow(currentFlow)">
         <div class="col-sm-12">
           <div class="toolbar-pf-actions">
             <div class="form-group toolbar-pf-filter">

--- a/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
+++ b/app/ui/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
@@ -74,7 +74,7 @@ export class FlowToolbarComponent implements OnInit {
   }
 
   isAlternateFlow(flow: Flow) {
-    return flow.type === ALTERNATE;
+    return flow.type && flow.type === ALTERNATE;
   }
 
   isConditionalFlow(flow: Flow) {

--- a/app/ui/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
+++ b/app/ui/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
@@ -31,7 +31,7 @@
                *ngFor="let flowSet of form.get('flowOptions').controls; let i = index;">
             <div class="form-group flowOptionsContainer" [formGroupName]="i">
               <label class="col-md-2 control-label">{{i + 1}}. When</label>
-              <div class="col-md-8 flow-col">
+              <div [className]="editMode ? 'col-md-6 flow-col' : 'col-md-8 flow-col'">
                 <span class="readonly" *ngIf="!editMode" [textContent]="flowSet.controls.condition.value"></span>
                 <input
                   *ngIf="editMode"
@@ -43,6 +43,28 @@
                 <span class="help-block" [textContent]="editMode ? 'Provide a condition that you want to evaluate.' : ''"></span>
                 <span *ngIf="editMode && flowSet.controls.condition.dirty && flowSet.controls.condition.errors?.required" class="help-block error">Condition is required</span>
                 <span *ngIf="editMode && flowSet.controls.condition.errors?.maxlength" class="help-block error">Maximum characters exceeded</span>
+              </div>
+              <div *ngIf="editMode" class="col-md-2">
+                <div class="flow-buttons">
+                  <a
+                    class="fa fa-arrow-circle-up"
+                    [attr.aria-label]="'Move flow up'"
+                    tooltip="Move flow up"
+                    placement="left"
+                    container="body"
+                    (keydown.enter)="moveUp(i)"
+                    (click)="moveUp(i)">
+                  </a>
+                  <a
+                    class="fa fa-arrow-circle-down"
+                    [attr.aria-label]="'Move flow down'"
+                    tooltip="Move flow up"
+                    placement="left"
+                    container="body"
+                    (keydown.enter)="moveDown(i)"
+                    (click)="moveDown(i)">
+                  </a>
+                </div>
               </div>
               <div *ngIf="!editMode" class="col-sm-12 col-md-2">
                 <button


### PR DESCRIPTION
Users can change the order of conditions in a conditional flows step. Also when the step configure page is left the step reconciles its flows in order to avoid left overs