### PR TITLE
fix(5560): Ensure a default value is set for email-send's protocol

### DIFF
--- a/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-send.json
+++ b/app/connector/email/src/main/resources/META-INF/syndesis/connector/email-send.json
@@ -197,6 +197,7 @@
     },
     "protocol": {
       "componentProperty": true,
+      "defaultValue": "smtp",
       "deprecated": false,
       "displayName": "Protocol",
       "group": "common",


### PR DESCRIPTION
* The protocol value is set programmatically using the configuredProperties.
  However, the UI reads the hidden & required metadata and expects the
  control to contain a value. By setting the default value this satisfies
  the requirements.