### PR TITLE
fix: Add db schema support to sample todo app

### DIFF
--- a/install/generator/04-todo-example.yml.mustache
+++ b/install/generator/04-todo-example.yml.mustache
@@ -119,6 +119,8 @@
                 value: syndesis-db
               - name: TODO_DB_NAME
                 value: sampledb
+              - name: TODO_DB_SCHEMA
+                value: sampledb
               - name: TODO_DB_USER
                 value: sampledb
               - name: TODO_DB_PASS

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -2282,6 +2282,8 @@ objects:
                 value: syndesis-db
               - name: TODO_DB_NAME
                 value: sampledb
+              - name: TODO_DB_SCHEMA
+                value: sampledb
               - name: TODO_DB_USER
                 value: sampledb
               - name: TODO_DB_PASS


### PR DESCRIPTION
todo sample application was not working after we have moved the tables in Postgres to a separate schema "sampledb". The todo app needs to use the schema in its SQL statements.

The corresponding todo app PR is https://github.com/syndesisio/todo-example/pull/17 and needs to be merged as well in order to fix this.