### PR TITLE
fix: Add liveness check to Spring Boot integrations

### DIFF
--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftConfigurationProperties.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftConfigurationProperties.java
@@ -25,6 +25,7 @@ import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 
 @ConfigurationProperties("openshift")
 @Validated
+@SuppressWarnings("PMD.TooManyFields")
 public class OpenShiftConfigurationProperties {
 
     private boolean enabled;
@@ -52,6 +53,8 @@ public class OpenShiftConfigurationProperties {
     private long pollingInterval = 5000;
 
     private Map<String, String> buildNodeSelector;
+
+    private int integrationLivenessProbeInitialDelaySeconds;
 
     public void setDebug(final boolean debug) {
         this.debug = debug;
@@ -171,5 +174,13 @@ public class OpenShiftConfigurationProperties {
 
     public void setBuildNodeSelector(Map<String, String> buildNodeSelector) {
         this.buildNodeSelector = buildNodeSelector;
+    }
+
+    public int getIntegrationLivenessProbeInitialDelaySeconds() {
+        return integrationLivenessProbeInitialDelaySeconds;
+    }
+
+    public void setIntegrationLivenessProbeInitialDelaySeconds(int integrationLivenessProbeInitialDelaySeconds) {
+        this.integrationLivenessProbeInitialDelaySeconds = integrationLivenessProbeInitialDelaySeconds;
     }
 }

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.Doneable;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
@@ -268,6 +269,13 @@ public class OpenShiftServiceImpl implements OpenShiftService {
                             .withMountPath("/deployments/config")
                             .withReadOnly(false)
                         .endVolumeMount()
+                        .withLivenessProbe(new ProbeBuilder()
+                            .withInitialDelaySeconds(config.getIntegrationLivenessProbeInitialDelaySeconds())
+                            .withNewHttpGet()
+                                .withPath("/health")
+                                .withNewPort(8080)
+                            .endHttpGet()
+                            .build())
                         .endContainer()
                         .addNewVolume()
                             .withName("secret-volume")
@@ -292,8 +300,6 @@ public class OpenShiftServiceImpl implements OpenShiftService {
             .endSpec()
             .done();
     }
-
-
 
     private boolean removeDeploymentConfig(String projectName) {
         return openShiftClient.deploymentConfigs().withName(projectName).delete();

--- a/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
+++ b/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -377,6 +378,13 @@ public class OpenShiftServiceImplTest {
                                 .withMountPath("/deployments/config")
                                 .withReadOnly(false)
                             .endVolumeMount()
+                            .withLivenessProbe(new ProbeBuilder()
+                                .withInitialDelaySeconds(config.getIntegrationLivenessProbeInitialDelaySeconds())
+                                .withNewHttpGet()
+                                    .withPath("/health")
+                                    .withNewPort(8080)
+                                .endHttpGet()
+                                .build())
                         .endContainer()
                         .addNewVolume()
                             .withName("secret-volume")

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -256,6 +256,7 @@
         deploymentMemoryRequestMi: 200
         deploymentMemoryLimitMi: 512
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
+        integrationLivenessProbeInitialDelaySeconds: 120
       dao:
         kind: jsondb
       controllers:

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1955,6 +1955,7 @@ objects:
         deploymentMemoryRequestMi: 200
         deploymentMemoryLimitMi: 512
         mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
+        integrationLivenessProbeInitialDelaySeconds: 120
       dao:
         kind: jsondb
       controllers:


### PR DESCRIPTION
The integration pod's initial delay to start the liveness probe is configurable via the `integrationLivenessProbeInitialDelaySeconds` property. Each integration app is different and we don't know exactly the maximum time an integration might take to start. Liveness probes must not start while the apps are still starting otherwise it risks restarting them before they are fully started.

fix #5328
