### PR TITLE
fix(ui): make sure `Integration.flows` is never null

### DIFF
--- a/app/ui-angular/src/app/integration/list/list.component.html
+++ b/app/ui-angular/src/app/integration/list/list.component.html
@@ -21,54 +21,46 @@
   >
     <ng-template #itemTemplate let-integration="item" let-index="index">
       <div class="list-view-pf-left integration-icons">
-        <ng-container
-          *ngIf="
-            integration.type === IntegrationType.SingleFlow;
-            else multiflowIntegration
-          "
-        >
-          <span
-            *ngIf="integrationActionsService.getStart(integration); let step"
-          >
-            <img
-              class="syn-icon-small"
-              [src]="step | synIconPath"
-              aria-hidden="true"
-            />
-          </span>
-          <span class="fa fa-angle-right"></span>
-          <span
-            *ngIf="integrationActionsService.getFinish(integration); let step"
-          >
-            <img
-              class="syn-icon-small"
-              [src]="step | synIconPath"
-              aria-hidden="true"
-            />
-          </span>
+        <ng-container [ngSwitch]="integration.type">
+          <ng-container *ngSwitchCase="IntegrationType.ApiProvider">
+            <span class="icon">
+              <img
+                class="syn-icon-small"
+                src="./../../assets/icons/api-provider.connection.png"
+                aria-hidden="true"
+              />
+            </span>
+            <span class="fa fa-angle-right"></span>
+            <span class="icon">
+              <img
+                class="syn-icon-small"
+                src="./../../assets/icons/multi-flow.connection.png"
+                aria-hidden="true"
+              />
+            </span>
+          </ng-container>
+          <ng-container *ngSwitchDefault>
+            <span
+              *ngIf="integrationActionsService.getStart(integration); let step"
+            >
+              <img
+                class="syn-icon-small"
+                [src]="step | synIconPath"
+                aria-hidden="true"
+              />
+            </span>
+            <span class="fa fa-angle-right"></span>
+            <span
+              *ngIf="integrationActionsService.getFinish(integration); let step"
+            >
+              <img
+                class="syn-icon-small"
+                [src]="step | synIconPath"
+                aria-hidden="true"
+              />
+            </span>
+          </ng-container>
         </ng-container>
-        <ng-template #multiflowIntegration>
-          <span
-            *ngIf="integrationActionsService.getStart(integration); let step"
-          >
-            <img
-              class="syn-icon-small"
-              [ngClass]="{
-                'api-provider': step.connection.id == 'api-provider'
-              }"
-              [src]="step.connection | synIconPath"
-              aria-hidden="true"
-            />
-          </span>
-          <span class="fa fa-angle-right"></span>
-          <span class="icon">
-            <img
-              class="syn-icon-small"
-              src="./../../assets/icons/multi-flow.connection.png"
-              aria-hidden="true"
-            />
-          </span>
-        </ng-template>
       </div>
       <div class="list-pf-content-wrapper">
         <div class="list-pf-main-content integration-content">

--- a/app/ui-angular/src/app/store/integration/integration.service.ts
+++ b/app/ui-angular/src/app/store/integration/integration.service.ts
@@ -23,6 +23,7 @@ function getFlowsCount(integration: Integration) {
 }
 
 function transform(integration: Integration): Integration {
+  integration.flows = integration.flows || [];
   if (integration.flows.length > 1) {
     // Multiflow isn't a thing we support but may as well flag it
     integration.type = IntegrationType.MultiFlow;


### PR DESCRIPTION
Transforms the integration so that `Integration.flows` always returns a value. In case when the `flows` is `undefined` or `null` the value returned will be an empty array.

Fixes #4977

I'm not sure about the failure cases for this, i.e. when `Object.getOwnPropertyDescriptor` will return something unexpected (i.e. something that doesn't have `.value`) or the reference received from `Object.getOwnPropertyDescriptor` can change over time, so we end up with consistency errors between what was set and what this getter returns.

I've also found an inconsistency with the display of the start icon in the integration list vs integration details pages.

Can you take a look @gashcrumb @kahboom @riccardo-forina 