### PR TITLE
fix(box connector): Add Technology Preview label for Box connector

### DIFF
--- a/app/connector/box/src/main/resources/META-INF/syndesis/connector/box.json
+++ b/app/connector/box/src/main/resources/META-INF/syndesis/connector/box.json
@@ -114,6 +114,9 @@
   "description": "Download and upload files.",
   "icon": "assets:box.png",
   "id": "box",
+  "metadata": {
+    "tech-preview": true
+  },
   "name": "Box",
   "properties": {
     "authenticationType": {


### PR DESCRIPTION
Fixes #5704 

SQS and SNS are not TP, Knative has already TP, mail connector too, odata I don't think is a TP.