### PR TITLE
5029 - Twitter search action can't have multiple keywords

### DIFF
--- a/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
+++ b/app/connector/twitter/src/main/resources/META-INF/syndesis/connector/twitter.json
@@ -77,11 +77,11 @@
               "keywords": {
                 "componentProperty": false,
                 "deprecated": false,
-                "displayName": "Keywords",
+                "displayName": "Query",
                 "group": "common",
                 "javaType": "java.lang.String",
                 "kind": "path",
-                "labelHint": "Multiple search values can be separated with comma",
+                "labelHint": "Use the keywords AND, OR, - and () to narrow the search results",
                 "required": true,
                 "secret": false,
                 "tags": [],

--- a/doc/connecting/topics/p_adding-twitter-connections.adoc
+++ b/doc/connecting/topics/p_adding-twitter-connections.adoc
@@ -34,8 +34,18 @@ text that you specify.
 * *Send* send a direct message to a twitter user.
 
 . Optionally, enter the configuration information that {prodname}
-prompts for. For example, the *Search* action prompts you to specify
-how often to search and keywords to search for.
+prompts for.
+
+For the *Search* action it will prompts you to specify
+how often to search and the query to search for. The query should be
+specified accordingly to https://developer.twitter.com/en/docs/tweets/search/guides/standard-operators[twitter search operators].
+
+Examples of a search query:
+
+* `syndesis OR fuse`
+* `(jboss fuse) AND camel`
+* `camel -knative`
+
 
 . Click *Done* to add the connection to the integration.
 


### PR DESCRIPTION
Issue: https://github.com/syndesisio/syndesis/issues/5029

The comma is not a valid character separator for multiple keywords, the camel-twitter component and syndesis documentation should be fixed to say the multiple keyword search should use the [twitter search standard operators](https://developer.twitter.com/en/docs/tweets/search/guides/standard-operators).

Examples of valid queries:
* `investiments AND cryptocurrency`
* `investiments -bitcoin`
* `(fuse online) AND salesforce`

For syndesis I could locate only (doc/connecting/topics/p_adding-twitter-connections.adoc) to update  and link to twitter search operators.

Also I changed the `Keywords` label to `Query` see the screenshot

![twitter_search](https://user-images.githubusercontent.com/836543/59530066-0b3aaf00-8eb9-11e9-9d2d-63d52a7aaa2a.png)