### PR TITLE
fix: Support conditional flows in API provider integrations

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
@@ -44,6 +44,7 @@ public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, WithM
 
     enum FlowType {
         PRIMARY,
+        API_PROVIDER,
         ALTERNATE;
     }
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Flow.java
@@ -106,6 +106,11 @@ public interface Flow extends WithName, WithId<Flow>, WithTags, WithSteps, WithM
     }
 
     @JsonIgnore
+    default boolean isApiProvider() {
+        return FlowType.API_PROVIDER == getType();
+    }
+
+    @JsonIgnore
     default boolean isAlternate() {
         return FlowType.ALTERNATE == getType();
     }

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/IntegrationActivityTrackingPolicyFactory.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/IntegrationActivityTrackingPolicyFactory.java
@@ -42,6 +42,6 @@ public class IntegrationActivityTrackingPolicyFactory implements ActivityTrackin
 
     @Override
     public boolean appliesTo(Flow flow) {
-        return flow.isPrimary();
+        return flow.isPrimary() || flow.isApiProvider();
     }
 }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
@@ -65,6 +65,7 @@ import static java.util.Optional.ofNullable;
 public class SwaggerAPIGenerator implements APIGenerator {
 
     private static final String DEFAULT_RETURN_CODE_METADATA_KEY = "default-return-code";
+    private static final String HTTP_RESPONSE_CODE_METADATA_KEY = "httpResponseCode";
 
     private static final String EXCERPT_METADATA_KEY = "excerpt";
 
@@ -151,7 +152,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
                     .action(modifiedEndAction)
                     .connection(template.getConnection())
                     .stepKind(StepKind.endpoint)
-                    .putConfiguredProperty("httpResponseCode", "501")
+                    .putConfiguredProperty(HTTP_RESPONSE_CODE_METADATA_KEY, "501")
                     .putMetadata("configured", "true")
                     .build();
 
@@ -170,6 +171,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
 
                 final Flow flow = new Flow.Builder()
                     .id(String.format("%s:flows:%s", integrationId, operationId))
+                    .type(Flow.FlowType.API_PROVIDER)
                     .putMetadata(EXCERPT_METADATA_KEY, "501 Not Implemented")
                     .putMetadata(DEFAULT_RETURN_CODE_METADATA_KEY, defaultCode)
                     .addStep(startStep)
@@ -266,7 +268,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
             return code;
         }
         final Optional<String> httpCodeDescription = lastAction
-            .flatMap(a -> ofNullable(a.getProperties().get("httpResponseCode")))
+            .flatMap(a -> ofNullable(a.getProperties().get(HTTP_RESPONSE_CODE_METADATA_KEY)))
             .flatMap(prop -> prop.getEnum().stream()
                 .filter(e -> code.equals(e.getValue()))
                 .map(ConfigurationProperty.PropertyValue::getLabel)
@@ -281,8 +283,8 @@ public class SwaggerAPIGenerator implements APIGenerator {
         }
 
         final Step last = steps.get(steps.size() - 1);
-        if (last.getConfiguredProperties().containsKey("httpResponseCode")) {
-            final String responseCode = last.getConfiguredProperties().get("httpResponseCode");
+        if (last.getConfiguredProperties().containsKey(HTTP_RESPONSE_CODE_METADATA_KEY)) {
+            final String responseCode = last.getConfiguredProperties().get(HTTP_RESPONSE_CODE_METADATA_KEY);
             final String responseDesc = decodeHttpReturnCode(steps, responseCode);
             return new Flow.Builder()
                 .createFrom(flow)

--- a/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
+++ b/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.html
@@ -26,7 +26,7 @@
                 dropdown
                 class="dropdown btn-group"
                 placement="bottom"
-                *ngIf="currentFlow && flows.length > 0"
+                *ngIf="currentFlow && getApiOperationFlows().length > 0"
               >
                 <button
                   dropdownToggle
@@ -60,7 +60,7 @@
                     </button>
                   </li>
                   <li role="separator" class="divider"></li>
-                  <ng-container *ngFor="let flow of flows">
+                  <ng-container *ngFor="let flow of getApiOperationFlows()">
                     <li *ngIf="flow.id !== currentFlow.id">
                       <a
                         [routerLink]="[
@@ -79,6 +79,86 @@
                         ></integration-api-provider-operation-description>
                       </a>
                     </li>
+                  </ng-container>
+                </ul>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="currentFlow && currentFlow.name">
+              <label for="flowName">Flow</label>&nbsp;
+              <syndesis-editable-text
+                name="flowName"
+                [value]="currentFlow.name"
+                (onSave)="flowNameUpdated($event)"
+              >
+              </syndesis-editable-text>
+            </div>
+            <div class="form-group" *ngIf="currentFlow && getApiOperationConditionalFlowGroups().length > 0">
+              <label for="flowSelectDropDown">Flows</label>&nbsp;
+              <div
+                id="flowSelectDropDown"
+                dropdown
+                class="dropdown btn-group"
+                placement="bottom"
+              >
+                <button
+                  dropdownToggle
+                  class="btn btn-default dropdown-toggle"
+                  type="button"
+                >
+                  Open flow&nbsp;<span class="caret"></span>
+                </button>
+                <ul
+                  *dropdownMenu
+                  class="dropdown-menu flow-select-menu"
+                  role="menu"
+                >
+                  <li style="padding: 0 4px;">
+                    <button
+                      class="btn btn-default"
+                      style="width: 100%"
+                      [disabled]="
+                      isPrimaryFlow(currentFlow) ||
+                      flowPageService.saveInProgress ||
+                      flowPageService.publishInProgress
+                    "
+                      (click)="
+                      save([
+                        '/integrations',
+                        currentFlowService.integration?.id,
+                        'operations',
+                        getPrimaryFlowId(currentFlow),
+                        'edit'
+                      ])
+                    "
+                    >
+                      Go to operation flow
+                    </button>
+                  </li>
+                  <li role="separator" class="divider"></li>
+                  <ng-container *ngFor="let group of getApiOperationConditionalFlowGroups(); let i=index; let lastGroup=last">
+                    <li class="dropdown-header">#{{i + 1}} Conditional Flows</li>
+                    <ng-container *ngFor="let flow of group.flows; let last=last">
+                      <li>
+                        <a
+                          [routerLink]="[
+                            '/integrations',
+                            currentFlowService.integration?.id,
+                            flow.id,
+                            'edit'
+                          ]"
+                        >
+                          <strong>{{ getFlowName(flow) }}</strong
+                          ><br />
+                          <div style="display: inline-flex">
+                            <span class="condition" [textContent]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"
+                                  [attr.data-verb]="isDefaultFlow(flow) ? 'OTHERWISE' : 'WHEN'"></span>&nbsp;
+                            <span>{{ flow.description }}</span>
+                          </div>
+                        </a>
+                      </li>
+                      <li *ngIf="!last" role="separator" class="divider"></li>
+                    </ng-container>
+                    <li *ngIf="!lastGroup" role="separator" class="divider"></li>
                   </ng-container>
                 </ul>
               </div>

--- a/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.scss
+++ b/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.scss
@@ -2,3 +2,14 @@
   max-height: 50vh;
   overflow: auto;
 }
+
+.condition {
+  font-weight: bold;
+}
+
+.condition[data-verb=WHEN] {
+  color: #3C96D4;
+}
+.condition[data-verb=OTHERWISE] {
+  color: #61AF5A;
+}

--- a/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
+++ b/app/ui-angular/src/app/integration/api-provider/editor-page/integration-api-provider-editor-toolbar.component.ts
@@ -9,4 +9,19 @@ import { FlowToolbarComponent } from '../../edit-page';
 export class ApiProviderOperationsToolbarComponent extends FlowToolbarComponent {
   @Input()
   showOperationsButton = false;
+
+  getApiOperationFlows() {
+    return this.flows.filter(flow => {
+      return this.isPrimaryFlow(flow) || this.isApiProviderFlow(flow);
+    });
+  }
+
+  getApiOperationConditionalFlowGroups() {
+    const conditionalFlowGroups = this.getConditionalFlowGroups();
+    return conditionalFlowGroups.filter(group => {
+      // filter groups with conditional flows that belong to api provider operations other than the current flow
+      const primaryFlowId = this.getPrimaryFlowId(group.flows[0]);
+      return primaryFlowId === this.currentFlow.id;
+    });
+  }
 }

--- a/app/ui-angular/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
+++ b/app/ui-angular/src/app/integration/api-provider/operations-page/integration-api-provider-operations-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
-import { Flow } from '@syndesis/ui/platform';
+import { Flow, ALTERNATE } from '@syndesis/ui/platform';
 import {
   ObjectPropertyFilterConfig,
   ObjectPropertySortConfig,
@@ -82,10 +82,13 @@ export class ApiProviderOperationsListComponent implements OnInit, OnDestroy {
       .pipe(
         map(flows => {
           return flows
+            .filter(f => {
+              return (typeof f.type === 'undefined') || f.type !== ALTERNATE;
+            })
             .map(f => {
               return {
                 ...f,
-                implemented: f.metadata.excerpt.startsWith('501') ? 0 : 1,
+                implemented: f.metadata && f.metadata.excerpt && f.metadata.excerpt.startsWith('501') ? 0 : 1,
               };
             })
             .sort((a, b) => b.implemented - a.implemented);

--- a/app/ui-angular/src/app/integration/edit-page/current-flow.service.ts
+++ b/app/ui-angular/src/app/integration/edit-page/current-flow.service.ts
@@ -11,7 +11,12 @@ import {
   ActionDescriptor,
   Flow,
   Flows,
-  StepOrConnection
+  StepOrConnection,
+  PRIMARY,
+  API_PROVIDER,
+  ALTERNATE,
+  CONDITIONAL,
+  DEFAULT
 } from '@syndesis/ui/platform';
 import { log, getCategory } from '@syndesis/ui/logging';
 import {
@@ -683,18 +688,48 @@ export class CurrentFlowService {
       );
   }
 
-  isApiProvider() {
+  isPrimary(maybeFlow?: Flow) {
+    const flow = maybeFlow || this.currentFlow;
+
+    return !flow.type || flow.type === PRIMARY;
+  }
+
+  isConditional(maybeFlow?: Flow) {
+    const flow = maybeFlow || this.currentFlow;
+
+    return this.isAlternate(flow) && flow.metadata.kind === CONDITIONAL;
+  }
+
+  isDefault(maybeFlow?: Flow) {
+    const flow = maybeFlow || this.currentFlow;
+
+    return this.isAlternate(flow) && flow.metadata.kind === DEFAULT;
+  }
+
+  isApiProvider(maybeFlow?: Flow) {
+    const flow = maybeFlow || this.currentFlow;
+
+    if (flow.type && flow.type === API_PROVIDER) {
+      return true;
+    }
+
     try {
-      return this.getStartStep().connection.connectorId === 'api-provider';
+      return getStartStep(this._integration, flow.id).connection.connectorId === 'api-provider';
     } catch (e) {
       // ignore
     }
     return false;
   }
 
-  isAlternateFlow() {
+  isAlternate(maybeFlow?: Flow) {
+    const flow = maybeFlow || this.currentFlow;
+
+    if (flow.type && flow.type === ALTERNATE) {
+      return true;
+    }
+
     try {
-      return this.getStartStep().connection.connectorId === 'flow';
+      return getStartStep(this._integration, flow.id).connection.connectorId === 'flow';
     } catch (e) {
       // ignore
     }

--- a/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/flow-toolbar/flow-toolbar.component.html
@@ -28,14 +28,13 @@
               >
               </syndesis-editable-text>
             </div>
-            <div class="form-group" *ngIf="flows.length > 1">
+            <div class="form-group" *ngIf="currentFlow && flows.length > 1">
               <label for="flowSelectDropDown">Flows</label>&nbsp;
               <div
                 id="flowSelectDropDown"
                 dropdown
                 class="dropdown btn-group"
                 placement="bottom"
-                *ngIf="currentFlow && flows.length > 1"
               >
                 <button
                   dropdownToggle
@@ -53,21 +52,14 @@
                     <button
                       class="btn btn-default"
                       style="width: 100%"
+                      [textContent]="getPrimaryFlowRouteDescription(currentFlow)"
                       [disabled]="
                       isPrimaryFlow(currentFlow) ||
                       flowPageService.saveInProgress ||
                       flowPageService.publishInProgress
                     "
-                      (click)="
-                      save([
-                        '/integrations',
-                        currentFlowService.integration?.id,
-                        'edit'
-                      ])
-                    "
-                    >
-                      Go to primary flow
-                    </button>
+                      (click)="save(getPrimaryFlowRoute(currentFlow))"
+                    ></button>
                   </li>
                   <li role="separator" class="divider"></li>
                   <ng-container *ngFor="let group of getConditionalFlowGroups(); let i=index; let lastGroup=last">
@@ -167,20 +159,13 @@
               <button
                 class="btn btn-default"
                 *ngIf="!flowPageService.showDone"
+                [textContent]="getPrimaryFlowRouteDescription(currentFlow)"
                 [disabled]="
                       flowPageService.saveInProgress ||
                       flowPageService.publishInProgress
                     "
-                (click)="
-                      save([
-                        '/integrations',
-                        currentFlowService.integration?.id,
-                        'edit'
-                      ])
-                    "
-              >
-                Go to primary flow
-              </button>
+                (click)="save(getPrimaryFlowRoute(currentFlow))"
+              ></button>
             </div>
           </div>
         </div>

--- a/app/ui-angular/src/app/integration/edit-page/flow-view/flow-view.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/flow-view/flow-view.component.ts
@@ -74,7 +74,7 @@ export class FlowViewComponent implements OnInit, OnDestroy {
   }
 
   isAlternateFlow() {
-    return this.currentFlowService.isAlternateFlow();
+    return this.currentFlowService.isAlternate();
   }
 
   isApiProvider() {

--- a/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.ts
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.ts
@@ -36,7 +36,10 @@ import {
   Step,
   Flow,
   key,
-  ALTERNATE
+  ALTERNATE,
+  FlowKind,
+  CONDITIONAL,
+  DEFAULT
 } from '@syndesis/ui/platform';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -258,7 +261,7 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
   }
 
   createDefaultFlow() {
-    this.doCreateFlow('Default Flow', 'default', 'Use this as default',
+    this.doCreateFlow('Default', DEFAULT, 'Use this as default',
         flowId => this.form.controls.defaultFlow.get('defaultFlow').setValue(flowId));
   }
 
@@ -306,10 +309,10 @@ export class ContentBasedRouterComponent implements OnChanges, OnDestroy, OnInit
   }
 
   createFlow() {
-    this.doCreateFlow('Conditional Flow', 'conditional', '* To be defined *', flowId => this.addFlow(flowId));
+    this.doCreateFlow('Conditional', CONDITIONAL, '* To be defined *', flowId => this.addFlow(flowId));
   }
 
-  doCreateFlow(name: string, kind: string, description: string, then: (flowId: string) => void) {
+  doCreateFlow(name: string, kind: FlowKind, description: string, then: (flowId: string) => void) {
     const currentFlow = this.currentFlowService.currentFlow;
     const primaryFlowId = currentFlow.id;
     const flowId = key();

--- a/app/ui-angular/src/app/platform/types/integration/integration.models.ts
+++ b/app/ui-angular/src/app/platform/types/integration/integration.models.ts
@@ -86,6 +86,7 @@ export interface Flow extends WithId {
   type?: FlowType;
   description: string;
   metadata: {
+    kind?: FlowKind;
     excerpt: string;
   };
   steps: Array<Step>;
@@ -93,11 +94,20 @@ export interface Flow extends WithId {
 }
 
 export const PRIMARY = 'PRIMARY';
+export const API_PROVIDER = 'API_PROVIDER';
 export const ALTERNATE = 'ALTERNATE';
 
 export type FlowType =
   | 'PRIMARY'
+  | 'API_PROVIDER'
   | 'ALTERNATE';
+
+export const CONDITIONAL = 'conditional';
+export const DEFAULT = 'default';
+
+export type FlowKind =
+  | 'conditional'
+  | 'default';
 
 export type Flows = Array<Flow>;
 


### PR DESCRIPTION
Fixes #5515

PR separating conditional flows from api provider operation flows in top level navigation and makes sure that navigation to/from primary flow is working for api provider integrations.

This is done in Angular code base but it may give some hints and ideas to solve this for the react code base, too.