### PR TITLE
fix: not all extensions have actions (the sequel)

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -298,7 +298,7 @@ export function mergeConnectionsSources(
     ),
     ...extensions.reduce(
       (extentionsByAction, extension) => {
-        extension.actions.forEach(a => {
+        (extension.actions || []).forEach(a => {
           let properties = {};
           if (
             a.descriptor &&


### PR DESCRIPTION
@zregvart this will be a blocker when someone notices it :-)

Effectively by uploading a library extension I've made it so nobody using staging can really add connections to integrations.