### PR TITLE
fix: remove rxjava from update handler

### DIFF
--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/ExtensionsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/ExtensionsITCase.java
@@ -346,13 +346,12 @@ public class ExtensionsITCase extends BaseITCase {
                     .build())
                 .build());
 
-        await().atMost(60, TimeUnit.SECONDS).pollInterval(250, TimeUnit.MILLISECONDS).untilAsserted(() -> {
-            // Get extension details again, we need to use RAW here as Jackson will not be able
-            // to write the `uses` property (access = READ_ONLY)
-            final ResponseEntity<Map<String, Object>> got = get("/api/v1/extensions/" + id,
-                RAW, tokenRule.validToken(), HttpStatus.OK);
+        await().atMost(10, TimeUnit.SECONDS).pollInterval(250, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            // Get extension details again directly from the database
+            dataManager.clearCache();
+            final Extension fetched = dataManager.fetch(Extension.class, id);
 
-            assertThat(got.getBody().get("uses")).isEqualTo(1);
+            assertThat(fetched.getUses()).isEqualTo(1);
         });
 
         // Get extension list

--- a/app/server/update-controller/pom.xml
+++ b/app/server/update-controller/pom.xml
@@ -46,12 +46,6 @@
     </dependency>
 
     <!-- ===================================================================================== -->
-
-    <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/usage/UsageUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/usage/UsageUpdateHandler.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -41,8 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
 
-import rx.subjects.PublishSubject;
-
 public final class UsageUpdateHandler implements ResourceUpdateHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(UsageUpdateHandler.class);
@@ -51,14 +48,8 @@ public final class UsageUpdateHandler implements ResourceUpdateHandler {
 
     private final DataManager dataManager;
 
-    private final PublishSubject<ChangeEvent> pipe = PublishSubject.create();
-
     public UsageUpdateHandler(final DataManager dataManager) {
         this.dataManager = dataManager;
-
-        // try not to overload the backend database by updating usage only
-        // after a quiet period
-        pipe.throttleWithTimeout(3, TimeUnit.SECONDS).subscribe(this::processInternal);
     }
 
     @Override
@@ -75,7 +66,7 @@ public final class UsageUpdateHandler implements ResourceUpdateHandler {
     @Override
     public void process(final ChangeEvent event) {
         LOG.debug("Received event: {}", event);
-        pipe.onNext(event);
+        processInternal(event);
     }
 
     void processInternal(final ChangeEvent event) {


### PR DESCRIPTION
Removing rxjava from the update handler should help with the determinism of the usage updates. Also changes the timeout in the test from 60 to 10 seconds.

Fixes #4827