### PR TITLE
chore: switch the syndesis-ui image to React

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,9 @@ jobs:
       - setup_remote_docker
       - checkout
       - restore_cache:
-          key: syndesis-mvn-ui-{{ checksum "app/ui-angular/pom.xml" }}
+          key: syndesis-mvn-ui-{{ checksum "app/ui-react/pom.xml" }}
       - restore_cache:
-          key: syndesis-yarn-{{ checksum "app/ui-angular/yarn.lock" }}
+          key: syndesis-yarn-{{ checksum "app/ui-react/yarn.lock" }}
       - run:
           name: Build UI
           command: |
@@ -97,20 +97,60 @@ jobs:
             curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
             apt-get update -y
             apt-get install -y --force-yes --no-install-recommends  google-chrome-stable fontconfig fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-symbola fonts-noto ttf-freefont
-            ./tools/bin/syndesis build --batch-mode --module ui-angular,ui-react --docker | tee build_log.txt
+            ./tools/bin/syndesis build --batch-mode --module ui-react --docker | tee build_log.txt
       - <<: *save_junit
       - store_test_results:
           path: /workspace/junit
       - store_artifacts:
           path: ./build_ui_log.txt
       - save_cache:
-          key: syndesis-yarn-{{ checksum "app/ui-angular/yarn.lock" }}
+          key: syndesis-yarn-{{ checksum "app/ui-react/yarn.lock" }}
           paths:
           - /usr/local/share/.cache/yarn/v1
       - store_artifacts:
           path: build_log.txt
       - save_cache:
-          key: syndesis-mvn-ui-{{ checksum "app/ui-angular/pom.xml" }}
+          key: syndesis-mvn-ui-{{ checksum "app/ui-react/pom.xml" }}
+          paths:
+          - ~/.m2
+      - <<: *push_images
+
+  ui-legacy:
+    <<: *job_defaults
+    environment:
+      DOCKER_IMAGES: syndesis-ui-legacy
+      CHROME_BIN: "/usr/bin/google-chrome"
+      <<: *common_env
+    steps:
+      - setup_remote_docker
+      - checkout
+      - restore_cache:
+          key: syndesis-mvn-ui-legacy-{{ checksum "app/ui-angular/pom.xml" }}
+      - restore_cache:
+          key: syndesis-yarn-legacy-{{ checksum "app/ui-angular/yarn.lock" }}
+      - run:
+          name: Build UI
+          command: |
+            apt-get update -y
+            apt-get install -y --force-yes libxss1 patch apt-transport-https
+            echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+            curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+            apt-get update -y
+            apt-get install -y --force-yes --no-install-recommends  google-chrome-stable fontconfig fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-symbola fonts-noto ttf-freefont
+            ./tools/bin/syndesis build --batch-mode --module ui-angular --docker | tee build_log.txt
+      - <<: *save_junit
+      - store_test_results:
+          path: /workspace/junit
+      - store_artifacts:
+          path: ./build_ui_log.txt
+      - save_cache:
+          key: syndesis-yarn-legacy-{{ checksum "app/ui-angular/yarn.lock" }}
+          paths:
+          - /usr/local/share/.cache/yarn/v1
+      - store_artifacts:
+          path: build_log.txt
+      - save_cache:
+          key: syndesis-mvn-ui-legacy{{ checksum "app/ui-angular/pom.xml" }}
           paths:
           - ~/.m2
       - <<: *push_images
@@ -438,6 +478,7 @@ workflows:
               only: master
       - license-check
       - ui
+      - ui-legacy
       - common
       - operator
       - extension:

--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -419,7 +419,7 @@
               <buildStrategy>docker</buildStrategy>
               <images>
                 <image>
-                  <name>${image.ui}</name>
+                  <name>syndesis/syndesis-ui-legacy:%l</name>
                   <build>
                     <assembly>
                       <inline>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -434,7 +434,7 @@
               <buildStrategy>docker</buildStrategy>
               <images>
                 <image>
-                  <name>syndesis/syndesis-ui:latest-react</name>
+                  <name>${image.ui}</name>
                   <build>
                     <assembly>
                       <inline>

--- a/install/generator/03-syndesis-ui.yml.mustache
+++ b/install/generator/03-syndesis-ui.yml.mustache
@@ -123,7 +123,7 @@
           "baseJSONInspectionServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/json/",
           "disableMappingPreviewMode": false
         },
-        "datavirt": { 
+        "datavirt": {
           "dvUrl": "/vdb-builder/v1/"
         },
         "features" : {

--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -86,12 +86,19 @@
             - --cookie-secret=$(OAUTH_COOKIE_SECRET)
             - --pass-access-token
             - --skip-provider-button
-            - --skip-auth-regex=/logout
-            - --skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)
-            - --skip-auth-regex=/api/v1/swagger.*
-            - --skip-auth-regex=/api/v1/index.html
-            - --skip-auth-regex=/api/v1/credentials/callback
-            - --skip-auth-regex=/api/v1/version
+            - '--skip-auth-regex=/api/v1/swagger.*'
+            - '--skip-auth-regex=/api/v1/index.html'
+            - '--skip-auth-regex=/api/v1/credentials/callback'
+            - '--skip-auth-regex=/service-worker.js'
+            - '--skip-auth-regex=/manifest.json'
+            - '--skip-auth-regex=/asset-manifest.json'
+            - '--skip-auth-regex=/precache-manifest.json'
+            - '--skip-auth-regex=/atlasmap.*'
+            - '--skip-auth-regex=/apicurio.*'
+            - '--skip-auth-regex=/favicon.ico'
+            - '--skip-auth-regex=/icons[^/]*'
+            - '--skip-auth-regex=/static[^/]*'
+            - '--skip-auth-regex=/precache-manifest.*.js'
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -503,7 +503,7 @@ objects:
           "baseJSONInspectionServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/json/",
           "disableMappingPreviewMode": false
         },
-        "datavirt": { 
+        "datavirt": {
           "dvUrl": "/vdb-builder/v1/"
         },
         "features" : {
@@ -1061,12 +1061,19 @@ objects:
             - --cookie-secret=$(OAUTH_COOKIE_SECRET)
             - --pass-access-token
             - --skip-provider-button
-            - --skip-auth-regex=/logout
-            - --skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)
-            - --skip-auth-regex=/api/v1/swagger.*
-            - --skip-auth-regex=/api/v1/index.html
-            - --skip-auth-regex=/api/v1/credentials/callback
-            - --skip-auth-regex=/api/v1/version
+            - '--skip-auth-regex=/api/v1/swagger.*'
+            - '--skip-auth-regex=/api/v1/index.html'
+            - '--skip-auth-regex=/api/v1/credentials/callback'
+            - '--skip-auth-regex=/service-worker.js'
+            - '--skip-auth-regex=/manifest.json'
+            - '--skip-auth-regex=/asset-manifest.json'
+            - '--skip-auth-regex=/precache-manifest.json'
+            - '--skip-auth-regex=/atlasmap.*'
+            - '--skip-auth-regex=/apicurio.*'
+            - '--skip-auth-regex=/favicon.ico'
+            - '--skip-auth-regex=/icons[^/]*'
+            - '--skip-auth-regex=/static[^/]*'
+            - '--skip-auth-regex=/precache-manifest.*.js'
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
This switches the `syndesis/syndesis-ui` image to React and publishes the Angular UI as `syndesis/syndesis-ui-legacy`. The fabric8 Maven plugin configuration was changed to reflect that and the CircleCI configuration was updated to build the two versions as separate jobs.

OAuth proxy configuration was switched to the configuration needed for the React UI.

Ref #5426