### PR TITLE
fix(integrationdetails): various UI fixes

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.css
+++ b/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.css
@@ -2,12 +2,17 @@
   border: none;
 }
 
-.integration-detail-activity-item .list-view-pf-main-info {
-  min-height: 68px;
+.integration-detail-activity-item .list-group-item-heading {
+  line-height: 2;
+  font-weight: normal;
+  overflow: visible;
+  white-space: nowrap;
+  width: auto;
 }
 
 .integration-detail-activity-item .integration-detail-activity-item__status-item {
-  padding-top: 6px;
+  display: flex;
+  align-items: center;
 }
 
 .integration-detail-activity-item .integration-detail-activity-item__output {
@@ -34,4 +39,24 @@
 
 .integration-detail-activity-item__expanded-table {
   margin-top: 25px;
+}
+
+.integration-detail-activity-item .list-view-pf-additional-info {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.integration-detail-activity-item .list-view-pf-additional-info-item:not(:last-child) {
+  margin-bottom: 10px;
+}
+
+@media (min-width: 992px) {
+  .integration-detail-activity-item .list-view-pf-additional-info {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .integration-detail-activity-item .list-view-pf-additional-info-item:not(:last-child) {
+    margin-bottom: 0;
+  }
 }

--- a/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.tsx
@@ -53,31 +53,30 @@ export class IntegrationDetailActivityItem extends React.Component<
       <ListView.Item
         className="integration-detail-activity-item"
         key={this.props.time}
-        actions={
-          <div className="integration-detail-activity-item__status-item">
-            {this.props.errorCount > 0 ? (
-              <span>
-                <Icon type="pf" name="error-circle-o" />
-                {'  '}
-                {this.props.i18nErrorsFound}
-              </span>
-            ) : (
-              <span>
-                <Icon type="pf" name="ok" />
-                {'  '}
-                {this.props.i18nNoErrors}
-              </span>
-            )}
-          </div>
-        }
-        leftContent={this.props.date}
-        heading={<></>}
+        heading={this.props.date}
         description={this.props.time}
         additionalInfo={[
           <ListView.InfoItem key={1}>
             {this.props.i18nVersion}
             &nbsp;
             {this.props.version}
+          </ListView.InfoItem>,
+          <ListView.InfoItem key={2}>
+            <div className="integration-detail-activity-item__status-item">
+              {this.props.errorCount > 0 ? (
+                <>
+                  <Icon type="pf" name="error-circle-o" />
+                  {'  '}
+                  {this.props.i18nErrorsFound}
+                </>
+              ) : (
+                <>
+                  <Icon type="pf" name="ok" />
+                  {'  '}
+                  {this.props.i18nNoErrors}
+                </>
+              )}
+            </div>
           </ListView.InfoItem>,
         ]}
       >

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.css
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.css
@@ -1,0 +1,3 @@
+.integration-exposed-url__list {
+  align-items: center;
+}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
@@ -1,6 +1,14 @@
+import {
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { PageSection } from '../../Layout';
 import { CopyToClipboard } from '../../Shared/CopyToClipboard';
+import './IntegrationExposedURL.css';
 
 export interface IIntegrationExposedURLProps {
   url?: string;
@@ -12,7 +20,19 @@ export const IntegrationExposedURL: React.FunctionComponent<
   <>
     {url && (
       <PageSection>
-        <CopyToClipboard>{url}</CopyToClipboard>
+        <TextContent>
+          <TextList
+            component={TextListVariants.dl}
+            className="integration-exposed-url__list"
+          >
+            <TextListItem component={TextListItemVariants.dt}>
+              External URL
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              <CopyToClipboard>{url}</CopyToClipboard>
+            </TextListItem>
+          </TextList>
+        </TextContent>
       </PageSection>
     )}
   </>

--- a/app/ui-react/packages/ui/src/Integration/IntegrationStepsHorizontalItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationStepsHorizontalItem.css
@@ -1,11 +1,11 @@
 .integration-steps-horizontal-item {
-  height: 100px;
+  margin-bottom: 10px;
   width: 120px;
   display: inline-block;
   text-align: center;
   vertical-align: top;
   position: relative;
-  padding: 0 10px;
+  padding-right: 20px;
 }
 
 .integration-steps-horizontal-item * {
@@ -43,7 +43,7 @@
 .integration-steps-horizontal-item .step-arrow {
   position: absolute;
   top: 23px;
-  left: -8px;
+  right: 10px;
   -webkit-transform: translate(50%, -50%);
   transform: translate(50%, -50%);
   font-size: 2em;

--- a/app/ui-react/packages/ui/src/Integration/IntegrationStepsHorizontalItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationStepsHorizontalItem.tsx
@@ -20,7 +20,7 @@ export interface IIntegrationStepsHorizontalItemProps {
    * The boolean value that determines if the step
    * is the first in the steps array.
    */
-  isFirst?: boolean;
+  isLast?: boolean;
 }
 
 export class IntegrationStepsHorizontalItem extends React.Component<
@@ -29,9 +29,6 @@ export class IntegrationStepsHorizontalItem extends React.Component<
   public render() {
     return (
       <div className="integration-steps-horizontal-item">
-        {this.props.isFirst === false ? (
-          <Icon name={'angle-right'} className="step-arrow" />
-        ) : null}
         {!this.props.href && (
           <div>
             <div className={'step-icon'} title={this.props.title}>
@@ -50,6 +47,9 @@ export class IntegrationStepsHorizontalItem extends React.Component<
             </div>
           </Link>
         )}
+        {this.props.isLast === false ? (
+          <Icon name={'angle-right'} className="step-arrow" />
+        ) : null}
       </div>
     );
   }

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -118,6 +118,7 @@ body {
   display: inline-block;
   width: 455px;
   max-width: 100%;
+  background: #fff;
 }
 
 @media (max-width: 768px) {

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailHeader.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailHeader.tsx
@@ -162,10 +162,9 @@ export const IntegrationDetailHeader: React.FunctionComponent<
                 i18nLogUrlText={t('shared:viewLogs')}
               />
             </PageSection>
-            <PageSection variant={'light'}>
-              {bulletinBoards.map((message: LeveledMessage, index) => (
+            {bulletinBoards.map((message: LeveledMessage, index) => (
+              <PageSection variant={'light'} key={index}>
                 <IntegrationBulletinBoardAlert
-                  key={index}
                   level={toAlertLevel(message.level || 'INFO')}
                   message={
                     message.message
@@ -176,8 +175,8 @@ export const IntegrationDetailHeader: React.FunctionComponent<
                   i18nTextExpanded={t('shared:HideDetails')}
                   i18nTextCollapsed={t('shared:ShowDetails')}
                 />
-              ))}
-            </PageSection>
+              </PageSection>
+            ))}
             <PageSection variant={'light'} noPadding={true}>
               <IntegrationDetailNavBar integration={props.data.integration} />
             </PageSection>

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.css
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.css
@@ -1,0 +1,3 @@
+.integration-detail-steps {
+  margin-bottom: -10px;
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.tsx
@@ -10,6 +10,7 @@ import { EntityIcon } from '../../../shared';
 import resolvers from '../../resolvers';
 import { IUIStep } from './editor/interfaces';
 import { toUIStepCollection } from './editor/utils';
+import './IntegrationDetailSteps.css';
 
 export interface IIntegrationDetailStepsProps {
   integration: Integration;
@@ -23,10 +24,10 @@ export class IntegrationDetailSteps extends React.Component<
     const steps = getSteps(this.props.integration, flowId);
 
     return (
-      <PageSection>
+      <PageSection className="integration-detail-steps">
         <IntegrationStepsHorizontalView>
           {toUIStepCollection(steps).map((s: IUIStep, idx: number) => {
-            const isFirst = idx === 0;
+            const isLast = idx === steps.length - 1;
             const stepUri =
               s.stepKind === ENDPOINT && !s.metadata[HIDE_FROM_CONNECTION_PAGES]
                 ? resolvers.connections.connection.details({
@@ -40,7 +41,7 @@ export class IntegrationDetailSteps extends React.Component<
                   title={s.title}
                   icon={<EntityIcon entity={s} alt={s.name} />}
                   href={stepUri}
-                  isFirst={isFirst}
+                  isLast={isLast}
                 />
               </React.Fragment>
             );


### PR DESCRIPTION
* wrap integration steps better when on multiple lines
* remove extra space under integration name when alert isn't present
* add label for external url copy to clipboard
* improve alignment in activity list view items

# Screenshots

## int detail steps wrapping

#### before
<img width="565" alt="Screen Shot 2019-06-14 at 12 30 45 PM" src="https://user-images.githubusercontent.com/35148959/59530199-a37c6800-8ea8-11e9-8fee-2ca7d2526070.png">

#### after
<img width="464" alt="Screen Shot 2019-06-14 at 12 41 46 PM" src="https://user-images.githubusercontent.com/35148959/59530210-a70fef00-8ea8-11e9-928c-f0cb55b750bb.png">

## extra space under integration name

#### before
<img width="638" alt="Screen Shot 2019-06-14 at 12 31 13 PM" src="https://user-images.githubusercontent.com/35148959/59530246-be4edc80-8ea8-11e9-96c7-b5a697cdeb90.png">

#### after
<img width="550" alt="Screen Shot 2019-06-14 at 12 32 40 PM" src="https://user-images.githubusercontent.com/35148959/59530258-c27afa00-8ea8-11e9-9e9c-06e132ce94f4.png">

## copy to clipboard - no label and background color issue

#### before
<img width="669" alt="Screen Shot 2019-06-14 at 12 29 35 PM" src="https://user-images.githubusercontent.com/35148959/59530290-d292d980-8ea8-11e9-8c6a-eea5444457a9.png">

#### after
<img width="715" alt="Screen Shot 2019-06-14 at 12 33 00 PM" src="https://user-images.githubusercontent.com/35148959/59530298-d6bef700-8ea8-11e9-87fa-a70690a6bf4e.png">

## integration activity row UI

#### before
<img width="1421" alt="Screen Shot 2019-06-14 at 12 28 27 PM" src="https://user-images.githubusercontent.com/35148959/59530356-fce49700-8ea8-11e9-9342-ae94e7e3acef.png">
<img width="612" alt="Screen Shot 2019-06-14 at 12 28 35 PM" src="https://user-images.githubusercontent.com/35148959/59530362-040ba500-8ea9-11e9-893d-0b6acbe68ee4.png">

#### after
<img width="1357" alt="Screen Shot 2019-06-14 at 12 33 52 PM" src="https://user-images.githubusercontent.com/35148959/59530372-0968ef80-8ea9-11e9-9295-cbb5b7e7ef2c.png">
<img width="647" alt="Screen Shot 2019-06-14 at 12 39 04 PM" src="https://user-images.githubusercontent.com/35148959/59530376-0b32b300-8ea9-11e9-8e0f-4573a72632a9.png">
