### PR TITLE
fix: suppress showing editor warning icons for the conditional flow step

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
@@ -131,6 +131,7 @@ export const configureDescribeDataShapeMapper = ({
   step,
   ...rest
 }: IEditorConfigureDataShape) => {
+  // TODO eventually this page can also be used for conditional flow step, at which point a connection object won't be available, this will need to be revisited
   const { params, state } = configureSelectActionMapper(rest);
   return {
     params: {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -188,6 +188,7 @@ export function toUIIntegrationStepCollection(
         const prev = getPreviousStepWithDataShape(steps, position);
         if (
           prev &&
+          prev.stepKind !== CHOICE && // TODO: suppress this until we can also use the describe data page for a step syndesisio/syndesis#5456
           prev.action &&
           prev.action.descriptor &&
           prev.action.descriptor.outputDataShape


### PR DESCRIPTION
fixes #5887

I also had to hide the data mapper warning icon as well when the conditional flow step is involved, as the conditional flow also causes that to show up if the describe data warning isn't shown.