### PR TITLE
chore: Data Mapper should skip maven classpath resolution in Syndesis…

### DIFF
--- a/app/ui-react/packages/atlasmap-assembly/src/app/data-mapper-host.component.ts
+++ b/app/ui-react/packages/atlasmap-assembly/src/app/data-mapper-host.component.ts
@@ -77,6 +77,7 @@ export class DataMapperHostComponent implements OnInit, OnDestroy, OnChanges {
     // initialize config information before initializing services
     const c: ConfigModel = this.initializationService.cfg;
 
+    c.initCfg.classPath = environment.classpath;
     c.initCfg.xsrfCookieName = environment.xsrf.cookieName;
     c.initCfg.xsrfDefaultTokenValue = environment.xsrf.defaultTokenValue;
     c.initCfg.xsrfHeaderName = environment.xsrf.headerName;

--- a/app/ui-react/packages/atlasmap-assembly/src/environments/environment.prod.ts
+++ b/app/ui-react/packages/atlasmap-assembly/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
+  classpath: ' ',
   production: true,
   xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',

--- a/app/ui-react/packages/atlasmap-assembly/src/environments/environment.ts
+++ b/app/ui-react/packages/atlasmap-assembly/src/environments/environment.ts
@@ -3,6 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
+  classpath: ' ',
   production: false,
   xsrf: {
     headerName: 'SYNDESIS-XSRF-TOKEN',


### PR DESCRIPTION
… (#5622)

A bit better error message for #5622, show a Step ID for which Document fails to load. atlasmap/atlasmap#971 will add human readable Document name in addition.