### PR TITLE
More fixes for release builds

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -100,7 +100,7 @@ release::run() {
     generate_versioned_files "$topdir" "$release_version"
 
     # Build and stage artefacts to Sonatype
-    build_and_stage_artefacts "$topdir" "$maven_opts"
+    build_and_stage_artefacts "$topdir" "$maven_opts -pl '!ui-angular,!ui-react"
 
     # Build all Docker Images
     docker_login

--- a/tools/upgrade/Dockerfile
+++ b/tools/upgrade/Dockerfile
@@ -16,6 +16,7 @@ ENV KUBECONFIG=/opt/kube-config \
 RUN yum clean all \
  && yum update -y \
  && yum install -y "epel-release" \
+ && sed -i -e 's/#baseurl/baseurl/g' -e 's/metalink/#metalink/g' /etc/yum.repos.d/epel.repo \
  && yum install -y "$openshift_yum_repo" \
  && yum install -y \
         "$openjdk_rpm" \


### PR DESCRIPTION
fix(build): disable metalink for epel

Seems that the mirror selected by metalink in most cases ends up
returning `503 Service Unavailable` this disables metalink for the EPEL
repository making the build more robust.

fix(build): don't rebuild UI when staging Maven artifacts

Skips UI related modules when staging Maven artifacts.

Ref #5468