### PR TITLE
fix(5241): Quote string used as key predicate for update

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -18,8 +18,6 @@ package io.syndesis.connector.odata.component;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.camel.Component;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.olingo4.Olingo4AppEndpointConfiguration;
@@ -34,10 +32,6 @@ import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 public final class ODataComponent extends ComponentProxyComponent implements ODataConstants {
-
-    private static final Pattern NUMBER_ONLY_PATTERN = Pattern.compile("-?\\d+");
-
-    private static final Pattern KEY_PREDICATE_PATTERN = Pattern.compile("\\(?'?(.+?)\\'?\\)?\\/(.+)");
 
     /**
      * These fields are populated using reflection by the HandlerCustomizer class.
@@ -269,60 +263,10 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         //
         String resourcePath = getResourcePath();
         if (getKeyPredicate() != null) {
-            resourcePath = resourcePath + formatKeyPredicate();
+            resourcePath = resourcePath + ODataUtil.formatKeyPredicate(getKeyPredicate(), true);
         }
 
         configuration.setResourcePath(resourcePath);
-    }
-
-    @SuppressWarnings("PMD")
-    private String formatKeyPredicate() {
-        String keyPredicate = getKeyPredicate();
-        String subPredicate = null;
-
-        Matcher kp1Matcher = KEY_PREDICATE_PATTERN.matcher(keyPredicate);
-        if (kp1Matcher.matches()) {
-            keyPredicate = kp1Matcher.group(1);
-            subPredicate = kp1Matcher.group(2);
-        }
-
-        if (keyPredicate.startsWith(OPEN_BRACKET)) {
-            keyPredicate = keyPredicate.substring(1);
-        }
-
-        if (keyPredicate.startsWith(QUOTE_MARK)) {
-            keyPredicate = keyPredicate.substring(1);
-        }
-
-        if (keyPredicate.endsWith(CLOSE_BRACKET)) {
-            keyPredicate = keyPredicate.substring(0, keyPredicate.length() - 1);
-        }
-
-        if (keyPredicate.endsWith(QUOTE_MARK)) {
-            keyPredicate = keyPredicate.substring(0, keyPredicate.length() - 1);
-        }
-
-        //
-        // if keyPredicate is a number only, it doesn't need quotes
-        //
-        Matcher numberOnlyMatcher = NUMBER_ONLY_PATTERN.matcher(keyPredicate);
-        boolean noQuotes = numberOnlyMatcher.matches();
-
-        StringBuilder buf = new StringBuilder(OPEN_BRACKET);
-        if (! noQuotes) {
-            buf.append(QUOTE_MARK);
-        }
-        buf.append(keyPredicate);
-        if (! noQuotes) {
-            buf.append(QUOTE_MARK);
-        }
-        buf.append(CLOSE_BRACKET);
-
-        if (subPredicate != null) {
-            buf.append(FORWARD_SLASH).append(subPredicate);
-        }
-
-        return buf.toString();
     }
 
     @Override

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataPatchCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataPatchCustomizer.java
@@ -21,6 +21,7 @@ import org.apache.camel.Message;
 import org.apache.camel.util.ObjectHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.syndesis.connector.odata.ODataUtil;
 
 public class ODataPatchCustomizer extends AbstractProducerCustomizer {
 
@@ -45,7 +46,7 @@ public class ODataPatchCustomizer extends AbstractProducerCustomizer {
 
         if (! ObjectHelper.isEmpty(keyPredicateNode)) {
             String keyPredicate = keyPredicateNode.asText();
-            in.setHeader(OLINGO4_PROPERTY_PREFIX + KEY_PREDICATE, keyPredicate);
+            in.setHeader(OLINGO4_PROPERTY_PREFIX + KEY_PREDICATE, ODataUtil.formatKeyPredicate(keyPredicate, false));
 
             // Remove the key predicate from the body
             ObjectNode objNode = ((ObjectNode) node);

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractODataTest implements ODataConstants {
 
     protected static ODataTestServer sslAuthTestServer;
 
-    protected static final String REF_SERVICE_URI = "https://services.odata.org/TripPinRESTierService";
+    protected static final String REF_SERVICE_URI = "https://services.odata.org/TripPinRESTierService/(S(4gus0w41xmxedlzbywj2srqo))";
 
     protected CamelContext context;
 


### PR DESCRIPTION
* ODataPatchCustomizer
 * Format the key predicate passed in by the data shape, quoting or not
   depending on whether integer or string

* ODataUtil
* ODataComponent
 * Share the formatKeyPredicate function

* Adds test that updates the reference odata service, which uses string
  key predicates.