### PR TITLE
feat: Add Google Sheets get values operation as middle step

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
@@ -40,6 +40,7 @@ import org.apache.camel.util.ObjectHelper;
 public final class GoogleSheetsMetadataRetrieval extends ComponentMetadataRetrieval {
 
     private static final String SHEETS_GET_VALUES_ACTION = "io.syndesis:sheets-get-values-connector";
+    private static final String SHEETS_RETRIEVE_VALUES_ACTION = "io.syndesis:sheets-retrieve-values-connector";
     private static final String SHEETS_UPDATE_VALUES_ACTION = "io.syndesis:sheets-update-values-connector";
     private static final String SHEETS_APPEND_VALUES_ACTION = "io.syndesis:sheets-append-values-connector";
 
@@ -82,7 +83,7 @@ public final class GoogleSheetsMetadataRetrieval extends ComponentMetadataRetrie
                 }
 
                 DataShape.Builder outputShapeBuilder = new DataShape.Builder().type("VALUE_RANGE_PARAM_OUT");
-                if (ObjectHelper.equal(actionId, SHEETS_GET_VALUES_ACTION)) {
+                if (ObjectHelper.isEqualToAny(actionId, SHEETS_GET_VALUES_ACTION, SHEETS_RETRIEVE_VALUES_ACTION)) {
                     outputShapeBuilder.kind(DataShapeKinds.JSON_SCHEMA)
                             .name("ValueRange Result")
                             .description(String.format("Results of range [%s]", valueRangeMetaData.getRange()))

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sheets;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
+import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.util.ObjectHelper;
+
+public class GoogleSheetsRetrieveValuesCustomizer implements ComponentProxyCustomizer {
+
+    private static final String ROW_PREFIX = "#";
+
+    private String spreadsheetId;
+    private String range;
+    private String majorDimension;
+    private String[] columnNames;
+
+    @Override
+    public void customize(ComponentProxyComponent component, Map<String, Object> options) {
+        setApiMethod(options);
+        component.setBeforeProducer(this::beforeProducer);
+        component.setAfterProducer(this::afterProducer);
+    }
+
+    private void setApiMethod(Map<String, Object> options) {
+        spreadsheetId = (String) options.get("spreadsheetId");
+        range = (String) options.get("range");
+        majorDimension = (String) Optional.ofNullable(options.get("majorDimension"))
+                .orElse(RangeCoordinate.DIMENSION_ROWS);
+        columnNames = Optional.ofNullable(options.get("columnNames"))
+                .map(Object::toString)
+                .map(names -> names.split(","))
+                .orElse(new String[]{});
+        Arrays.parallelSetAll(columnNames, (i) -> columnNames[i].trim());
+
+        options.put("apiName",
+                GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName());
+        options.put("methodName", "get");
+    }
+
+    private void beforeProducer(Exchange exchange) {
+        final Message in = exchange.getIn();
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId", spreadsheetId);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "range", range);
+        in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "majorDimension", majorDimension);
+    }
+
+    private void afterProducer(Exchange exchange) throws JsonProcessingException {
+        final Message in = exchange.getIn();
+        List<String> jsonBeans = createModelFromValueRange(in);
+        in.setBody(jsonBeans);
+    }
+
+    private List<String> createModelFromValueRange(Message in) throws JsonProcessingException {
+        final List<String> jsonBeans = new ArrayList<>();
+        final ValueRange valueRange = in.getBody(ValueRange.class);
+
+        if (valueRange != null) {
+            if (ObjectHelper.isNotEmpty(valueRange.getRange())) {
+                range = valueRange.getRange();
+            }
+            RangeCoordinate rangeCoordinate = RangeCoordinate.fromRange(range);
+
+            if (ObjectHelper.isNotEmpty(valueRange.getMajorDimension())) {
+                majorDimension = valueRange.getMajorDimension();
+            }
+
+            if (ObjectHelper.equal(RangeCoordinate.DIMENSION_ROWS, majorDimension)) {
+                for (List<Object> values : valueRange.getValues()) {
+                    final Map<String, Object> model = new HashMap<>();
+                    model.put("spreadsheetId", spreadsheetId);
+                    int columnIndex = rangeCoordinate.getColumnStartIndex();
+                    for (Object value : values) {
+                        model.put(CellCoordinate.getColumnName(columnIndex, rangeCoordinate.getColumnStartIndex(), columnNames), value);
+                        columnIndex++;
+                    }
+                    jsonBeans.add(Json.writer().writeValueAsString(model));
+                }
+            } else if (ObjectHelper.equal(RangeCoordinate.DIMENSION_COLUMNS, majorDimension)) {
+                for (List<Object> values : valueRange.getValues()) {
+                    final Map<String, Object> model = new HashMap<>();
+                    model.put("spreadsheetId", spreadsheetId);
+                    int rowIndex = rangeCoordinate.getRowStartIndex() + 1;
+                    for (Object value : values) {
+                        model.put(ROW_PREFIX + rowIndex, value);
+                        rowIndex++;
+                    }
+                    jsonBeans.add(Json.writer().writeValueAsString(model));
+                }
+            }
+        }
+
+        return jsonBeans;
+    }
+}

--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -437,6 +437,119 @@
     },
     {
       "actionType": "connector",
+      "description": "Retrieve data range values from a spreadsheet on your the Google Sheets account that this connection is authorized to access.",
+      "descriptor": {
+        "componentScheme": "google-sheets",
+        "connectorCustomizers": [
+          "io.syndesis.connector.sheets.GoogleSheetsRetrieveValuesCustomizer"
+        ],
+        "inputDataShape": {
+          "kind": "none"
+        },
+        "outputDataShape": {
+          "kind": "json-schema"
+        },
+        "propertyDefinitionSteps": [
+          {
+            "description": "Specify the value range that you want to retrieve.",
+            "name": "Retrieve spreadsheet values from Google Sheets",
+            "properties": {
+              "headerRow": {
+                "deprecated": false,
+                "displayName": "Header row number",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Enter the row number that represents the headers. These values are used as column names.",
+                "order": "4",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "majorDimension": {
+                "defaultValue": "ROWS",
+                "deprecated": false,
+                "displayName": "Major Dimension",
+                "enum": [
+                  {
+                    "label": "Rows",
+                    "value": "ROWS"
+                  },
+                  {
+                    "label": "Columns",
+                    "value": "COLUMNS"
+                  }
+                ],
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The major dimension that results should use. Indicates which dimension results apply to.",
+                "order": "3",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "range": {
+                "defaultValue": "A:A",
+                "deprecated": false,
+                "displayName": "Range",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Value range in a spreadsheet to obtain.",
+                "order": "2",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              },
+              "spreadsheetId": {
+                "deprecated": false,
+                "displayName": "SpreadsheetId",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "The spreadsheet identifier.",
+                "order": "1",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Specify column names.",
+            "name": "Column name mappings",
+            "properties": {
+              "columnNames": {
+                "deprecated": false,
+                "displayName": "Column names",
+                "group": "producer",
+                "javaType": "java.lang.String",
+                "kind": "parameter",
+                "label": "producer",
+                "labelHint": "Comma delimited list of names that describe the columns.",
+                "order": "4",
+                "required": false,
+                "secret": false,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "id": "io.syndesis:sheets-retrieve-values-connector",
+      "name": "Retrieve sheet values",
+      "pattern": "To",
+      "tags": [
+        "dynamic"
+      ]
+    },
+    {
+      "actionType": "connector",
       "description": "Obtain data range values from a spreadsheet on your the Google Sheets account that this connection is authorized to access.",
       "descriptor": {
         "componentScheme": "google-sheets-stream",

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.connector.sheets;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
+import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
+
+    private GoogleSheetsRetrieveValuesCustomizer customizer;
+
+    @Before
+    public void setupCustomizer() {
+        customizer = new GoogleSheetsRetrieveValuesCustomizer();
+    }
+
+    @Test
+    public void testBeforeProducerFromOptions() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("spreadsheetId", getSpreadsheetId());
+        options.put("range", "A1");
+        options.put("majorDimension", RangeCoordinate.DIMENSION_ROWS);
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+        getComponent().getBeforeProducer().process(inbound);
+
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
+        Assert.assertEquals("get", options.get("methodName"));
+
+        Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId"));
+        Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "range"));
+        Assert.assertEquals(RangeCoordinate.DIMENSION_ROWS, inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "majorDimension"));
+    }
+
+    @Test
+    public void testAfterProducerRowDimension() throws Exception {
+        String range = "A1:A5";
+        String sheetName = "Sheet1";
+        String majorDimension = RangeCoordinate.DIMENSION_ROWS;
+
+        List<List<Object>> values = Arrays.asList(Collections.singletonList("a1"),
+                Collections.singletonList("a2"),
+                Collections.singletonList("a3"),
+                Collections.singletonList("a4"),
+                Collections.singletonList("a5"));
+
+        List<String> expectedValueModel = Arrays.asList("{\"spreadsheetId\":\"%s\", \"A\":\"a1\"}",
+                "{\"spreadsheetId\":\"%s\", \"A\":\"a2\"}",
+                "{\"spreadsheetId\":\"%s\", \"A\":\"a3\"}",
+                "{\"spreadsheetId\":\"%s\", \"A\":\"a4\"}",
+                "{\"spreadsheetId\":\"%s\", \"A\":\"a5\"}");
+
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("spreadsheetId", getSpreadsheetId());
+        options.put("range", range);
+        options.put("splitResults", false);
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        ValueRange valueRange = new ValueRange();
+        valueRange.setRange(sheetName + "!" + range);
+        valueRange.setMajorDimension(majorDimension);
+        valueRange.setValues(values);
+
+        inbound.getIn().setBody(valueRange);
+        getComponent().getAfterProducer().process(inbound);
+
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
+        Assert.assertEquals("get", options.get("methodName"));
+
+        @SuppressWarnings("unchecked")
+        List<String> model = inbound.getIn().getBody(List.class);
+        Assert.assertEquals(expectedValueModel.size(), model.size());
+        Iterator<String> modelIterator = model.iterator();
+        for (String expected : expectedValueModel) {
+            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+        }
+    }
+
+    @Test
+    public void testAfterProducerColumnDimension() throws Exception {
+        String range = "A1:A5";
+        String sheetName = "Sheet1";
+        String majorDimension = RangeCoordinate.DIMENSION_COLUMNS;
+
+        List<List<Object>> values = Collections.singletonList(Arrays.asList("a1", "a2", "a3", "a4", "a5"));
+        List<String> expectedValueModel = Collections.singletonList("{\"spreadsheetId\":\"%s\", \"#1\":\"a1\",\"#2\":\"a2\",\"#3\":\"a3\",\"#4\":\"a4\",\"#5\":\"a5\"}");
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("spreadsheetId", getSpreadsheetId());
+        options.put("range", range);
+        options.put("splitResults", false);
+
+        customizer.customize(getComponent(), options);
+
+        Exchange inbound = new DefaultExchange(createCamelContext());
+
+        ValueRange valueRange = new ValueRange();
+        valueRange.setRange(sheetName + "!" + range);
+        valueRange.setMajorDimension(majorDimension);
+        valueRange.setValues(values);
+
+        inbound.getIn().setBody(valueRange);
+        getComponent().getAfterProducer().process(inbound);
+
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
+        Assert.assertEquals("get", options.get("methodName"));
+
+        @SuppressWarnings("unchecked")
+        List<String> model = inbound.getIn().getBody(List.class);
+        Assert.assertEquals(expectedValueModel.size(), model.size());
+        Iterator<String> modelIterator = model.iterator();
+        for (String expected : expectedValueModel) {
+            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new google-sheets connector action that enables an integration to read values from a spreadsheet in the middle of an integration. Before the read values action was only available as a start connection in an integration

Fixes #5132 