### PR TITLE
fix: handle credentials response without transformation

### DIFF
--- a/app/ui-react/packages/api/src/useConnectorCredentials.tsx
+++ b/app/ui-react/packages/api/src/useConnectorCredentials.tsx
@@ -4,10 +4,6 @@ import { useApiResource } from './useApiResource';
 export const useConnectorCredentials = (connectorId: string) => {
   return useApiResource<AcquisitionMethod | undefined>({
     defaultValue: {},
-    transformResponse: async response => {
-      const am = await response.json();
-      return Object.keys(am).length > 0 ? am : undefined;
-    },
     url: `/connectors/${connectorId}/credentials`,
   });
 };


### PR DESCRIPTION
When `GET /api/v1/connectors/{id}/credentials` response is `{}` the `useApiResource` will provide `undefined` as the the response. This causes an issue as `Object.keys(undefined)` throws an Error. Also there is no need to transform it to `undefined` as the code that handles the response handles both `{}` and `undefined` cases as the result from `useConnectionCredentials` is typed `<AcquisitionMethod | undefined>`.

The check later in the code tries to determine by accessing `AcquisitionMethod.type` and `AcquisitionMethod.configured`, but also handles when the returned `AcquisitionMethod` is `undefined`.

The very odd thing about this issue is that when running locally via `yarn watch:app:proxy` this issue did not occur, but could be reproduced when deployed on minishift.

Fixes #5831