### PR TITLE
fix(connector): set parameters from HTTP request

### DIFF
--- a/app/connector/support/processor/pom.xml
+++ b/app/connector/support/processor/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
When Camel Servlet component binds query parameters to the Camel message headers it uses the configured `HttpHeaderFilterStrategy`, and in Syndesis this is the `SyndesisHeaderStrategy` which will bind only the `Content-Type` header and will not bind the query parameters to Camel message headers.

With this in addition to Camel message headers the query parameter value is fetched from the `HttpServletRequest` if it is present in the Camel message headers, and when the Servlet component is used this is usually the case.

This also refines the support for query parameters allowing multiple query parameter values to be set for the parameter value making the parameter value a JSON array.

Fixes #5152