### PR TITLE
chore: add addon for installing legacy UI

### DIFF
--- a/install/addons/syndesis-legacy-ui-serviceaccount.yml
+++ b/install/addons/syndesis-legacy-ui-serviceaccount.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: syndesis-oauth-client-legacy
+  labels:
+    app: syndesis
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirecturi.local: https://localhost:4200
+    serviceaccounts.openshift.io/oauth-redirecturi.route: https://
+    serviceaccounts.openshift.io/oauth-redirectreference.route: '{"kind": "OAuthRedirectReference", "apiVersion": "v1", "reference": {"kind": "Route","name": "syndesis-legacy"}}'

--- a/install/addons/syndesis-legacy-ui.yml
+++ b/install/addons/syndesis-legacy-ui.yml
@@ -1,0 +1,342 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: syndesis-legacy-ui
+parameters:
+- name: ROUTE_HOSTNAME
+  description: The external hostname to access Syndesis Legacy UI
+- name: OPENSHIFT_PROJECT
+  description: The name of the OpenShift project Syndesis is being deployed into.
+  displayName: OpenShift project to deploy into
+  required: true
+- name: SAR_PROJECT
+  description: The user needs to have permissions to at least get a list of pods in the given project in order to be granted access to the Syndesis installation in the $OPENSHIFT_PROJECT
+  displayName: OpenShift project to be used to authenticate the user against
+  required: true
+- name: OPENSHIFT_OAUTH_CLIENT_SECRET
+  description: OpenShift OAuth client secret
+  generate: expression
+  from: "[a-zA-Z0-9]{64}"
+  required: true
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  value: 'docker.io'
+- description: Namespace containing image streams
+  displayName: Image Stream Namespace
+  name: IMAGE_STREAM_NAMESPACE
+  value: ''
+- description: Secret to use to encrypt oauth cookies
+  displayName: OAuth Cookie Secret
+  name: OAUTH_COOKIE_SECRET
+  generate: expression
+  from: '[a-zA-Z0-9]{32}'
+message: |-
+  Syndesis legacy UI is deployed to ${ROUTE_HOSTNAME}.
+objects:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    name: syndesis-ui-legacy
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-ui-legacy
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui-legacy:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: syndesis-oauth-proxy-cookie-secret-legacy
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+  stringData:
+    oauthCookieSecret: ${OAUTH_COOKIE_SECRET}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: syndesis-ui-legacy
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-ui-legacy
+  spec:
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/component: syndesis-ui-legacy
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-ui-legacy
+    name: syndesis-ui-legacy
+  spec:
+    replicas: 1
+    selector:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/component: syndesis-ui-legacy
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      resources:
+        limits:
+          memory: "256Mi"
+        requests:
+          memory: "20Mi"
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: syndesis
+          syndesis.io/app: syndesis
+          syndesis.io/type: infrastructure
+          syndesis.io/component: syndesis-ui-legacy
+      spec:
+        serviceAccountName: syndesis-default
+        containers:
+        - name: syndesis-ui-legacy
+          image: ' '
+
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: 8080
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 8080
+            initialDelaySeconds: 1
+          ports:
+          - containerPort: 8080
+          volumeMounts:
+          - mountPath: /usr/share/nginx/html/config
+            name: config-volume
+          # Set to burstable with a low memory footprint to start (50 Mi)
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 50Mi
+        volumes:
+        - configMap:
+            name: syndesis-ui-config-legacy
+          name: config-volume
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - syndesis-ui-legacy
+        from:
+          kind: ImageStreamTag
+          name: syndesis-ui-legacy:latest
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: ImageChange
+
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-oauthproxy-legacy
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: syndesis-oauthproxy-tls-legacy
+    name: syndesis-oauthproxy-legacy
+  spec:
+    ports:
+    - port: 8443
+      protocol: TCP
+      targetPort: 8443
+    selector:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/component: syndesis-oauthproxy-legacy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+    annotations:
+      console.alpha.openshift.io/overview-app-route: "true"
+    name: syndesis-legacy
+  spec:
+    host: ${ROUTE_HOSTNAME}
+    port:
+      targetPort: 8443
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: reencrypt
+    to:
+      kind: Service
+      name: syndesis-oauthproxy-legacy
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-oauthproxy-legacy
+    name: syndesis-oauthproxy-legacy
+  spec:
+    replicas: 1
+    selector:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/component: syndesis-oauthproxy-legacy
+    strategy:
+      resources:
+        limits:
+          memory: "256Mi"
+        requests:
+          memory: "20Mi"
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: syndesis
+          syndesis.io/app: syndesis
+          syndesis.io/type: infrastructure
+          syndesis.io/component: syndesis-oauthproxy-legacy
+      spec:
+        containers:
+        - name: syndesis-oauthproxy-legacy
+          image: ' '
+          args:
+            - --provider=openshift
+            - --client-id=system:serviceaccount:${OPENSHIFT_PROJECT}:syndesis-oauth-client-legacy
+            - --client-secret=${OPENSHIFT_OAUTH_CLIENT_SECRET}
+            - --upstream=http://syndesis-server/api/
+            - --upstream=http://syndesis-server/mapper/
+            - --upstream=http://syndesis-ui-legacy/
+            - --upstream=http://komodo-server/vdb-builder/
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret=$(OAUTH_COOKIE_SECRET)
+            - --pass-access-token
+            - --skip-provider-button
+            - '--skip-auth-regex=/logout'
+            - '--skip-auth-regex=/[^/]+\.(png|jpg|eot|svg|ttf|woff|woff2)'
+            - '--skip-auth-regex=/api/v1/swagger.*'
+            - '--skip-auth-regex=/api/v1/index.html'
+            - '--skip-auth-regex=/api/v1/credentials/callback'
+            - '--skip-auth-regex=/api/v1/version'
+            - --skip-auth-preflight
+            - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
+            - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --openshift-sar={"namespace":"${SAR_PROJECT}","resource":"pods","verb":"get"}
+            # Disabled for now: --pass-user-bearer-token as this requires extra permission which only
+            # can be given by a cluster-admin
+          env:
+          - name: OAUTH_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: syndesis-oauth-proxy-cookie-secret-legacy
+                key: oauthCookieSecret
+          ports:
+          - containerPort: 8443
+            name: public
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              port: 8443
+              path: /oauth/healthz
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              port: 8443
+              path: /oauth/healthz
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: syndesis-oauthproxy-tls-legacy
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 20Mi
+        serviceAccountName: syndesis-oauth-client-legacy
+        volumes:
+        - name: syndesis-oauthproxy-tls-legacy
+          secret:
+            secretName: syndesis-oauthproxy-tls-legacy
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - syndesis-oauthproxy-legacy
+        from:
+          kind: ImageStreamTag
+          name: oauth-proxy:v4.0.0
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: ImageChange
+
+    - type: ConfigChange
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: syndesis-ui-config-legacy
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-ui-legacy
+  data:
+    config.json: |
+      {
+        "apiBase": "https://${ROUTE_HOSTNAME}",
+        "apiEndpoint": "/api/v1",
+        "title": "Syndesis",
+        "consoleUrl": "${OPENSHIFT_CONSOLE_URL}",
+        "project": "${OPENSHIFT_PROJECT}",
+        "datamapper": {
+          "baseMappingServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/",
+          "baseJavaInspectionServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/java/",
+          "baseXMLInspectionServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/xml/",
+          "baseJSONInspectionServiceUrl": "https://${ROUTE_HOSTNAME}/api/v1/atlas/json/",
+          "disableMappingPreviewMode": false
+        },
+        "features" : {
+          "logging": false
+        },
+        "branding": {
+          "appName": "Syndesis",
+          "favicon32": "/favicon-32x32.png",
+          "favicon16": "/favicon-16x16.png",
+          "touchIcon": "/apple-touch-icon.png",
+          "productBuild": false
+       }
+      }


### PR DESCRIPTION
Angular UI can be installed via:

```shell
$ oc create -f syndesis-legacy-ui.yml
$ oc create -f syndesis-legacy-ui-serviceaccount.yml
$ oc new-app syndesis-legacy-ui \
  -p ROUTE_HOSTNAME=syndesis-legacy.$(minishift ip).nip.io \
  -p OPENSHIFT_PROJECT=$(oc project -q) \
  -p OPENSHIFT_OAUTH_CLIENT_SECRET=$(oc sa get-token syndesis-oauth-client-legacy) \
  -p SAR_PROJECT=$(oc project -q)
```

Ref #5426