### PR TITLE
chore: Update to AtlasMap 1.40.0-alpha2

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
     <camel.version>2.21.0.fuse-740013</camel.version>
-    <atlasmap.version>1.39.6</atlasmap.version>
+    <atlasmap.version>1.40.0-alpha2</atlasmap.version>
     <jackson.databind.version>2.8.11.3</jackson.databind.version>
   </properties>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,7 +37,7 @@
     <syndesis.version>${project.version}</syndesis.version>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>1.39.6</atlasmap.version>
+    <atlasmap.version>1.40.0-alpha2</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-angular/package.json
+++ b/app/ui-angular/package.json
@@ -46,7 +46,7 @@
     "@angular/platform-browser": "~6",
     "@angular/platform-browser-dynamic": "~6",
     "@angular/router": "~6",
-    "@atlasmap/atlasmap-data-mapper": "1.39.6",
+    "@atlasmap/atlasmap-data-mapper": "1.40.0-alpha2",
     "@ng-dynamic-forms/core": "~5",
     "@ngrx/effects": "~6",
     "@ngrx/store": "~6",

--- a/app/ui-angular/yarn.lock
+++ b/app/ui-angular/yarn.lock
@@ -180,10 +180,10 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap-data-mapper@1.39.6":
-  version "1.39.6"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.39.6.tgz#e3e6565202e7900c20bf6409f58496863535a72e"
-  integrity sha512-anw+B3ZDeLlSp1AZvqG+Phu77D598b2zl06w/EvONmhiWOny1eNzHOz5QgHnIDtr7iCCokvONJ/NaTi5QDqwEQ==
+"@atlasmap/atlasmap-data-mapper@1.40.0-alpha2":
+  version "1.40.0-alpha2"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.40.0-alpha2.tgz#f7e6152715394d91bc783a8bdb72cd78eac2a14d"
+  integrity sha512-MQRmMJO6pRgcJHqiv09bT78gpZlGkvDXyPrbWB4io1mcr5piKb+VB/OpHu8ehOZagAxGw3yoFn2976nx1xzQQg==
   dependencies:
     tslib "^1.9.0"
 

--- a/app/ui-react/packages/atlasmap-assembly/package.json
+++ b/app/ui-react/packages/atlasmap-assembly/package.json
@@ -90,7 +90,7 @@
     "@angular/platform-browser": "7.2.7",
     "@angular/platform-browser-dynamic": "7.2.7",
     "@angular/router": "7.2.7",
-    "@atlasmap/atlasmap-data-mapper": "1.39.6",
+    "@atlasmap/atlasmap-data-mapper": "^1.40.0-alpha2",
     "@types/jasmine": "^3.3.9",
     "@types/jasmine-jquery": "^1.5.32",
     "@types/jasminewd2": "^2.0.3",

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -313,10 +313,10 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap-data-mapper@1.39.6":
-  version "1.39.6"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.39.6.tgz#e3e6565202e7900c20bf6409f58496863535a72e"
-  integrity sha512-anw+B3ZDeLlSp1AZvqG+Phu77D598b2zl06w/EvONmhiWOny1eNzHOz5QgHnIDtr7iCCokvONJ/NaTi5QDqwEQ==
+"@atlasmap/atlasmap-data-mapper@^1.40.0-alpha2":
+  version "1.40.0-alpha2"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.40.0-alpha2.tgz#f7e6152715394d91bc783a8bdb72cd78eac2a14d"
+  integrity sha512-MQRmMJO6pRgcJHqiv09bT78gpZlGkvDXyPrbWB4io1mcr5piKb+VB/OpHu8ehOZagAxGw3yoFn2976nx1xzQQg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Hi @riccardo-forina, it seems [this yarn.lock](https://github.com/syndesisio/syndesis/compare/master...igarashitm:atlasmap-1.40.0-alpha2?expand=1#diff-ea95db000913ed9454fdab13745b9f2e) was updated once I run yarn add with [this package.json](https://github.com/syndesisio/syndesis/compare/master...igarashitm:atlasmap-1.40.0-alpha2?expand=1#diff-35b3a34961dde4306d53b3a854bc5cee), am I doing right?