### PR TITLE
fix: honor both syntaxes for authenticationType

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypes.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypes.java
@@ -16,6 +16,7 @@
 package io.syndesis.server.api.generator.swagger;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -50,6 +51,16 @@ enum SupportedAuthenticationTypes {
         this.label = label;
         this.filter = filter;
         propertyValue = new ConfigurationProperty.PropertyValue.Builder().value(name()).label(label).build();
+    }
+
+    public static SupportedAuthenticationTypes fromConfiguredPropertyValue(final String value) {
+        final int idx = Objects.requireNonNull(value, "value").indexOf(':');
+
+        return SupportedAuthenticationTypes.valueOf(idx > 0 ? value.substring(0, idx) : value);
+    }
+
+    public static SupportedAuthenticationTypes fromSecurityDefinition(final String value) {
+        return valueOf(value);
     }
 
     static ConfigurationProperty.PropertyValue asPropertyValue(final String name, final SecuritySchemeDefinition def) {

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/PropertyGeneratorsTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/PropertyGeneratorsTest.java
@@ -91,6 +91,36 @@ public class PropertyGeneratorsTest {
     }
 
     @Test
+    public void shouldDetermineSecurityDefinitionToUseFromTheConfiguredAuthenticationType() {
+        final BasicAuthDefinition securityDefinition = new BasicAuthDefinition();
+
+        final Swagger swagger = new Swagger()
+            .securityDefinition("username-password", securityDefinition);
+
+        final ConnectorSettings settings = new ConnectorSettings.Builder()
+            .putConfiguredProperty(PropertyGenerators.authenticationType.name(), "basic")
+            .build();
+
+        final Optional<BasicAuthDefinition> got = PropertyGenerators.securityDefinition(swagger, settings, BasicAuthDefinition.class);
+        assertThat(got).containsSame(securityDefinition);
+    }
+
+    @Test
+    public void shouldDetermineSecurityDefinitionToUseFromTheConfiguredAuthenticationTypeWithName() {
+        final BasicAuthDefinition securityDefinition = new BasicAuthDefinition();
+
+        final Swagger swagger = new Swagger()
+            .securityDefinition("username-password", securityDefinition);
+
+        final ConnectorSettings settings = new ConnectorSettings.Builder()
+            .putConfiguredProperty(PropertyGenerators.authenticationType.name(), "basic:name")
+            .build();
+
+        final Optional<BasicAuthDefinition> got = PropertyGenerators.securityDefinition(swagger, settings, BasicAuthDefinition.class);
+        assertThat(got).containsSame(securityDefinition);
+    }
+
+    @Test
     public void shouldReturnNullIfNoHostGivenAnywhere() {
         assertThat(determineHost(new Swagger())).isNull();
         assertThat(determineHost(new Swagger().scheme(Scheme.HTTP))).isNull();

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypesTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SupportedAuthenticationTypesTest.java
@@ -25,6 +25,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SupportedAuthenticationTypesTest {
 
     @Test
+    public void shouldDetermineValueFromConfiguredPropertyValue() {
+        assertThat(SupportedAuthenticationTypes.fromConfiguredPropertyValue("basic")).isEqualTo(SupportedAuthenticationTypes.basic);
+        assertThat(SupportedAuthenticationTypes.fromConfiguredPropertyValue("basic:name")).isEqualTo(SupportedAuthenticationTypes.basic);
+        assertThat(SupportedAuthenticationTypes.fromConfiguredPropertyValue("basic:")).isEqualTo(SupportedAuthenticationTypes.basic);
+    }
+
+    @Test
+    public void shouldDetermineValueFromSecurityDefinitionValue() {
+        assertThat(SupportedAuthenticationTypes.fromConfiguredPropertyValue("basic")).isEqualTo(SupportedAuthenticationTypes.basic);
+    }
+
+    @Test
     public void shouldGenerateLabelsWithDescription() {
         final BasicAuthDefinition withDescription = new BasicAuthDefinition();
         withDescription.setDescription("description");


### PR DESCRIPTION
With #5669 we added support for adding a name of the security definition to distinguish between two authentication methods of the same type to the `authenticationType` configured property value. At the same time when the connector is to be created the authentication method selected by the end user needs to be paired with the security definition from the OpenAPI document.

Here we did not account for the additional name of the security definition that can be present in the value of the `authenticationType` configured property. This makes sure that we support both variants in the `authenticationType` configured property.

Fixes #5855