### PR TITLE
Fix Jira connector validation

### DIFF
--- a/app/connector/jira/pom.xml
+++ b/app/connector/jira/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>jira-rest-java-client-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         <!-- atlassian-util-concurrent is a dependency of jira-rest-java-client-api but dependency:analyze show as warning when scope=compile -->
         <dependency>
             <groupId>io.atlassian.util.concurrent</groupId>


### PR DESCRIPTION
Fix Jira connector validation. Previously the angular-ui didn't send the "password" parameter, now the react-ui sends an empty username/password that needs to be checked. Without this fix, when the user correctly set the oauth parameters, as the username/password takes precedence and are only checked for null, the verify connection will fail.