### PR TITLE
fix(build): increase `craco build` memory to 2GB

### DIFF
--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -46,7 +46,7 @@
     "replay:dev-server": "BACKEND=http://localhost:8556 yarn proxy:setup; BACKEND=http://localhost:8556 PROXY_NO_WS=true yarn start",
     "replay": "npm-run-all -p replay:dev-server \"mock-server -- {1}\" --",
     "start": "BROWSER=false HOST=0.0.0.0 craco start",
-    "build": "craco build",
+    "build": "NODE_OPTIONS=--max-old-space-size=2048 craco build",
     "test": "craco test",
     "eject": "react-scripts eject",
     "minishift:setup": "./scripts/minishift-setup.sh",


### PR DESCRIPTION
Increasing the memory size to fix build failures on CI. Setting this in `.env` file is not helping, probably because it's read from Create React App at too late to influence `node` memory.

Fixes #5468