### PR TITLE
feat: require OAuth settings for connection creation

### DIFF
--- a/app/server/credential/src/main/java/io/syndesis/server/credential/AcquisitionMethod.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/AcquisitionMethod.java
@@ -15,9 +15,9 @@
  */
 package io.syndesis.server.credential;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
 import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Information on the method of credential acquisition, needed for UI to present
@@ -33,6 +33,8 @@ public interface AcquisitionMethod {
         // builder implemented by Immutables, access allowed through this
         // subclass
     }
+
+    boolean configured();
 
     String getDescription();
 

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1CredentialProvider.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1CredentialProvider.java
@@ -31,21 +31,38 @@ public final class OAuth1CredentialProvider<A> extends BaseCredentialProvider {
 
     private final Applicator<OAuthToken> applicator;
 
+    private boolean configured;
+
     private final OAuth1ConnectionFactory<A> connectionFactory;
 
     private final String id;
 
+    public OAuth1CredentialProvider(final String id) {
+        this(id, null, null, false);
+    }
+
     public OAuth1CredentialProvider(final String id, final OAuth1ConnectionFactory<A> connectionFactory,
         final Applicator<OAuthToken> applicator) {
+        this(id, connectionFactory, applicator, true);
+    }
+
+    private OAuth1CredentialProvider(final String id, final OAuth1ConnectionFactory<A> connectionFactory,
+        final Applicator<OAuthToken> applicator, final boolean configured) {
         this.id = id;
         this.connectionFactory = connectionFactory;
         this.applicator = applicator;
+        this.configured = configured;
     }
 
     @Override
     public AcquisitionMethod acquisitionMethod() {
-        return new AcquisitionMethod.Builder().label(labelFor(id)).icon(iconFor(id)).type(Type.OAUTH1)
-            .description(descriptionFor(id)).build();
+        return new AcquisitionMethod.Builder()
+            .label(labelFor(id))
+            .icon(iconFor(id))
+            .type(Type.OAUTH1)
+            .description(descriptionFor(id))
+            .configured(configured)
+            .build();
     }
 
     @Override

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
@@ -31,25 +31,44 @@ import org.springframework.social.oauth2.OAuth2Parameters;
 
 public final class OAuth2CredentialProvider<S> extends BaseCredentialProvider {
 
+    private final Map<String, List<String>> additionalQueryParameters;
+
     private final Applicator<AccessGrant> applicator;
+
+    private boolean configured;
 
     private final OAuth2ConnectionFactory<S> connectionFactory;
 
     private final String id;
 
-    private final Map<String, List<String>> additionalQueryParameters;
+    public OAuth2CredentialProvider(final String id) {
+        this(id, null, null, Collections.emptyMap(), false);
+    }
 
     public OAuth2CredentialProvider(final String id, final OAuth2ConnectionFactory<S> connectionFactory, final Applicator<AccessGrant> applicator,
         final Map<String, String> additionalQueryParameters) {
+        this(id, connectionFactory, applicator, additionalQueryParameters, true);
+    }
+
+    private OAuth2CredentialProvider(final String id, final OAuth2ConnectionFactory<S> connectionFactory, final Applicator<AccessGrant> applicator,
+        final Map<String, String> additionalQueryParameters, final boolean configured) {
         this.id = id;
         this.connectionFactory = connectionFactory;
         this.applicator = applicator;
-        this.additionalQueryParameters = additionalQueryParameters.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> Collections.singletonList(e.getValue())));
+        this.configured = configured;
+        this.additionalQueryParameters = additionalQueryParameters.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> Collections.singletonList(e.getValue())));
     }
 
     @Override
     public AcquisitionMethod acquisitionMethod() {
-        return new AcquisitionMethod.Builder().label(labelFor(id)).icon(iconFor(id)).type(Type.OAUTH2).description(descriptionFor(id)).build();
+        return new AcquisitionMethod.Builder()
+            .label(labelFor(id))
+            .icon(iconFor(id))
+            .type(Type.OAUTH2)
+            .description(descriptionFor(id))
+            .configured(configured)
+            .build();
     }
 
     @Override

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/UnconfiguredProperties.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/UnconfiguredProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.credential;
+
+import org.springframework.boot.autoconfigure.social.SocialProperties;
+
+public final class UnconfiguredProperties extends SocialProperties {
+    public static final SocialProperties INSTANCE = new UnconfiguredProperties();
+
+    private UnconfiguredProperties() {
+        // marker implementation
+    }
+}

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/generic/OAuth2CredentialProviderFactory.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/generic/OAuth2CredentialProviderFactory.java
@@ -20,6 +20,7 @@ import io.syndesis.server.credential.CredentialProviderFactory;
 import io.syndesis.server.credential.OAuth2Applicator;
 import io.syndesis.server.credential.OAuth2ConnectorProperties;
 import io.syndesis.server.credential.OAuth2CredentialProvider;
+import io.syndesis.server.credential.UnconfiguredProperties;
 
 import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.social.connect.support.OAuth2ConnectionFactory;
@@ -32,6 +33,10 @@ public class OAuth2CredentialProviderFactory implements CredentialProviderFactor
 
     @Override
     public CredentialProvider create(final SocialProperties properties) {
+        if (properties instanceof UnconfiguredProperties) {
+            return new OAuth2CredentialProvider<>("oauth2");
+        }
+
         final OAuth2ConnectorProperties oauth2Properties = (OAuth2ConnectorProperties) properties;
 
         final String appId = oauth2Properties.getAppId();

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/salesforce/SalesforceCredentialProviderFactory.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/salesforce/SalesforceCredentialProviderFactory.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import io.syndesis.server.credential.CredentialProvider;
 import io.syndesis.server.credential.CredentialProviderFactory;
 import io.syndesis.server.credential.OAuth2CredentialProvider;
+import io.syndesis.server.credential.UnconfiguredProperties;
 import io.syndesis.server.credential.salesforce.SalesforceConfiguration.SalesforceApplicator;
 
 import org.springframework.boot.autoconfigure.social.SocialProperties;
@@ -39,7 +40,7 @@ public final class SalesforceCredentialProviderFactory implements CredentialProv
     }
 
     static SalesforceConnectionFactory
-    createConnectionFactory(final SocialProperties salesforceProperties) {
+        createConnectionFactory(final SocialProperties salesforceProperties) {
         final SalesforceConnectionFactory salesforce = new SalesforceConnectionFactory(salesforceProperties.getAppId(),
             salesforceProperties.getAppSecret());
 
@@ -52,6 +53,10 @@ public final class SalesforceCredentialProviderFactory implements CredentialProv
     }
 
     static CredentialProvider createCredentialProvider(final SocialProperties properties) {
+        if (properties instanceof UnconfiguredProperties) {
+            return new OAuth2CredentialProvider<>("salesforce");
+        }
+
         final SalesforceConnectionFactory connectionFactory = createConnectionFactory(properties);
 
         return new OAuth2CredentialProvider<>("salesforce", connectionFactory,

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/twitter/TwitterCredentialProviderFactory.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/twitter/TwitterCredentialProviderFactory.java
@@ -19,6 +19,7 @@ import io.syndesis.server.credential.CredentialProvider;
 import io.syndesis.server.credential.CredentialProviderFactory;
 import io.syndesis.server.credential.OAuth1Applicator;
 import io.syndesis.server.credential.OAuth1CredentialProvider;
+import io.syndesis.server.credential.UnconfiguredProperties;
 
 import org.springframework.boot.autoconfigure.social.SocialProperties;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
@@ -27,6 +28,10 @@ public final class TwitterCredentialProviderFactory implements CredentialProvide
 
     @Override
     public CredentialProvider create(final SocialProperties properties) {
+        if (properties instanceof UnconfiguredProperties) {
+            return new OAuth1CredentialProvider<>("twitter");
+        }
+
         return createCredentialProvider(properties);
     }
 

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth1CredentialProviderTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth1CredentialProviderTest.java
@@ -29,8 +29,13 @@ public class OAuth1CredentialProviderTest {
         final OAuth1CredentialProvider<?> oauth1 = new OAuth1CredentialProvider<>("provider1",
             mock(OAuth1ConnectionFactory.class), mock(Applicator.class));
 
-        final AcquisitionMethod method1 = new AcquisitionMethod.Builder().description("provider1")
-            .label("provider1").icon("provider1").type(Type.OAUTH1).build();
+        final AcquisitionMethod method1 = new AcquisitionMethod.Builder()
+            .description("provider1")
+            .label("provider1")
+            .icon("provider1")
+            .type(Type.OAUTH1)
+            .configured(true)
+            .build();
 
         assertThat(oauth1.acquisitionMethod()).isEqualTo(method1);
     }

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth2CredentialProviderTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth2CredentialProviderTest.java
@@ -31,8 +31,13 @@ public class OAuth2CredentialProviderTest {
         final OAuth2CredentialProvider<?> oauth2 = new OAuth2CredentialProvider<>("provider2",
             mock(OAuth2ConnectionFactory.class), mock(Applicator.class), Collections.emptyMap());
 
-        final AcquisitionMethod method2 = new AcquisitionMethod.Builder().description("provider2")
-            .label("provider2").icon("provider2").type(Type.OAUTH2).build();
+        final AcquisitionMethod method2 = new AcquisitionMethod.Builder()
+            .description("provider2")
+            .label("provider2")
+            .icon("provider2")
+            .type(Type.OAUTH2)
+            .configured(true)
+            .build();
 
         assertThat(oauth2.acquisitionMethod()).isEqualTo(method2);
     }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
@@ -22,6 +22,7 @@ import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.AcquisitionMethod;
 import io.syndesis.server.credential.CredentialFlowState;
 import io.syndesis.server.credential.CredentialProvider;
 import io.syndesis.server.credential.CredentialProviderLocator;
@@ -104,14 +105,22 @@ public class SetupITCase extends BaseITCase {
         put("/api/v1/setup/oauth-apps/twitter", twitter);
 
         given().ignoreExceptions().await().atMost(10, SECONDS).pollInterval(1, SECONDS).until(() -> {
-            return locator.providerWithId("twitter") != null;
+            final CredentialProvider twitterProvider = locator.providerWithId("twitter");
+
+            final AcquisitionMethod acquisitionMethod = twitterProvider.acquisitionMethod();
+
+            return acquisitionMethod.configured();
         });
 
         delete("/api/v1/setup/oauth-apps/twitter");
 
         given().ignoreExceptions().await().atMost(10, SECONDS).pollInterval(1, SECONDS).until(() -> {
             try {
-                return locator.providerWithId("twitter") == null;
+                final CredentialProvider twitterProvider = locator.providerWithId("twitter");
+
+                final AcquisitionMethod acquisitionMethod = twitterProvider.acquisitionMethod();
+
+                return !acquisitionMethod.configured();
             } catch (final IllegalArgumentException e) {
                 return e.getMessage().startsWith("No property tagged with `oauth-client-id` on connector");
             }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
@@ -24,6 +24,9 @@ import java.util.UUID;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.NewCookie;
 
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
 import io.syndesis.server.credential.AcquisitionMethod;
 import io.syndesis.server.credential.AcquisitionResponse;
 import io.syndesis.server.credential.AcquisitionResponse.State;
@@ -31,9 +34,6 @@ import io.syndesis.server.credential.CredentialFlowState;
 import io.syndesis.server.credential.Credentials;
 import io.syndesis.server.credential.OAuth2CredentialFlowState;
 import io.syndesis.server.credential.Type;
-import io.syndesis.common.model.connection.ConfigurationProperty;
-import io.syndesis.common.model.connection.Connection;
-import io.syndesis.common.model.connection.Connector;
 import io.syndesis.server.endpoint.v1.state.ClientSideState;
 import io.syndesis.server.runtime.BaseITCase;
 
@@ -91,14 +91,22 @@ public class CredentialITCase extends BaseITCase {
     @Before
     public void prepopulateDatabase() {
         final Connector provider = new Connector.Builder().id("test-provider")
-            .putProperty("clientId", new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_ID_TAG).build())
+            .putProperty("clientId", new ConfigurationProperty.Builder()
+                .addTag(Credentials.CLIENT_ID_TAG)
+                .build())
             .putProperty("clientSecret",
-                new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_SECRET_TAG).build())
-            .putConfiguredProperty("clientId", "a-client-id").putConfiguredProperty("clientSecret", "a-client-secret")
+                new ConfigurationProperty.Builder()
+                    .addTag(Credentials.CLIENT_SECRET_TAG)
+                    .build())
+            .putConfiguredProperty("clientId", "a-client-id")
+            .putConfiguredProperty("clientSecret", "a-client-secret")
             .build();
         dataManager.create(provider);
 
-        dataManager.create(new Connection.Builder().id("test-connection").connector(provider).build());
+        dataManager.create(new Connection.Builder()
+            .id("test-connection")
+            .connector(provider)
+            .build());
     }
 
     @Test
@@ -204,8 +212,14 @@ public class CredentialITCase extends BaseITCase {
 
         final AcquisitionMethod acquisitionMethod = acquisitionMethodEntity.getBody();
 
-        final AcquisitionMethod salesforce = new AcquisitionMethod.Builder().type(Type.OAUTH2).label("test-provider")
-            .icon("test-provider").label("test-provider").description("test-provider").build();
+        final AcquisitionMethod salesforce = new AcquisitionMethod.Builder()
+            .type(Type.OAUTH2)
+            .label("test-provider")
+            .icon("test-provider")
+            .label("test-provider")
+            .description("test-provider")
+            .configured(true)
+            .build();
 
         assertThat(acquisitionMethod).isEqualTo(salesforce);
     }

--- a/app/ui-react/packages/models/swagger.internal.json
+++ b/app/ui-react/packages/models/swagger.internal.json
@@ -2184,6 +2184,9 @@
         },
         "label": {
           "type": "string"
+        },
+        "configured": {
+          "type": "boolean"
         }
       }
     },
@@ -2229,17 +2232,17 @@
     "ActionDescriptor": {
       "type": "object",
       "properties": {
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
-        },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         }
       }
     },
@@ -2270,16 +2273,16 @@
     "ActionsSummary": {
       "type": "object",
       "properties": {
+        "totalActions": {
+          "type": "integer",
+          "format": "int32"
+        },
         "actionCountByTags": {
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "int32"
           }
-        },
-        "totalActions": {
-          "type": "integer",
-          "format": "int32"
         }
       }
     },
@@ -2298,17 +2301,14 @@
         "displayName": {
           "type": "string"
         },
+        "connectorValue": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
-        },
-        "enum": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PropertyValue"
-          }
         },
         "kind": {
           "type": "string"
@@ -2319,25 +2319,16 @@
         "group": {
           "type": "string"
         },
+        "enum": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PropertyValue"
+          }
+        },
         "secret": {
           "type": "boolean"
         },
-        "multiple": {
-          "type": "boolean"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "generator": {
-          "type": "string"
-        },
-        "connectorValue": {
-          "type": "string"
-        },
-        "labelHint": {
-          "type": "string"
-        },
-        "placeholder": {
+        "controlHint": {
           "type": "string"
         },
         "relation": {
@@ -2346,14 +2337,26 @@
             "$ref": "#/definitions/PropertyRelation"
           }
         },
-        "javaType": {
+        "placeholder": {
           "type": "string"
         },
-        "controlHint": {
+        "labelHint": {
           "type": "string"
         },
         "componentProperty": {
           "type": "boolean"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "javaType": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "generator": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -2396,9 +2399,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -2411,6 +2411,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -2513,9 +2516,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -2528,6 +2528,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -2572,6 +2575,9 @@
           "readOnly": true,
           "$ref": "#/definitions/OptionalInt"
         },
+        "actionsSummary": {
+          "$ref": "#/definitions/ActionsSummary"
+        },
         "connectorGroup": {
           "$ref": "#/definitions/ConnectorGroup"
         },
@@ -2589,9 +2595,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "actionsSummary": {
-          "$ref": "#/definitions/ActionsSummary"
         },
         "id": {
           "type": "string"
@@ -2689,6 +2692,9 @@
     "ConnectorDescriptor": {
       "type": "object",
       "properties": {
+        "connectorId": {
+          "type": "string"
+        },
         "camelConnectorGAV": {
           "type": "string"
         },
@@ -2704,23 +2710,20 @@
             "type": "string"
           }
         },
-        "connectorId": {
-          "type": "string"
-        },
         "camelConnectorPrefix": {
           "type": "string"
-        },
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
         },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         },
         "configuredProperties": {
           "type": "object",
@@ -2752,17 +2755,17 @@
         "description": {
           "type": "string"
         },
-        "connectorGroup": {
-          "$ref": "#/definitions/ConnectorGroup"
-        },
-        "componentScheme": {
-          "type": "string"
-        },
         "connectorProperties": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/ConfigurationProperty"
           }
+        },
+        "connectorGroup": {
+          "$ref": "#/definitions/ConnectorGroup"
+        },
+        "componentScheme": {
+          "type": "string"
         },
         "id": {
           "type": "string"
@@ -2788,20 +2791,20 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "releaseTag": {
-          "type": "string"
-        },
-        "lastExportedAt": {
+        "lastTaggedAt": {
           "type": "string",
           "format": "date-time"
         },
-        "lastTaggedAt": {
+        "lastExportedAt": {
           "type": "string",
           "format": "date-time"
         },
         "lastImportedAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "releaseTag": {
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -2827,6 +2830,9 @@
             "$ref": "#/definitions/DataShape"
           }
         },
+        "collectionType": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
@@ -2849,6 +2855,9 @@
             "type": "string"
           }
         },
+        "collectionClassName": {
+          "type": "string"
+        },
         "specification": {
           "type": "string"
         },
@@ -2858,12 +2867,6 @@
             "type": "string",
             "format": "byte"
           }
-        },
-        "collectionType": {
-          "type": "string"
-        },
-        "collectionClassName": {
-          "type": "string"
         }
       }
     },
@@ -3018,14 +3021,14 @@
         "description": {
           "type": "string"
         },
+        "scheduler": {
+          "$ref": "#/definitions/Scheduler"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "scheduler": {
-          "$ref": "#/definitions/Scheduler"
         },
         "name": {
           "type": "string"
@@ -3176,6 +3179,21 @@
         "description": {
           "type": "string"
         },
+        "deleted": {
+          "type": "boolean"
+        },
+        "connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "continuousDeliveryState": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
+          }
+        },
         "flows": {
           "type": "array",
           "items": {
@@ -3186,21 +3204,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Step"
-          }
-        },
-        "connections": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          }
-        },
-        "deleted": {
-          "type": "boolean"
-        },
-        "continuousDeliveryState": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
           }
         },
         "properties": {
@@ -3288,21 +3291,17 @@
     "IntegrationDeployment": {
       "type": "object",
       "properties": {
-        "spec": {
-          "$ref": "#/definitions/Integration"
-        },
         "integrationId": {
           "type": "string"
+        },
+        "spec": {
+          "$ref": "#/definitions/Integration"
         },
         "error": {
           "$ref": "#/definitions/IntegrationDeploymentError"
         },
         "userId": {
           "type": "string"
-        },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "stepsDone": {
           "type": "object",
@@ -3312,6 +3311,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -3378,10 +3381,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -3390,6 +3389,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -3427,12 +3430,12 @@
           "type": "integer",
           "format": "int64"
         },
+        "metricsProvider": {
+          "type": "string"
+        },
         "lastProcessed": {
           "type": "string",
           "format": "date-time"
-        },
-        "metricsProvider": {
-          "type": "string"
         },
         "integrationDeploymentMetrics": {
           "type": "array",
@@ -3462,20 +3465,9 @@
         "board": {
           "$ref": "#/definitions/IntegrationBulletinBoard"
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "deploymentVersion": {
           "type": "integer",
           "format": "int32"
-        },
-        "targetState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "deployments": {
           "type": "array",
@@ -3483,11 +3475,37 @@
             "$ref": "#/definitions/IntegrationDeploymentOverview"
           }
         },
+        "draft": {
+          "type": "boolean"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
+        },
+        "targetState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
+        },
         "id": {
           "type": "string"
         },
         "description": {
           "type": "string"
+        },
+        "deleted": {
+          "type": "boolean"
+        },
+        "connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "continuousDeliveryState": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
+          }
         },
         "flows": {
           "type": "array",
@@ -3499,21 +3517,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Step"
-          }
-        },
-        "connections": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          }
-        },
-        "deleted": {
-          "type": "boolean"
-        },
-        "continuousDeliveryState": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
           }
         },
         "properties": {
@@ -3905,16 +3908,16 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Environment"
-          }
-        },
         "users": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/User"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Environment"
           }
         },
         "id": {
@@ -3961,11 +3964,7 @@
     "Quota": {
       "type": "object",
       "properties": {
-        "maxIntegrationsPerUser": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "maxDeploymentsPerUser": {
+        "usedDeploymentsPerUser": {
           "type": "integer",
           "format": "int32"
         },
@@ -3973,7 +3972,11 @@
           "type": "integer",
           "format": "int32"
         },
-        "usedDeploymentsPerUser": {
+        "maxIntegrationsPerUser": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxDeploymentsPerUser": {
           "type": "integer",
           "format": "int32"
         }
@@ -4069,17 +4072,14 @@
     "Step": {
       "type": "object",
       "properties": {
+        "connection": {
+          "$ref": "#/definitions/Connection"
+        },
         "name": {
           "type": "string"
         },
         "extension": {
           "$ref": "#/definitions/Extension"
-        },
-        "connection": {
-          "$ref": "#/definitions/Connection"
-        },
-        "action": {
-          "$ref": "#/definitions/Action"
         },
         "stepKind": {
           "type": "string",
@@ -4097,6 +4097,9 @@
             "headers",
             "template"
           ]
+        },
+        "action": {
+          "$ref": "#/definitions/Action"
         },
         "id": {
           "type": "string"
@@ -4134,17 +4137,17 @@
         "entrypoint": {
           "type": "string"
         },
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
-        },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         }
       }
     },
@@ -4172,7 +4175,10 @@
         "username": {
           "type": "string"
         },
-        "organizationId": {
+        "lastName": {
+          "type": "string"
+        },
+        "firstName": {
           "type": "string"
         },
         "integrations": {
@@ -4184,10 +4190,7 @@
         "roleId": {
           "type": "string"
         },
-        "lastName": {
-          "type": "string"
-        },
-        "firstName": {
+        "organizationId": {
           "type": "string"
         },
         "id": {

--- a/app/ui-react/packages/models/swagger.json
+++ b/app/ui-react/packages/models/swagger.json
@@ -731,17 +731,17 @@
     "ActionDescriptor": {
       "type": "object",
       "properties": {
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
-        },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         }
       }
     },
@@ -772,16 +772,16 @@
     "ActionsSummary": {
       "type": "object",
       "properties": {
+        "totalActions": {
+          "type": "integer",
+          "format": "int32"
+        },
         "actionCountByTags": {
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "int32"
           }
-        },
-        "totalActions": {
-          "type": "integer",
-          "format": "int32"
         }
       }
     },
@@ -800,17 +800,14 @@
         "displayName": {
           "type": "string"
         },
+        "connectorValue": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
         "label": {
           "type": "string"
-        },
-        "enum": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PropertyValue"
-          }
         },
         "kind": {
           "type": "string"
@@ -821,25 +818,16 @@
         "group": {
           "type": "string"
         },
+        "enum": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PropertyValue"
+          }
+        },
         "secret": {
           "type": "boolean"
         },
-        "multiple": {
-          "type": "boolean"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "generator": {
-          "type": "string"
-        },
-        "connectorValue": {
-          "type": "string"
-        },
-        "labelHint": {
-          "type": "string"
-        },
-        "placeholder": {
+        "controlHint": {
           "type": "string"
         },
         "relation": {
@@ -848,14 +836,26 @@
             "$ref": "#/definitions/PropertyRelation"
           }
         },
-        "javaType": {
+        "placeholder": {
           "type": "string"
         },
-        "controlHint": {
+        "labelHint": {
           "type": "string"
         },
         "componentProperty": {
           "type": "boolean"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "javaType": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "generator": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -898,9 +898,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -913,6 +910,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -1015,9 +1015,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -1030,6 +1027,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -1074,6 +1074,9 @@
           "readOnly": true,
           "$ref": "#/definitions/OptionalInt"
         },
+        "actionsSummary": {
+          "$ref": "#/definitions/ActionsSummary"
+        },
         "connectorGroup": {
           "$ref": "#/definitions/ConnectorGroup"
         },
@@ -1091,9 +1094,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "actionsSummary": {
-          "$ref": "#/definitions/ActionsSummary"
         },
         "id": {
           "type": "string"
@@ -1191,6 +1191,9 @@
     "ConnectorDescriptor": {
       "type": "object",
       "properties": {
+        "connectorId": {
+          "type": "string"
+        },
         "camelConnectorGAV": {
           "type": "string"
         },
@@ -1206,23 +1209,20 @@
             "type": "string"
           }
         },
-        "connectorId": {
-          "type": "string"
-        },
         "camelConnectorPrefix": {
           "type": "string"
-        },
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
         },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         },
         "configuredProperties": {
           "type": "object",
@@ -1248,20 +1248,20 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "releaseTag": {
-          "type": "string"
-        },
-        "lastExportedAt": {
+        "lastTaggedAt": {
           "type": "string",
           "format": "date-time"
         },
-        "lastTaggedAt": {
+        "lastExportedAt": {
           "type": "string",
           "format": "date-time"
         },
         "lastImportedAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "releaseTag": {
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -1302,6 +1302,9 @@
             "$ref": "#/definitions/DataShape"
           }
         },
+        "collectionType": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
@@ -1324,6 +1327,9 @@
             "type": "string"
           }
         },
+        "collectionClassName": {
+          "type": "string"
+        },
         "specification": {
           "type": "string"
         },
@@ -1333,12 +1339,6 @@
             "type": "string",
             "format": "byte"
           }
-        },
-        "collectionType": {
-          "type": "string"
-        },
-        "collectionClassName": {
-          "type": "string"
         }
       }
     },
@@ -1465,14 +1465,14 @@
         "description": {
           "type": "string"
         },
+        "scheduler": {
+          "$ref": "#/definitions/Scheduler"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "scheduler": {
-          "$ref": "#/definitions/Scheduler"
         },
         "name": {
           "type": "string"
@@ -1643,6 +1643,21 @@
         "description": {
           "type": "string"
         },
+        "deleted": {
+          "type": "boolean"
+        },
+        "connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "continuousDeliveryState": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
+          }
+        },
         "flows": {
           "type": "array",
           "items": {
@@ -1653,21 +1668,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Step"
-          }
-        },
-        "connections": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          }
-        },
-        "deleted": {
-          "type": "boolean"
-        },
-        "continuousDeliveryState": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
           }
         },
         "properties": {
@@ -1755,21 +1755,17 @@
     "IntegrationDeployment": {
       "type": "object",
       "properties": {
-        "spec": {
-          "$ref": "#/definitions/Integration"
-        },
         "integrationId": {
           "type": "string"
+        },
+        "spec": {
+          "$ref": "#/definitions/Integration"
         },
         "error": {
           "$ref": "#/definitions/IntegrationDeploymentError"
         },
         "userId": {
           "type": "string"
-        },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "stepsDone": {
           "type": "object",
@@ -1779,6 +1775,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -1821,10 +1821,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -1833,6 +1829,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -1868,12 +1868,12 @@
         "integrationId": {
           "type": "string"
         },
-        "podName": {
-          "type": "string"
-        },
         "detailedState": {
           "type": "string",
           "enum": ["ASSEMBLING", "BUILDING", "DEPLOYING", "STARTING"]
+        },
+        "podName": {
+          "type": "string"
         },
         "linkType": {
           "type": "string",
@@ -1894,20 +1894,9 @@
         "board": {
           "$ref": "#/definitions/IntegrationBulletinBoard"
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "deploymentVersion": {
           "type": "integer",
           "format": "int32"
-        },
-        "targetState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "deployments": {
           "type": "array",
@@ -1915,11 +1904,37 @@
             "$ref": "#/definitions/IntegrationDeploymentOverview"
           }
         },
+        "draft": {
+          "type": "boolean"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
+        },
+        "targetState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
+        },
         "id": {
           "type": "string"
         },
         "description": {
           "type": "string"
+        },
+        "deleted": {
+          "type": "boolean"
+        },
+        "connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "continuousDeliveryState": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
+          }
         },
         "flows": {
           "type": "array",
@@ -1931,21 +1946,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Step"
-          }
-        },
-        "connections": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          }
-        },
-        "deleted": {
-          "type": "boolean"
-        },
-        "continuousDeliveryState": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ContinuousDeliveryEnvironment"
           }
         },
         "properties": {
@@ -2102,16 +2102,16 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Environment"
-          }
-        },
         "users": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/User"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Environment"
           }
         },
         "id": {
@@ -2206,17 +2206,14 @@
     "Step": {
       "type": "object",
       "properties": {
+        "connection": {
+          "$ref": "#/definitions/Connection"
+        },
         "name": {
           "type": "string"
         },
         "extension": {
           "$ref": "#/definitions/Extension"
-        },
-        "connection": {
-          "$ref": "#/definitions/Connection"
-        },
-        "action": {
-          "$ref": "#/definitions/Action"
         },
         "stepKind": {
           "type": "string",
@@ -2234,6 +2231,9 @@
             "headers",
             "template"
           ]
+        },
+        "action": {
+          "$ref": "#/definitions/Action"
         },
         "id": {
           "type": "string"
@@ -2271,17 +2271,17 @@
         "entrypoint": {
           "type": "string"
         },
-        "propertyDefinitionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ActionDescriptorStep"
-          }
-        },
         "inputDataShape": {
           "$ref": "#/definitions/DataShape"
         },
         "outputDataShape": {
           "$ref": "#/definitions/DataShape"
+        },
+        "propertyDefinitionSteps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionDescriptorStep"
+          }
         }
       }
     },
@@ -2300,7 +2300,10 @@
         "username": {
           "type": "string"
         },
-        "organizationId": {
+        "lastName": {
+          "type": "string"
+        },
+        "firstName": {
           "type": "string"
         },
         "integrations": {
@@ -2312,10 +2315,7 @@
         "roleId": {
           "type": "string"
         },
-        "lastName": {
-          "type": "string"
-        },
-        "firstName": {
+        "organizationId": {
           "type": "string"
         },
         "id": {

--- a/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
@@ -1,0 +1,55 @@
+import * as H from '@syndesis/history';
+import { Card } from 'patternfly-react';
+import * as React from 'react';
+import { ButtonLink } from '../Layout';
+
+export interface IConnectionSetupOAuthProps {
+  i18nTitle: string;
+  i18nDescription: string;
+  i18nOAuthSettingsButton: string;
+  backHref: H.LocationDescriptor;
+  oauthSettingsHref: string;
+}
+
+export const ConnectionSetupOAuthCard: React.FunctionComponent<
+  IConnectionSetupOAuthProps
+> = ({
+  i18nTitle,
+  i18nDescription,
+  i18nOAuthSettingsButton,
+  backHref,
+  oauthSettingsHref,
+}) => (
+  <Card
+    style={{
+      margin: 'auto',
+      maxWidth: 600,
+    }}
+  >
+    <Card.Heading>
+      <Card.Title>
+        <div>{i18nTitle}</div>
+      </Card.Title>
+    </Card.Heading>
+    <Card.Body>
+      <p>{i18nDescription}</p>
+    </Card.Body>
+    <Card.Footer>
+      <ButtonLink
+        data-testid={'connection-creator-back-button'}
+        href={backHref}
+        className={'wizard-pf-back'}
+      >
+        <i className="fa fa-angle-left" /> Back
+      </ButtonLink>
+      &nbsp;
+      <ButtonLink
+        data-testid={'connection-creator-settings'}
+        href={oauthSettingsHref}
+        as={'primary'}
+      >
+        {i18nOAuthSettingsButton}
+      </ButtonLink>
+    </Card.Footer>
+  </Card>
+);

--- a/app/ui-react/packages/ui/src/Connection/index.ts
+++ b/app/ui-react/packages/ui/src/Connection/index.ts
@@ -9,3 +9,4 @@ export * from './ConnectionSkeleton';
 export * from './ConnectionsListView';
 export * from './ConnectorAuthorization';
 export * from './ConnectorConfigurationForm';
+export * from './ConnectionSetupOAuthCard';

--- a/app/ui-react/syndesis/src/modules/connections/locales/connections-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/connections/locales/connections-translations.en.json
@@ -39,6 +39,7 @@
     "title": "{{name}} Configuration",
     "description": "This connection is configured using OAuth. Use the validate button to check if the connection is still authorized.",
     "validateButton": "Validate",
-    "reconnectButton": "Reconnect"
+    "reconnectButton": "Reconnect",
+    "settingsMissing": "OAuth settings needed to create this connection are missing. Provide the required parameters in the OAuth settings."
   }
 }


### PR DESCRIPTION
When creating OAuth-capable connections issues can arise when connection properties are configured by manual entry. For instance refresh token that is hidden from the UI will not be filled and the connection will not be valid as the access token for it will expire and could not be renewed.

This introduces a change in the connection creation that if a new OAuth-capable connection creation is attempted OAuth settings must be set. The user is prompted to enter the properties in OAuth settings and when those are set, connection creation via OAuth flow is allowed.

![Peek 2019-06-14 15-42](https://user-images.githubusercontent.com/1306050/59513554-5fdf2980-8ebb-11e9-8374-6e8e83ca0a0b.gif)

Fixes #5582