### PR TITLE
user doc: Correct Query input field description for SQL connection

### DIFF
--- a/doc/connecting/topics/p_adding-db-connection-start.adoc
+++ b/doc/connecting/topics/p_adding-db-connection-start.adoc
@@ -5,7 +5,7 @@
 = Starting an integration by accessing a database
 
 To trigger execution of an integration based on the result of invoking a SQL
-query or a SQL stored procedures, choose a database connection as the 
+statement or a SQL stored procedure, choose a database connection as the 
 integration's start connection. 
 
 .Prerequisite
@@ -20,11 +20,12 @@ database connection that you want to use to start an integration.
 . On the *Choose an Action* page, click one of the following:
 +
 * *Periodic SQL invocation* obtains data by periodically invoking the
-SQL query you specify.
+SQL statement that you specify.
 * *Periodic stored procedure invocation* obtains data by periodically invoking
 the stored procedure that you specify or select.
 . If you selected *Periodic SQL invocation*, in the *Query* field,
-enter a SQL `SELECT` statement to obtain one or more records. For 
+enter a SQL `SELECT` statement or some other SQL statement that 
+obtains one or more records. For 
 example: `*SELECT * from my_db_table*`.
 The database table that contains the data you want must already exist.
 +
@@ -36,14 +37,14 @@ procedures you need to use in an integration.
 . In the *Period* field, enter an integer and indicate whether the unit is 
 milliseconds, seconds, 
 minutes, hours, or days. For example, if you specify `5 minutes` then
-the connection invokes the specified query or stored procedure every
+the connection invokes the specified statement or stored procedure every
 five minutes.
 . Click *Done*.
 
 .Result
 {prodname} tries to validate the connection, which includes
-checking that a specified SQL query is syntactically correct and
-confirming that the query or stored procedure target data exists. If
+checking that a specified SQL statement is syntactically correct and
+confirming that the statement or stored procedure target data exists. If
 verification is successful then {prodname} adds the start connection to
 the integration. If verification fails then {prodname} displays a message
 about the problem. Update your input as needed and try again.


### PR DESCRIPTION
Previously, the doc for the Query input field for a SQL start connection, Periodic SQL Invocation action, said that you had to enter a SELECT statement. This was wrong. I updated it to indicate that you have to enter a SQL statement that returns one or more records. 