### PR TITLE
TTOOLS-661 resolve issue with view name validation

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -95,6 +95,7 @@ export interface ProjectedColumn {
 
 export interface ViewDefinition {
   isComplete: boolean;
+  isUserDefined: boolean;
   viewName: string;
   keng__description: string;
   sourcePaths: string[];

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
@@ -61,7 +61,6 @@ export interface IViewEditContentProps {
 }
 
 interface IViewEditContentState {
-  ddlChanged: boolean;
   ddlValue: string;
   initialDdlValue: string;
   needsValidation: boolean;
@@ -78,7 +77,6 @@ export class ViewEditContent extends React.Component<
   constructor(props: IViewEditContentProps) {
     super(props);
     this.state = {
-      ddlChanged: false,
       ddlValue: this.props.viewDdl,
       initialDdlValue: this.props.viewDdl,
       needsValidation: false,
@@ -89,8 +87,7 @@ export class ViewEditContent extends React.Component<
   }
 
   public handleDdlValidation = () => (event: any) => {
-    const currentDdl = this.state.ddlValue;
-    this.props.onValidate(currentDdl);
+    this.props.onValidate(this.state.ddlValue);
     this.setState({
       needsValidation: false,
     });
@@ -98,7 +95,6 @@ export class ViewEditContent extends React.Component<
 
   public handleDdlChange(editor: ITextEditor, data: any, value: string) {
     this.setState({
-      ddlChanged: true,
       ddlValue: value,
       needsValidation: true,
     });
@@ -146,7 +142,7 @@ export class ViewEditContent extends React.Component<
             />
             <Button
               bsStyle="default"
-              disabled={this.props.isWorking}
+              disabled={this.props.isWorking || !this.state.needsValidation}
               onClick={this.handleDdlValidation()}
             >
               {this.props.isWorking ? (
@@ -170,7 +166,6 @@ export class ViewEditContent extends React.Component<
               disabled={
                 this.props.isWorking ||
                 !this.props.isValid ||
-                !this.state.ddlChanged ||
                 this.state.needsValidation
               }
               onClick={this.handleSave()}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -70,6 +70,9 @@
     "importViewsFailed": "Import data source failed for virtualization {{name}}. Details: {{details}}",
     "createViewSuccess": "Created view named: {{name}}.",
     "createViewFailed": "Create view failed. Details: {{details}}",
+    "saveViewSuccess": "Saved view : {{name}}.",
+    "saveViewFailed": "Save view {{name}} failed. Details: {{details}}",
+    "validateViewRequired": "Please re-validate view {{name}} and re-try",
     "activeConnectionsEmptyStateTitle": "No Active Connections",
     "activeConnectionsEmptyStateInfo": "There are no active connections available. Try again."
   }

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -69,6 +69,9 @@
     "importViewsFailed": "Import data source failed for virtualization {{name}}. Details: {{details}}",
     "createViewSuccess": "Created view named: {{name}}.",
     "createViewFailed": "Create view failed. Details: {{details}}",
+    "saveViewSuccess": "Saved view : {{name}}.",
+    "saveViewFailed": "Save view {{name}} failed. Details: {{details}}",
+    "validateViewRequired": "Please re-validate view {{name}} and re-try",
     "activeConnectionsEmptyStateTitle": "No Active Connections",
     "activeConnectionsEmptyStateInfo": "There are no active connections available. Please retry."
   }

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -179,6 +179,7 @@ export function generateViewEditorState(
     vwName,
     PROJECTED_COLS_ALL,
     srcPaths,
+    false,
     vwDescription
   );
 }
@@ -206,7 +207,8 @@ export function generateViewEditorStates(
         serviceVdbName,
         viewInfo.viewName,
         PROJECTED_COLS_ALL,
-        srcPaths
+        srcPaths,
+        false
       )
     );
   }
@@ -220,6 +222,7 @@ export function generateViewEditorStates(
  * @param name the view name
  * @param projectedCols projected columns for the view
  * @param srcPaths paths for the sources used in the view
+ * @param userDefined specifies if the ddl has been altered from defaults
  * @param description the (optional) view description
  * @param viewDdl the (optional) view DDL
  */
@@ -228,6 +231,7 @@ function getViewEditorState(
   name: string,
   projectedCols: ProjectedColumn[],
   srcPaths: string[],
+  userDefined: boolean,
   description?: string,
   viewDdl?: string
 ) {
@@ -236,6 +240,7 @@ function getViewEditorState(
     compositions: [],
     ddl: viewDdl ? viewDdl : '',
     isComplete: true,
+    isUserDefined: userDefined,
     keng__description: description ? description : '',
     projectedColumns: projectedCols,
     sourcePaths: srcPaths,


### PR DESCRIPTION
ENTESB-10845 - Addresses view DDL validation issues.
- adds 'isUserDefined' attribute to ViewDefinition.  For new views userDefined is false.  When the user edits/saves the viewDdl via the editor, userDefined is true
- ViewEditPage - the server call to get model ddl was eliminated.  The individual view ddl is now maintained in komodoServer.  It can be obtained directly from the viewDefinition.  Also added pushNotifications on this page