### PR TITLE
Add olm integration files for syndesis

### DIFF
--- a/install/operator/deploy/manifests/1.7.x/syndesis.crd.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesis.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: syndesises.syndesis.io
+spec:
+  group: syndesis.io
+  names:
+    kind: Syndesis
+    listKind: SyndesisList
+    plural: syndesises
+    singular: syndesis
+  scope: Namespaced
+  version: v1alpha1

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ spec:
     mediatype: image/png
   links:
   - name: Syndesis
-    url: https://github.com/syndesisio/syndesis
+    url: https://syndesis.io
   - name: Syndesis Operator
     url: https://github.com/syndesisio/syndesis/tree/master/install/operator
   installModes:

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ spec:
   - name: Red Hat Fuse Online
     email: fuse-online@redhat.com
   provider:
-    name: Red Hat
+    name: Syndesis team
   labels:
     name: syndesis-operator
   selector:

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ spec:
   maturity: alpha
   maintainers:
   - name: Syndesis team
-    email: fuse-online@redhat.com
+    email: syndesis@googlegroups.com
   provider:
     name: Syndesis team
   labels:

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -1,0 +1,933 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: syndesisoperator.1.7.x
+  namespace: placeholder
+  annotations:
+    capabilities: Basic Install
+    categories: "Integration & Delivery"
+    certified: "false"
+    createdAt: 2019-05-08T16:12:00Z
+    containerImage: syndesis/syndesis-operator
+    support: Red Hat Fuse Online
+    description: Manages the installation of Syndesis, a flexible and customizable open source platform that provides core integration capabilities as a service.
+    repository: https://github.com/syndesisio/syndesis/
+    alm-examples: |
+      [{
+          "apiVersion": "syndesis.io/v1alpha1",
+          "kind": "Syndesis",
+          "metadata": {
+          	"name": "app"
+          },
+          "spec": {
+          	"integration": {
+          		"limit": 0
+          	}
+          }
+      }]
+spec:
+  displayName: Syndesis Operator
+  description: |
+    ### Syndesis operator
+    Syndesis is a flexible and customizable, open source platform that provides core integration capabilities as a service.
+
+    This operator installs as well as configures all syndesis components.
+
+    ### How to install
+    When the operator is installed (you have created a subscription and the operator is running in the selected namespace) create a new CR of Kind Syndesis (click the Create New button). The CR spec contains all defaults (see below).
+
+    ### CR Defaults
+    The CR definition is pretty simple and an empy CR will trigger a base installation
+  keywords: ['camel', 'integration', 'syndesis', 'fuse', 'online']
+  version: 1.7.x
+  maturity: alpha
+  maintainers:
+  - name: Red Hat Fuse Online
+    email: fuse-online@redhat.com
+  provider:
+    name: Red Hat
+  labels:
+    name: syndesis-operator
+  selector:
+    matchLabels:
+      name: syndesis-operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAo6UlEQVR4nOydC1gb15n337noBpIRN0fCF2FbgkBSGwUIvirxhriRGkg2F7efXbYtbky6jUnbz91NN/42m9206W692xqn2WCv3Xa9cbd2nCawRalN41R2HIjBEDc2ASnY8gXJAYQAgTSa2/fI4K7r2kaIkWZGzO95+jwNls78NdJ/znve855zUJCQkLglGN8CJG6O3pinXfrEX31TUXiv2ne6tZdvPbMVhG8BEn9KeXXNstXrN2zOMeVvGAkzqb+7OI4DwHiw39Pq7+po8Z/t+NDf1fF7f1enn2+tswHJIAIhr2ylesOLL/9Tjin/W9f/vfnCGDlKsrIbXh4GgBMeR9OhgNv1hmtfnTexamcPkkF4pthacU95dU31kntKvgoAqTf+e2d/iDw3Qt1okBtxehxN74f6vSf9XR1HvA67M36KZxeSQXji4dqtuSW2ih/nmPIfvd3rLgVI8uQVYiqD3Ih31O085HXY3/A6mt4PuF3kzNTOXiSDJJB0nR5bvX5j+ar1GzZl6HMeiyZJEqZZpun8GMvGnlAZAYBWj6PpZMDtahloc7T4uzr7Y2xr1iEZJEEUWytMNa/sfh0ASqf73hOeYPjKOC3nUM4R5766NwNuZ4PXYe/jsN2kQzJInCmvrnlo9foN1Tmm/EoAUMTSxuUAFfrwSkjJvTqgAKB76GzHydCAp8XrsLcG3M7TAbeLicO1RIlkkDhQbK3QFdsqvl5iq9wEALlctGk/PxYO0SyXvcitCAX7PS3+ro53vQ57S6jf0+bv6hxKwHUFiWQQDtEb82Q1r+z+fo4p/9sAgHPZdtuVEHkxMGU2Kx7QAHDM42h6K+B2HXLtq7vEgwbekAzCAYvNxfPLq2s2ldgqvwwAxnhcwz1CUqf6CU5NFyPOobMd7w20H3s/4Hae9DrsZ/kWFE8kg8wAvTFPu+HFH76Qv3zlUzebw+CSEMXQdve4EEuDvKNu51teh/2Q19H0+2RLKUsGiYHy6pq7F5uLN5fYKr8IAHMTdd2jl8YJP8HENNBPECMAcMrjaDpx/tDef/d3dYo+HBPiE0mwFFsrcl/8reNnd1nW/jjHlL883r3GTSC83KZ7uSZi3lyNwbQGT1UPeR12B9+CZooQYlrBU2ytKCyvrvnGkntKvsaDKf7IfDWeenqAIBkW+BisTwttgfk+AHiJbx0zRTLILVhsLp5z15q1f7lq/YZvZOhzyvjWE0GGIjBXhYF3nOZbypSosvX36yxWnddhF3UhpWSQG9Ab89ANL/7wr/KXr3wZAHR867mRuSkYJgaDRH5bCyu+vMnrsH+fbyEzQTLIJIvNxbry6pqqElvl5nilarkgW4VF3CGKlaCZy8q+rMzS/SA04GX51hIrkkEAYPPOXdUltso6PscX0TJHjsnkGBBhOraylQRzp7bQXCDmuZJZa5Bia4Vusbn4yw9uevqbXJWDJIpsFY5eDlB8y4gKbUHRA5JBRERe2Urlhhdf/tscU/42sX7+uSoME4tBskos90H9yzv51hErovyBxMJic/H8J//uxdol95Q8FXmw8a1nJmSJaByiMZgeUBuMMrHOsCf9RKHemKet2bn7bx/9znO/zNDn3A8A8SgbTyhyDME841SASEx170xRhod9p3ynWz/hW0gsJG2pSbG1orDYVvHVElvlVxJZDpIoeofJ0EcDhFjM3mBfZ3yEbxGxkFQhlt6YJ1u9fsOGBzc9/VUAsIglDIkFgwZXnvERJMUIf1YdACp1FutCr8N+gW8h0yVpDLJ5566qElvlvwhxci8eYCgCWUrRTBqC2mBcCwC/4FvHdBH1EzZdp0+pqN36lR8eP+UosVX+52wxxzUmB+uiIKt4zV/wrSEWRNmDXCsHyVu+8h8RgAV86+GLbBUmmrXj6YX3PMC3hlgQVRZrsbk4+8nnX/zmxn/8YX3W/AVPIQBpfGviEwWG4BdGqRDJiOJBNwcAjvhOt17kW8h0EEUWS2/MS9nw4g+/m7985Xcmb7TEJF2+MPHJUFgMZScR/sO+zvgU3yKmg6CfPHpjnnb1+g1fL9/09LcQgHl86xEiuXNw/JOhMCOS8eR6bUHRs/6uznG+hUSLIA2SV7YS3/Diy8/nmPKfS4aJvXiiwlFMq0ApP8GIwSBzlNn65dDV+S7fQqJFUAYptlbkllfX/PXkRs7ZfOsRC5lKjPUT4hiv6yzWcq/DLhqDCGIMUl5d80B5dc22yVIQiWkyEKTJY31BMUwYRuiyrzMW8i0iWnjNYlXUbl2+df+bjXdZ1v6NSqMRVcm5kFDhCNbjJwlWYBHBLYhEBq/7Trf6+BYSDQmPW/XGPNmTf/cPX9r1qfdoxbNb3weAokRrSDYQBIHcOTLRrNrTWayb+dYQLQkNsTbv3PVYia3yp7NtxjsRDBF0+L1LQTFU90YYOPbUQ3eIYZPsuHfJ6Tp9Snl1zaYHNz1dAwB3xft6s5V0BSZPlSHk2J8f1yZEstQGU3HA7TrJt5CpiJtB9MY8tNhW+Vjls1t/JLYlrWIlS4kxY6Q4VhrqLNYHvQ777DPIYnNxdnl1zZcmdwe5m+v2JW7NXBWGuUfFYRBtgXktAPyAbx1TwZlByqtr7lu9fsOmHFP+Y2LYHSQZuSMVxxAg6Bkc15YwVNl6i7agKM3f1TnMt5bbMWODFFsrSje/svvfEIDV3EiSiBUZiiAZShQGQ4If+0aQZ5Wsud/f1fk230JuR0wGSdfpkdXrN95XuOb+TUvuKfmS0GbkZzOZSoweDDGC70Hg6iIq0/0AIGiDTDvNW1G7taji2a2vAMCq+EiSmAn9QYo43hcSS3Xvafs64zK+RdyOqJ786Tq9YvX6jZWTxxd/Pv6yJGIlU4kpcAQIihXFzot36yzWxV6HvZdvIbdiyq44MsZ47tBvmvOXr3xapdEIds9aiQkQBIEQxeJD4iheRORpmaOXj7x5lG8ht+K2IdY3Ws6/mq3EqrNUOK7EEVHEtRIAQyGaeO9yUAw9SIQLRzesXhwa8Apyff1tf/RofmnJkEZX7homUc84FQhRLKvCEVaOSWYRMiocxd0jZIhiRZE8SfN3dbwdcLs8fAu5Gbf9odNE0K232J6JeIWgWflAiMZ7h0nMPUKGB0M0BCmWQQEoFY5KhhEYw2GGGQ6LI5sFAC6vw36CbxE347ZPGK/Dfj7Y7/lAla1fc/3fgzQrD47R0Dc20SsiAGSGEkMzlCiZrsCwDCWKSqbhF30KDhfEM6v+KABs51vHzZiyC/Z3dfzuRoPcCAsgi/QogyEaA5jYo1gjQ4M5akw2LxVn0xSYGArokorsFEweCQL4XvMTDaps/fKMpWVa3+lWP99abmTKm6fM0tHZJZbq6TYcZljZYIhBz41Q2IVRMuwjGCZEX12yQCowBEcQQSxmTFowBIGRME2PkqzgDRIJ4TGlyut12Fv5FnIjU/5K1QajbM3ud0a43DwBQ4DQpeDoPDVO6VIxFSaZJS54x6jxD7yhFL51RMnH9nXGz/Et4kamfLqEh33M/IeeXCVL1Zi4uigLgI+SDHZ5jJL1DJG0Z5yix0iGJhlg5CgCOIqIYYcOwZMqQ2S9wyRJs8IPswBgbsDt3B9wuwS1FDeqG6ctNOdoDKYH46QBDdEs5gtdNQzmGibRCwEyQNLAKjAk8j8xfLmCJBLGDhE0I5IwK8IZr8PezreI64n2xhF6iy1h64hJBq6mlM+NkNj5ETI8PDF+icRhpBJDMGn8Ej1hmmWujNOiMAg1Njp+6Z2Db/Ct43qimkiadLWXj7XkIZqVXwxQcHHiTL5IBEbMS8WxuSlYaF4qrsZQySy3I0slCm9cRYgbXEd993QWa7pCm2mJr5ypiYxfRsIM6hmj5c5hkrwyRsFwmKFYFhg5BgiOSt3L9SgwFOsLUATBsGKYVU8BgBO+062CKV6M+seks1h15m073ZGneHwlzYwUHAmnKzEkU4mhaXKUzFCiytnuGfcISZzqJ8RSm/U7+zpjOd8irhF1tsjrsEdCLMEvsh+nWPnlACU7PUBgx/qCyv85N0Z+6A2RF0bJcYYVzdZRnLJAgyuQazO4wucBncV6B98irjGtAFVtMC7SGEy8h1nTgQXARkkG84zRMpefJD8bp5CRMENRDDAyFFjZLEgpIwgCgyGaHaNYUXzWUL+nfaD9+Md864AYyhAQvcX2lThpiTsRs4xTLOIj/iyljKhlCCSzWUIUy/QHaVF8vtCAd8jrsDfyrQOmu+RWmaVTrt1/3CP2g/hvAZuCI0SGEsMylSimVWB0ugKVJUFK2dXW1LDreEPD6z6CTtUWmMu0BeYH0gvNpQBQINBzRc7b1xkX8S0CYlmTbj3s2g0AX4+PHGGBXi2JwVB9Kk6IMKXs7W458b39Lzz3nx5Xz02XF+os1hy1wVRpqqp9DADiNREcEx0vbVnkddjP861j2t+4saq21FRV+2F85AgXBIDOUmGgVaBkhgLDMlUopsBQwT19fZ6+1vcP7P/3M8eOHurtaA9E+z61wZiSVbymTFtoXqEtMJeqsvV/wedxd+cO7fn6J/Uv7+Hr+teI6ZFoPew6DQCCKyxLNCoMCWeoMCRdgSLpCoziMaU81ufsbjx+YP9rzXvrf89Fg8osHaYtNOdrC8wrlNm6Mr3FVgYAS7loOxqC/Z7fvLdxzcOJut6tiOnbLNpWV6e32LZwL0fcIADkfDUO89Q4MVeFJSIkowHg1/XPPPXddntj3MORjKVl2oxlZY+YqmqfBoDlcb7cSOvWjZm+0628rvqK6RvMfexrlQVPPy/oDb/4BkOATFdcHexTGcqJXiZFhnI1m/1ZW1PDr3o72nc1763nJR2qs1i1yizdcm3h1UF/mSpbv4Lr5I1zX9161766g1y2OV1iMojaYNSs2f2OT9pRcXqkK9BQTiqOzFPjWGqMZulzdh+sf+apzR5Xj+BW3xmrapdnLC37Yuayskc52tG/2b7OyGvyIOYYwHrY9WsAeJRbObOGqynldAWGZakmehmtApXfZvzi//RU28+b99bvbrc3nk2s1NjQWaxFOou1VJmlvze90BzpXfJjeKDSHzz7hN7f1dkfJ5lTErNBjFW1D5uqagUxmZMMXEspL9DIqJxUXDX5Z6rP2f3j/S987+97Wk+EeJY4I3QWa7baYHrcVFX7CACUR2sW574dT7r27eStBD7mWujw8OA5Q+WXvzFZgSkxQyZWWbLY5QAluzBKBtMUGJ0iQ//rndd2NjM0Pehx9USdshUiAbdr3He6tc21r+51r6PpX32nW48AwCWNwUREok8AUN3sfahMPnTpnYP/k3jFE8wozbJ6t/0NjcH0OHdyZjcoAtTdmXJ2SZr8ZrvAdHa3nHiru/XEr/6nbvsnPMiLG2qDUaaz2FbpLNZHNAbTEwAw/7p//sS+zljAl7YZGeTOmu/99aLHN/2UOzmzkxQcoQ1zZMxCNY6myKbeT4wFcLY3Nbw/5Ok72dvR3tLb0faHIa9HLNW6U6KzWE3aAvNaZbZuhd5iK3Puq/uia1/dH/jQMiODaAuKclbseOMyd3JmFUxOKkYbNDJkbgo203VeYyxAZ3tTw4nejvb3hjx9J9rtjYLLcomRGc9kWQ+7uiKdCTdyZgd3pGChomyFLCWOu0+yAC09LSfeeO+/fnYoEZOIycqMDbL8JwdeSS+855vcyEleEAA6d44MFmpwOkOJJXRVJgvwae+ptpYhb9/J9qbGSEjWNuT1CHI3daExY4MYq7Y8Zqp69hA3cpITXQoWvjtTgWrknM2kz5R+AHi7Ycf2Qz2tJ5p7Wk+IYxNfHpixQbQFRZkrdrzRJ/S16okGR4Cer8HZRXNkoFVgQjHGzQj5PH2RXiUy4L868G+3N/bxLUoocFJNZz3sagQA3isvhUAklFo0B6cKMhQyOSbaFYp/aGtq2ONx9rzdWLd9Vo9fODGIsar2UVNV7a+5aEusYAiQCzUy1KSVsbHWWQkRFsDpcXZ/eMZxtKW3o721t6Pt9JDXQ/CtK1FwVo9tPewa5nOBDZ8smoOHPpelUM6STbj9fc7u/25vajzU1tTwe4+rJ2nmX24GZ9/o/a8f+7UqWz9riheVGBI2aHB0UZoMmcWHBY0AwKm2poYTHmfPh2eOHW3t7Wj38i2KSzgzyJ013/vKosc3/Zyr9oRIZHyhS8HAMEfG6lPxpAmjOOb8p6faIqHY73o72k9OzvKLNqXMmUF0FmuuedvOc1y1JzTmyFGyZK4SSVMkz/giQfQDwG8admw/2NN64rDYUsqcBs3Ww65WALiXyzZ5htGlYFTuHBl6x8zLQSQmUsqRXqVlsndp7u1oH+Jb1O3g9Bs3VtV+3VRVu5vLNvkiW4WFi7IUqFo4k3vJCM0CnGxvajjocfa8KcSUMqcG0VmsWvO2nX23qu0XOigC1AI1DrlzZGyGUjp4NNGwAL0eZ/cHfc7uk+1NjUeEsHqS85jBetjVDACCO+dhKgyaiVStTFybwyU7/j5n98G2psY325sa3vO4ehK+qpLzX0PRtrrn9RbbS1y3Gw9wBOh5GpzJ1cjQDCU2W1O1YmEUANqbf/3Wh007t78UcLtGE3HRePwohvQW21/HoV3OSJOjZGGGnDVnK9H5ahmuwoW3Q6LE/0IzLJwbIZGPBgjDSNaiNXJtxpVEHRkdl3jCetjljIzZ49H2TFDLUGpplpy5IwWXCitFgssfJs/6wizN/kkxbMKW4cYlrFAbjBqNwSSYcYhWgVJ3pssp81yFTCOXQimhE6ZZptsfpts/I+jLY7SM/fPfaVbA7fxlwO0ajLeWuIQWAbdrbzzanS4pOBJeqVdSa+en4IvSZLfbd0pCADAsC05/OHz4whjdPUTiQYq9ZSZRZ7GuTYSmuBjEta/OCwB87QDPzFVh5HKdkly3MEV+R4pUEiJ0xkmGPusLU0cujNMfD4blJANTptiVWbq/SIS2uP14PI6m3+sttoTOqmcqsfCyLAWapkClOQwREAmlunwEeW6EQlmY2hTXk6gjo+OWvfGf7WiOV9s3EOkxwpYcFWWZp5JLtVLCJ0Qx9NlBgjpyYYztHaEU0zXHJJk6i3VZHOT9CXH7MQ20H3NE7kWkN4zXNTKVaPiebCWqlqNSVkoE0CwLfxggQudGKBkXvz2dxfqA12H/iBt1NyduBgm4XaFRt/OgxmCq4rLdyTM4kMVpMjZdgcqT4AzBpGeYYKhzIyRycZRkKJa7B6a2wBwZh/wbV+3djLimPOXaTFfmsrJvcNGWVoFSJq2MKtMp5fM1MlSFo5hkDuFCMixzcZSiTn1GMJ8MhWV+gkEZjn9vslSNIeB2vhpwu4Jctns9cZ1Bntwuckb7yMpQIO+9Q3E1VWvUyuUiO0hzVnJlnKIOu8eZjn5CNhxm4pkwUagNpv8Tx/bjfwTw0NlTMZ2ZlyZHqaWZcnLdwlRsnlomDbwFztVykGEyfPTSOHXCE8LDDJuQ78xUVRvXE5fjPquszNYpM5ctXx/t61NlCGXOVpLLshXyDCWGYdLsnuCJGOO4J0h7xml5iGYTXdemC7id+wJuV1wWXsX9wwy0HYv0IFMus8xWYeHSO5RU+YIUfJ4aV8Rbl8TMCFEM3T0Upt5xj5GdA4T8hlqphKItKIrbpGHcDTJ5fNYtF76k4Eg4MsZYnaOSz1fj0rJWgcOwLJwZJEJ29zic9YVvWw6SKLJKLHGbNExId+hxNB254U9Xy0FK75goB5HGGMJnnGToT4YmykF6/KQyEeF5tGgMprVqgzEuv+WEGCTgdr577f9nKrHwffNU9KoclWy+GpdJqVphE6ZZ5sxgmDhycZzt8oXxcYoVjDGu4w6dxRaXMCshH5Yhw1dWrd/w4OeyFBmFGXLFLN5oTTQMEzTt9JN0R38I+Sx4teRc0IvK5NoM+YXG1zk/ZSChj+/F5mJ1ui6npNhWUZpjyl+pN+WXIgDzEqlB4tZExhdXxmnq/AjJesdpPNG/jxkSlyOjeb8BD9duvTPHlPfFElvlVzk6fF4iBj4bp8N/GCSQkfhO7MUV574dX3Lt2/krLtvk3SDXSNfpkcXmEuNic3Fpuj5nVYmtshQAlknnjsQPimHZSwGKco+Q4CPEa4xrDJ09Vd/yrfVPc9mmYAxyM/LKVqrzylY+XPHs1moE4EG+9SQLLMuCe5QKn/WFgaDZZHoA9djXGfO5bFDQBrkevTEvJceUX1psq1i12FxSmqHPWQ4AOr51iYnIGOPCKBV2+sNYgBRkNmrGOPfVmV376jq5ak80BrkZFbVbi/LKVj6St3zllxDppN3b4h4hqdODBEUx8VufIwQGP2r9yYff3fhtrtoTtUGup9haYZrIjOWVFtsqVyEAhbN9/BKmWebcCEmfHyHZcSqpQqnbMXh0w2p9aMDLycE+SWOQG1lsLk5J1+UURUKySGiWY8qPhGQL+NYVbyJhVH+QJs+PkNA3RmOJmgwWEl2vff8L59/8WRMXbSWtQW7Gw7Vbl+eXrXw8f/nKJ5IxpTwaZqi2z0LgJ5hZXbrjcTT9qPOl2r/hoq1ZZZDrKbZWLF5sLl6ers8pLbFVrgIAczyXIMeTK+MUdX6EAs8Yhdxkk7XZyCn7OmMxFw3NWoPcSLG1IjvHlP/Iw89ufRwBKBeDWQZDNNnRTzCjYUZaHnADzn11C1z76i7NtB3JIDdBb8xT5pjyy4ptFfcuNpeszNDnlIJASmIiY4xLAerqGGMwxIitHCRheBxNf9/5Uu0/zbQd6eZGSUXt1s8V2yqqc0z5kfHLfD40DIZo4vQAgc32MUaUXLKvM844KSMZJAYmU8qlelPeihJbZRkALAWAuIQ5FMOynjGK6R0haV+ImS2pWk7oeGnLMq/DfnombUgG4YBia4U2x5T/0MPPbn0MAXiEi/kXlmXhYoAKnfWFMSGs2hMjHkfTls6Xal+ZSRu8GERbUJSZ+3j1tlC/96S/q+OE12EX3OGNsbLYXDwnXZdzT7GtYuVEL5NfhgDoo31/iGLoSwEKzo2QbIBMzM4gyUqw39P43sY1lTNpg7cexHrY9QEALJ/8z8+GznYcCQ14Tnod9paA23kq4HZxMhMqBIqtFbnp+px7i60V5YvvKSlFAO6+MUs2TDBUZOB9fpREGFZK1XJE8INnn5jr7+oMxNoAbwaZ4sjoEAC849xX96uA2/mO12H3J1heXJlMKX/h4We3PkFQzIOd/QTtGadFeTKw0Ol4acsDXof93Vjfz9uTKjw86DRUfvlbcPOdvSNP1zszl5U9obfYvjP/oScf1BaaC5VZOrUyWz+SqAMc40UoMBpceNdSLS6XF86dN++uDCWGpStQVoWjDMMCTdDJWWnLE16vwx7zSQO8DtJncGT0mcGPWg/6Tre+zWVpcyKoqN1aVPHs1n+/Lrz8MyiGJS4FKMQ7RpFXgnQqwyZWY5Jx0r7OGPM5NbwapGhb3d/pLbbvz7CZy8H+q2OXd/1dHS3+sx2nQwNegiOJnFFeXXNfeXXN8xn6nGkt/KIYlvQTDOYnaGogRKNDIQZCtDR4nwZUx0tbFngddm8sb+bVIDqLtcy8bWcLx82OAECTc1/d276PWt/ynW5N+OHz11NsrSiteWX3qwBQwlWbvhAd6hujkL4xChuTMl1TMvhR67YPv7sxpgcxrwZRZulka/cfvxDHlYFhAPjI42hqCfV7W7yOpnf9XZ0xPUmmg96Yh65ev+Hx8k1P1yAA98WrrotlgR2nGGKIoLHBEIP5QzQ1RDByKSL7Mz45umF1YWjAO+1bw/tE4b0/ev1HmcvKtibwkp0eR9NbAbfrV659dTM6muFmbN6565ESW+VrfC0HDtNs8GKAUl0Zp4gr47RUxDhJx0tb7vI67LfcAvdW8G4QncV6p3nbzi6eLn951O1sCbidrZExTMDt7Ai4Xcx0G0nX6ZWr12+sWLV+w+YMfU55fKROH5plyaEQg/iu9iw05gsxaGiWZsjOHdpT+0n9yzun+z7eDQIT2azWSGfCt47J+Zd2j6PphP9sx8nQQCQss1+81YuLrRV3FtsqqktslV8BgLmJlRobQYoJ9wdppD9Iy0bCTNhPzI76rmC/p/m9jWumvTOOIAxStK3uZb3F9hzfOm7BJ4MTg/1fXUspF1srcmpe2R0Z9FUJaRPnWKAYlogM9vsCFJHkKeVw69aNadNN2gjCILmPfW1dwdPP/5ZvHVFwfkmarG1plsIKAKl8i+GaSEjmJxh0KETT13oZOokM43E0be586ZbVGzdFEAZRG4zKNbvfGRbDLiQyFIGHFyWdN26Jn2CClwIkmiQp5eP2dcY103mDIMKD8LCPmv/Qkw/KUjUGvrVMRSQE0aVg5GzZoV6JI7K5KTi+JE2OGubgRIYSZWUowrIAZFh8E5YLA27nnoDbNRLtGwTzAf1dHUdU2XoL3zqiYTBEs+nKWeGPPyEFRxUpahTmq6+Wz+Fhmg1dDFDK/iAd9IxRoii2VBuMDwDAL6J9vWC+ZWWWjskusVTzrSMaEABmgUYmmHvHFxiK4BlKDOarcVl+uoyaq8LZNDlK4ChAiGYRhhVGCH89qEzuv/TOwbejfb1gPoAyS4es3X+8Vwz7VUVumi03NSTHkKTexnMmsCywAZIJDxE0OhiiMT/BUAJJKfuOPfWQLtr1RoJ5ClLjAchYWqZO0c2P24mlXKLEUSRDic26XQujBUEAUWAInqbAMH0qjiyaI8Py0mWkWoayGIKMjZGMgqcEmSo87DvlO90aVRWFYAwSgSaCF/UW2zNi2C5znGTpJWlSmDUdUATB0hQYOk+NK4xaGZmlxEAjR0kMAZZkAKETFJJlLitTuvbVRXXQjmAG6REm16Z/DABFfGuZigDJyAIkQ6hlqFTvFAMYcjU7BnNT/vch7SeY4OUAiV2eSCnH8+HzqM5iTfM67MNT6oyjiJhQG4xLNAbTKr51RMMcGQrpUpjFGZMpZWxJmhxdoMHD6QqUUaBIZNAXJjhOKfvPdnzo7+qcMswS3JcbcDvf41tDtAyEKMEkOZINtQyVL9TIZOa5Smzt/BSlLTc1VDxXQetTcU7W92gLzWujeZ3gvmBtQZF6xY43+iMPFL61TIUcBcaWm8oiCCK4njiZYViWGiIYGAjSjC9EI4MhGiOZaT/su+zrjIVTvUhwPcjkFi1v8K0jGsIMoAMhhuJbx2wDRRA8U4nh+ely+Qq9SvaFXDWsna8aM2lloVQZQkfZTIHOYr1jqhcJ9ck3nLms7Ct8i4gGmgVqnhoXVLJjtoEggChxVP7HkhgNTl63Swx1q11iQv2ejwbaj992a1LBhVjXsB52fQoAi/nWEQ1WQwqpxFFpe1CBQrMsORikUT/BkJFwbIhgMIJm0WC/5433Nq558nbvFVyIdQ2Po+kw3xqiZTBEC/ZBI/HHlDKWly5XRkIyW24q+sCClGDhkoUrpnqvYA0S6vf8nm8N0XJlPNqwV0IghPs/PnWoZ9cPHprqhYKNnf1dnb/jW0O0fBaUehCx0Ofs/u/9L3zv2z2tJ6La3UawBvE67P0AEAmz1vGtZSqCFIsNE3QoTYEJPjU9S/F/eqrt581763e32xuntbOJULNYfyRzWdljfGuIDiSsS8WlgbqwoPuc3f9Sv2VzRcOP//k3HldP/3QbEHRoMLkUN9IVpvGtZSpkE5OGDIoggu2VZxGftTU1/FdvR/vPmvfWfzyThgT9ZQbcrtCo23lcYzB9gW8tU0EygPpCNGSpBH1Lk52x7pYTO/e/8Nw/e1w9nByZIfhvM+B2HhWDQSL0B2kmS4ULNjOYxLjamhr+o3lv/eu9He0zPvr5egRvEK/D/qbeYtvOt45o6BujoCBDqn5PEIzP03fo/QP7dx8/8Pq7Q15PXHLtYjDIOQA4L4aluCNhFidplpBhiOSS+NJZ/8xTm9vtjSfjfSFRhANDZ0/FfIRWovksSIvinooQos/ZffDA918o37xEZ06EOUAMPUiEgfZjh9ML7xHFjiefjVPYPLUobquYeKv+mae+3W5vTPhpyKJ42g20HTsGAKKo5xgI0aLQKQJ8fc7uVw98/4Vlm5fo/pIPc4BYehB/V2cfAERMcj/fWqYiQLKykTATnCNHRbGRmhDpc3ZHeoyvcZWqnQmi6EFgorp3L98aouX8CCn4CgUB4v/0VNtP6595auk/PHTfXwrBHCD0mfTrURuMsjW737kkhnM4UATgC7mpJI4iUunJ7WEA4P0je17bc/zA/v0eV09Um7klElGEWDAxq06Oup3HNAbT43xrmQqGvToWwXQporm9CYcFuNje1PDVXVs2CzpDKapvcKDN0SwGg0QYGKdpXYo0q34jPk+f4/0D+/ceP/D6wSGvZ5xvPVMhKoP4uzqP8q0hWvonsllSiPW/tDfu2L61sW67aLZ1ArEZxOuwdwPAGQC4i28tUzFMMMogxYRVOCqEDZv5gvZ5+t5+/8D+PccPvP7beJWDxBNRGQQmDoXfnbms7Cd865gKFgAujFJIfvrs9Eefs7uxvanxO4112118a5kJosliXUNnserM23a6xXBcmwpH6M8vTEURRHz3OUaIPmd3w/ED+3/evLe+iW8xXCC6HsTrsHsB4CQACH7/3iDFYiMkQ6bJZ8WWQG/VP/PU89Nd0ip0RJll8TiaRDNYHxhP6o0X/ZPlIPdOloMklTlAjD0ITPQiDXqLbRvfOqKhb4yGJVq+VXCLz9P34fsH9r965tjRt3s72gUx4x0vxGqQSIgVCbV0fGuZCh9By2iWJTEkKWbV/W1NDf9315bNoin7mSmiNEiEUbdzj8Zgep5vHVPBsAAXRykmd46o/XHyyJ7Xfnr8wP6DHleP4Cf3uES0BvE67D/XVAnfIBHOjZCoSA3iamtqqBF6OUg8EXX60XrY9bEYJg0jfH5hCpkiE0c2y+fpa23eW/+PZxxH3/G4ehi+9fCJaHsQmMhmvau32ERhkIEgDQtlgk8anmncsf0ZsZWDxBPBf2O3w3+2QzT7914R7v69tM/T19i4Y/sX/naV2SyZ408RdQ8y0H5MNLHxgDAN8m7jju01Yi8HiSeiNkjA7RoFgLcA4FG+tUxFiGax0TBNauQY3+MQ4tNTbb9s3lv/aqJ2BhEzQnyqTQtjVe1yU1XtB3zriIbCDDmVny7n66Hkamtq+M/mvfU/43r3wWRG9AaJsHq3fZfGYKoS+sm4c1UYsSpHlehN5bzdLSd+uP+F514V4pJWoZMUBoGJ46NTlNn6Ip3FukptMJVqDKblALCAb13XgyIAD+emklgC1qr7PH0f9na0/aJ5b/3+ZC8HiSdJY5CbYayqvVNtMD6mt9ieBIAivvVEKMpS0IvSZPHc9eRM447t2xrrtr8Vx2vMGpLaINejLSjK1llsDyqzdaV6i20FAJj5WFOSqcRClnmqeISCJ4/see0/mvfW/2LI6yHi0P6sZNYY5EYylpYpM5aV2UxVtZHe5aGIhxJ1bashhVDiKFdjkcjg+zu7tmxu5Kg9ieuYtQa5HmWWTqYtNK/UWaz3agvMK1XZ+lIAmBev6xXPVYQXamQz6b2oPmf3b884ju45fmD/27O9HCSeSAa5BTqLdb7aYFqhNhgjIdnKyTFMKhdt56TiZJlOGctAfezTU20/P/iDF/61t6P9HBdaJG6PZJAoURuMSp3F9qSpqvYxAHhwJmbBEIDKxeppvafP2f2T/S987//1tJ4IxHpdiekjGSQGrkspl0V6GY3BVDrdA36W65SEPhWfahzi/fRU22vNe+v3ttsbL85MtUQsSAbhCGNVrVFtMD6ut9g2AYBpqtfPS8WD9+qUt9oBPtTW1PDcri2bd3CvVGI6SAaJAzqLNVeZpbtXW2heobfYIr1L6Y0pZRQBsBlSSRn2J5OGF47see2fJzdylib3BIBkkAQwmVJ+yFRV+3UA+Py1ItGyOxR0jvrqpKG/u+XEP0jlIMJDMkiCiQz21QbTPTqLddWS3AV3Zwb7W5v31v+yt6N9iG9tEhISEtNC1CsKJSTizf8PAAD//yXxc47X1bQxAAAAAElFTkSuQmCC
+    mediatype: image/png
+  links:
+  - name: Syndesis
+    url: https://github.com/syndesisio/syndesis
+  - name: Syndesis Operator
+    url: https://github.com/syndesisio/syndesis/tree/master/install/operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: syndesis-operator
+        rules:
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          verbs:
+          - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          - operatorgroups
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.operators.coreos.com
+          resources:
+          - packagemanifests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - packages.operators.coreos.com
+          resources:
+          - packagemanifests
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreams/secrets
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimports
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/attach
+          - pods/exec
+          - pods/portforward
+          - pods/proxy
+          - secrets
+          - services/proxy
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - persistentvolumeclaims
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - secrets
+          - serviceaccounts
+          - services
+          - services/proxy
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/rollback
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/rollback
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/details
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs/instantiate
+          - buildconfigs/instantiatebinary
+          - builds/clone
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigrollbacks
+          - deploymentconfigs/instantiate
+          - deploymentconfigs/rollback
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/log
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - quota.openshift.io
+          resources:
+          - appliedclusterresourcequotas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - extensions
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - resourcequotausages
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreamtags
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - syndesises.syndesis.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+        - apiGroups:
+          - syndesis.io
+          resources:
+          - syndesises
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - persistentvolumeclaims
+          - pods
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - serviceaccounts
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - events
+          - limitranges
+          - namespaces/status
+          - pods/log
+          - pods/status
+          - replicationcontrollers/status
+          - resourcequotas
+          - resourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - controllerrevisions
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - syndesis.io
+          resources:
+          - syndesises
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - syndesises.syndesis.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+        - apiGroups:
+          - syndesis.io
+          resources:
+          - syndesises
+          verbs:
+          - get
+          - list
+          - watch
+      permissions:
+      - serviceAccountName: syndesis-operator
+        rules:
+        - apiGroups:
+          - syndesis.io
+          resources:
+          - '*'
+          - '*/finalizers'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - authorization.openshift.io
+          resources:
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - camel.apache.org
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - prometheuses
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - eventing.knative.dev
+          resources:
+          - channels
+          verbs:
+          - get
+          - list
+          - watch
+      deployments:
+      - name: syndesis-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: syndesis-operator
+              syndesis.io/app: syndesis
+              syndesis.io/type: operator
+              syndesis.io/component: syndesis-operator
+          template:
+            metadata:
+              labels:
+                name: syndesis-operator
+                syndesis.io/app: syndesis
+                syndesis.io/type: operator
+                syndesis.io/component: syndesis-operator
+            spec:
+              serviceAccountName: syndesis-operator
+              containers:
+                - name: syndesis-operator
+                  image: syndesis/syndesis-operator:1.7.1-20190607
+                  imagePullPolicy: Always
+                  ports:
+                    - containerPort: 60000
+                      name: metrics
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "syndesis-operator"
+  customresourcedefinitions:
+    owned:
+    - name: syndesises.syndesis.io
+      version: v1alpha1
+      kind: Syndesis
+      displayName: Syndesis CRD
+      description: Syndesis CRD

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ spec:
   version: 1.7.x
   maturity: alpha
   maintainers:
-  - name: Red Hat Fuse Online
+  - name: Syndesis team
     email: fuse-online@redhat.com
   provider:
     name: Syndesis team

--- a/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.x/syndesisoperator.1.7.x.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     certified: "false"
     createdAt: 2019-05-08T16:12:00Z
     containerImage: syndesis/syndesis-operator
-    support: Red Hat Fuse Online
+    support: Syndesis
     description: Manages the installation of Syndesis, a flexible and customizable open source platform that provides core integration capabilities as a service.
     repository: https://github.com/syndesisio/syndesis/
     alm-examples: |

--- a/install/operator/deploy/manifests/syndesis.package.yaml
+++ b/install/operator/deploy/manifests/syndesis.package.yaml
@@ -1,0 +1,4 @@
+packageName: fuseonline
+channels:
+- name: alpha
+  currentCSV: syndesisoperator.1.7.x

--- a/install/operator/deploy/manifests/syndesis.package.yaml
+++ b/install/operator/deploy/manifests/syndesis.package.yaml
@@ -1,4 +1,4 @@
-packageName: fuseonline
+packageName: syndesis
 channels:
 - name: alpha
   currentCSV: syndesisoperator.1.7.x


### PR DESCRIPTION
Based on our previous discussions I created this new PR, some considerations:

 - This is an operator for upstream, I have replaced Fuse Online references for Syndesis
 - It is using the [manifests format](https://github.com/operator-framework/operator-registry#manifest-format) recommended by [operator-courier](https://github.com/operator-framework/operator-courier)
 - All relevant files are now under `deploy` dir
 - The package version is 1.7.x while the operator version will be the latest within 1.7.x range

Observations:
 - I couldn't come up with that much for the description. Having a look at other operators, ppl have a sections describing the accepted values of the CR, but since we don't use the CR for reconciling (as far as I know), this section fell flat for us, unless we want to comment that our CR can be empty. Maybe we can describe the update procedure here (atm the operator is listed with install only capabilities)
 - The clusterPermission section is pretty much an abomination, but needed with the current version of the operator. The operator ServiceAccount passes down the edit ClusterRole to some of the syndesis service accounts, most likely syndesis-server. I will figure out what specifically is needed and narrow this down.