### PR TITLE
Use maven-deploy-plugin 2.8.2, 3.0-M1 not backwards compatible…

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -47,6 +47,7 @@
 
     <fabric8.maven.plugin.version>3.5.38</fabric8.maven.plugin.version>
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
+    <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
     <node.version>v10.15.1</node.version>


### PR DESCRIPTION
Use maven-deploy-plugin 2.8.2, 3.0-M1 not backwards compatible for altDeploymentRepository