### PR TITLE
fix(5512): Fixes 500 response failure in odata queries

### DIFF
--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -23,7 +23,6 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.component.olingo4.Olingo4AppEndpointConfiguration;
 import org.apache.camel.component.olingo4.Olingo4Component;
 import org.apache.camel.util.ObjectHelper;
-import org.apache.http.HttpHeaders;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import io.syndesis.connector.odata.ODataConstants;
@@ -193,11 +192,7 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         Olingo4Component component = new Olingo4Component(getCamelContext());
         Olingo4AppEndpointConfiguration configuration = new Olingo4AppEndpointConfiguration();
 
-        //
-        // Ensure that full odata metadata is returned by the olingo request
-        //
         Map<String, String> httpHeaders = new HashMap<>();
-        httpHeaders.put(HttpHeaders.ACCEPT, "application/json;odata.metadata=full,application/xml,*/*");
         configuration.setHttpHeaders(httpHeaders);
 
         String methodName = ConnectorOptions.extractOption(options, METHOD_NAME);

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/AbstractODataReadRouteTest.java
@@ -35,6 +35,7 @@ public abstract class AbstractODataReadRouteTest extends AbstractODataRouteTest 
     protected static final String TEST_SERVER_DATA_2_WITH_COUNT = "test-server-data-2-with-count.json";
     protected static final String TEST_SERVER_DATA_3_WITH_COUNT = "test-server-data-3-with-count.json";
     protected static final String REF_SERVER_PEOPLE_DATA_1 = "ref-server-people-data-1.json";
+    protected static final String REF_SERVER_PEOPLE_DATA_1_EXPANDED_TRIPS = "ref-server-people-data-1-expanded-trips.json";
     protected static final String REF_SERVER_PEOPLE_DATA_2 = "ref-server-people-data-2.json";
     protected static final String REF_SERVER_PEOPLE_DATA_3 = "ref-server-people-data-3.json";
     protected static final String REF_SERVER_PEOPLE_DATA_KLAX = "ref-server-data-klax.json";

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -219,7 +219,6 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         context.addRoutes(routes);
         MockEndpoint result = initMockEndpoint();
         result.setMinimumExpectedMessageCount(1);
-        result.setResultWaitTime(360000);
 
         context.start();
 

--- a/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1-expanded-trips.json
+++ b/app/connector/odata/src/test/resources/io/syndesis/connector/odata/consumer/ref-server-people-data-1-expanded-trips.json
@@ -1,0 +1,60 @@
+{
+  "UserName": "russellwhyte",
+  "FirstName": "Russell",
+  "LastName": "Whyte",
+  "Gender": "Male",
+  "MiddleName": "",
+  "Age": "",
+  "Emails": [
+    "Russell@example.com",
+    "Russell@contoso.com"
+  ],
+  "FavoriteFeature": "Feature1",
+  "Features": [
+    "Feature1",
+    "Feature2"
+  ],
+  "AddressInfo": [
+    {
+      "Address":"187 Suffolk Ln.",
+      "City":{
+        "Name":"Boise",
+        "CountryRegion":"United States",
+        "Region":"ID"
+      }
+    }
+  ],
+  "HomeAddress": "",
+  "Trips": [
+    {
+      "TripId": 0,
+      "ShareId": "9d9b2fa0-efbf-490e-a5e3-bac8f7d47354",
+      "Name": "Trip in US",
+      "Budget": 3000,
+      "Description": "Trip from San Francisco to New York City",
+      "Tags": ["business","New York meeting"],
+      "StartsAt": "2014-01-01T00:00:00Z",
+      "EndsAt": "2014-01-04T00:00:00Z"
+    },
+    {
+      "TripId": 1,
+      "ShareId": "f94e9116-8bdd-4dac-ab61-08438d0d9a71",
+      "Name": "Trip in Beijing",
+      "Budget": 2000,
+      "Description": "Trip from Shanghai to Beijing",
+      "Tags": ["Travel","Beijing"],
+      "StartsAt": "2014-02-01T00:00:00Z",
+      "EndsAt": "2014-02-04T00:00:00Z"
+    },
+    {
+      "TripId": 2,
+      "ShareId": "9ce142c3-5fd6-4a71-848e-5220ebf1e9f3",
+      "Name": "Honeymoon",
+      "Budget": 2650,
+      "Description": "Happy honeymoon trip",
+      "Tags":["Travel","honeymoon"],
+      "StartsAt": "2014-02-01T00:00:00Z",
+      "EndsAt": "2014-02-04T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
* ODataComponent
 * ACCEPT header was overridden to include odata.metadata=full, which was
   thought to be necessary to make complex values work correctly. This is
   not the case with removal complex value work fine & queries work again.
 * Specifically, despite odata.metadata=full being legitimate it appears
   to cause an error on the reference server when added to the ACCEPT
   header & since not necessary, removal is preferable.

* Adds test for filter & expand and removes hang-over increases in mock
  result wait times which are only required for debugging.