### PR TITLE
fix(ci): don't try to push images that do not exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,17 @@ push_images: &push_images
         curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar xz -C /usr/bin --strip-components 1
       fi
 
+      IMAGES_TO_PUSH=""
+      for image in ${IMAGES}; do
+        if [ ! -z "$(docker images -q $image)" ]; then
+          IMAGES_TO_PUSH="$IMAGES_TO_PUSH $image"
+        fi
+      done
+
+      if [ -z $IMAGES_TO_PUSH ]; then
+        exit 0
+      fi
+
       if [ "${CIRCLE_BRANCH}" == "master" ]; then
         docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
         for image in ${DOCKER_IMAGES} ; do
@@ -48,7 +59,7 @@ push_images: &push_images
       fi
       if [[ "${CIRCLE_TAG}" =~ ^[0-9]+(\.[0-9]+){2} ]]; then
         docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-        for image in ${IMAGES} ; do
+        for image in ${IMAGES_TO_PUSH} ; do
           docker push syndesis/${image}:${CIRCLE_TAG} | cat -
           docker tag syndesis/${image}:${CIRCLE_TAG} syndesis/${image}:$(echo ${CIRCLE_TAG} | sed -e 's/\.[0-9][0-9]*$//')
           docker push syndesis/${image}:$(echo ${CIRCLE_TAG} | sed -e 's/\.[0-9][0-9]*$//')


### PR DESCRIPTION
Tries to filter out images that haven't been built from so that the build doesn't fail trying to push images that do not exist.

Kinda wrote this one blindly (no way to test really), might need a second pair of eyes.