### PR TITLE
fix(5533): Fix OData Read Customizer in the event of null message body

### DIFF
--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -596,4 +596,62 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         assertEquals(backoffIdleThreshold, consumerProperties.get(BACKOFF_IDLE_THRESHOLD));
         assertEquals(backoffMultiplier, consumerProperties.get(BACKOFF_MULTIPLIER));
     }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void testReferenceODataRouteAlreadySeenWithKeyPredicate() throws Exception {
+        String resourcePath = "Airports";
+        String keyPredicate = "KSFO";
+        String backoffIdleThreshold = "1";
+        String backoffMultiplier = "1";
+
+        Connector odataConnector = createODataConnector(new PropertyBuilder<String>()
+                                                            .property(SERVICE_URI, REF_SERVICE_URI)
+                                                            .property(KEY_PREDICATE, keyPredicate)
+                                                            .property(FILTER_ALREADY_SEEN, Boolean.TRUE.toString())
+                                                            .property(BACKOFF_IDLE_THRESHOLD, backoffIdleThreshold)
+                                                            .property(BACKOFF_MULTIPLIER, backoffMultiplier));
+
+        Step odataStep = createODataStep(odataConnector, resourcePath);
+        Integration odataIntegration = createIntegration(odataStep, mockStep);
+
+        RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
+        context.addRoutes(routes);
+
+        int expectedMsgCount = 3;
+        MockEndpoint result = initMockEndpoint();
+        result.setMinimumExpectedMessageCount(expectedMsgCount);
+
+        context.start();
+
+        result.assertIsSatisfied();
+
+        for (int i = 0; i < expectedMsgCount; ++i) {
+            String json = extractJsonFromExchgMsg(result, i, String.class);
+            assertNotNull(json);
+
+            String expected;
+            if (i == 0) {
+                expected = testData(REF_SERVER_AIRPORT_DATA_1);
+                JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+            } else {
+                //
+                // Subsequent polling messages should be empty
+                //
+                expected = testData(TEST_SERVER_DATA_EMPTY);
+                JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+            }
+        }
+
+        //
+        // Check backup consumer options carried through to olingo4 component
+        //
+        Olingo4Endpoint olingo4Endpoint = context.getEndpoint(OLINGO4_READ_ENDPOINT, Olingo4Endpoint.class);
+        assertNotNull(olingo4Endpoint);
+        Map<String, Object> consumerProperties = olingo4Endpoint.getConsumerProperties();
+        assertNotNull(consumerProperties);
+        assertTrue(consumerProperties.size() > 0);
+        assertEquals(backoffIdleThreshold, consumerProperties.get(BACKOFF_IDLE_THRESHOLD));
+        assertEquals(backoffMultiplier, consumerProperties.get(BACKOFF_MULTIPLIER));
+    }
 }


### PR DESCRIPTION
* If a null body is encountered (filtered out by consumer) then the
  converter returns the message as the body. As such. the jackson object
  mapper is unable to serialise this to json and present a stackoverflow
  exception.

* Properly handles a null body and returns empty json without resorting to
  the object mapper.

* Tests to verify the fix.