### PR TITLE
fix #4234 kafka validation kills meta pod

### DIFF
--- a/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
+++ b/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
@@ -104,7 +104,7 @@
       "javaType": "java.lang.String",
       "kind": "property",
       "label": "common",
-      "labelHint": "Comma separated list of Kafka broker URIs in the form host:port.",
+      "labelHint": "Comma separated list of Kafka broker URIs in the form host:port. Note that SSL URIs are not supported at this time and will cause an OOM at connection verification (see also https://issues.apache.org/jira/browse/KAFKA-4090)",
       "order": "1",
       "required": true,
       "secret": false,


### PR DESCRIPTION
Adding more info to the tooltip to address #4234. 