### PR TITLE
required update of project.version to 7.4 in dictionary file

### DIFF
--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -82,7 +82,7 @@
       },
       "project": {
         "name": "Syndesis",
-        "version": "7.1"
+        "version": "7.4"
       },
       "error": {
         "title": "Something is wrong",


### PR DESCRIPTION
This updates the value of **product.version** from **7.1** to **7.4** in:

app/ui-react/syndesis/src/i18n/locales/shared-translations-en.json

Also in that file, there are user doc links that refer to **product.version**.

Currently, in the staging site, the help icon links still point to 7.3 doc, so the angular dictionary file must still be in use for staging. 

The links to 7.4 doc **WILL NOT WORK** until 7.4 GA, which is when the doc is published. 

These are the links that will work when 7.4 doc is published:

https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html-single/fuse_online_sample_integration_tutorials/index
https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html-single/integrating_applications_with_fuse_online/index
https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html-single/connecting_fuse_online_to_applications_and_services/index