### PR TITLE
fix(ci): consider changes on `master` for commit

### DIFF
--- a/tools/bin/commands/util/common_funcs
+++ b/tools/bin/commands/util/common_funcs
@@ -151,6 +151,11 @@ has_changes() {
   local ref="${2:-master}"
 
   local changed_paths="$(git diff ..${ref} --name-only | tr '\n' ' ') $(git status --porcelain=v1 | cut -c 4- | tr '\n' ' ')"
+
+  # when on `master` on CircleCI, compute changed paths for the commit being built
+  if [ ! -z "$CIRCLE_SHA1" ] && [ "master" == "$CIRCLE_BRANCH" ]; then
+    changed_paths="$changed_paths $(git log $CIRCLE_SHA1^..$CIRCLE_SHA1 --name-only --pretty='format:' | tr '\n' ' ')"
+  fi
   if [[ " $changed_paths" == *" ${subtree_path}"* ]]; then
     echo "true"
   fi


### PR DESCRIPTION
When on CircleCI and running a build for the `master` branch the computation of incremental changes is not taken into account as it tries to determine differences between `master` and `master`, for this we need to check the `CIRCLE_SHA1` environment variable to gather the files changed for a particular commit.