### PR TITLE
feat(api): add `PUT /api/v1/apis/generator`

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelper.java
@@ -18,12 +18,19 @@ package io.syndesis.server.endpoint.v1.handler.api;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.Kind;
+import io.syndesis.common.model.ResourceIdentifier;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.api.generator.APIGenerator;
 import io.syndesis.server.api.generator.APIIntegration;
 import io.syndesis.server.api.generator.ProvidedApiTemplate;
@@ -56,6 +63,15 @@ public final class ApiGeneratorHelper {
         return apiGenerator.generateIntegration(spec, template);
     }
 
+    public static Optional<OpenApi> specificationFrom(IntegrationResourceManager resourceManager, final Integration integration) {
+        final Optional<ResourceIdentifier> specification = integration.getResources().stream().filter(r -> r.getKind() == Kind.OpenApi)
+            .max(ResourceIdentifier.LATEST_VERSION);
+
+        return specification
+            .flatMap(s -> s.getId()
+                .flatMap(resourceManager::loadOpenApiDefinition));
+    }
+
     public static APIIntegration generateIntegrationUpdateFrom(final Integration existing, final APIFormData apiFormData, final DataManager dataManager,
         final APIGenerator apiGenerator) {
         final APIIntegration newApiIntegration = generateIntegrationFrom(apiFormData, dataManager, apiGenerator);
@@ -66,6 +82,67 @@ public final class ApiGeneratorHelper {
             .flows(withSameIntegrationIdPrefix(existing, newIntegration.getFlows())).build();
 
         return new APIIntegration(updatedIntegration, newApiIntegration.getSpec());
+    }
+
+    public static Integration updateFlowsAndStartAndEndDataShapes(final Integration existing, final Integration given) {
+        // will contain updated flows
+        final List<Flow> updatedFlows = new ArrayList<>(given.getFlows().size());
+
+        for (final Flow givenFlow : given.getFlows()) {
+            final String flowId = givenFlow.getId().get();
+
+            final Optional<Flow> maybeExistingFlow = existing.findFlowById(flowId);
+            if (!maybeExistingFlow.isPresent()) {
+                // this is a flow generated from a new operation or it
+                // has it's operation id changed, either way we only
+                // need to add it, since we don't know what flow we need
+                // to update
+                updatedFlows.add(givenFlow);
+                continue;
+            }
+
+            final List<Step> givenSteps = givenFlow.getSteps();
+            if (givenSteps.size() != 2) {
+                throw new IllegalArgumentException("Expecting to get exactly two steps per flow");
+            }
+
+            // this is a freshly minted flow from the specification
+            // there should be only two steps (start and end) in the
+            // flow
+            final Step givenStart = givenSteps.get(0);
+            final Optional<DataShape> givenStartDataShape = givenStart.outputDataShape();
+
+            // generated flow has only a start and an end, start is at 0
+            // and the end is at 1
+            final Step givenEnd = givenSteps.get(1);
+            final Optional<DataShape> givenEndDataShape = givenEnd.inputDataShape();
+
+            final Flow existingFlow = maybeExistingFlow.get();
+            final List<Step> existingSteps = existingFlow.getSteps();
+
+            // readability
+            final int start = 0;
+            final int end = existingSteps.size() - 1;
+
+            // now we update the data shapes of the start and end steps
+            final Step existingStart = existingSteps.get(start);
+            final Step updatedStart = existingStart.updateOutputDataShape(givenStartDataShape);
+
+            final Step existingEnd = existingSteps.get(end);
+            final Step updatedEnd = existingEnd.updateInputDataShape(givenEndDataShape);
+
+            final List<Step> updatedSteps = new ArrayList<>(existingSteps);
+            updatedSteps.set(start, updatedStart);
+            updatedSteps.set(end, updatedEnd);
+
+            final Flow updatedFlow = existingFlow.builder().name(givenFlow.getName()).description(givenFlow.getDescription()).steps(updatedSteps).build();
+            updatedFlows.add(updatedFlow);
+        }
+
+        return existing.builder().flows(updatedFlows)
+            // we replace all resources counting that the only resource
+            // present is the OpenAPI specification
+            .resources(given.getResources()).build();
     }
 
     static String getSpec(final APIFormData apiFormData) {

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelperTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelperTest.java
@@ -16,16 +16,98 @@
 package io.syndesis.server.endpoint.v1.handler.api;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
 
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApiGeneratorHelperTest {
+
+    @Test
+    public void shouldAddNewFlowsNonTrivialCase() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow flow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
+        final Flow flow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
+        final Flow flow3 = new Flow.Builder().id("flow3").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().addFlows(flow1, flow3).build();
+        final Integration given = new Integration.Builder().addFlows(flow1, flow2, flow3).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated).as("there should be three flows").isEqualTo(given);
+    }
+
+    @Test
+    public void shouldAddNewFlowsTrivialCase() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().build();
+        final Integration given = new Integration.Builder().addFlow(flow).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated).as("there should be one flow").isEqualTo(given);
+    }
+
+    @Test
+    public void shouldDeleteFlowsThatHaveBeenRemovedNonTrivialCase() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow existingFlow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
+        final Flow existingFlow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().addFlows(existingFlow1, existingFlow2).build();
+        final Integration given = new Integration.Builder().addFlow(existingFlow2).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated).as("there should be only one flow").isEqualTo(given);
+    }
+
+    @Test
+    public void shouldDeleteFlowsThatHaveBeenRemovedTrivialCase() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow existingFlow = new Flow.Builder().id("flow1").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().addFlow(existingFlow).build();
+        final Integration given = new Integration.Builder().build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated.getFlows()).as("there shouldn't be any flows as we removed the single existing flow").isEmpty();
+    }
 
     @Test
     public void shouldMaintainSameIntegrationPrefixForFlowIds() {
@@ -38,4 +120,118 @@ public class ApiGeneratorHelperTest {
 
         assertThat(sameIntegrationPrefixFlows).allMatch(f -> f.getId().get().startsWith("existing:flows:operation-"));
     }
+
+    @Test
+    public void shouldUpdateFlowNameAndDescription() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow flow = new Flow.Builder().id("flow1").name("name").description("description").addSteps(step, step).build();
+        final Flow flowUpdated = new Flow.Builder().id("flow1").name("updated name").description("updated description").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().addFlow(flow).build();
+        final Integration given = new Integration.Builder().addFlow(flowUpdated).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated).as("name and description should be updated").isEqualTo(given);
+    }
+
+    @Test
+    public void shouldUpdateFlowsDataShapes() {
+        final Step startStep = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder()
+                    .outputDataShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification("{\"start\":\"existing\"}")
+                        .build())
+                    .build())
+                .build())
+            .build();
+
+        final Step endStep = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder()
+                    .inputDataShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_INSTANCE)
+                        .specification("{\"end\":\"existing\"}")
+                        .build())
+                    .build())
+                .build())
+            .build();
+
+        final Step stepWithShapes = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder()
+                    .inputDataShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.ANY)
+                        .build())
+                    .outputDataShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.NONE)
+                        .build())
+                    .build())
+                .build())
+            .build();
+
+        final Flow existingFlow = new Flow.Builder().id("flow1").addSteps(startStep, stepWithShapes, endStep).build();
+        final Integration existing = new Integration.Builder().addFlow(existingFlow).build();
+
+        final DataShape givenStartShape = new DataShape.Builder()
+            .kind(DataShapeKinds.JSON_INSTANCE)
+            .specification("{\"start\":\"updated\"}")
+            .build();
+
+        final DataShape givenEndShape = new DataShape.Builder()
+            .kind(DataShapeKinds.JSON_INSTANCE)
+            .specification("{\"end\":\"updated\"}")
+            .build();
+
+        final Step givenStartStep = startStep.updateOutputDataShape(Optional.of(givenStartShape));
+        final Step givenEndStep = endStep.updateInputDataShape(Optional.of(givenEndShape));
+        final Flow givenFlow = new Flow.Builder()
+            .id("flow1")
+            .steps(Arrays.asList(
+                givenStartStep,
+                givenEndStep))
+            .build();
+        final Integration given = new Integration.Builder().addFlow(givenFlow).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        final Flow expectedFlow = new Flow.Builder()
+            .id("flow1")
+            .steps(Arrays.asList(
+                givenStartStep,
+                stepWithShapes,
+                givenEndStep))
+            .build();
+        final Integration expected = existing.builder()
+            .flows(Collections.singleton(expectedFlow))
+            .build();
+
+        assertThat(updated).as("should update only the data shapes").isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldUpdateFlowsStartAndEndDataShapesWithoutChanges() {
+        final Step step = new Step.Builder()
+            .action(new ConnectorAction.Builder()
+                .descriptor(new ConnectorDescriptor.Builder().build())
+                .build())
+            .build();
+
+        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
+
+        final Integration existing = new Integration.Builder().addFlow(flow).build();
+        final Integration given = new Integration.Builder().addFlow(flow).build();
+
+        final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
+
+        assertThat(updated).as("there should be no changes in trivial case").isEqualTo(existing);
+    }
+
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationSpecificationHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationSpecificationHandlerTest.java
@@ -17,16 +17,12 @@ package io.syndesis.server.endpoint.v1.handler.integration;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import io.syndesis.common.model.DataShape;
-import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.ResourceIdentifier;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -78,81 +74,6 @@ public class IntegrationSpecificationHandlerTest {
         try (Response response = handler.fetch("integration-id")) {
             assertThat(response.getStatus()).isEqualTo(Status.NOT_FOUND.getStatusCode());
         }
-    }
-
-    @Test
-    public void shouldAddNewFlowsNonTrivialCase() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow flow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
-        final Flow flow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
-        final Flow flow3 = new Flow.Builder().id("flow3").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().addFlows(flow1, flow3).build();
-        final Integration given = new Integration.Builder().addFlows(flow1, flow2, flow3).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated).as("there should be three flows").isEqualTo(given);
-    }
-
-    @Test
-    public void shouldAddNewFlowsTrivialCase() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().build();
-        final Integration given = new Integration.Builder().addFlow(flow).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated).as("there should be one flow").isEqualTo(given);
-    }
-
-    @Test
-    public void shouldDeleteFlowsThatHaveBeenRemovedNonTrivialCase() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow existingFlow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
-        final Flow existingFlow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().addFlows(existingFlow1, existingFlow2).build();
-        final Integration given = new Integration.Builder().addFlow(existingFlow2).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated).as("there should be only one flow").isEqualTo(given);
-    }
-
-    @Test
-    public void shouldDeleteFlowsThatHaveBeenRemovedTrivialCase() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow existingFlow = new Flow.Builder().id("flow1").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().addFlow(existingFlow).build();
-        final Integration given = new Integration.Builder().build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated.getFlows()).as("there shouldn't be any flows as we removed the single existing flow").isEmpty();
     }
 
     @Test
@@ -274,116 +195,4 @@ public class IntegrationSpecificationHandlerTest {
         }));
     }
 
-    @Test
-    public void shouldUpdateFlowNameAndDescription() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow flow = new Flow.Builder().id("flow1").name("name").description("description").addSteps(step, step).build();
-        final Flow flowUpdated = new Flow.Builder().id("flow1").name("updated name").description("updated description").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().addFlow(flow).build();
-        final Integration given = new Integration.Builder().addFlow(flowUpdated).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated).as("name and description should be updated").isEqualTo(given);
-    }
-
-    @Test
-    public void shouldUpdateFlowsDataShapes() {
-        final Step startStep = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder()
-                    .outputDataShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.JSON_INSTANCE)
-                        .specification("{\"start\":\"existing\"}")
-                        .build())
-                    .build())
-                .build())
-            .build();
-
-        final Step endStep = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder()
-                    .inputDataShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.JSON_INSTANCE)
-                        .specification("{\"end\":\"existing\"}")
-                        .build())
-                    .build())
-                .build())
-            .build();
-
-        final Step stepWithShapes = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder()
-                    .inputDataShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.ANY)
-                        .build())
-                    .outputDataShape(new DataShape.Builder()
-                        .kind(DataShapeKinds.NONE)
-                        .build())
-                    .build())
-                .build())
-            .build();
-
-        final Flow existingFlow = new Flow.Builder().id("flow1").addSteps(startStep, stepWithShapes, endStep).build();
-        final Integration existing = new Integration.Builder().addFlow(existingFlow).build();
-
-        final DataShape givenStartShape = new DataShape.Builder()
-            .kind(DataShapeKinds.JSON_INSTANCE)
-            .specification("{\"start\":\"updated\"}")
-            .build();
-
-        final DataShape givenEndShape = new DataShape.Builder()
-            .kind(DataShapeKinds.JSON_INSTANCE)
-            .specification("{\"end\":\"updated\"}")
-            .build();
-
-        final Step givenStartStep = startStep.updateOutputDataShape(Optional.of(givenStartShape));
-        final Step givenEndStep = endStep.updateInputDataShape(Optional.of(givenEndShape));
-        final Flow givenFlow = new Flow.Builder()
-            .id("flow1")
-            .steps(Arrays.asList(
-                givenStartStep,
-                givenEndStep))
-            .build();
-        final Integration given = new Integration.Builder().addFlow(givenFlow).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        final Flow expectedFlow = new Flow.Builder()
-            .id("flow1")
-            .steps(Arrays.asList(
-                givenStartStep,
-                stepWithShapes,
-                givenEndStep))
-            .build();
-        final Integration expected = existing.builder()
-            .flows(Collections.singleton(expectedFlow))
-            .build();
-
-        assertThat(updated).as("should update only the data shapes").isEqualTo(expected);
-    }
-
-    @Test
-    public void shouldUpdateFlowsStartAndEndDataShapesWithoutChanges() {
-        final Step step = new Step.Builder()
-            .action(new ConnectorAction.Builder()
-                .descriptor(new ConnectorDescriptor.Builder().build())
-                .build())
-            .build();
-
-        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
-
-        final Integration existing = new Integration.Builder().addFlow(flow).build();
-        final Integration given = new Integration.Builder().addFlow(flow).build();
-
-        final Integration updated = IntegrationSpecificationHandler.updateFlowsAndStartAndEndDataShapes(existing, given);
-
-        assertThat(updated).as("there should be no changes in trivial case").isEqualTo(existing);
-    }
 }


### PR DESCRIPTION
When creating an integration from the OpenAPI document prior to saving the integration there is a need to modify the OpenAPI document and have the changes reflect in the integration.

This adds a `PUT /api/v1/apis/generator` that returns HTTP status `202` and the updated integration when the provided OpenAPI document produces changes to the integration; and HTTP status `304` with no content when there are no changes to the integration.

There's a side effect of storing the updated OpenAPI document and referencing it from the integration resources, if there was an update.

Fixes #5719