### PR TITLE
ENTESB-10855 Download action of box connector doesn't show as Start Action

### DIFF
--- a/app/connector/box/src/main/resources/META-INF/syndesis/connector/box.json
+++ b/app/connector/box/src/main/resources/META-INF/syndesis/connector/box.json
@@ -97,7 +97,7 @@
       },
       "id": "io.syndesis:box-download-connector",
       "name": "Download",
-      "pattern": "To"
+      "pattern": "From"
     }
   ],
   "componentScheme": "box",


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-10855