### PR TITLE
fix: pass `configuredProperties` from connector in OAuth flow

### DIFF
--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -132,8 +132,13 @@ export const ConfigurationPage: React.FunctionComponent = () => {
    * about to be closed
    */
   const onOAuthSuccess = () => {
+    // any configuredProperties that have already been configured on the
+    // connector need to be passed to the connection for the connection
+    // validation to function
+    const configuredProperties = connector.configuredProperties;
     history.push(
       resolvers.create.review({
+        configuredProperties,
         connector,
       })
     );


### PR DESCRIPTION
When we create a connection in OAuth flow we need to pass the `configuredProperties` that have been pre-configured on the connector.

Another way to fix this would be to include `configuredProperties` from the connector when passing parameters to connection validation. This makes it in-line for OAuth based connectors as it does for non-OAuth based connectors.

Fixes #5891