### PR TITLE
fix: Add simple language syntax examples in conditional flows config page

### DIFF
--- a/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
+++ b/app/ui-angular/src/app/integration/edit-page/step-configure/content-based-router/content-based-router.component.html
@@ -39,8 +39,8 @@
                   formControlName="condition"
                   type="text"
                   [attr.list]="'path-list-' + i"
-                  placeholder="Condition">
-                <span class="help-block" [textContent]="editMode ? 'Provide a condition that you want to evaluate.' : ''"></span>
+                  placeholder="Simple language expression">
+                <span class="help-block" [textContent]="editMode ? 'Provide a condition that you want to evaluate (e.g. ${in.header.type} == \'note\' or ${in.body.title} contains \'Important\').' : ''"></span>
                 <span *ngIf="editMode && flowSet.controls.condition.dirty && flowSet.controls.condition.errors?.required" class="help-block error">Condition is required</span>
                 <span *ngIf="editMode && flowSet.controls.condition.errors?.maxlength" class="help-block error">Maximum characters exceeded</span>
               </div>

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -81,9 +81,9 @@
       "saveAndPublish": "Save and publish"
     },
     "choiceForm": {
-      "conditionDescription": "Provide a condition that you want to evaluate.",
+      "conditionDescription": "Provide a condition that you want to evaluate (e.g. ${in.header.type} == 'note' or ${in.body.title} contains 'Important').",
       "conditionName": "Condition",
-      "conditionPlaceholder": "Condition",
+      "conditionPlaceholder": "Simple language expression",
       "addCondition": "+ Add another condition",
       "addConditionTitle": "When",
       "useDefaultFlowDescription": "Use this flow when no other condition matches",


### PR DESCRIPTION
Adds simple language expression examples to conditional flows configuration page.

Tried to fix for both angular and react

Fixes #5485 