### PR TITLE
fix: missing db schema handling in sql connector customizer

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
@@ -44,7 +44,7 @@ public class SqlConnectorMetaDataExtension extends AbstractMetaDataExtension {
         if (sqlStatement != null) {
             try (Connection connection = SqlSupport.createConnection(properties)) {
                 DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
-                final String defaultSchema = dbHelper.getDefaultSchema(String.valueOf(properties.get("user")));
+                final String defaultSchema = dbHelper.getDefaultSchema((String) properties.getOrDefault("user", ""));
                 final String schemaPattern = (String) properties.getOrDefault("schema", defaultSchema);
                 final SqlStatementParser parser = new SqlStatementParser(connection, schemaPattern, sqlStatement);
                 final SqlStatementMetaData sqlStatementMetaData = parseStatement(parser);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
@@ -83,7 +83,7 @@ public final class SqlSupport {
 
             final DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
             final String catalog = (String) parameters.getOrDefault("catalog", null);
-            final String defaultSchema = dbHelper.getDefaultSchema(String.valueOf(parameters.get("user")));
+            final String defaultSchema = dbHelper.getDefaultSchema((String) parameters.getOrDefault("user", ""));
             final String schemaPattern = (String) parameters.getOrDefault("schema", defaultSchema);
             final String procedurePattern = (String) parameters.getOrDefault("procedure-pattern", null);
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.json.JsonUtils;
+import io.syndesis.connector.sql.common.DbMetaDataHelper;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.common.SqlParam;
 import io.syndesis.connector.sql.common.SqlStatementMetaData;
@@ -112,8 +113,11 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
 
             final Map<String, Integer> tmpMap = new HashMap<>();
             try (Connection connection = dataSource.getConnection()) {
+                DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
+                final String defaultSchema = dbHelper.getDefaultSchema((String) options.getOrDefault("user", ""));
+                final String schemaPattern = (String) options.getOrDefault("schema", defaultSchema);
 
-                SqlStatementMetaData statementInfo = new SqlStatementParser(connection, null, sql).parse();
+                SqlStatementMetaData statementInfo = new SqlStatementParser(connection, schemaPattern, sql).parse();
                 for (SqlParam sqlParam: statementInfo.getInParams()) {
                     tmpMap.put(sqlParam.getName(), sqlParam.getJdbcType().getVendorTypeNumber());
                 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbDerby.java
@@ -17,14 +17,16 @@ package io.syndesis.connector.sql.db;
 
 import java.util.Locale;
 
+import org.apache.camel.util.ObjectHelper;
+
 public class DbDerby extends DbStandard {
 
     @Override
     public String getDefaultSchema(String dbUser) {
-        if (dbUser != null) {
+        if (ObjectHelper.isNotEmpty(dbUser)) {
             return dbUser.toUpperCase(Locale.US);
         } else {
-            return "NULL";
+            return null;
         }
     }
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbOracle.java
@@ -17,11 +17,17 @@ package io.syndesis.connector.sql.db;
 
 import java.util.Locale;
 
+import org.apache.camel.util.ObjectHelper;
+
 public class DbOracle extends DbStandard {
 
     @Override
     public String getDefaultSchema(final String dbUser) {
-        return dbUser.toUpperCase(Locale.US);
+        if (ObjectHelper.isNotEmpty(dbUser)) {
+            return dbUser.toUpperCase(Locale.US);
+        } else {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #5647

SQL connector customizer was not using proper db schema property when parsing the given statement to its meta data. This caused parameters (e.g. for insert) to be missing for SQL statement execution