### PR TITLE
fix for 5528 - Wrong schema in the default postgres connection

### DIFF
--- a/install/generator/04-syndesis-db.yml.mustache
+++ b/install/generator/04-syndesis-db.yml.mustache
@@ -42,6 +42,7 @@
         GRANT ALL PRIVILEGES ON DATABASE sampledb to sampledb;
       EOF
       psql -d sampledb -U sampledb <<'EOF'
+        CREATE SCHEMA AUTHORIZATION sampledb;
         CREATE TABLE IF NOT EXISTS contact (first_name VARCHAR, last_name VARCHAR, company VARCHAR, lead_source VARCHAR, create_date DATE);
         INSERT INTO contact VALUES ('Joe','Jackson','Red Hat','db',current_timestamp);
         CREATE TABLE IF NOT EXISTS todo (id SERIAL PRIMARY KEY, task VARCHAR, completed INTEGER);

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -562,6 +562,7 @@ objects:
         GRANT ALL PRIVILEGES ON DATABASE sampledb to sampledb;
       EOF
       psql -d sampledb -U sampledb <<'EOF'
+        CREATE SCHEMA AUTHORIZATION sampledb;
         CREATE TABLE IF NOT EXISTS contact (first_name VARCHAR, last_name VARCHAR, company VARCHAR, lead_source VARCHAR, create_date DATE);
         INSERT INTO contact VALUES ('Joe','Jackson','Red Hat','db',current_timestamp);
         CREATE TABLE IF NOT EXISTS todo (id SERIAL PRIMARY KEY, task VARCHAR, completed INTEGER);


### PR DESCRIPTION
Fix for #5528, now creating a sampledb schema - and creating the tables and functions inside of this schema.