### PR TITLE
TT-624 Fix Connector selection in DV wizard

### DIFF
--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
@@ -54,7 +54,7 @@ export class DvConnectionCard extends React.PureComponent<
             this.props.name
           )}-card`}
           matchHeight={true}
-          accented={this.state.isSelected}
+          accented={this.props.selected}
         >
           <Card.Body>
             <div className="dv-connection-card__status">

--- a/app/ui-react/packages/ui/src/Shared/TextEditor/TextEditor.css
+++ b/app/ui-react/packages/ui/src/Shared/TextEditor/TextEditor.css
@@ -1,5 +1,6 @@
 @import url('~codemirror/addon/lint/lint.css');
 @import url('~codemirror/lib/codemirror.css');
+@import url('~codemirror/addon/hint/show-hint.css');
 
 .text-editor .cm-mustache {
   color: #b21eab;

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
@@ -8,27 +8,39 @@ import {
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { ApiError, EntityIcon } from '../../../shared';
-import {
-  getDvConnectionStatus,
-  isDvConnectionSelected,
-} from './VirtualizationUtils';
+import { getDvConnectionStatus } from './VirtualizationUtils';
 
 export interface IDvConnectionsProps {
   error: boolean;
   loading: boolean;
   connections: Connection[];
+  initialSelection: string; // Name of initially selected connection
   onConnectionSelectionChanged: (name: string, selected: boolean) => void;
 }
 
-export class DvConnections extends React.Component<IDvConnectionsProps> {
+export interface IDvConnectionsState {
+  selectedConnection: string;
+}
+
+export class DvConnections extends React.Component<
+  IDvConnectionsProps,
+  IDvConnectionsState
+> {
   public constructor(props: IDvConnectionsProps) {
     super(props);
+    this.state = {
+      selectedConnection: this.props.initialSelection, // initial selection
+    };
     this.handleConnSourceSelectionChanged = this.handleConnSourceSelectionChanged.bind(
       this
     );
   }
 
   public handleConnSourceSelectionChanged(name: string, isSelected: boolean) {
+    const newSelection = isSelected ? name : '';
+    this.setState({
+      selectedConnection: newSelection,
+    });
     this.props.onConnectionSelectionChanged(name, isSelected);
   }
 
@@ -57,7 +69,7 @@ export class DvConnections extends React.Component<IDvConnectionsProps> {
                   description={c.description || ''}
                   dvStatus={getDvConnectionStatus(c)}
                   icon={<EntityIcon entity={c} alt={c.name} width={46} />}
-                  selected={isDvConnectionSelected(c)}
+                  selected={this.state.selectedConnection === c.name}
                   onSelectionChanged={this.handleConnSourceSelectionChanged}
                 />
               </DvConnectionsGridCell>

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
@@ -72,7 +72,7 @@ export interface IDvConnectionsWithToolbarProps {
   children?: any;
 }
 export interface IDvConnectionsWithToolbarState {
-  selectedConnection: any;
+  selectedConnection: string;
 }
 
 export class DvConnectionsWithToolbar extends React.Component<
@@ -91,6 +91,9 @@ export class DvConnectionsWithToolbar extends React.Component<
 
   public handleConnectionSelectionChanged(name: string, selected: boolean) {
     this.props.onConnectionSelectionChanged(name, selected);
+    this.setState({
+      selectedConnection: selected ? name : '',
+    });
   }
 
   public render() {
@@ -138,6 +141,7 @@ export class DvConnectionsWithToolbar extends React.Component<
                         error={this.props.error}
                         loading={this.props.loading}
                         connections={filteredAndSortedConnections}
+                        initialSelection={this.state.selectedConnection}
                         onConnectionSelectionChanged={
                           this.handleConnectionSelectionChanged
                         }


### PR DESCRIPTION
Fix issue with highlighting of selected connection in the DV import data wizard.
- DvConnections component maintains current connection selection.  The wizard allows a single connection to be selected
- Now allow setting of an initial selection on DvConnections
- also adding 'show-hint' import to TextEditor.css.  The SQL autocomplete hints are now displayed 