### PR TITLE
chore(dev): add a update-manifest dev command

### DIFF
--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -115,6 +115,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
 

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -115,7 +115,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
+      <artifactId>spring-boot-actuator</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsEndpoint.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.actuator;
+
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.dao.manager.DataManager;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * Defines methods for refreshing connectors without restarting the server.
+ */
+@Configuration
+@ConditionalOnProperty(value = "endpoints.connectors.enabled", havingValue = "true", matchIfMissing = true)
+public class ConnectorsEndpoint extends AbstractEndpoint<List<Connector>> {
+
+    private DataManager dataManager;
+
+    public ConnectorsEndpoint(DataManager dataManager) {
+        super("connectors", false, true);
+        this.dataManager = dataManager;
+    }
+
+    @Override
+    public List<Connector> invoke() {
+        return dataManager.fetchAll(Connector.class).getItems();
+    }
+
+    public void updateConnector(Connector value) {
+        dataManager.set(value);
+    }
+}
+

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsMvcEndpoint.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsMvcEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.actuator;
+
+import io.syndesis.common.model.connection.Connector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.boot.actuate.endpoint.mvc.HypermediaDisabled;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Binds an additional post method to the connectors endpoint,
+ * using spring-boot 1.5.x actuator binding (should be changed in spring-boot 2.x).
+ */
+@Configuration
+@ConditionalOnProperty(value = "endpoints.connectors.enabled", havingValue = "true", matchIfMissing = true)
+public class ConnectorsMvcEndpoint extends EndpointMvcAdapter {
+
+    private static Logger LOG = LoggerFactory.getLogger(ConnectorsMvcEndpoint.class);
+
+    private ConnectorsEndpoint delegate;
+
+    public ConnectorsMvcEndpoint(ConnectorsEndpoint delegate) {
+        super(delegate);
+        this.delegate = delegate;
+    }
+
+    @RequestMapping(
+        method = {RequestMethod.POST},
+        consumes = {"application/vnd.spring-boot.actuator.v1+json", "application/json"},
+        produces = {"application/vnd.spring-boot.actuator.v1+json", "application/json"}
+    )
+    @HypermediaDisabled
+    public Object set(@RequestBody Connector connector) {
+        if (!this.delegate.isEnabled()) {
+            return this.getDisabledResponse();
+        } else {
+            try {
+                this.delegate.updateConnector(connector);
+                return ResponseEntity.ok().build();
+            } catch (Exception ex) {
+                LOG.error("Error while updating the connector", ex);
+                return ResponseEntity.badRequest().build();
+            }
+        }
+    }
+}
+

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsMvcEndpoint.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/actuator/ConnectorsMvcEndpoint.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @ConditionalOnProperty(value = "endpoints.connectors.enabled", havingValue = "true", matchIfMissing = true)
 public class ConnectorsMvcEndpoint extends EndpointMvcAdapter {
 
-    private static Logger LOG = LoggerFactory.getLogger(ConnectorsMvcEndpoint.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorsMvcEndpoint.class);
 
     private ConnectorsEndpoint delegate;
 

--- a/app/server/endpoint/src/main/resources/META-INF/spring.factories
+++ b/app/server/endpoint/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    io.syndesis.server.endpoint.v1.V1Configuration
+    io.syndesis.server.endpoint.v1.V1Configuration,\
+    io.syndesis.server.endpoint.actuator.ConnectorsMvcEndpoint,\
+    io.syndesis.server.endpoint.actuator.ConnectorsEndpoint

--- a/tools/bin/commands/dev
+++ b/tools/bin/commands/dev
@@ -23,6 +23,7 @@ dev::usage() {
     --cleanup                 Removes 'Completed' pods
     --refresh                 Used in conjuction with --cookie, forces a refresh of the cookie.
                               Ex: curl -k --cookie $(syndesis dev --cookie --refresh)  "https://$(oc get route syndesis  --template={{.spec.host}})/api/v1/connections"
+    --update-manifest <name>  Updates the json manifest for the given connector
     --version                 Show running version of cluster
 EOT
 }
@@ -107,6 +108,33 @@ create_api_cookie() {
          "https://$openshift_ip_and_port/oauth/authorize/approve" 2>/dev/null
 }
 
+update_connector_manifest() {
+    local connector=$1
+    manifest_dir=$(appdir)/connector/$connector/target/classes/META-INF/syndesis/connector
+
+    syndesis_server_pod=$(oc get pod -l syndesis.io/component=syndesis-server -o=jsonpath='{.items[0].metadata.name}' --ignore-not-found)
+    if [ -z "$syndesis_server_pod" ]; then
+        echo "Syndesis server pod not found"
+        exit 1
+    fi
+
+    if [ -d "$manifest_dir" ]; then
+        files=$(ls $manifest_dir | grep ".json")
+        if [ -z "$files" ]; then
+            echo "No manifest files found in $manifest_dir"
+            exit 1
+        fi
+
+        for m in $files; do
+            oc cp $manifest_dir/$m $syndesis_server_pod:/tmp/
+            oc exec $syndesis_server_pod -- curl -X POST http://localhost:8181/connectors -H "Content-Type: application/json" -H "Syndesis-Xsrf-Token: awesome" -d @/tmp/$m
+            echo "Manifest $m updated"
+        done
+    else
+        echo "Cannot find manifest dir $manifest_dir"
+        exit 1
+    fi
+}
 
 dev::run() {
     source "$(basedir)/commands/util/openshift_funcs"
@@ -151,5 +179,13 @@ dev::run() {
         fi
         oc --as system:admin adm prune images --registry-url=http://$(oc --as system:admin -n default get route docker-registry -o jsonpath='{.spec.host}') --confirm
         echo done
+    elif [ $(hasflag --update-manifest) ]; then
+        local connector=$(readopt --update-manifest)
+        if [ -z "${connector}" ]; then
+            echo "Cannot get the name of the connector manifest to sync"
+            echo "Usage: syndesis dev --update-manifest <connector-name>"
+            exit 1
+        fi
+        update_connector_manifest $connector
     fi
 }

--- a/tools/bin/commands/kamel
+++ b/tools/bin/commands/kamel
@@ -159,7 +159,7 @@ EOF
         | oc apply -f -
 
     # Configuring catalog
-    local syndesis_version=$(grep -Pzo "(?s)<parent>.*?<version>\K[^<]*" $app_dir/integration/pom.xml)
+    local syndesis_version=$(grep -Pzo "(?s)<parent>.*?<version>\K[^<]*" $app_dir/integration/pom.xml | tr -d '\0')
     echo "Using Syndesis version: $syndesis_version"
 
     local catalog=$LOCAL_MAVEN_REPOSITORY/io/syndesis/integration/integration-runtime-camelk/$syndesis_version/integration-runtime-camelk-$syndesis_version-catalog.yaml


### PR DESCRIPTION
This is the `syndesis dev --update-manifest <connector>` command I've shown.

It uses spring-boot actuator under the hood to pass the new connector. Don't know if we should use a different strategy or we need to protect more the endpoint (management port is only exposed locally to the container and cannot be called from outside.. I port-forward in the pod to call it).

Wdyt?