### PR TITLE
fix(5386): Correct disparity between odata meta schema and processed …

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataPatchCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataPatchCustomizer.java
@@ -16,6 +16,7 @@
 package io.syndesis.connector.odata.customizer;
 
 import java.io.IOException;
+import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.util.ObjectHelper;
@@ -52,6 +53,9 @@ public class ODataPatchCustomizer extends AbstractProducerCustomizer {
             ObjectNode objNode = ((ObjectNode) node);
             objNode.remove(KEY_PREDICATE);
             body = OBJECT_MAPPER.writeValueAsString(objNode);
+        } else {
+            // No key predicate found ... this means trouble!
+            throw new CamelExecutionException("No Key Predicate available for OData Patching", exchange);
         }
 
         if (! ObjectHelper.isEmpty(body)) {

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadCustomizer.java
@@ -24,19 +24,22 @@ import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 public class ODataReadCustomizer extends AbstractODataCustomizer {
 
     /*
-     * The component subsumes the split property from the options map
-     * and makes it available via a getter, hence the need to look at the
-     * component rather than the options
+     * The component subsumes the split & key predicate properties from the
+     * options map & makes them available via a getter, hence the need to look
+     * at the component rather than the options
      */
-    private boolean hasSplitProperty(ComponentProxyComponent component) {
-        return
-            (component instanceof ODataComponent) &&
-                ((ODataComponent)component).isSplitResult();
+    private boolean shouldSplitResult(ComponentProxyComponent component) {
+        if (! (component instanceof ODataComponent)) {
+            return false;
+        }
+
+        ODataComponent oc = (ODataComponent) component;
+        return oc.getKeyPredicate() != null || oc.isSplitResult();
     }
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        setSplit(hasSplitProperty(component));
+        setSplit(shouldSplitResult(component));
         component.setBeforeConsumer(this::beforeConsumer);
     }
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
@@ -192,11 +192,11 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         // If a key predicate is used then only one entity is expected to be returned
         // hence an array schema is not required.
         //
-        boolean hasKeyPredicate = basicProperties.containsKey(KEY_PREDICATE);
+        Object keyPredicate = basicProperties.get(KEY_PREDICATE);
         boolean isSplit = isSplit(basicProperties);
 
         if (! entitySchema.getProperties().isEmpty()) {
-            if (hasKeyPredicate || isSplit) {
+            if (keyPredicate != null || isSplit) {
                 //
                 // A split will mean that the schema is no longer an array schema
                 //

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
@@ -230,7 +230,6 @@ public class ODataSerializerTest extends AbstractODataTest {
             String schema = getMetadataSchema(serviceURI, resourcePath, keyPredicate);
             JsonNode schemaNode = OBJECT_MAPPER.readTree(schema);
 
-            System.out.println(jsonResult);
             // Validate the result against the schema
             validateResultAgainstSchema(jsonResultNode, schemaNode);
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -224,7 +224,10 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
+        //
+        // Return singleton json object rather than list due to key predicate
+        //
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX);
     }
 
     @Test
@@ -249,7 +252,10 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
+        //
+        // Return singleton json object rather than list due to key predicate
+        //
+        testResult(result, 0, REF_SERVER_PEOPLE_DATA_KLAX_LOC);
     }
 
     @Test
@@ -328,6 +334,13 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         testListResult(result, 0, TEST_SERVER_DATA_2, TEST_SERVER_DATA_1);
     }
 
+    /**
+     * Despite split being set to false, the existence of a key predicate
+     * forces the split since a predicate demands only 1 result which is
+     * pointless putting into an array.
+     *
+     * @throws Exception
+     */
     @Test
     public void testODataRouteWithKeyPredicate() throws Exception {
         String keyPredicate = "1";
@@ -346,9 +359,20 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
+
+        //
+        // We expect the result object to be a single json object & not an array
+        //
+        testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
+    /**
+     * Despite split being set to false, the existence of a key predicate
+     * forces the split since a predicate demands only 1 result which is
+     * pointless putting into an array.
+     *
+     * @throws Exception
+     */
     @Test
     public void testODataRouteWithKeyPredicateWithBrackets() throws Exception {
         String keyPredicate = "(1)";
@@ -367,7 +391,10 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         context.start();
 
         result.assertIsSatisfied();
-        testListResult(result, 0, TEST_SERVER_DATA_1);
+        //
+        // We expect the result object to be a single json object & not an array
+        //
+        testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
     @Test

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
@@ -207,6 +207,50 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
     }
 
     @Test
+    public void testReadMetaDataRetrievalWithKeyPredicate() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
+
+        String resourcePath = "Products";
+        String keyPredicate = "1";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(METHOD_NAME, Methods.READ.id());
+        parameters.put(SERVICE_URI, defaultTestServer.servicePlainUri());
+        parameters.put(RESOURCE_PATH, resourcePath);
+        parameters.put(SPLIT_RESULT, false);
+        parameters.put(KEY_PREDICATE, keyPredicate);
+
+        String componentId = "odata";
+        String actionId = "io.syndesis:" + Methods.READ.connectorId();
+
+        SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
+        assertNotNull(metadata);
+
+        Map<String, List<PropertyPair>> properties = metadata.properties;
+        assertFalse(properties.isEmpty());
+
+        //
+        // The method names are important for collecting prior
+        // to the filling in of the integration step (values such as resource etc...)
+        //
+        List<PropertyPair> resourcePaths = properties.get(RESOURCE_PATH);
+        assertNotNull(resourcePaths);
+        assertFalse(resourcePaths.isEmpty());
+
+        PropertyPair pair = resourcePaths.get(0);
+        assertNotNull(pair);
+        assertEquals(resourcePath, pair.getValue());
+
+        //
+        // The out data shape is defined after the integration step has
+        // been populated and should be a dynamic json-schema based
+        // on the contents of the OData Edm metadata object.
+        //
+        checkTestServerSchemaMap(checkShape(metadata.outputShape, ObjectSchema.class));
+    }
+
+    @Test
     public void testCreateMetaDataRetrieval() throws Exception {
         CamelContext context = new DefaultCamelContext();
         ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
@@ -381,45 +425,45 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
     }
 
     @Test
-        public void testReadMetaDataRetrievalReferenceServerSSL() throws Exception {
-            CamelContext context = new DefaultCamelContext();
-            ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
+    public void testReadMetaDataRetrievalReferenceServerSSL() throws Exception {
+        CamelContext context = new DefaultCamelContext();
+        ODataMetaDataRetrieval retrieval = new ODataMetaDataRetrieval();
 
-            String resourcePath = "Airlines";
+        String resourcePath = "Airlines";
 
-            Map<String, Object> parameters = new HashMap<>();
-            parameters.put(METHOD_NAME, Methods.READ.id());
-            parameters.put(SERVICE_URI, REF_SERVICE_URI);
-            parameters.put(RESOURCE_PATH, resourcePath);
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(METHOD_NAME, Methods.READ.id());
+        parameters.put(SERVICE_URI, REF_SERVICE_URI);
+        parameters.put(RESOURCE_PATH, resourcePath);
 
-            String componentId = "odata";
-            String actionId = "io.syndesis:" + Methods.READ.connectorId();
+        String componentId = "odata";
+        String actionId = "io.syndesis:" + Methods.READ.connectorId();
 
-            SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
-            assertNotNull(metadata);
+        SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
+        assertNotNull(metadata);
 
-            Map<String, List<PropertyPair>> properties = metadata.properties;
-            assertFalse(properties.isEmpty());
+        Map<String, List<PropertyPair>> properties = metadata.properties;
+        assertFalse(properties.isEmpty());
 
-            //
-            // The method names are important for collecting prior
-            // to the filling in of the integration step (values such as resource etc...)
-            //
-            List<PropertyPair> resourcePaths = properties.get(RESOURCE_PATH);
-            assertNotNull(resourcePaths);
-            assertFalse(resourcePaths.isEmpty());
+        //
+        // The method names are important for collecting prior
+        // to the filling in of the integration step (values such as resource etc...)
+        //
+        List<PropertyPair> resourcePaths = properties.get(RESOURCE_PATH);
+        assertNotNull(resourcePaths);
+        assertFalse(resourcePaths.isEmpty());
 
-            PropertyPair pair = resourcePaths.get(0);
-            assertNotNull(pair);
-            assertEquals(resourcePath, pair.getValue());
+        PropertyPair pair = resourcePaths.get(0);
+        assertNotNull(pair);
+        assertEquals(resourcePath, pair.getValue());
 
-            //
-            // The out data shape is defined after the integration step has
-            // been populated and should be a dynamic json-schema based
-            // on the contents of the OData Edm metadata object.
-            //
-            Map<String, JsonSchema> schemaMap = checkShape(metadata.outputShape, ArraySchema.class);
-            assertNotNull(schemaMap.get("Name"));
-            assertNotNull(schemaMap.get("AirlineCode"));
-        }
+        //
+        // The out data shape is defined after the integration step has
+        // been populated and should be a dynamic json-schema based
+        // on the contents of the OData Edm metadata object.
+        //
+        Map<String, JsonSchema> schemaMap = checkShape(metadata.outputShape, ArraySchema.class);
+        assertNotNull(schemaMap.get("Name"));
+        assertNotNull(schemaMap.get("AirlineCode"));
+    }
 }

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/test-server-data-1.json
@@ -9,5 +9,4 @@
       "Detail2":"Dual-Core Cores",
       "PowerType": "240V"
     }
-  }
 }


### PR DESCRIPTION
…results

* ODataPatchCustomizer
 * Stop odd errors by making explicit that if a key predicate is not
   provided then an update cannot continue

* ODataReadCustomizer
 * Observe keyPredicate property to determine split status consistent with
   the ODataMetaDataRetrieval

* ODataMetaDataRetrieval
 * KeyPredicate always resident in properties even if null so cannot use
   containsKey. Replaces this with get instead and test for null.

* Modify and fix tests appropriately.