### PR TITLE
Auto form adjustments

### DIFF
--- a/app/ui-react/packages/.storybook/vendor.css
+++ b/app/ui-react/packages/.storybook/vendor.css
@@ -1,6 +1,11 @@
 @import url('~patternfly/dist/css/patternfly.css');
 @import url('~patternfly/dist/css/patternfly-additions.css');
 @import url('~patternfly-react/dist/css/patternfly-react.css');
+@import url('~@patternfly/patternfly/patternfly-variables.css');
+@import url('~@patternfly/patternfly/patternfly-shield-noninheritable.css');
+@import url('~@patternfly/patternfly/patternfly-common.css');
+@import url('~@patternfly/patternfly/utilities/Spacing/spacing.css');
+@import url('~@patternfly/patternfly/utilities/Display/display.css');
 
 html,
 body {

--- a/app/ui-react/packages/auto-form/package.json
+++ b/app/ui-react/packages/auto-form/package.json
@@ -77,6 +77,9 @@
     }
   },
   "dependencies": {
+    "@patternfly/react-core": "^3.38.1",
+    "@patternfly/react-icons": "^3.10.1",
+    "@patternfly/react-styles": "^3.3.3",
     "formik": "^1.5.4",
     "patternfly-react": "^2.32.2"
   }

--- a/app/ui-react/packages/auto-form/src/FormBuilder.tsx
+++ b/app/ui-react/packages/auto-form/src/FormBuilder.tsx
@@ -9,6 +9,7 @@ import {
 } from './models';
 import { enrichAndOrderProperties, massageType, sanitizeValues } from './utils';
 import {
+  FormArrayComponent,
   FormCheckboxComponent,
   FormDurationComponent,
   FormHiddenComponent,
@@ -16,7 +17,6 @@ import {
   FormSelectComponent,
   FormTextAreaComponent,
 } from './widgets';
-import { FormArrayComponent } from './widgets/FormArrayComponent';
 
 export interface IFormBuilderProps<T> {
   definition: IFormDefinition;

--- a/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
@@ -1,3 +1,3 @@
-.syn-auto-form-checkbox-group .checkbox input[type="checkbox"] {
+.form-horizontal .form-group .checkbox input[type="checkbox"] {
   margin-top: 9px;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
@@ -1,0 +1,3 @@
+.syn-auto-form-checkbox-group .checkbox input[type="checkbox"] {
+  margin-top: 9px;
+}

--- a/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.css
@@ -1,3 +1,3 @@
-.form-horizontal .form-group .checkbox input[type="checkbox"] {
+form .form-group .checkbox input[type="checkbox"] {
   margin-top: 9px;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -1,7 +1,10 @@
-import { Checkbox, FieldLevelHelp, FormGroup } from 'patternfly-react';
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Checkbox, ControlLabel, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
 import { AutoFormHelpBlock } from './AutoFormHelpBlock';
+import './FormCheckboxComponent.css';
 import { getValidationState, toValidHtmlId } from './helpers';
 
 export const FormCheckboxComponent: React.FunctionComponent<
@@ -11,23 +14,29 @@ export const FormCheckboxComponent: React.FunctionComponent<
     {...props.property.formGroupAttributes}
     controlId={toValidHtmlId(props.field.name)}
     validationState={getValidationState(props)}
+    className="syn-auto-form-checkbox-group"
   >
     <Checkbox
       {...props.property.fieldAttributes}
       {...props.field}
+      className="pf-u-display-inline-block"
       checked={props.field.value}
+      id={toValidHtmlId(props.field.name)}
       data-testid={toValidHtmlId(props.field.name)}
       disabled={props.form.isSubmitting || props.property.disabled}
       title={props.property.controlHint}
-    >
+    />
+    <ControlLabel htmlFor={toValidHtmlId(props.field.name)}>
       {props.property.displayName}
-      {props.property.labelHint && (
-        <FieldLevelHelp
-          className={'inline-block'}
-          content={props.property.labelHint}
-        />
-      )}
-    </Checkbox>
+    </ControlLabel>
+    {props.property.labelHint && (
+      <Popover
+        aria-label={props.property.labelHint}
+        bodyContent={props.property.labelHint}
+      >
+        <InfoCircleIcon className="pf-u-ml-xs" />
+      </Popover>
+    )}
     <AutoFormHelpBlock
       error={props.form.errors[props.field.name] as string}
       description={props.property.description}

--- a/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Checkbox, ControlLabel, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
@@ -14,7 +14,6 @@ export const FormCheckboxComponent: React.FunctionComponent<
     {...props.property.formGroupAttributes}
     controlId={toValidHtmlId(props.field.name)}
     validationState={getValidationState(props)}
-    className="syn-auto-form-checkbox-group"
   >
     <Checkbox
       {...props.property.fieldAttributes}
@@ -34,7 +33,7 @@ export const FormCheckboxComponent: React.FunctionComponent<
         aria-label={props.property.labelHint}
         bodyContent={props.property.labelHint}
       >
-        <InfoCircleIcon className="pf-u-ml-xs" />
+        <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
       </Popover>
     )}
     <AutoFormHelpBlock

--- a/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
@@ -1,7 +1,8 @@
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import {
   ControlLabel,
   DropdownButton,
-  FieldLevelHelp,
   Form,
   FormGroup,
   MenuItem,
@@ -119,9 +120,12 @@ export class FormDurationComponent extends React.Component<
           {this.props.property.displayName}
         </ControlLabel>
         {this.props.property.labelHint && (
-          <ControlLabel>
-            <FieldLevelHelp content={this.props.property.labelHint} />
-          </ControlLabel>
+          <Popover
+            aria-label={this.props.property.labelHint}
+            bodyContent={this.props.property.labelHint}
+          >
+            <InfoCircleIcon className="pf-u-ml-xs" />
+          </Popover>
         )}
         <Form.InputGroup>
           <Form.FormControl

--- a/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
   ControlLabel,
   DropdownButton,
@@ -124,7 +124,7 @@ export class FormDurationComponent extends React.Component<
             aria-label={this.props.property.labelHint}
             bodyContent={this.props.property.labelHint}
           >
-            <InfoCircleIcon className="pf-u-ml-xs" />
+            <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
           </Popover>
         )}
         <Form.InputGroup>

--- a/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
@@ -1,9 +1,6 @@
-import {
-  ControlLabel,
-  FieldLevelHelp,
-  FormControl,
-  FormGroup,
-} from 'patternfly-react';
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
 import { AutoFormHelpBlock } from './AutoFormHelpBlock';
@@ -30,9 +27,12 @@ export const FormInputComponent: React.FunctionComponent<
       </ControlLabel>
     )}
     {props.property.labelHint && (
-      <ControlLabel>
-        <FieldLevelHelp content={props.property.labelHint} />
-      </ControlLabel>
+      <Popover
+        aria-label={props.property.labelHint}
+        bodyContent={props.property.labelHint}
+      >
+        <InfoCircleIcon className="pf-u-ml-xs" />
+      </Popover>
     )}
     <FormControl
       {...props.property.fieldAttributes}

--- a/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
@@ -31,7 +31,7 @@ export const FormInputComponent: React.FunctionComponent<
         aria-label={props.property.labelHint}
         bodyContent={props.property.labelHint}
       >
-        <InfoCircleIcon className="pf-u-ml-xs" />
+        <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
       </Popover>
     )}
     <FormControl

--- a/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
@@ -47,7 +47,7 @@ export const FormSelectComponent: React.FunctionComponent<
           aria-label={props.property.labelHint}
           bodyContent={props.property.labelHint}
         >
-          <InfoCircleIcon className="pf-u-ml-xs" />
+          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
         </Popover>
       )}
       <FormControl

--- a/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
@@ -1,9 +1,6 @@
-import {
-  ControlLabel,
-  FieldLevelHelp,
-  FormControl,
-  FormGroup,
-} from 'patternfly-react';
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
 import { AutoFormHelpBlock } from './AutoFormHelpBlock';
@@ -46,9 +43,12 @@ export const FormSelectComponent: React.FunctionComponent<
         </ControlLabel>
       )}
       {props.property.labelHint && (
-        <ControlLabel>
-          <FieldLevelHelp content={props.property.labelHint} />
-        </ControlLabel>
+        <Popover
+          aria-label={props.property.labelHint}
+          bodyContent={props.property.labelHint}
+        >
+          <InfoCircleIcon className="pf-u-ml-xs" />
+        </Popover>
       )}
       <FormControl
         size={isMultiple ? 12 : undefined}

--- a/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
@@ -1,9 +1,6 @@
-import {
-  ControlLabel,
-  FieldLevelHelp,
-  FormControl,
-  FormGroup,
-} from 'patternfly-react';
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
 import { AutoFormHelpBlock } from './AutoFormHelpBlock';
@@ -29,9 +26,12 @@ export const FormTextAreaComponent: React.FunctionComponent<
       </ControlLabel>
     )}
     {props.property.labelHint && (
-      <ControlLabel>
-        <FieldLevelHelp content={props.property.labelHint} />
-      </ControlLabel>
+      <Popover
+        aria-label={props.property.labelHint}
+        bodyContent={props.property.labelHint}
+      >
+        <InfoCircleIcon className="pf-u-ml-xs" />
+      </Popover>
     )}
     <FormControl
       {...props.property.fieldAttributes}

--- a/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { IFormControlProps } from '../models';
@@ -30,7 +30,7 @@ export const FormTextAreaComponent: React.FunctionComponent<
         aria-label={props.property.labelHint}
         bodyContent={props.property.labelHint}
       >
-        <InfoCircleIcon className="pf-u-ml-xs" />
+        <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
       </Popover>
     )}
     <FormControl

--- a/app/ui-react/packages/auto-form/src/widgets/helpers.ts
+++ b/app/ui-react/packages/auto-form/src/widgets/helpers.ts
@@ -4,7 +4,7 @@ export function getValidationState({ form, field }: IFormControlProps) {
   return form.touched[field.name] && form.errors[field.name]
     ? 'error'
     : form.touched[field.name]
-    ? 'success'
+    ? null
     : null;
 }
 

--- a/app/ui-react/packages/auto-form/src/widgets/index.ts
+++ b/app/ui-react/packages/auto-form/src/widgets/index.ts
@@ -1,4 +1,5 @@
 export * from './AutoFormHelpBlock';
+export * from './FormArrayComponent';
 export * from './FormInputComponent';
 export * from './FormSelectComponent';
 export * from './FormTextAreaComponent';

--- a/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
@@ -1,10 +1,7 @@
+import { Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import * as H from '@syndesis/history';
-import {
-  ControlLabel,
-  FieldLevelHelp,
-  FormControl,
-  FormGroup,
-} from 'patternfly-react';
+import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../../Layout';
 import { TextEditor } from '../../../Shared';
@@ -71,9 +68,12 @@ export class DescribeDataShapeForm extends React.Component<
                 <form>
                   <FormGroup>
                     <ControlLabel>{this.props.i18nSelectType}</ControlLabel>
-                    <ControlLabel>
-                      <FieldLevelHelp content={this.props.i18nSelectTypeHelp} />
-                    </ControlLabel>
+                    <Popover
+                      aria-label={this.props.i18nSelectTypeHelp}
+                      bodyContent={this.props.i18nSelectTypeHelp}
+                    >
+                      <InfoCircleIcon className="pf-u-ml-xs" />
+                    </Popover>
                     <FormControl
                       data-testid={'describe-data-shape-form-kind-input'}
                       componentClass="select"
@@ -93,9 +93,12 @@ export class DescribeDataShapeForm extends React.Component<
                     <>
                       <FormGroup>
                         <ControlLabel>{this.props.i18nDefinition}</ControlLabel>
-                        <FieldLevelHelp
-                          content={this.props.i18nDefinitionHelp}
-                        />
+                        <Popover
+                          aria-label={this.props.i18nDefinitionHelp}
+                          bodyContent={this.props.i18nDefinitionHelp}
+                        >
+                          <InfoCircleIcon className="pf-u-ml-xs" />
+                        </Popover>
                         <TextEditor
                           id={'describe-data-shape-form-definition-editor'}
                           value={this.props.definition || ''}
@@ -112,16 +115,16 @@ export class DescribeDataShapeForm extends React.Component<
                           }}
                         />
                       </FormGroup>
-
                       <FormGroup>
                         <ControlLabel>
                           {this.props.i18nDataTypeName}
                         </ControlLabel>
-                        <ControlLabel>
-                          <FieldLevelHelp
-                            content={this.props.i18nDataTypeNameHelp}
-                          />
-                        </ControlLabel>
+                        <Popover
+                          aria-label={this.props.i18nDataTypeNameHelp}
+                          bodyContent={this.props.i18nDataTypeNameHelp}
+                        >
+                          <InfoCircleIcon className="pf-u-ml-xs" />
+                        </Popover>
                         <FormControl
                           data-testid={'describe-data-shape-form-name-input'}
                           type="text"
@@ -135,11 +138,12 @@ export class DescribeDataShapeForm extends React.Component<
                         <ControlLabel>
                           {this.props.i18nDataTypeDescription}
                         </ControlLabel>
-                        <ControlLabel>
-                          <FieldLevelHelp
-                            content={this.props.i18nDataTypeDescriptionHelp}
-                          />
-                        </ControlLabel>
+                        <Popover
+                          aria-label={this.props.i18nDataTypeDescriptionHelp}
+                          bodyContent={this.props.i18nDataTypeDescriptionHelp}
+                        >
+                          <InfoCircleIcon className="pf-u-ml-xs" />
+                        </Popover>
                         <FormControl
                           type="text"
                           data-testid={

--- a/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as H from '@syndesis/history';
 import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
 import * as React from 'react';
@@ -72,7 +72,7 @@ export class DescribeDataShapeForm extends React.Component<
                       aria-label={this.props.i18nSelectTypeHelp}
                       bodyContent={this.props.i18nSelectTypeHelp}
                     >
-                      <InfoCircleIcon className="pf-u-ml-xs" />
+                      <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
                     </Popover>
                     <FormControl
                       data-testid={'describe-data-shape-form-kind-input'}
@@ -97,7 +97,7 @@ export class DescribeDataShapeForm extends React.Component<
                           aria-label={this.props.i18nDefinitionHelp}
                           bodyContent={this.props.i18nDefinitionHelp}
                         >
-                          <InfoCircleIcon className="pf-u-ml-xs" />
+                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
                         </Popover>
                         <TextEditor
                           id={'describe-data-shape-form-definition-editor'}
@@ -123,7 +123,7 @@ export class DescribeDataShapeForm extends React.Component<
                           aria-label={this.props.i18nDataTypeNameHelp}
                           bodyContent={this.props.i18nDataTypeNameHelp}
                         >
-                          <InfoCircleIcon className="pf-u-ml-xs" />
+                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
                         </Popover>
                         <FormControl
                           data-testid={'describe-data-shape-form-name-input'}
@@ -142,7 +142,7 @@ export class DescribeDataShapeForm extends React.Component<
                           aria-label={this.props.i18nDataTypeDescriptionHelp}
                           bodyContent={this.props.i18nDataTypeDescriptionHelp}
                         >
-                          <InfoCircleIcon className="pf-u-ml-xs" />
+                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
                         </Popover>
                         <FormControl
                           type="text"

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -20,6 +20,7 @@
   --pf-c-nav__list-link--m-current--after--BackgroundColor: #0088ce;
   --pf-global--link--Color--hover: #00659c;
   --pf-c-backdrop--Color: rgba(3,3,3,.62);
+  --pf-c-popover__content--PaddingRight: 3rem;
 }
 
 .pf-c-page__header-brand-link .pf-c-brand {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2632,6 +2632,26 @@
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
 
+"@patternfly/react-core@^3.38.1":
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.38.1.tgz#ca2ac43c2860b4aad49197328126331f2d21f207"
+  integrity sha512-BZUZD+DCryfNCiqhFqIR6IV0AMfFeIl0mfcIZ+N7tSM/S9GPJAAN6xtohBItYe+dM6oEs1lVFYae9MiYEieAkw==
+  dependencies:
+    "@patternfly/react-icons" "^3.9.5"
+    "@patternfly/react-styles" "^3.3.3"
+    "@patternfly/react-tokens" "^2.5.5"
+    "@tippy.js/react" "^1.1.1"
+    emotion "^9.2.9"
+    exenv "^1.2.2"
+    focus-trap-react "^4.0.1"
+
+"@patternfly/react-icons@^3.10.1", "@patternfly/react-icons@^3.9.5":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.1.tgz#580cce74c582632289e29ea761ab1472be57f740"
+  integrity sha512-F7YcGid5Z4NSSVC2MClPQAVmydSpPbULxmjTKPO5J+ntiWVN2e9evXmSsJKuL78GHOq9v9ND/3/pdSxBXXuEPQ==
+  dependencies:
+    "@fortawesome/free-brands-svg-icons" "^5.8.1"
+
 "@patternfly/react-icons@^3.9.2", "@patternfly/react-icons@^3.9.3":
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.9.3.tgz#a06a589ef90472568a40a01491473e741e6a91a5"
@@ -2675,10 +2695,34 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
+"@patternfly/react-styles@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.3.3.tgz#30b82b38b8976b9102cbc863a8261f056db092a6"
+  integrity sha512-Mhs+wsysc9XT+rTMHIrvsLEa6jJEkYCs97x7woFmHBJBcdl31bhT9n9gWgg5JstOUjtdMkmBHMo8gJcjgbxQxw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
+    camel-case "^3.0.0"
+    css "^2.2.3"
+    cssom "^0.3.4"
+    cssstyle "^0.3.1"
+    emotion "^9.2.9"
+    emotion-server "^9.2.9"
+    fbjs-scripts "^0.8.3"
+    fs-extra "^6.0.1"
+    jsdom "^15.1.0"
+    relative "^3.0.2"
+    resolve-from "^4.0.0"
+    typescript "3.4.5"
+
 "@patternfly/react-tokens@^2.5.3":
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.3.tgz#b1804626762583534745cede7599acf5a715fab8"
   integrity sha512-vH3fHKkx7VxyKkAiLx+VvOzZAuFIHhX01lW3HP66koFeUnKbCRynPuBy/Ep4nGZINZAgf5l9LNDmLS1ymntrLg==
+
+"@patternfly/react-tokens@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.5.tgz#4d1ff0c2f6091be5c0031a70079e0b745c5d57f0"
+  integrity sha512-5ztqkgBjSNcBnCqJFltG2OaP1bUgk+s5+Fp4kTDpVZLu3LNI46O/gPTRwObYXkbCna0r/hv2k3JVGER53G9fEA==
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -4118,7 +4162,7 @@ acorn-dynamic-import@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
 
-acorn-globals@^4.1.0, acorn-globals@^4.3.0:
+acorn-globals@^4.1.0, acorn-globals@^4.3.0, acorn-globals@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
   integrity sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==
@@ -4156,7 +4200,7 @@ acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
-acorn@^6.0.1, acorn@^6.0.4, acorn@^6.0.5, acorn@^6.0.7:
+acorn@^6.0.1, acorn@^6.0.4, acorn@^6.0.5, acorn@^6.0.7, acorn@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
 
@@ -4657,7 +4701,7 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async-limiter@~1.0.0:
+async-limiter@^1.0.0, async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
@@ -7900,7 +7944,7 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4, cssom@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.6.tgz#f85206cee04efa841f3c5982a74ba96ab20d65ad"
 
@@ -7911,7 +7955,7 @@ cssstyle@^0.3.1:
   dependencies:
     cssom "0.3.x"
 
-cssstyle@^1.0.0, cssstyle@^1.1.1:
+cssstyle@^1.0.0, cssstyle@^1.1.1, cssstyle@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.2.tgz#427ea4d585b18624f6fdbf9de7a2a1a3ba713077"
   integrity sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==
@@ -8960,7 +9004,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.11.0, escodegen@^1.9.1:
+escodegen@^1.11.0, escodegen@^1.11.1, escodegen@^1.9.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
   integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
@@ -12729,6 +12773,38 @@ jsdom@^14.0.0:
     ws "^6.1.2"
     xml-name-validator "^3.0.0"
 
+jsdom@^15.1.0:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.1.1.tgz#21ed01f81d95ef4327f3e564662aef5e65881252"
+  integrity sha512-cQZRBB33arrDAeCrAEWn1U3SvrvC8XysBua9Oqg1yWrsY/gYcusloJC3RZJXuY5eehSCmws8f2YeliCqGSkrtQ==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^6.1.1"
+    acorn-globals "^4.3.2"
+    array-equal "^1.0.0"
+    cssom "^0.3.6"
+    cssstyle "^1.2.2"
+    data-urls "^1.1.0"
+    domexception "^1.0.1"
+    escodegen "^1.11.1"
+    html-encoding-sniffer "^1.0.2"
+    nwsapi "^2.1.4"
+    parse5 "5.1.0"
+    pn "^1.1.0"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
+    symbol-tree "^3.2.2"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
+    xml-name-validator "^3.0.0"
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -15028,7 +15104,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nwsapi@^2.0.7, nwsapi@^2.1.3:
+nwsapi@^2.0.7, nwsapi@^2.1.3, nwsapi@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
@@ -18532,7 +18608,7 @@ request-promise-core@1.1.2:
   dependencies:
     lodash "^4.17.11"
 
-request-promise-native@^1.0.5:
+request-promise-native@^1.0.5, request-promise-native@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
   integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
@@ -20812,7 +20888,7 @@ touch@^2.0.1:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@>=0.12.0:
+tough-cookie@>=0.12.0, tough-cookie@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
   dependencies:
@@ -21067,7 +21143,7 @@ typescript@3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
 
-typescript@>=2.8.3, typescript@^3.4.5:
+typescript@3.4.5, typescript@>=2.8.3, typescript@^3.4.5:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
@@ -22243,6 +22319,13 @@ ws@^6.1.0, ws@^6.1.2:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.0.0.tgz#79351cbc3f784b3c20d0821baf4b4ff809ffbf51"
+  integrity sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==
+  dependencies:
+    async-limiter "^1.0.0"
 
 ws@~3.3.1:
   version "3.3.3"


### PR DESCRIPTION
This PR removes the green text highlighting and border from auto-form inputs in success states and replaces the pf3 style field level help with a pf4 variation. I've updated the shared widgets in auto-form as well as the describe data shape step.

What do we think about the new info icon. That was the closest match to what we had previously, can update if need be.

The only other thing is that I find it difficult to close the popover, my cursor is in within bounds of the button element but seem to only be able to close it when hovered over the svg inside. It's pretty annoying now that we have more of these popovers throughout the app. Does anyone else see this? I can investigate this on the pf side if so.

remove green input border for success state in auto-form
replace pf3 field level help with pf4 popover in auto-form components
update styles for auto-form storybook
refactor checkbox to not nest label

Current field level help

<img width="456" alt="Screen Shot 2019-06-14 at 1 37 06 PM" src="https://user-images.githubusercontent.com/5942899/59527470-a7f55080-8ea9-11e9-8f22-60a083483aca.png">

New field level help

<img width="696" alt="Screen Shot 2019-06-14 at 5 30 43 PM" src="https://user-images.githubusercontent.com/5942899/59539155-2eba2580-8eca-11e9-9de0-679f2a2abbe8.png">




