### PR TITLE
fix: make sure that operation and label are unique

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -108,6 +108,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
@@ -27,12 +27,12 @@ public interface Op extends Serializable {
 
     Op EQUALS = new Op.Builder().label("equals").operator("==").build();
     Op EQUALS_IGNORE_CASE = new Op.Builder().label("equals (ignores case)").operator("=~").build();
-    Op NOT_EQUALS = new Op.Builder().label("not equals").operator("==").build();
+    Op NOT_EQUALS = new Op.Builder().label("not equals").operator("!=").build();
 
-    Op LESS_THAN = new Op.Builder().label("").operator("<").build();
-    Op LESS_THAN_OR_EQUALS = new Op.Builder().label("").operator("<=").build();
-    Op GREATER_THAN = new Op.Builder().label("").operator(">").build();
-    Op GREATER_THAN_OR_EQUALS = new Op.Builder().label("").operator(">=").build();
+    Op LESS_THAN = new Op.Builder().label("less than").operator("<").build();
+    Op LESS_THAN_OR_EQUALS = new Op.Builder().label("less than or equal to").operator("<=").build();
+    Op GREATER_THAN = new Op.Builder().label("greater than").operator(">").build();
+    Op GREATER_THAN_OR_EQUALS = new Op.Builder().label("greater than or equal to").operator(">=").build();
 
     Op CONTAINS = new Op.Builder().label("contains").operator("contains").build();
     Op CONTAINS_IGNORE_CASE = new Op.Builder().label("contains (ignore case)").operator("~~").build();

--- a/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model.filter;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.camel.language.simple.types.BinaryOperatorType;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpTest {
+
+    @Test
+    public void allOperationsShouldBeKnownCamelSimpleOperations() {
+        assertThat(Stream.of(Op.DEFAULT_OPTS)
+            .map(Op::getOperator))
+                .allSatisfy(BinaryOperatorType::asOperator);
+    }
+
+    @Test
+    public void allOperationsShouldHaveDistinctBinaryOperator() {
+        assertThat(Stream.of(Op.DEFAULT_OPTS)
+            .map(Op::getOperator)
+            .collect(Collectors.toSet()))
+                .hasSameSizeAs(Op.DEFAULT_OPTS);
+    }
+
+    @Test
+    public void allOperationsShouldHaveDistinctLabels() {
+        assertThat(Stream.of(Op.DEFAULT_OPTS)
+            .map(Op::getLabel)
+            .collect(Collectors.toSet()))
+                .hasSameSizeAs(Op.DEFAULT_OPTS);
+    }
+}


### PR DESCRIPTION
This adds labels for filter operations that had them set to empty string and fixes the operator for the not equal filter operation.

Fixes #5702