### PR TITLE
fixes: #4878 Correct description of Periodic SQL invocation action

### DIFF
--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -44,7 +44,7 @@
     },
     {
       "actionType": "connector",
-      "description": "Periodically invoke SQL to obtain, store, update, or delete data.",
+      "description": "Periodically invoke SQL to obtain data.",
       "descriptor": {
         "componentScheme": "sql",
         "connectorCustomizers": [


### PR DESCRIPTION
I think this update corrects the description for the Periodic SQL Invocation action, which is available only as a SQL start connection, and supports only specification of a SELECT statement. 

I should have put "fixes: #4878 " in the commit message. 