### PR TITLE
user doc: Add SSL limitation to doc for Kafka connector

### DIFF
--- a/doc/connecting/topics/p_creating-kafka-connections.adoc
+++ b/doc/connecting/topics/p_creating-kafka-connections.adoc
@@ -9,6 +9,10 @@ or publish data to a Kafka topic,
 create a connection to Kafka and then add that connection to an 
 integration.
 
+[IMPORTANT]
+In this release, connections to Kafka do not support SSL. 
+It is expected that this will change in a future release.
+
 .Prerequisite
 You must know the URI for the Kafka broker that you want to connect to. 
 


### PR DESCRIPTION
This adds the following note to the topic about creating a Kafka connection: 

In this release, connections to Kafka do not support SSL. It is expected that this will change in a future release.