### PR TITLE
fix: connection creation issue

### DIFF
--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -162,7 +162,7 @@ export const ConfigurationPage: React.FunctionComponent = () => {
                   errorChildren={<ApiError />}
                 >
                   {() =>
-                    acquisitionMethod ? (
+                    acquisitionMethod && acquisitionMethod.type && acquisitionMethod.type.startsWith('OAUTH') ? (
                       <OAuthFlow
                         connectorId={connector.id!}
                         connectorName={connector.name}


### PR DESCRIPTION
We should not invoke `POST /api/v1/connectors/{id}/credentials` when
`GET /api/v1/connectors/{id}/credentials` is not returning
`AcquisitionMethod` of type `OAUTH*`.

Fixes #5831