### PR TITLE
user doc: Add name of MethodOutcome field, id.idPart, that contains resource ID

### DIFF
--- a/doc/connecting/topics/p_adding-fhir-connection-create.adoc
+++ b/doc/connecting/topics/p_adding-fhir-connection-create.adoc
@@ -56,7 +56,8 @@ The connection appears in the integration flow
 in the location where you added it. During execution, the connection 
 creates a new resource on the FHIR server.  
 The connection returns a *MethodOutcome* resource that includes 
-the new resource’s resource ID, which you might want to map to a 
+an `id.idPart` field. This field contains the new resource’s
+resource ID, which you might want to map to a 
 subsequent step in the flow.
 
 .Next steps

--- a/doc/connecting/topics/p_adding-fhir-connection-delete.adoc
+++ b/doc/connecting/topics/p_adding-fhir-connection-delete.adoc
@@ -37,8 +37,8 @@ the resource that you want to delete from a previous step.
 The connection appears in the integration flow 
 in the location where you added it. During execution, the connection 
 deletes the specified resource on the FHIR server and returns a 
-*MethodOutcome* resource, which includes the resource ID for 
-the deleted resource.
+*MethodOutcome* resource that includes an `id.idPart` field. 
+This field contains the resource ID for the deleted resource.
 
 .Next steps
 To map a value to the *Resource Id* field or the *Resource version* field, add a data mapper step 

--- a/doc/connecting/topics/p_adding-fhir-connection-patch.adoc
+++ b/doc/connecting/topics/p_adding-fhir-connection-patch.adoc
@@ -110,7 +110,8 @@ This is the new value that you want the field to contain.
 
 .Result
 The connection appears in the integration flow 
-in the location where you added it. During execution, 
+where you added it. During execution, 
 the connection updates the specified resource field(s)
-and returns a *MethodOutcome* resource that contains 
+and returns a *MethodOutcome* resource that includes 
+an `id.idPart` field. This field contains 
 the ID of the resource that was updated. 

--- a/doc/connecting/topics/p_adding-fhir-connection-update.adoc
+++ b/doc/connecting/topics/p_adding-fhir-connection-update.adoc
@@ -71,6 +71,7 @@ changing, as well as fields whose values need to be updated.
 The connection appears in the integration flow 
 in the location where you added it. During execution, the connection 
 updates or creates a resource on the FHIR server and returns a 
-*MethodOutcome* resource that includes the updated/created 
-resource's resource ID, which you might want to map 
+*MethodOutcome* resource that includes an `id.idPart` field. 
+This field contains the updated/created resource's ID, 
+which you might want to map 
 to a subsequent step in the flow. 


### PR DESCRIPTION
Updated the description of the results of various actions to add the name of the field that contains the resource ID. Rafal approved these updates. This is related to 
https://github.com/syndesisio/syndesis/pull/555 