### PR TITLE
[fix] Auto save changes when applying conditional flows config

### DIFF
--- a/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
@@ -70,26 +70,30 @@
                     </button>
                   </li>
                   <li role="separator" class="divider"></li>
-                  <ng-container *ngFor="let flow of getConditionalFlows()">
-                    <li>
-                      <a
-                        [routerLink]="[
-                          '/integrations',
-                          currentFlowService.integration?.id,
-                          flow.id,
-                          'edit'
-                        ]"
-                      >
-                        <strong>{{ getFlowName(flow) }}</strong
-                        ><br />
-                        <div style="display: inline-flex">
-                          <span class="condition" [textContent]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"
-                                                  [attr.data-verb]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"></span>&nbsp;
-                          <span>{{ flow.description }}</span>
-                        </div>
-                      </a>
-                    </li>
-                    <li role="separator" class="divider"></li>
+                  <ng-container *ngFor="let group of getConditionalFlowGroups(); let i=index; let lastGroup=last">
+                    <li class="dropdown-header">#{{i + 1}} Conditional Flows</li>
+                    <ng-container *ngFor="let flow of group.flows; let last=last">
+                      <li>
+                        <a
+                          [routerLink]="[
+                            '/integrations',
+                            currentFlowService.integration?.id,
+                            flow.id,
+                            'edit'
+                          ]"
+                        >
+                          <strong>{{ getFlowName(flow) }}</strong
+                          ><br />
+                          <div style="display: inline-flex">
+                            <span class="condition" [textContent]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"
+                                                    [attr.data-verb]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"></span>&nbsp;
+                            <span>{{ flow.description }}</span>
+                          </div>
+                        </a>
+                      </li>
+                      <li *ngIf="!last" role="separator" class="divider"></li>
+                    </ng-container>
+                    <li *ngIf="!lastGroup" role="separator" class="divider"></li>
                   </ng-container>
                 </ul>
               </div>
@@ -175,7 +179,7 @@
                       ])
                     "
               >
-                Back to primary flow
+                Go to primary flow
               </button>
             </div>
           </div>

--- a/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
@@ -85,33 +85,25 @@ export class FlowToolbarComponent implements OnInit {
     return this.isAlternateFlow(flow) && flow.metadata['kind'] === 'default';
   }
 
-  getConditionalFlows(): Flow[] {
+  getConditionalFlowGroups() {
     const conditionalFlows = this.flows.filter(flow => this.isConditionalFlow(flow));
 
     // Add default flows to the very end of the list, ensures that default flows are always at the end of a group
     conditionalFlows.push(...this.flows.filter(flow => this.isDefaultFlow(flow)));
 
     // potentially we have many flows that belong to different steps, so group flows by step id
-    const ids = [];
-    const result = [];
+    const flowGroups = [];
     conditionalFlows.forEach(flow => {
       const stepId = flow.metadata['stepId'];
-      const index = ids.indexOf(stepId);
-      if (index > -1) {
-        result[index].push(flow);
+      const flowGroup = flowGroups.find(group => group.id === stepId);
+      if (flowGroup) {
+        flowGroup['flows'].push(flow);
       } else {
-        ids.push(stepId);
-        result.push([flow]);
+        flowGroups.push({id: stepId, flows: [flow]});
       }
     });
 
-    if (result.length) {
-      return result.reduce((prev, curr) => {
-        return prev.concat(curr);
-      });
-    } else {
-      return result;
-    }
+    return flowGroups;
   }
 
   publish() {

--- a/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.ts
@@ -105,9 +105,13 @@ export class FlowToolbarComponent implements OnInit {
       }
     });
 
-    return result.reduce((prev, curr) => {
-      return prev.concat(curr);
-    });
+    if (result.length) {
+      return result.reduce((prev, curr) => {
+        return prev.concat(curr);
+      });
+    } else {
+      return result;
+    }
   }
 
   publish() {

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
@@ -77,7 +77,7 @@
               <div *ngIf="editMode" class="col-sm-12 col-md-2">
                 <div class="pull-right flow-buttons">
                   <a
-                    *ngIf="i > 0"
+                    *ngIf="i > 0 || form.get('flowOptions').controls.length > 1"
                     tabindex="1"
                     [attr.aria-label]="'Remove flow #' + i"
                     class="fa fa-trash-o"

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
@@ -26,7 +26,7 @@
     <ng-template #content>
       <form (change)="onChange($event)" [formGroup]="form" class="cbr-form form-horizontal">
         <fieldset>
-          <legend>Conditions <button class="btn btn-default manage-flows pull-right" (click)="toggleEditMode()" [disabled]="!form.valid" [textContent]="editMode ? 'Apply' : 'Manage'"></button></legend>
+          <legend>Conditions <button class="btn btn-default manage-flows pull-right" (click)="applyChanges()" [disabled]="!form.valid" [textContent]="editMode ? 'Apply' : 'Manage'"></button></legend>
           <div formArrayName="flowOptions"
                *ngFor="let flowSet of form.get('flowOptions').controls; let i = index;">
             <div class="form-group flowOptionsContainer" [formGroupName]="i">

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.ts
@@ -214,7 +214,7 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
       .map(flow => flow.id);
 
     Array.from(new Set([...unfinishedFlows, ...unknownFlows])).forEach(flowId => {
-      this.doRemoveFlow(flowId, undefined);
+      this.doRemoveFlow(flowId);
     });
   }
 
@@ -240,7 +240,12 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
     return <FormArray>this.flowOptions;
   }
 
-  toggleEditMode() {
+  applyChanges() {
+    if (this.editMode) {
+      this.onChange();
+      this.flowPageService.save(this.route);
+    }
+
     this.editMode = !this.editMode;
   }
 
@@ -267,7 +272,7 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
       () => this.myFlows.removeAt(index));
   }
 
-  doRemoveFlow(flowId: string, then: () => void): void {
+  doRemoveFlow(flowId: string, then?: () => void): void {
     this.currentFlowService.events.emit({
       kind: INTEGRATION_REMOVE_FLOW,
       flowId: flowId,
@@ -282,17 +287,15 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
 
   openDefaultFlow() {
     const flowId = this.configuredProperties.default;
-    const integrationId = this.currentFlowService.integration.id;
-    this.router.navigate([
-      '/integrations',
-      integrationId,
-      flowId,
-      'edit'
-    ]);
+    this.doOpenFlow(flowId);
   }
 
   openFlow(index: number) {
     const flowId = this.myFlows.controls[index].get('flow').value;
+    this.doOpenFlow(flowId);
+  }
+
+  doOpenFlow(flowId: string) {
     const integrationId = this.currentFlowService.integration.id;
     this.router.navigate([
       '/integrations',

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/step-configure.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/step-configure.component.html
@@ -121,6 +121,7 @@
                               [(configuredProperties)]="customProperties"
                               [(valid)]="valid"
                               [position]="position"
+                              (configuredPropertiesChange)="saveProperties($event)"
                             ></syndesis-content-based-router>
                             <div class="control-buttons">
                               <ng-container

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/step-configure.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/step-configure.component.ts
@@ -85,6 +85,15 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
     } else {
       data = this.formGroup ? this.formGroup.value : {};
     }
+    this.saveProperties(data, () => {
+      this.router.navigate(['save-or-add-step'], {
+        queryParams: { validate: true },
+        relativeTo: this.route.parent,
+      });
+    });
+  }
+
+  saveProperties(data: any = {}, then?: () => void) {
     const properties = this.formFactory.sanitizeValues(
       { ...data },
       this.formConfig
@@ -101,10 +110,9 @@ export class IntegrationStepConfigureComponent implements OnInit, OnDestroy {
           position: this.position,
           metadata: { configured: 'true' },
           onSave: () => {
-            this.router.navigate(['save-or-add-step'], {
-              queryParams: { validate: true },
-              relativeTo: this.route.parent,
-            });
+            if (then) {
+              then();
+            }
           },
         });
       },


### PR DESCRIPTION
Fixes #5489 #5491 #5484 #5487 #5488
Ref #5216 

Avoid loosing changes when applying configuration changes and directly opening a conditional flow before hitting the `Done` button.

Basically when hitting the `Apply` button things get persisted in the conditional step configuration and the flow gets saved, too.