### PR TITLE
feat: Support batch update in SQL connector

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -20,7 +20,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -208,17 +207,16 @@ public final class JSONBeanUtil {
      * Converts Camel Generated Key output to a list of JSON Bean Strings.
      *
      * @param in
-     * @param the name of the auto increment column name
+     * @param autoIncrementColumnName the name of the auto increment column name
      * @return List of JSON beans.
      */
     public static List<String> toJSONBeansFromHeader(Message in, String autoIncrementColumnName) {
         final List<String> jsonBeans = new ArrayList<>();
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> generatedKeys = in.getHeader(SqlConstants.SQL_GENERATED_KEYS_DATA, List.class);
-        Iterator<Map<String, Object>> iterator = generatedKeys.iterator();
-        while (iterator.hasNext()) {
+        for (Map<String, Object> generatedKey : generatedKeys) {
             final Map<String, Object> map = new HashMap<>();
-            map.put(autoIncrementColumnName, iterator.next().values().iterator().next());
+            map.put(autoIncrementColumnName, generatedKey.values().iterator().next());
             final String bean = JSONBeanUtil.toJSONBean(map);
             jsonBeans.add(bean);
         }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
@@ -139,7 +139,44 @@ public class SqlMetadataAdapterTest {
         ObjectWriter writer = Json.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
         assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+    }
 
+    @Test
+    public void adaptForSqlUpdateTest() throws IOException, JSONException {
+        CamelContext camelContext = new DefaultCamelContext();
+        SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
+        Map<String,Object> parameters = new HashMap<>();
+        for (final String name: props.stringPropertyNames()) {
+            parameters.put(name.substring(name.indexOf('.') + 1), props.getProperty(name));
+        }
+        parameters.put("query", "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)");
+        Optional<MetaData> metadata = ext.meta(parameters);
+        SqlMetadataRetrieval adapter = new SqlMetadataRetrieval();
+
+        SyndesisMetadata syndesisMetaData2 = adapter.adapt(camelContext, "sql", "sql-connector", parameters, metadata.get());
+        String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_update_metadata.json"), StandardCharsets.UTF_8).trim();
+        ObjectWriter writer = Json.writer();
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void adaptForSqlUpdateNoParamTest() throws IOException, JSONException {
+        CamelContext camelContext = new DefaultCamelContext();
+        SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
+        Map<String,Object> parameters = new HashMap<>();
+        for (final String name: props.stringPropertyNames()) {
+            parameters.put(name.substring(name.indexOf('.') + 1), props.getProperty(name));
+        }
+        parameters.put("query", "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES ('Sheldon', 'Cooper')");
+        Optional<MetaData> metadata = ext.meta(parameters);
+        SqlMetadataRetrieval adapter = new SqlMetadataRetrieval();
+
+        SyndesisMetadata syndesisMetaData2 = adapter.adapt(camelContext, "sql", "sql-connector", parameters, metadata.get());
+        String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_update_no_param_metadata.json"), StandardCharsets.UTF_8).trim();
+        ObjectWriter writer = Json.writer();
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
     }
 
     @Test

--- a/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
@@ -3,6 +3,9 @@
     "kind" : "json-schema",
     "type" : "SQL_PARAM_IN",
     "name" : "SQL Parameter",
+    "metadata": {
+      "variant": "element"
+    },
     "description" : "Parameters of SQL [SELECT * FROM NAME WHERE ID=:#id]",
     "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}"
   },

--- a/app/connector/sql/src/test/resources/sql/name_sql_update_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_update_metadata.json
@@ -1,0 +1,22 @@
+{
+  "inputShape" : {
+    "kind" : "json-schema",
+    "type" : "SQL_PARAM_IN",
+    "name" : "SQL Parameter",
+    "metadata": {
+      "variant": "collection"
+    },
+    "description" : "Parameters of SQL [INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)]",
+    "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"firstname\":{\"type\":\"string\",\"required\":true},\"lastname\":{\"type\":\"string\",\"required\":true}}}}"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "SQL_PARAM_OUT"
+  },
+  "properties" : {
+    "query" : [ {
+      "displayValue" : "query",
+      "value" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)"
+    } ]
+  }
+}

--- a/app/connector/sql/src/test/resources/sql/name_sql_update_no_param_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_update_no_param_metadata.json
@@ -1,0 +1,16 @@
+{
+  "inputShape" : {
+    "kind" : "none",
+    "type" : "SQL_PARAM_IN"
+  },
+  "outputShape" : {
+    "kind" : "none",
+    "type" : "SQL_PARAM_OUT"
+  },
+  "properties" : {
+    "query" : [ {
+      "displayValue" : "query",
+      "value" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES ('Sheldon', 'Cooper')"
+    } ]
+  }
+}


### PR DESCRIPTION
Adds batch update support to sql connector for INSERT, UPDATE, DELETE

New collection support in Syndesis is used to pass a list of parameter sets to the connector. The updates will be executed as batch using prepared statements.

Fixes #5158

