### PR TITLE
fix(5321): Actually delete integrations and connections on delete

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
@@ -45,6 +45,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public interface IntegrationBase extends WithProperties, WithResourceId, WithVersion, WithModificationTimestamps, WithTags, WithName, WithSteps, ToJson, WithResources {
 
+    /**
+     * @deprecated fully deleted from the data manager in 7.4+.
+     *      Retained for filtering in existing installations.
+     */
+    @Deprecated
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     @Value.Default
     default boolean isDeleted() {

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeployment.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationDeployment.java
@@ -84,6 +84,11 @@ public interface IntegrationDeployment extends IntegrationDeploymentBase, WithId
         return builder().targetState(IntegrationDeploymentState.Unpublished).stepsDone(stepsDone).build();
     }
 
+    /**
+     * @deprecated fully deleted from the data manager in 7.4+
+     *      Retained for filtering in existing installations.
+     */
+    @Deprecated
     default IntegrationDeployment deleted() {
         final Integration integration = new Integration.Builder().createFrom(getSpec()).isDeleted(true).build();
         return builder().spec(integration).build();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -164,6 +164,16 @@ public class ConnectionHandler
         return Creator.super.create(sec, connectionToCreate);
     }
 
+    @Override
+    public void delete(String id) {
+        final DataManager dataManager = getDataManager();
+
+        dataManager.fetchIdsByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id)
+            .forEach(cbbId -> dataManager.delete(ConnectionBulletinBoard.class, cbbId));
+
+        Deleter.super.delete(id);
+    }
+
     Connection applyCredentialFlowStateTo(final Connection connection) {
         final Set<CredentialFlowState> flowStates = CredentialFlowState.Builder.restoreFrom(state::restoreFrom, request);
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.connection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.HashSet;
+import java.util.Set;
+import javax.validation.Validator;
+import org.junit.Before;
+import org.junit.Test;
+import io.syndesis.common.model.bulletin.ConnectionBulletinBoard;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.server.credential.Credentials;
+import io.syndesis.server.dao.manager.DataManager;
+import io.syndesis.server.dao.manager.EncryptionComponent;
+import io.syndesis.server.endpoint.v1.state.ClientSideState;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
+
+public class ConnectionHandlerTest {
+
+    private ConnectionHandler handler;
+    private DataManager dataManager;
+
+    @Before
+    public void setUp() {
+        dataManager = mock(DataManager.class);
+        Validator validator = mock(Validator.class);
+        Credentials credentials = mock(Credentials.class);
+        ClientSideState state = mock(ClientSideState.class);
+        MetadataConfigurationProperties config = mock(MetadataConfigurationProperties.class);
+        EncryptionComponent encryptionSupport = mock(EncryptionComponent.class);
+        handler = new ConnectionHandler(dataManager, validator, credentials, state, config, encryptionSupport);
+    }
+
+    @Test
+    public void shouldDeleteConnectionsAndDeletingAssociatedResources() {
+        String id = "to-delete";
+        Connection connection = new Connection.Builder().id(id).build();
+
+        when(dataManager.fetch(Connection.class, id)).thenReturn(connection);
+
+        // Connection bulletin boards identifiers
+        Set<String> cbbIds = new HashSet<>();
+        for (int i = 1; i <= 2; ++i) {
+            cbbIds.add(id + "-cbb" + i);
+        }
+
+        when(dataManager.fetchIdsByPropertyValue(ConnectionBulletinBoard.class, "targetResourceId", id))
+            .thenReturn(cbbIds);
+        for (String cbbId : cbbIds) {
+            when(dataManager.delete(ConnectionBulletinBoard.class, cbbId)).thenReturn(true);
+        }
+        when(dataManager.delete(Connection.class, id)).thenReturn(true);
+
+        handler.delete(id);
+
+        verify(dataManager).delete(Connection.class, id);
+        for (String cbbId : cbbIds) {
+            verify(dataManager).delete(ConnectionBulletinBoard.class, cbbId);
+        }
+    }
+}


### PR DESCRIPTION
* Rather than updating resources in jsondb with a deleted flag, actually
  remove them instead.

* Deprecate delete flag methods, preserving for use by existing installs

* ConnectionHandler
 * Remove ConectionBulletinBoards when deleting connections

* IntegrationHandler
 * Remove Integrations, IntegationDeployments & IntegrationBulletinBoards

* Adds / updates tests