### PR TITLE
fix(connector): support named authentication type

### DIFF
--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizer.java
@@ -30,7 +30,8 @@ public class AuthenticationCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(final ComponentProxyComponent proxyComponent, final Map<String, Object> options) {
         consumeOption(options, "authenticationType", authenticationTypeObject -> {
-            final AuthenticationType authenticationType = AuthenticationType.valueOf(String.valueOf(authenticationTypeObject));
+            final String authenticationTypeAsString = String.valueOf(authenticationTypeObject);
+            final AuthenticationType authenticationType = AuthenticationType.fromString(authenticationTypeAsString);
             if (authenticationType == AuthenticationType.none) {
                 return;
             }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.rest.swagger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
@@ -147,6 +148,40 @@ public class AuthenticationCustomizerTest {
         assertThat(options).doesNotContainKeys("authenticationType", "accessToken", "refreshToken", "authorizationEndpoint");
 
         assertAuthorizationHeaderSetTo(component, "Bearer new-access-token");
+    }
+
+    @Test
+    public void shouldSupportAllAuthenticatioValues() {
+        final ComponentProxyComponent component = new SwaggerProxyComponent("test", "test");
+        final CamelContext context = mock(CamelContext.class);
+        component.setCamelContext(context);
+
+        final AuthenticationCustomizer customizer = new AuthenticationCustomizer();
+
+        Stream.of(AuthenticationType.values()).forEach(authenticationType -> {
+            final Map<String, Object> options = new HashMap<>();
+            options.put("authenticationType", authenticationType.name());
+
+            customizer.customize(component, options);
+            // no IllegalStateException thrown
+        });
+    }
+
+    @Test
+    public void shouldSupportNamedAuthenticatioValues() {
+        final ComponentProxyComponent component = new SwaggerProxyComponent("test", "test");
+        final CamelContext context = mock(CamelContext.class);
+        component.setCamelContext(context);
+
+        final AuthenticationCustomizer customizer = new AuthenticationCustomizer();
+
+        Stream.of(AuthenticationType.values()).forEach(authenticationType -> {
+            final Map<String, Object> options = new HashMap<>();
+            options.put("authenticationType", authenticationType.name() + ":name");
+
+            customizer.customize(component, options);
+            // no IllegalStateException thrown
+        });
     }
 
     private static void assertAuthorizationHeaderSetTo(final ComponentProxyComponent component, final String value) throws Exception {


### PR DESCRIPTION
Due to the change in how the values for `authenticationType` option are configured, the support for named security definitions, the connector customizer for authentication needs to handle conversion from String to `AuthenticationType` enum differently -- using `AuthenticationType::fromString` method.

Fixes #5900