### PR TITLE
Fixes #5888: Only compile in the dev mode logic if you build with “-—tags dev”

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -20,7 +20,7 @@ readopt() {
                return
             fi
             echo $var
-            break;
+            return
         fi
         if [[ "$var" = "${filter}"* ]]; then
             local value="${var//${filter}=/}"

--- a/install/operator/pkg/generator/assets/assets_generate.go
+++ b/install/operator/pkg/generator/assets/assets_generate.go
@@ -5,12 +5,12 @@ package main
 
 import (
 	"github.com/shurcooL/vfsgen"
-	"github.com/syndesisio/syndesis/install/operator/pkg/generator"
+	"github.com/syndesisio/syndesis/install/operator/pkg/generator/dev"
 	"log"
 )
 
 func main() {
-	err := vfsgen.Generate(generator.GetAssetsFS(true), vfsgen.Options{
+	err := vfsgen.Generate(dev.GetAssetsFS(), vfsgen.Options{
 		PackageName: "generator",
 	})
 	if err != nil {

--- a/install/operator/pkg/generator/dev/dev.go
+++ b/install/operator/pkg/generator/dev/dev.go
@@ -1,0 +1,34 @@
+package dev
+
+import (
+	"github.com/shurcooL/httpfs/filter"
+	"github.com/syndesisio/syndesis/install/operator/pkg/build"
+	"github.com/syndesisio/syndesis/install/operator/pkg/util"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func GetAssetsFS() http.FileSystem {
+	assetsDir := filepath.Join(build.GO_MOD_DIRECTORY, "pkg", "generator", "assets")
+	return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
+		if fi.Name() == ".DS_Store" {
+			return false
+		}
+		if fi.Name() == "assets_generate.go" {
+			return false
+		}
+		return true
+	}), func(fi os.FileInfo) (os.FileInfo, error) {
+		return &zeroTimeFileInfo{fi}, nil
+	})
+}
+
+type zeroTimeFileInfo struct {
+	os.FileInfo
+}
+
+func (*zeroTimeFileInfo) ModTime() time.Time {
+	return time.Time{}
+}

--- a/install/operator/pkg/generator/generator.go
+++ b/install/operator/pkg/generator/generator.go
@@ -6,18 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hoisie/mustache"
-	"github.com/shurcooL/httpfs/filter"
-	"github.com/syndesisio/syndesis/install/operator/pkg/build"
 	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net/http"
-	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 )
 
 type supportImages struct {
@@ -160,35 +155,8 @@ func AssetAsBytes(path string) ([]byte, error) {
 	return prometheusRules, nil
 }
 
-type zeroTimeFileInfo struct {
-	os.FileInfo
-}
-
-func (*zeroTimeFileInfo) ModTime() time.Time {
-	return time.Time{}
-}
-
-func GetAssetsFS(devMode bool) http.FileSystem {
-	if devMode {
-		assetsDir := filepath.Join(build.GO_MOD_DIRECTORY, "pkg", "generator", "assets")
-		return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
-			if fi.Name() == ".DS_Store" {
-				return false
-			}
-			if fi.Name() == "assets_generate.go" {
-				return false
-			}
-			return true
-		}), func(fi os.FileInfo) (os.FileInfo, error) {
-			return &zeroTimeFileInfo{fi}, nil
-		})
-	} else {
-		return assets
-	}
-}
-
 func RenderDir(directory string, context interface{}) ([]unstructured.Unstructured, error) {
-	return RenderFSDir(GetAssetsFS(true), directory, context)
+	return RenderFSDir(GetAssetsFS(), directory, context)
 }
 
 func RenderFSDir(assets http.FileSystem, directory string, context interface{}) ([]unstructured.Unstructured, error) {

--- a/install/operator/pkg/generator/generator_test.go
+++ b/install/operator/pkg/generator/generator_test.go
@@ -21,11 +21,11 @@ func TestGenerator(t *testing.T) {
 	err = json.Unmarshal(templateConfig, gen)
 	require.NoError(t, err)
 
-	resources, err := generator.RenderFSDir(generator.GetAssetsFS(true), "./install/", gen)
+	resources, err := generator.RenderFSDir(generator.GetAssetsFS(), "./install/", gen)
 	require.NoError(t, err)
 	assert.True(t, len(resources) > 0)
 
-	resources, err = generator.RenderFSDir(generator.GetAssetsFS(true), "./upgrade/", gen)
+	resources, err = generator.RenderFSDir(generator.GetAssetsFS(), "./upgrade/", gen)
 	require.NoError(t, err)
 	assert.True(t, len(resources) > 0)
 }

--- a/install/operator/pkg/generator/mode_dev.go
+++ b/install/operator/pkg/generator/mode_dev.go
@@ -1,0 +1,12 @@
+// +build dev
+
+package generator
+
+import (
+	"github.com/syndesisio/syndesis/install/operator/pkg/generator/dev"
+	"net/http"
+)
+
+func GetAssetsFS() http.FileSystem {
+	return dev.GetAssetsFS()
+}

--- a/install/operator/pkg/generator/mode_prod.go
+++ b/install/operator/pkg/generator/mode_prod.go
@@ -1,0 +1,11 @@
+// +build !dev
+
+package generator
+
+import (
+	"net/http"
+)
+
+func GetAssetsFS() http.FileSystem {
+	return assets
+}


### PR DESCRIPTION
This lets you have quicker cycles on if your testing from your desktop.  But if if it’s compiled into prod mode, it panics since it can’t find the source files.