### PR TITLE
docs: Fix permission grant command line on arbitrary cluster install

### DIFF
--- a/doc/sdh/cli/cmd_install.adoc
+++ b/doc/sdh/cli/cmd_install.adoc
@@ -105,7 +105,7 @@ minishift start --memory 4192
 oc login -u system:admin
 
 # Register CRD and grant permissions to "developer"
-syndesis --setup --grant developer --cluster
+syndesis install --setup --grant developer --cluster
 
 # Switch to account developer
 oc login -u developer


### PR DESCRIPTION
permission grant command line is missing the `install` command. By default `build` command is executed in syndesis binary