### PR TITLE
fix: save the updated connection on OAuth reconnect

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/credential/CredentialHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/credential/CredentialHandler.java
@@ -158,7 +158,12 @@ public class CredentialHandler {
 
     static void removeCredentialCookies(final HttpServletRequest request,
         final HttpServletResponse response) {
-        Arrays.stream(request.getCookies()).filter(c -> c.getName().startsWith(CredentialFlowState.CREDENTIAL_PREFIX))
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return;
+        }
+
+        Arrays.stream(cookies).filter(c -> c.getName().startsWith(CredentialFlowState.CREDENTIAL_PREFIX))
             .forEach(c -> {
                 final Cookie removal = new Cookie(c.getName(), "");
                 removal.setPath("/");

--- a/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
@@ -28,18 +28,22 @@ export interface IConnectionDetailsOauthProps {
   connectorId: string;
   connectionName: string;
   configuredProperties: Pick<IConnectionOverview, 'configuredProperties'>;
+  onOAuthReconnect: () => void;
 }
 const ConnectionDetailsOAuth: React.FunctionComponent<
   IConnectionDetailsOauthProps
-> = ({ connectorId, connectionName, configuredProperties }) => {
+> = ({
+  connectorId,
+  connectionName,
+  configuredProperties,
+  onOAuthReconnect,
+}) => {
   const { t } = useTranslation(['connections', 'shared']);
   const { pushNotification } = React.useContext(UIContext);
   const { connectOAuth, isConnecting } = useOAuthFlow(
     connectorId,
     connectionName,
-    () => {
-      pushNotification(`Connection successful`, 'success');
-    }
+    onOAuthReconnect
   );
   const { loading: isVerifying, read: verify } = useConnectorVerifier();
 
@@ -174,6 +178,11 @@ export const ConnectionDetailsPage: React.FunctionComponent<
     await save({ configuredProperties });
     actions.setSubmitting(false);
     setIsWorking(false);
+  };
+
+  const onOAuthReconnect = async () => {
+    await save(connection);
+    pushNotification(`Connection successful`, 'success');
   };
 
   /**
@@ -314,6 +323,7 @@ export const ConnectionDetailsPage: React.FunctionComponent<
                     connectorId={connection.connector!.id!}
                     connectionName={connection.name}
                     configuredProperties={connection.configuredProperties || {}}
+                    onOAuthReconnect={onOAuthReconnect}
                   />
                 )}
               </>


### PR DESCRIPTION
We need to save (invoke `PUT /api/v1/connections/{id}`) when reconnecting the OAuth-capable connection.

Fixes #5763