### PR TITLE
refactor: don't use flow id to correlate API operations

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
@@ -20,5 +20,5 @@ package io.syndesis.common.model;
  */
 public class Schema {
     // changing this will reset all the DB data.
-    public static final int VERSION = 29;
+    public static final int VERSION = 30;
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
@@ -21,10 +21,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.immutables.value.Value;
 
 import io.syndesis.common.model.ToJson;
 import io.syndesis.common.model.WithId;
@@ -39,6 +38,9 @@ import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.util.json.OptionalStringTrimmingConverter;
+
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -160,4 +162,11 @@ public interface IntegrationBase extends WithProperties, WithResourceId, WithVer
             .filter(flow -> id.equals(flow.getId().get()))
             .findFirst();
     }
+
+    default Optional<Flow> findFlowBy(final Predicate<Flow> p) {
+        return getFlows().stream()
+            .filter(p)
+            .findFirst();
+    }
+
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/openapi/OpenApi.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/openapi/OpenApi.java
@@ -30,6 +30,8 @@ import org.immutables.value.Value;
 @SuppressWarnings("immutables")
 public interface OpenApi extends WithId<OpenApi>, WithName, WithVersion, WithMetadata, Serializable {
 
+    String OPERATION_ID = "openapi-operationid";
+
     @Override
     default Kind getKind() {
         return Kind.OpenApi;

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGenerator.java
@@ -65,9 +65,9 @@ import static java.util.Optional.ofNullable;
 public class SwaggerAPIGenerator implements APIGenerator {
 
     private static final String DEFAULT_RETURN_CODE_METADATA_KEY = "default-return-code";
-    private static final String HTTP_RESPONSE_CODE_METADATA_KEY = "httpResponseCode";
-
     private static final String EXCERPT_METADATA_KEY = "excerpt";
+
+    private static final String HTTP_RESPONSE_CODE_METADATA_KEY = "httpResponseCode";
 
     private final DataShapeGenerator dataShapeGenerator;
 
@@ -85,10 +85,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
             .flatMap(i -> ofNullable(i.getTitle()))
             .orElse(null);
 
-        final String integrationId = KeyGenerator.createKey();
-
-        Integration.Builder integration = new Integration.Builder()
-            .id(integrationId)
+        final Integration.Builder integration = new Integration.Builder()
             .addTag("api-provider")
             .createdAt(System.currentTimeMillis())
             .name(name);
@@ -169,9 +166,12 @@ public class SwaggerAPIGenerator implements APIGenerator {
                     defaultCode = defaultResponse.get().getKey();
                 }
 
+                final String flowId = KeyGenerator.createKey();
+
                 final Flow flow = new Flow.Builder()
-                    .id(String.format("%s:flows:%s", integrationId, operationId))
+                    .id(flowId)
                     .type(Flow.FlowType.API_PROVIDER)
+                    .putMetadata(OpenApi.OPERATION_ID, operationId)
                     .putMetadata(EXCERPT_METADATA_KEY, "501 Not Implemented")
                     .putMetadata(DEFAULT_RETURN_CODE_METADATA_KEY, defaultCode)
                     .addStep(startStep)
@@ -180,7 +180,7 @@ public class SwaggerAPIGenerator implements APIGenerator {
                     .description(operationDescription)
                     .build();
 
-                integration = integration.addFlow(flow);
+                integration.addFlow(flow);
             }
 
         }

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/SwaggerAPIGeneratorTest.java
@@ -25,6 +25,7 @@ import io.syndesis.common.model.api.APISummary;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.server.api.generator.APIIntegration;
 import io.syndesis.server.api.generator.APIValidationContext;
 import io.syndesis.server.api.generator.ProvidedApiTemplate;
@@ -81,9 +82,9 @@ public class SwaggerAPIGeneratorTest {
 
         final List<Flow> flows = apiIntegration.getIntegration().getFlows();
 
-        assertThat(flows).filteredOn(idEndsWith("-1")).first().hasFieldOrPropertyWithValue("name", "Receiving GET request on /hi");
-        assertThat(flows).filteredOn(idEndsWith("-2")).first().hasFieldOrPropertyWithValue("name", "post operation");
-        assertThat(flows).filteredOn(idEndsWith("-3")).first().hasFieldOrPropertyWithValue("name", "Receiving PUT request on /hi");
+        assertThat(flows).filteredOn(operationIdEquals("operation-1")).first().hasFieldOrPropertyWithValue("name", "Receiving GET request on /hi");
+        assertThat(flows).filteredOn(operationIdEquals("operation-2")).first().hasFieldOrPropertyWithValue("name", "post operation");
+        assertThat(flows).filteredOn(operationIdEquals("operation-3")).first().hasFieldOrPropertyWithValue("name", "Receiving PUT request on /hi");
     }
 
     private static Connection dummyConnection() {
@@ -101,7 +102,7 @@ public class SwaggerAPIGeneratorTest {
         return new Connection.Builder().connector(connector).build();
     }
 
-    private static Predicate<Flow> idEndsWith(final String end) {
-        return f -> f.getId().map(id -> id.endsWith(end)).orElse(false);
+    private static Predicate<Flow> operationIdEquals(final String operationId) {
+        return f -> f.getMetadata(OpenApi.OPERATION_ID).map(id -> id.equals(operationId)).orElse(false);
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelperTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelperTest.java
@@ -17,7 +17,6 @@ package io.syndesis.server.endpoint.v1.handler.api;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import io.syndesis.common.model.DataShape;
@@ -27,6 +26,7 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.openapi.OpenApi;
 
 import org.junit.Test;
 
@@ -42,9 +42,9 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow flow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
-        final Flow flow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
-        final Flow flow3 = new Flow.Builder().id("flow3").addSteps(step, step).build();
+        final Flow flow1 = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").addSteps(step, step).build();
+        final Flow flow2 = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow2").addSteps(step, step).build();
+        final Flow flow3 = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow3").addSteps(step, step).build();
 
         final Integration existing = new Integration.Builder().addFlows(flow1, flow3).build();
         final Integration given = new Integration.Builder().addFlows(flow1, flow2, flow3).build();
@@ -62,7 +62,7 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
+        final Flow flow = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").addSteps(step, step).build();
 
         final Integration existing = new Integration.Builder().build();
         final Integration given = new Integration.Builder().addFlow(flow).build();
@@ -80,8 +80,8 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow existingFlow1 = new Flow.Builder().id("flow1").addSteps(step, step).build();
-        final Flow existingFlow2 = new Flow.Builder().id("flow2").addSteps(step, step).build();
+        final Flow existingFlow1 = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").addSteps(step, step).build();
+        final Flow existingFlow2 = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow2").addSteps(step, step).build();
 
         final Integration existing = new Integration.Builder().addFlows(existingFlow1, existingFlow2).build();
         final Integration given = new Integration.Builder().addFlow(existingFlow2).build();
@@ -110,18 +110,6 @@ public class ApiGeneratorHelperTest {
     }
 
     @Test
-    public void shouldMaintainSameIntegrationPrefixForFlowIds() {
-        final Integration existing = new Integration.Builder().id("existing").build();
-
-        final List<Flow> flows = Arrays.asList(new Flow.Builder().id("generated:flows:operation-1").build(),
-            new Flow.Builder().id("generated:flows:operation-2").build());
-
-        final Iterable<Flow> sameIntegrationPrefixFlows = ApiGeneratorHelper.withSameIntegrationIdPrefix(existing, flows);
-
-        assertThat(sameIntegrationPrefixFlows).allMatch(f -> f.getId().get().startsWith("existing:flows:operation-"));
-    }
-
-    @Test
     public void shouldUpdateFlowNameAndDescription() {
         final Step step = new Step.Builder()
             .action(new ConnectorAction.Builder()
@@ -129,8 +117,9 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow flow = new Flow.Builder().id("flow1").name("name").description("description").addSteps(step, step).build();
-        final Flow flowUpdated = new Flow.Builder().id("flow1").name("updated name").description("updated description").addSteps(step, step).build();
+        final Flow flow = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").name("name").description("description").addSteps(step, step).build();
+        final Flow flowUpdated = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").name("updated name").description("updated description")
+            .addSteps(step, step).build();
 
         final Integration existing = new Integration.Builder().addFlow(flow).build();
         final Integration given = new Integration.Builder().addFlow(flowUpdated).build();
@@ -177,7 +166,7 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow existingFlow = new Flow.Builder().id("flow1").addSteps(startStep, stepWithShapes, endStep).build();
+        final Flow existingFlow = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").addSteps(startStep, stepWithShapes, endStep).build();
         final Integration existing = new Integration.Builder().addFlow(existingFlow).build();
 
         final DataShape givenStartShape = new DataShape.Builder()
@@ -193,7 +182,7 @@ public class ApiGeneratorHelperTest {
         final Step givenStartStep = startStep.updateOutputDataShape(Optional.of(givenStartShape));
         final Step givenEndStep = endStep.updateInputDataShape(Optional.of(givenEndShape));
         final Flow givenFlow = new Flow.Builder()
-            .id("flow1")
+            .putMetadata(OpenApi.OPERATION_ID, "flow1")
             .steps(Arrays.asList(
                 givenStartStep,
                 givenEndStep))
@@ -203,7 +192,7 @@ public class ApiGeneratorHelperTest {
         final Integration updated = ApiGeneratorHelper.updateFlowsAndStartAndEndDataShapes(existing, given);
 
         final Flow expectedFlow = new Flow.Builder()
-            .id("flow1")
+            .putMetadata(OpenApi.OPERATION_ID, "flow1")
             .steps(Arrays.asList(
                 givenStartStep,
                 stepWithShapes,
@@ -224,7 +213,7 @@ public class ApiGeneratorHelperTest {
                 .build())
             .build();
 
-        final Flow flow = new Flow.Builder().id("flow1").addSteps(step, step).build();
+        final Flow flow = new Flow.Builder().putMetadata(OpenApi.OPERATION_ID, "flow1").addSteps(step, step).build();
 
         final Integration existing = new Integration.Builder().addFlow(flow).build();
         final Integration given = new Integration.Builder().addFlow(flow).build();

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationSpecificationHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationSpecificationHandlerTest.java
@@ -78,9 +78,25 @@ public class IntegrationSpecificationHandlerTest {
 
     @Test
     public void shouldPerformUpdatesBasedOnNewSpecification() {
-        final Integration existing = new Integration.Builder().id("integration-1").addFlow(new Flow.Builder().id("integration-1:flows:flow1").build()).build();
-        final Integration given = new Integration.Builder().id("integration-2").addFlow(new Flow.Builder().id("integration-2:flows:flow2").build()).build();
-        final Integration expected = new Integration.Builder().id("integration-1").addFlow(new Flow.Builder().id("integration-1:flows:flow2").build()).build();
+        final Integration existing = new Integration.Builder().id("integration-1")
+            .addFlow(new Flow.Builder()
+                .putMetadata(OpenApi.OPERATION_ID, "flow1")
+                .build())
+            .build();
+
+        final Integration given = new Integration.Builder()
+            .id("integration-2")
+            .addFlow(new Flow.Builder()
+                .putMetadata(OpenApi.OPERATION_ID, "flow2")
+                .build())
+            .build();
+
+        final Integration expected = new Integration.Builder()
+            .id("integration-1")
+            .addFlow(new Flow.Builder()
+                .putMetadata(OpenApi.OPERATION_ID, "flow2")
+                .build())
+            .build();
 
         final OpenApi updatedSpecification = new OpenApi.Builder().build();
         final APIIntegration updatedApiIntegration = new APIIntegration(given, updatedSpecification);
@@ -166,7 +182,7 @@ public class IntegrationSpecificationHandlerTest {
         final Integration integration = new Integration.Builder()
             .id("integration-1")
             .addFlow(new Flow.Builder()
-                .id("integration-1:flows:flow1")
+                .putMetadata(OpenApi.OPERATION_ID, "flow1")
                 .addSteps(step, step)
                 .build())
             .build();

--- a/app/server/runtime/src/main/resources/migrations/up-30.js
+++ b/app/server/runtime/src/main/resources/migrations/up-30.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Helpers
+//
+var migrate = function(type, path, consumer) {
+    console.log("Start " + type + " migration")
+
+    var migrated  = 0;
+    var inspected = 0;
+    var elements  = jsondb.get(path);
+
+    if (elements) {
+        Object.keys(elements).forEach(function(elementId) {
+            inspected++;
+
+            if (consumer(elements[elementId])) {
+                migrated++;
+            }
+        });
+
+        if (migrated > 0) {
+            jsondb.update(path, elements);
+        }
+    }
+
+    console.log(type + ": migrated " + migrated + " out of " + inspected);
+}
+
+//
+// Migration
+//
+
+var KeyGenerator = Java.type('io.syndesis.common.util.KeyGenerator')
+
+console.log("Migration to schema 30 ...");
+migrate("integrations", "/integrations", function(integration) {
+    var changed = false;
+    if (integration.flows) {
+        integration.flows.forEach(function (flow) {
+            var parts = /.+:flows:(.+)/.exec(flow.id);
+            if (parts && parts.length > 1) {
+                var operationId = parts[1];
+                flow.id = KeyGenerator.createKey()
+                flow.metadata['openapi-operationid'] = operationId;
+
+                changed = true;
+            }
+        });
+    }
+
+    return changed;
+});
+
+console.log("Migrated to schema 30 completed");

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationSpecificationITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationSpecificationITCase.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 
 import io.swagger.util.Json;
 import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.server.runtime.BaseITCase;
 
 import org.json.JSONException;
@@ -50,9 +51,12 @@ public class IntegrationSpecificationITCase extends BaseITCase {
             MULTIPART);
 
         final Integration integration = integrationResponse.getBody();
-        dataManager.create(integration);
+        final String integrationId = KeyGenerator.createKey();
+        dataManager.create(integration.builder()
+            .id(integrationId)
+            .build());
 
-        final ResponseEntity<ByteArrayResource> specificationResponse = get("/api/v1/integrations/" + integration.getId().get() + "/specification",
+        final ResponseEntity<ByteArrayResource> specificationResponse = get("/api/v1/integrations/" + integrationId + "/specification",
             ByteArrayResource.class);
 
         assertThat(specificationResponse.getHeaders().getContentType()).isEqualTo(MediaType.valueOf("application/vnd.oai.openapi+json"));
@@ -75,9 +79,12 @@ public class IntegrationSpecificationITCase extends BaseITCase {
             MULTIPART);
 
         final Integration integration = integrationResponse.getBody();
-        dataManager.create(integration);
+        final String integrationId = KeyGenerator.createKey();
+        dataManager.create(integration.builder()
+            .id(integrationId)
+            .build());
 
-        final ResponseEntity<ByteArrayResource> specificationResponse = get("/api/v1/integrations/" + integration.getId().get() + "/specification",
+        final ResponseEntity<ByteArrayResource> specificationResponse = get("/api/v1/integrations/" + integrationId + "/specification",
             ByteArrayResource.class);
 
         assertThat(specificationResponse.getHeaders().getContentType()).isEqualTo(MediaType.valueOf("application/vnd.oai.openapi"));

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.runtime.migrations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.syndesis.common.util.Json;
+import io.syndesis.server.jsondb.JsonDB;
+
+final class MigrationsHelper {
+
+    static <T> List<T> load(final JsonDB jsondb, final String path, final Class<T> type) throws IOException {
+        final List<T> items = new ArrayList<>();
+        final String raw = jsondb.getAsString(path);
+
+        Json.reader().readTree(raw).fieldNames().forEachRemaining(id -> {
+            try {
+                final String itemRaw = jsondb.getAsString(path + "/" + id);
+                final T item = Json.reader().forType(type).readValue(itemRaw);
+
+                items.add(item);
+            } catch (final IOException e) {
+                throw new RuntimeException();
+            }
+        });
+
+        return items;
+    }
+
+}

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion30Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion30Test.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.runtime.migrations;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.openapi.OpenApi;
+import io.syndesis.server.jsondb.CloseableJsonDB;
+import io.syndesis.server.jsondb.dao.Migrator;
+import io.syndesis.server.jsondb.impl.MemorySqlJsonDB;
+import io.syndesis.server.runtime.DefaultMigrator;
+
+import org.junit.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import static io.syndesis.server.runtime.migrations.MigrationsHelper.load;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpgradeVersion30Test {
+
+    @Test
+    public void shouldPerformSchemaUpgrade() throws IOException {
+        try (CloseableJsonDB jsondb = MemorySqlJsonDB.create(Collections.emptyList());
+            InputStream data = UpgradeVersion30Test.class.getResourceAsStream("/migrations/30/integration.json")) {
+
+            jsondb.push("/integrations", data);
+
+            final Migrator migrator = new DefaultMigrator(new DefaultResourceLoader());
+            migrator.migrate(jsondb, 30);
+
+            final List<Integration> integrations = load(jsondb, "/integrations", Integration.class);
+
+            // integrations
+            assertThat(integrations).hasSize(1).allSatisfy(integration -> {
+                assertThat(integration.getFlows()).allSatisfy(flow -> {
+                    assertThat(flow.getId()).hasValueSatisfying(id -> assertThat(id).doesNotContain(":"));
+                    assertThat(flow.getMetadata(OpenApi.OPERATION_ID)).isPresent();
+                });
+            });
+        }
+    }
+
+}

--- a/app/server/runtime/src/test/resources/migrations/30/integration.json
+++ b/app/server/runtime/src/test/resources/migrations/30/integration.json
@@ -1,0 +1,5738 @@
+{
+  "id": "i-LhBSmGn6AjytuGiCOTEz",
+  "version": 3,
+  "createdAt": 1560356004979,
+  "updatedAt": 1560356172889,
+  "tags": [
+    "api-provider"
+  ],
+  "name": "api 1",
+  "resources": [
+    {
+      "id": "i-LhBSk806AjytuGiCOTDz",
+      "kind": "open-api"
+    }
+  ],
+  "flows": [
+    {
+      "name": "List All names",
+      "id": "i-LhBSk7z6AjytuGiCOT2z:flows:getnames",
+      "steps": [
+        {
+          "id": "i-LhBSk7z6AjytuGiCOT3z",
+          "configuredProperties": {
+            "name": "getnames"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-start",
+            "name": "Provided API",
+            "description": "Start a Syndesis integration from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "name": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The operation ID as defined in the API spec",
+                      "displayName": "Operation ID",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "componentScheme": "direct",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+              ]
+            },
+            "tags": [
+              "expose"
+            ],
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT4z",
+          "configuredProperties": {
+            "httpResponseCode": "501"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-end",
+            "name": "Provided API Return Path",
+            "description": "End action of Syndesis integrations that start from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "name": "Response",
+                "description": "API response payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"            \",\"properties\":{\"name\":{\"type\":\"string\"}},\"example\":\"{\\\"name\\\":\\\"gary\\\"}\"}}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string",
+                      "enum": [
+                        {
+                          "label": "100 Continue",
+                          "value": "100"
+                        },
+                        {
+                          "label": "101 Switching Protocols",
+                          "value": "101"
+                        },
+                        {
+                          "label": "102 Processing",
+                          "value": "102"
+                        },
+                        {
+                          "label": "103 Early Hints",
+                          "value": "103"
+                        },
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "203 Non-Authoritative Information",
+                          "value": "203"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        },
+                        {
+                          "label": "205 Reset Content",
+                          "value": "205"
+                        },
+                        {
+                          "label": "206 Partial Content",
+                          "value": "206"
+                        },
+                        {
+                          "label": "207 Multi-Status",
+                          "value": "207"
+                        },
+                        {
+                          "label": "208 Already Reported",
+                          "value": "208"
+                        },
+                        {
+                          "label": "226 IM Used",
+                          "value": "226"
+                        },
+                        {
+                          "label": "300 Multiple Choices",
+                          "value": "300"
+                        },
+                        {
+                          "label": "301 Moved Permanently",
+                          "value": "301"
+                        },
+                        {
+                          "label": "302 Found",
+                          "value": "302"
+                        },
+                        {
+                          "label": "303 See Other",
+                          "value": "303"
+                        },
+                        {
+                          "label": "304 Not Modified",
+                          "value": "304"
+                        },
+                        {
+                          "label": "305 Use Proxy",
+                          "value": "305"
+                        },
+                        {
+                          "label": "306 Switch Proxy",
+                          "value": "306"
+                        },
+                        {
+                          "label": "307 Temporary Redirect",
+                          "value": "307"
+                        },
+                        {
+                          "label": "308 Permanent Redirect",
+                          "value": "308"
+                        },
+                        {
+                          "label": "400 Bad Request",
+                          "value": "400"
+                        },
+                        {
+                          "label": "401 Unauthorized",
+                          "value": "401"
+                        },
+                        {
+                          "label": "402 Payment Required",
+                          "value": "402"
+                        },
+                        {
+                          "label": "403 Forbidden",
+                          "value": "403"
+                        },
+                        {
+                          "label": "404 Not Found",
+                          "value": "404"
+                        },
+                        {
+                          "label": "405 Method Not Allowed",
+                          "value": "405"
+                        },
+                        {
+                          "label": "406 Not Acceptable",
+                          "value": "406"
+                        },
+                        {
+                          "label": "407 Proxy Authentication Required",
+                          "value": "407"
+                        },
+                        {
+                          "label": "408 Request Timeout",
+                          "value": "408"
+                        },
+                        {
+                          "label": "409 Conflict",
+                          "value": "409"
+                        },
+                        {
+                          "label": "410 Gone",
+                          "value": "410"
+                        },
+                        {
+                          "label": "411 Length Required",
+                          "value": "411"
+                        },
+                        {
+                          "label": "412 Precondition Failed",
+                          "value": "412"
+                        },
+                        {
+                          "label": "413 Payload Too Large",
+                          "value": "413"
+                        },
+                        {
+                          "label": "414 URI Too Long",
+                          "value": "414"
+                        },
+                        {
+                          "label": "415 Unsupported Media Type",
+                          "value": "415"
+                        },
+                        {
+                          "label": "416 Range Not Satisfiable",
+                          "value": "416"
+                        },
+                        {
+                          "label": "417 Expectation Failed",
+                          "value": "417"
+                        },
+                        {
+                          "label": "418 I'm a teapot",
+                          "value": "418"
+                        },
+                        {
+                          "label": "421 Misdirected Request",
+                          "value": "421"
+                        },
+                        {
+                          "label": "422 Unprocessable Entity",
+                          "value": "422"
+                        },
+                        {
+                          "label": "423 Locked",
+                          "value": "423"
+                        },
+                        {
+                          "label": "424 Failed Dependency",
+                          "value": "424"
+                        },
+                        {
+                          "label": "426 Upgrade Required",
+                          "value": "426"
+                        },
+                        {
+                          "label": "428 Precondition Required",
+                          "value": "428"
+                        },
+                        {
+                          "label": "429 Too Many Requests",
+                          "value": "429"
+                        },
+                        {
+                          "label": "431 Request Header Fields Too Large",
+                          "value": "431"
+                        },
+                        {
+                          "label": "451 Unavailable For Legal Reasons",
+                          "value": "451"
+                        },
+                        {
+                          "label": "500 Internal Server Error",
+                          "value": "500"
+                        },
+                        {
+                          "label": "501 Not Implemented",
+                          "value": "501"
+                        },
+                        {
+                          "label": "502 Bad Gateway",
+                          "value": "502"
+                        },
+                        {
+                          "label": "503 Service Unavailable",
+                          "value": "503"
+                        },
+                        {
+                          "label": "504 Gateway Timeout",
+                          "value": "504"
+                        },
+                        {
+                          "label": "505 HTTP Version Not Supported",
+                          "value": "505"
+                        },
+                        {
+                          "label": "506 Variant Also Negotiates",
+                          "value": "506"
+                        },
+                        {
+                          "label": "507 Insufficient Storage",
+                          "value": "507"
+                        },
+                        {
+                          "label": "508 Loop Detected",
+                          "value": "508"
+                        },
+                        {
+                          "label": "510 Not Extended",
+                          "value": "510"
+                        },
+                        {
+                          "label": "511 Network Authentication Required",
+                          "value": "511"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "configuredProperties": {
+                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                "method": "process"
+              },
+              "componentScheme": "bean",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+              ]
+            },
+            "actionType": "connector",
+            "pattern": "To"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        }
+      ],
+      "metadata": {
+        "default-return-code": "200",
+        "excerpt": "501 Not Implemented"
+      },
+      "type": "API_PROVIDER",
+      "description": "GET /names"
+    },
+    {
+      "name": "Create a name",
+      "id": "i-LhBSk7z6AjytuGiCOT2z:flows:createname",
+      "steps": [
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT5z",
+          "configuredProperties": {
+            "name": "createname"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-start",
+            "name": "Provided API",
+            "description": "Start a Syndesis integration from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "name": "Request",
+                "description": "API request payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"            \",\"properties\":{\"name\":{\"type\":\"string\"}},\"example\":\"{\\\"name\\\":\\\"gary\\\"}\"}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "name": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The operation ID as defined in the API spec",
+                      "displayName": "Operation ID",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "componentScheme": "direct",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+              ]
+            },
+            "tags": [
+              "expose"
+            ],
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT6z",
+          "configuredProperties": {
+            "httpResponseCode": "501"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-end",
+            "name": "Provided API Return Path",
+            "description": "End action of Syndesis integrations that start from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string",
+                      "enum": [
+                        {
+                          "label": "100 Continue",
+                          "value": "100"
+                        },
+                        {
+                          "label": "101 Switching Protocols",
+                          "value": "101"
+                        },
+                        {
+                          "label": "102 Processing",
+                          "value": "102"
+                        },
+                        {
+                          "label": "103 Early Hints",
+                          "value": "103"
+                        },
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "203 Non-Authoritative Information",
+                          "value": "203"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        },
+                        {
+                          "label": "205 Reset Content",
+                          "value": "205"
+                        },
+                        {
+                          "label": "206 Partial Content",
+                          "value": "206"
+                        },
+                        {
+                          "label": "207 Multi-Status",
+                          "value": "207"
+                        },
+                        {
+                          "label": "208 Already Reported",
+                          "value": "208"
+                        },
+                        {
+                          "label": "226 IM Used",
+                          "value": "226"
+                        },
+                        {
+                          "label": "300 Multiple Choices",
+                          "value": "300"
+                        },
+                        {
+                          "label": "301 Moved Permanently",
+                          "value": "301"
+                        },
+                        {
+                          "label": "302 Found",
+                          "value": "302"
+                        },
+                        {
+                          "label": "303 See Other",
+                          "value": "303"
+                        },
+                        {
+                          "label": "304 Not Modified",
+                          "value": "304"
+                        },
+                        {
+                          "label": "305 Use Proxy",
+                          "value": "305"
+                        },
+                        {
+                          "label": "306 Switch Proxy",
+                          "value": "306"
+                        },
+                        {
+                          "label": "307 Temporary Redirect",
+                          "value": "307"
+                        },
+                        {
+                          "label": "308 Permanent Redirect",
+                          "value": "308"
+                        },
+                        {
+                          "label": "400 Bad Request",
+                          "value": "400"
+                        },
+                        {
+                          "label": "401 Unauthorized",
+                          "value": "401"
+                        },
+                        {
+                          "label": "402 Payment Required",
+                          "value": "402"
+                        },
+                        {
+                          "label": "403 Forbidden",
+                          "value": "403"
+                        },
+                        {
+                          "label": "404 Not Found",
+                          "value": "404"
+                        },
+                        {
+                          "label": "405 Method Not Allowed",
+                          "value": "405"
+                        },
+                        {
+                          "label": "406 Not Acceptable",
+                          "value": "406"
+                        },
+                        {
+                          "label": "407 Proxy Authentication Required",
+                          "value": "407"
+                        },
+                        {
+                          "label": "408 Request Timeout",
+                          "value": "408"
+                        },
+                        {
+                          "label": "409 Conflict",
+                          "value": "409"
+                        },
+                        {
+                          "label": "410 Gone",
+                          "value": "410"
+                        },
+                        {
+                          "label": "411 Length Required",
+                          "value": "411"
+                        },
+                        {
+                          "label": "412 Precondition Failed",
+                          "value": "412"
+                        },
+                        {
+                          "label": "413 Payload Too Large",
+                          "value": "413"
+                        },
+                        {
+                          "label": "414 URI Too Long",
+                          "value": "414"
+                        },
+                        {
+                          "label": "415 Unsupported Media Type",
+                          "value": "415"
+                        },
+                        {
+                          "label": "416 Range Not Satisfiable",
+                          "value": "416"
+                        },
+                        {
+                          "label": "417 Expectation Failed",
+                          "value": "417"
+                        },
+                        {
+                          "label": "418 I'm a teapot",
+                          "value": "418"
+                        },
+                        {
+                          "label": "421 Misdirected Request",
+                          "value": "421"
+                        },
+                        {
+                          "label": "422 Unprocessable Entity",
+                          "value": "422"
+                        },
+                        {
+                          "label": "423 Locked",
+                          "value": "423"
+                        },
+                        {
+                          "label": "424 Failed Dependency",
+                          "value": "424"
+                        },
+                        {
+                          "label": "426 Upgrade Required",
+                          "value": "426"
+                        },
+                        {
+                          "label": "428 Precondition Required",
+                          "value": "428"
+                        },
+                        {
+                          "label": "429 Too Many Requests",
+                          "value": "429"
+                        },
+                        {
+                          "label": "431 Request Header Fields Too Large",
+                          "value": "431"
+                        },
+                        {
+                          "label": "451 Unavailable For Legal Reasons",
+                          "value": "451"
+                        },
+                        {
+                          "label": "500 Internal Server Error",
+                          "value": "500"
+                        },
+                        {
+                          "label": "501 Not Implemented",
+                          "value": "501"
+                        },
+                        {
+                          "label": "502 Bad Gateway",
+                          "value": "502"
+                        },
+                        {
+                          "label": "503 Service Unavailable",
+                          "value": "503"
+                        },
+                        {
+                          "label": "504 Gateway Timeout",
+                          "value": "504"
+                        },
+                        {
+                          "label": "505 HTTP Version Not Supported",
+                          "value": "505"
+                        },
+                        {
+                          "label": "506 Variant Also Negotiates",
+                          "value": "506"
+                        },
+                        {
+                          "label": "507 Insufficient Storage",
+                          "value": "507"
+                        },
+                        {
+                          "label": "508 Loop Detected",
+                          "value": "508"
+                        },
+                        {
+                          "label": "510 Not Extended",
+                          "value": "510"
+                        },
+                        {
+                          "label": "511 Network Authentication Required",
+                          "value": "511"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "configuredProperties": {
+                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                "method": "process"
+              },
+              "componentScheme": "bean",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+              ]
+            },
+            "actionType": "connector",
+            "pattern": "To"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        }
+      ],
+      "metadata": {
+        "default-return-code": "200",
+        "excerpt": "501 Not Implemented"
+      },
+      "type": "API_PROVIDER",
+      "description": "POST /names"
+    },
+    {
+      "name": "Get a name",
+      "id": "i-LhBSk7z6AjytuGiCOT2z:flows:getname",
+      "steps": [
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT7z",
+          "configuredProperties": {
+            "name": "getname"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-start",
+            "name": "Provided API",
+            "description": "Start a Syndesis integration from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "name": "Request",
+                "description": "API request payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"nameId\":{\"type\":\"string\",\"title\":\"nameId\",\"description\":\"A unique identifier for a `name`.\"}}}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "name": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The operation ID as defined in the API spec",
+                      "displayName": "Operation ID",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "componentScheme": "direct",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+              ]
+            },
+            "tags": [
+              "expose"
+            ],
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT8z",
+          "configuredProperties": {
+            "httpResponseCode": "501"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-end",
+            "name": "Provided API Return Path",
+            "description": "End action of Syndesis integrations that start from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "name": "Response",
+                "description": "API response payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"            \",\"properties\":{\"name\":{\"type\":\"string\"}},\"example\":\"{\\\"name\\\":\\\"gary\\\"}\"}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string",
+                      "enum": [
+                        {
+                          "label": "100 Continue",
+                          "value": "100"
+                        },
+                        {
+                          "label": "101 Switching Protocols",
+                          "value": "101"
+                        },
+                        {
+                          "label": "102 Processing",
+                          "value": "102"
+                        },
+                        {
+                          "label": "103 Early Hints",
+                          "value": "103"
+                        },
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "203 Non-Authoritative Information",
+                          "value": "203"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        },
+                        {
+                          "label": "205 Reset Content",
+                          "value": "205"
+                        },
+                        {
+                          "label": "206 Partial Content",
+                          "value": "206"
+                        },
+                        {
+                          "label": "207 Multi-Status",
+                          "value": "207"
+                        },
+                        {
+                          "label": "208 Already Reported",
+                          "value": "208"
+                        },
+                        {
+                          "label": "226 IM Used",
+                          "value": "226"
+                        },
+                        {
+                          "label": "300 Multiple Choices",
+                          "value": "300"
+                        },
+                        {
+                          "label": "301 Moved Permanently",
+                          "value": "301"
+                        },
+                        {
+                          "label": "302 Found",
+                          "value": "302"
+                        },
+                        {
+                          "label": "303 See Other",
+                          "value": "303"
+                        },
+                        {
+                          "label": "304 Not Modified",
+                          "value": "304"
+                        },
+                        {
+                          "label": "305 Use Proxy",
+                          "value": "305"
+                        },
+                        {
+                          "label": "306 Switch Proxy",
+                          "value": "306"
+                        },
+                        {
+                          "label": "307 Temporary Redirect",
+                          "value": "307"
+                        },
+                        {
+                          "label": "308 Permanent Redirect",
+                          "value": "308"
+                        },
+                        {
+                          "label": "400 Bad Request",
+                          "value": "400"
+                        },
+                        {
+                          "label": "401 Unauthorized",
+                          "value": "401"
+                        },
+                        {
+                          "label": "402 Payment Required",
+                          "value": "402"
+                        },
+                        {
+                          "label": "403 Forbidden",
+                          "value": "403"
+                        },
+                        {
+                          "label": "404 Not Found",
+                          "value": "404"
+                        },
+                        {
+                          "label": "405 Method Not Allowed",
+                          "value": "405"
+                        },
+                        {
+                          "label": "406 Not Acceptable",
+                          "value": "406"
+                        },
+                        {
+                          "label": "407 Proxy Authentication Required",
+                          "value": "407"
+                        },
+                        {
+                          "label": "408 Request Timeout",
+                          "value": "408"
+                        },
+                        {
+                          "label": "409 Conflict",
+                          "value": "409"
+                        },
+                        {
+                          "label": "410 Gone",
+                          "value": "410"
+                        },
+                        {
+                          "label": "411 Length Required",
+                          "value": "411"
+                        },
+                        {
+                          "label": "412 Precondition Failed",
+                          "value": "412"
+                        },
+                        {
+                          "label": "413 Payload Too Large",
+                          "value": "413"
+                        },
+                        {
+                          "label": "414 URI Too Long",
+                          "value": "414"
+                        },
+                        {
+                          "label": "415 Unsupported Media Type",
+                          "value": "415"
+                        },
+                        {
+                          "label": "416 Range Not Satisfiable",
+                          "value": "416"
+                        },
+                        {
+                          "label": "417 Expectation Failed",
+                          "value": "417"
+                        },
+                        {
+                          "label": "418 I'm a teapot",
+                          "value": "418"
+                        },
+                        {
+                          "label": "421 Misdirected Request",
+                          "value": "421"
+                        },
+                        {
+                          "label": "422 Unprocessable Entity",
+                          "value": "422"
+                        },
+                        {
+                          "label": "423 Locked",
+                          "value": "423"
+                        },
+                        {
+                          "label": "424 Failed Dependency",
+                          "value": "424"
+                        },
+                        {
+                          "label": "426 Upgrade Required",
+                          "value": "426"
+                        },
+                        {
+                          "label": "428 Precondition Required",
+                          "value": "428"
+                        },
+                        {
+                          "label": "429 Too Many Requests",
+                          "value": "429"
+                        },
+                        {
+                          "label": "431 Request Header Fields Too Large",
+                          "value": "431"
+                        },
+                        {
+                          "label": "451 Unavailable For Legal Reasons",
+                          "value": "451"
+                        },
+                        {
+                          "label": "500 Internal Server Error",
+                          "value": "500"
+                        },
+                        {
+                          "label": "501 Not Implemented",
+                          "value": "501"
+                        },
+                        {
+                          "label": "502 Bad Gateway",
+                          "value": "502"
+                        },
+                        {
+                          "label": "503 Service Unavailable",
+                          "value": "503"
+                        },
+                        {
+                          "label": "504 Gateway Timeout",
+                          "value": "504"
+                        },
+                        {
+                          "label": "505 HTTP Version Not Supported",
+                          "value": "505"
+                        },
+                        {
+                          "label": "506 Variant Also Negotiates",
+                          "value": "506"
+                        },
+                        {
+                          "label": "507 Insufficient Storage",
+                          "value": "507"
+                        },
+                        {
+                          "label": "508 Loop Detected",
+                          "value": "508"
+                        },
+                        {
+                          "label": "510 Not Extended",
+                          "value": "510"
+                        },
+                        {
+                          "label": "511 Network Authentication Required",
+                          "value": "511"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "configuredProperties": {
+                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                "method": "process"
+              },
+              "componentScheme": "bean",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+              ]
+            },
+            "actionType": "connector",
+            "pattern": "To"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        }
+      ],
+      "metadata": {
+        "default-return-code": "200",
+        "excerpt": "501 Not Implemented"
+      },
+      "type": "API_PROVIDER",
+      "description": "GET /names/{nameId}"
+    },
+    {
+      "name": "Update a name",
+      "id": "i-LhBSk7z6AjytuGiCOT2z:flows:updatename",
+      "steps": [
+        {
+          "id": "i-LhBSk8-6AjytuGiCOT9z",
+          "configuredProperties": {
+            "name": "updatename"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-start",
+            "name": "Provided API",
+            "description": "Start a Syndesis integration from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "name": "Request",
+                "description": "API request payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"nameId\":{\"type\":\"string\",\"title\":\"nameId\",\"description\":\"A unique identifier for a `name`.\"}}},\"body\":{\"type\":\"object\",\"description\":\"            \",\"properties\":{\"name\":{\"type\":\"string\"}},\"example\":\"{\\\"name\\\":\\\"gary\\\"}\"}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "name": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The operation ID as defined in the API spec",
+                      "displayName": "Operation ID",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "componentScheme": "direct",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+              ]
+            },
+            "tags": [
+              "expose"
+            ],
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "i-LhBSk8-6AjytuGiCOTAz",
+          "configuredProperties": {
+            "httpResponseCode": "501"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-end",
+            "name": "Provided API Return Path",
+            "description": "End action of Syndesis integrations that start from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string",
+                      "enum": [
+                        {
+                          "label": "100 Continue",
+                          "value": "100"
+                        },
+                        {
+                          "label": "101 Switching Protocols",
+                          "value": "101"
+                        },
+                        {
+                          "label": "102 Processing",
+                          "value": "102"
+                        },
+                        {
+                          "label": "103 Early Hints",
+                          "value": "103"
+                        },
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "203 Non-Authoritative Information",
+                          "value": "203"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        },
+                        {
+                          "label": "205 Reset Content",
+                          "value": "205"
+                        },
+                        {
+                          "label": "206 Partial Content",
+                          "value": "206"
+                        },
+                        {
+                          "label": "207 Multi-Status",
+                          "value": "207"
+                        },
+                        {
+                          "label": "208 Already Reported",
+                          "value": "208"
+                        },
+                        {
+                          "label": "226 IM Used",
+                          "value": "226"
+                        },
+                        {
+                          "label": "300 Multiple Choices",
+                          "value": "300"
+                        },
+                        {
+                          "label": "301 Moved Permanently",
+                          "value": "301"
+                        },
+                        {
+                          "label": "302 Found",
+                          "value": "302"
+                        },
+                        {
+                          "label": "303 See Other",
+                          "value": "303"
+                        },
+                        {
+                          "label": "304 Not Modified",
+                          "value": "304"
+                        },
+                        {
+                          "label": "305 Use Proxy",
+                          "value": "305"
+                        },
+                        {
+                          "label": "306 Switch Proxy",
+                          "value": "306"
+                        },
+                        {
+                          "label": "307 Temporary Redirect",
+                          "value": "307"
+                        },
+                        {
+                          "label": "308 Permanent Redirect",
+                          "value": "308"
+                        },
+                        {
+                          "label": "400 Bad Request",
+                          "value": "400"
+                        },
+                        {
+                          "label": "401 Unauthorized",
+                          "value": "401"
+                        },
+                        {
+                          "label": "402 Payment Required",
+                          "value": "402"
+                        },
+                        {
+                          "label": "403 Forbidden",
+                          "value": "403"
+                        },
+                        {
+                          "label": "404 Not Found",
+                          "value": "404"
+                        },
+                        {
+                          "label": "405 Method Not Allowed",
+                          "value": "405"
+                        },
+                        {
+                          "label": "406 Not Acceptable",
+                          "value": "406"
+                        },
+                        {
+                          "label": "407 Proxy Authentication Required",
+                          "value": "407"
+                        },
+                        {
+                          "label": "408 Request Timeout",
+                          "value": "408"
+                        },
+                        {
+                          "label": "409 Conflict",
+                          "value": "409"
+                        },
+                        {
+                          "label": "410 Gone",
+                          "value": "410"
+                        },
+                        {
+                          "label": "411 Length Required",
+                          "value": "411"
+                        },
+                        {
+                          "label": "412 Precondition Failed",
+                          "value": "412"
+                        },
+                        {
+                          "label": "413 Payload Too Large",
+                          "value": "413"
+                        },
+                        {
+                          "label": "414 URI Too Long",
+                          "value": "414"
+                        },
+                        {
+                          "label": "415 Unsupported Media Type",
+                          "value": "415"
+                        },
+                        {
+                          "label": "416 Range Not Satisfiable",
+                          "value": "416"
+                        },
+                        {
+                          "label": "417 Expectation Failed",
+                          "value": "417"
+                        },
+                        {
+                          "label": "418 I'm a teapot",
+                          "value": "418"
+                        },
+                        {
+                          "label": "421 Misdirected Request",
+                          "value": "421"
+                        },
+                        {
+                          "label": "422 Unprocessable Entity",
+                          "value": "422"
+                        },
+                        {
+                          "label": "423 Locked",
+                          "value": "423"
+                        },
+                        {
+                          "label": "424 Failed Dependency",
+                          "value": "424"
+                        },
+                        {
+                          "label": "426 Upgrade Required",
+                          "value": "426"
+                        },
+                        {
+                          "label": "428 Precondition Required",
+                          "value": "428"
+                        },
+                        {
+                          "label": "429 Too Many Requests",
+                          "value": "429"
+                        },
+                        {
+                          "label": "431 Request Header Fields Too Large",
+                          "value": "431"
+                        },
+                        {
+                          "label": "451 Unavailable For Legal Reasons",
+                          "value": "451"
+                        },
+                        {
+                          "label": "500 Internal Server Error",
+                          "value": "500"
+                        },
+                        {
+                          "label": "501 Not Implemented",
+                          "value": "501"
+                        },
+                        {
+                          "label": "502 Bad Gateway",
+                          "value": "502"
+                        },
+                        {
+                          "label": "503 Service Unavailable",
+                          "value": "503"
+                        },
+                        {
+                          "label": "504 Gateway Timeout",
+                          "value": "504"
+                        },
+                        {
+                          "label": "505 HTTP Version Not Supported",
+                          "value": "505"
+                        },
+                        {
+                          "label": "506 Variant Also Negotiates",
+                          "value": "506"
+                        },
+                        {
+                          "label": "507 Insufficient Storage",
+                          "value": "507"
+                        },
+                        {
+                          "label": "508 Loop Detected",
+                          "value": "508"
+                        },
+                        {
+                          "label": "510 Not Extended",
+                          "value": "510"
+                        },
+                        {
+                          "label": "511 Network Authentication Required",
+                          "value": "511"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "configuredProperties": {
+                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                "method": "process"
+              },
+              "componentScheme": "bean",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+              ]
+            },
+            "actionType": "connector",
+            "pattern": "To"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        }
+      ],
+      "metadata": {
+        "default-return-code": "200",
+        "excerpt": "501 Not Implemented"
+      },
+      "type": "API_PROVIDER",
+      "description": "PUT /names/{nameId}"
+    },
+    {
+      "name": "Delete a name",
+      "id": "i-LhBSk7z6AjytuGiCOT2z:flows:deletename",
+      "steps": [
+        {
+          "id": "i-LhBSk8-6AjytuGiCOTBz",
+          "configuredProperties": {
+            "name": "deletename"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-start",
+            "name": "Provided API",
+            "description": "Start a Syndesis integration from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "name": "Request",
+                "description": "API request payload",
+                "kind": "json-schema",
+                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"nameId\":{\"type\":\"string\",\"title\":\"nameId\",\"description\":\"A unique identifier for a `name`.\"}}}}}",
+                "metadata": {
+                  "unified": "true"
+                }
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "name": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The operation ID as defined in the API spec",
+                      "displayName": "Operation ID",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string"
+                    }
+                  }
+                }
+              ],
+              "componentScheme": "direct",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+              ]
+            },
+            "tags": [
+              "expose"
+            ],
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "i-LhBSk8-6AjytuGiCOTCz",
+          "configuredProperties": {
+            "httpResponseCode": "501"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:api-provider-end",
+            "name": "Provided API Return Path",
+            "description": "End action of Syndesis integrations that start from a provided API",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "configuration",
+                  "properties": {
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "required": true,
+                      "secret": false,
+                      "type": "string",
+                      "enum": [
+                        {
+                          "label": "100 Continue",
+                          "value": "100"
+                        },
+                        {
+                          "label": "101 Switching Protocols",
+                          "value": "101"
+                        },
+                        {
+                          "label": "102 Processing",
+                          "value": "102"
+                        },
+                        {
+                          "label": "103 Early Hints",
+                          "value": "103"
+                        },
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "203 Non-Authoritative Information",
+                          "value": "203"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        },
+                        {
+                          "label": "205 Reset Content",
+                          "value": "205"
+                        },
+                        {
+                          "label": "206 Partial Content",
+                          "value": "206"
+                        },
+                        {
+                          "label": "207 Multi-Status",
+                          "value": "207"
+                        },
+                        {
+                          "label": "208 Already Reported",
+                          "value": "208"
+                        },
+                        {
+                          "label": "226 IM Used",
+                          "value": "226"
+                        },
+                        {
+                          "label": "300 Multiple Choices",
+                          "value": "300"
+                        },
+                        {
+                          "label": "301 Moved Permanently",
+                          "value": "301"
+                        },
+                        {
+                          "label": "302 Found",
+                          "value": "302"
+                        },
+                        {
+                          "label": "303 See Other",
+                          "value": "303"
+                        },
+                        {
+                          "label": "304 Not Modified",
+                          "value": "304"
+                        },
+                        {
+                          "label": "305 Use Proxy",
+                          "value": "305"
+                        },
+                        {
+                          "label": "306 Switch Proxy",
+                          "value": "306"
+                        },
+                        {
+                          "label": "307 Temporary Redirect",
+                          "value": "307"
+                        },
+                        {
+                          "label": "308 Permanent Redirect",
+                          "value": "308"
+                        },
+                        {
+                          "label": "400 Bad Request",
+                          "value": "400"
+                        },
+                        {
+                          "label": "401 Unauthorized",
+                          "value": "401"
+                        },
+                        {
+                          "label": "402 Payment Required",
+                          "value": "402"
+                        },
+                        {
+                          "label": "403 Forbidden",
+                          "value": "403"
+                        },
+                        {
+                          "label": "404 Not Found",
+                          "value": "404"
+                        },
+                        {
+                          "label": "405 Method Not Allowed",
+                          "value": "405"
+                        },
+                        {
+                          "label": "406 Not Acceptable",
+                          "value": "406"
+                        },
+                        {
+                          "label": "407 Proxy Authentication Required",
+                          "value": "407"
+                        },
+                        {
+                          "label": "408 Request Timeout",
+                          "value": "408"
+                        },
+                        {
+                          "label": "409 Conflict",
+                          "value": "409"
+                        },
+                        {
+                          "label": "410 Gone",
+                          "value": "410"
+                        },
+                        {
+                          "label": "411 Length Required",
+                          "value": "411"
+                        },
+                        {
+                          "label": "412 Precondition Failed",
+                          "value": "412"
+                        },
+                        {
+                          "label": "413 Payload Too Large",
+                          "value": "413"
+                        },
+                        {
+                          "label": "414 URI Too Long",
+                          "value": "414"
+                        },
+                        {
+                          "label": "415 Unsupported Media Type",
+                          "value": "415"
+                        },
+                        {
+                          "label": "416 Range Not Satisfiable",
+                          "value": "416"
+                        },
+                        {
+                          "label": "417 Expectation Failed",
+                          "value": "417"
+                        },
+                        {
+                          "label": "418 I'm a teapot",
+                          "value": "418"
+                        },
+                        {
+                          "label": "421 Misdirected Request",
+                          "value": "421"
+                        },
+                        {
+                          "label": "422 Unprocessable Entity",
+                          "value": "422"
+                        },
+                        {
+                          "label": "423 Locked",
+                          "value": "423"
+                        },
+                        {
+                          "label": "424 Failed Dependency",
+                          "value": "424"
+                        },
+                        {
+                          "label": "426 Upgrade Required",
+                          "value": "426"
+                        },
+                        {
+                          "label": "428 Precondition Required",
+                          "value": "428"
+                        },
+                        {
+                          "label": "429 Too Many Requests",
+                          "value": "429"
+                        },
+                        {
+                          "label": "431 Request Header Fields Too Large",
+                          "value": "431"
+                        },
+                        {
+                          "label": "451 Unavailable For Legal Reasons",
+                          "value": "451"
+                        },
+                        {
+                          "label": "500 Internal Server Error",
+                          "value": "500"
+                        },
+                        {
+                          "label": "501 Not Implemented",
+                          "value": "501"
+                        },
+                        {
+                          "label": "502 Bad Gateway",
+                          "value": "502"
+                        },
+                        {
+                          "label": "503 Service Unavailable",
+                          "value": "503"
+                        },
+                        {
+                          "label": "504 Gateway Timeout",
+                          "value": "504"
+                        },
+                        {
+                          "label": "505 HTTP Version Not Supported",
+                          "value": "505"
+                        },
+                        {
+                          "label": "506 Variant Also Negotiates",
+                          "value": "506"
+                        },
+                        {
+                          "label": "507 Insufficient Storage",
+                          "value": "507"
+                        },
+                        {
+                          "label": "508 Loop Detected",
+                          "value": "508"
+                        },
+                        {
+                          "label": "510 Not Extended",
+                          "value": "510"
+                        },
+                        {
+                          "label": "511 Network Authentication Required",
+                          "value": "511"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "configuredProperties": {
+                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                "method": "process"
+              },
+              "componentScheme": "bean",
+              "connectorCustomizers": [
+                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+              ]
+            },
+            "actionType": "connector",
+            "pattern": "To"
+          },
+          "connection": {
+            "uses": 2,
+            "id": "api-provider",
+            "name": "API Provider",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "api-provider",
+              "version": 18,
+              "actions": [
+                {
+                  "id": "io.syndesis:api-provider-start",
+                  "name": "Provided API",
+                  "description": "Start a Syndesis integration from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "any"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "name": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The operation ID as defined in the API spec",
+                            "displayName": "Operation ID",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "API Provider Configuration"
+                      }
+                    ],
+                    "componentScheme": "direct",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                    ]
+                  },
+                  "tags": [
+                    "expose"
+                  ],
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:api-provider-end",
+                  "name": "Provided API Return Path",
+                  "description": "End action of Syndesis integrations that start from a provided API",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "any"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "configuration",
+                        "properties": {
+                          "httpResponseCode": {
+                            "componentProperty": false,
+                            "deprecated": false,
+                            "description": "The return code to set in the HTTP response",
+                            "displayName": "Return Code",
+                            "javaType": "String",
+                            "kind": "parameter",
+                            "required": true,
+                            "secret": false,
+                            "type": "string",
+                            "enum": [
+                              {
+                                "label": "100 Continue",
+                                "value": "100"
+                              },
+                              {
+                                "label": "101 Switching Protocols",
+                                "value": "101"
+                              },
+                              {
+                                "label": "102 Processing",
+                                "value": "102"
+                              },
+                              {
+                                "label": "103 Early Hints",
+                                "value": "103"
+                              },
+                              {
+                                "label": "200 OK",
+                                "value": "200"
+                              },
+                              {
+                                "label": "201 Created",
+                                "value": "201"
+                              },
+                              {
+                                "label": "202 Accepted",
+                                "value": "202"
+                              },
+                              {
+                                "label": "203 Non-Authoritative Information",
+                                "value": "203"
+                              },
+                              {
+                                "label": "204 No Content",
+                                "value": "204"
+                              },
+                              {
+                                "label": "205 Reset Content",
+                                "value": "205"
+                              },
+                              {
+                                "label": "206 Partial Content",
+                                "value": "206"
+                              },
+                              {
+                                "label": "207 Multi-Status",
+                                "value": "207"
+                              },
+                              {
+                                "label": "208 Already Reported",
+                                "value": "208"
+                              },
+                              {
+                                "label": "226 IM Used",
+                                "value": "226"
+                              },
+                              {
+                                "label": "300 Multiple Choices",
+                                "value": "300"
+                              },
+                              {
+                                "label": "301 Moved Permanently",
+                                "value": "301"
+                              },
+                              {
+                                "label": "302 Found",
+                                "value": "302"
+                              },
+                              {
+                                "label": "303 See Other",
+                                "value": "303"
+                              },
+                              {
+                                "label": "304 Not Modified",
+                                "value": "304"
+                              },
+                              {
+                                "label": "305 Use Proxy",
+                                "value": "305"
+                              },
+                              {
+                                "label": "306 Switch Proxy",
+                                "value": "306"
+                              },
+                              {
+                                "label": "307 Temporary Redirect",
+                                "value": "307"
+                              },
+                              {
+                                "label": "308 Permanent Redirect",
+                                "value": "308"
+                              },
+                              {
+                                "label": "400 Bad Request",
+                                "value": "400"
+                              },
+                              {
+                                "label": "401 Unauthorized",
+                                "value": "401"
+                              },
+                              {
+                                "label": "402 Payment Required",
+                                "value": "402"
+                              },
+                              {
+                                "label": "403 Forbidden",
+                                "value": "403"
+                              },
+                              {
+                                "label": "404 Not Found",
+                                "value": "404"
+                              },
+                              {
+                                "label": "405 Method Not Allowed",
+                                "value": "405"
+                              },
+                              {
+                                "label": "406 Not Acceptable",
+                                "value": "406"
+                              },
+                              {
+                                "label": "407 Proxy Authentication Required",
+                                "value": "407"
+                              },
+                              {
+                                "label": "408 Request Timeout",
+                                "value": "408"
+                              },
+                              {
+                                "label": "409 Conflict",
+                                "value": "409"
+                              },
+                              {
+                                "label": "410 Gone",
+                                "value": "410"
+                              },
+                              {
+                                "label": "411 Length Required",
+                                "value": "411"
+                              },
+                              {
+                                "label": "412 Precondition Failed",
+                                "value": "412"
+                              },
+                              {
+                                "label": "413 Payload Too Large",
+                                "value": "413"
+                              },
+                              {
+                                "label": "414 URI Too Long",
+                                "value": "414"
+                              },
+                              {
+                                "label": "415 Unsupported Media Type",
+                                "value": "415"
+                              },
+                              {
+                                "label": "416 Range Not Satisfiable",
+                                "value": "416"
+                              },
+                              {
+                                "label": "417 Expectation Failed",
+                                "value": "417"
+                              },
+                              {
+                                "label": "418 I'm a teapot",
+                                "value": "418"
+                              },
+                              {
+                                "label": "421 Misdirected Request",
+                                "value": "421"
+                              },
+                              {
+                                "label": "422 Unprocessable Entity",
+                                "value": "422"
+                              },
+                              {
+                                "label": "423 Locked",
+                                "value": "423"
+                              },
+                              {
+                                "label": "424 Failed Dependency",
+                                "value": "424"
+                              },
+                              {
+                                "label": "426 Upgrade Required",
+                                "value": "426"
+                              },
+                              {
+                                "label": "428 Precondition Required",
+                                "value": "428"
+                              },
+                              {
+                                "label": "429 Too Many Requests",
+                                "value": "429"
+                              },
+                              {
+                                "label": "431 Request Header Fields Too Large",
+                                "value": "431"
+                              },
+                              {
+                                "label": "451 Unavailable For Legal Reasons",
+                                "value": "451"
+                              },
+                              {
+                                "label": "500 Internal Server Error",
+                                "value": "500"
+                              },
+                              {
+                                "label": "501 Not Implemented",
+                                "value": "501"
+                              },
+                              {
+                                "label": "502 Bad Gateway",
+                                "value": "502"
+                              },
+                              {
+                                "label": "503 Service Unavailable",
+                                "value": "503"
+                              },
+                              {
+                                "label": "504 Gateway Timeout",
+                                "value": "504"
+                              },
+                              {
+                                "label": "505 HTTP Version Not Supported",
+                                "value": "505"
+                              },
+                              {
+                                "label": "506 Variant Also Negotiates",
+                                "value": "506"
+                              },
+                              {
+                                "label": "507 Insufficient Storage",
+                                "value": "507"
+                              },
+                              {
+                                "label": "508 Loop Detected",
+                                "value": "508"
+                              },
+                              {
+                                "label": "510 Not Extended",
+                                "value": "510"
+                              },
+                              {
+                                "label": "511 Network Authentication Required",
+                                "value": "511"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "API Provider Return Path Configuration"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                      "method": "process"
+                    },
+                    "componentScheme": "bean",
+                    "connectorCustomizers": [
+                      "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                    ]
+                  },
+                  "actionType": "connector",
+                  "pattern": "To"
+                }
+              ],
+              "name": "API Provider",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-api-provider:1.8-SNAPSHOT"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-swagger-java:2.21.0.fuse-740028"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-servlet-starter:2.21.0.fuse-740028"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg"
+            },
+            "connectorId": "api-provider",
+            "icon": "assets:api-provider.svg",
+            "description": "Expose Restful APIs",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        }
+      ],
+      "metadata": {
+        "default-return-code": "200",
+        "excerpt": "501 Not Implemented"
+      },
+      "type": "API_PROVIDER",
+      "description": "DELETE /names/{nameId}"
+    }
+  ],
+  "continuousDeliveryState": {
+    "Paul": {
+      "name": "Paul",
+      "releaseTag": "i-LhtsmmAiUGJdbaf6EnIz",
+      "lastTaggedAt": 1561118059658
+    },
+    "Production": {
+      "name": "Production",
+      "releaseTag": "i-LhtsmmAiUGJdbaf6EnJz",
+      "lastTaggedAt": 1561118059658
+    }
+  },
+  "currentState": "Unpublished",
+  "targetState": "Published",
+  "deployments": [
+    {
+      "id": "i-LhBSmGn6AjytuGiCOTEz:3",
+      "version": 3,
+      "createdAt": 1560367566144,
+      "updatedAt": 1561655026080,
+      "userId": "gaughan",
+      "currentState": "Unpublished",
+      "targetState": "Published",
+      "stepsDone": {
+        "buildv3": "172.30.39.149:5000/syndesis-staging/i-api-1:3"
+      },
+      "statusMessage": "Integration has still active deployments. Will retry shortly"
+    },
+    {
+      "id": "i-LhBSmGn6AjytuGiCOTEz:2",
+      "version": 2,
+      "createdAt": 1560356173298,
+      "updatedAt": 1560356437609,
+      "userId": "gaughan",
+      "currentState": "Unpublished",
+      "targetState": "Unpublished",
+      "stepsDone": {
+        "buildv2": "172.30.39.149:5000/syndesis-staging/i-api-1:2"
+      }
+    },
+    {
+      "id": "i-LhBSmGn6AjytuGiCOTEz:1",
+      "version": 1,
+      "createdAt": 1560356005308,
+      "updatedAt": 1560356179797,
+      "userId": "gaughan",
+      "currentState": "Unpublished",
+      "targetState": "Unpublished",
+      "stepsDone": {
+        "buildv1": "172.30.39.149:5000/syndesis-staging/i-api-1:1"
+      }
+    }
+  ],
+  "board": {
+    "id": "i-LhBSmKM6AjytuGiCOTFz",
+    "metadata": {
+      "integration-id": "i-LhBSmGn6AjytuGiCOTEz",
+      "integration-version": "3"
+    },
+    "messages": [
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:getnames",
+          "step": "i-LhBSk7z6AjytuGiCOT3z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:getnames",
+          "step": "i-LhBSk8-6AjytuGiCOT4z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:createname",
+          "step": "i-LhBSk8-6AjytuGiCOT5z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:createname",
+          "step": "i-LhBSk8-6AjytuGiCOT6z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:getname",
+          "step": "i-LhBSk8-6AjytuGiCOT7z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:getname",
+          "step": "i-LhBSk8-6AjytuGiCOT8z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:updatename",
+          "step": "i-LhBSk8-6AjytuGiCOT9z"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:updatename",
+          "step": "i-LhBSk8-6AjytuGiCOTAz"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:deletename",
+          "step": "i-LhBSk8-6AjytuGiCOTBz"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      },
+      {
+        "metadata": {
+          "flow": "i-LhBSk7z6AjytuGiCOT2z:flows:deletename",
+          "step": "i-LhBSk8-6AjytuGiCOTCz"
+        },
+        "level": "WARN",
+        "code": "SYNDESIS011",
+        "detail": "API Provider:Connection > API Provider:Connector$dependencies\n\t=> '[Dependenc ... 7-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n\t=> '[Dependenc ... 8-SNAPSHOT}, Dependency{type=MAVEN, id=org.apache.camel:camel-swagger- ...'\n"
+      }
+    ],
+    "createdAt": 1560356005207,
+    "updatedAt": 1560958012375,
+    "targetResourceId": "i-LhBSmGn6AjytuGiCOTEz",
+    "notices": 0,
+    "warnings": 10,
+    "errors": 0
+  },
+  "isDraft": true
+}


### PR DESCRIPTION
Before this we correlated API operations from OpenAPI document by embedding the integration id and the operation id in the flow id. This stores the operation id in the flow metadata and uses key generator generated keys for flow ids.

List of endpoint changes:

 - `POST /api/v1/apis/generator` doesn't set integration id, flow ids are key-generated, operation ids are placed in metadata
 - `PUT /api/v1/apis/generator` and `PUT /api/v1/integrations/{id}/specification` correlate using operation id stored in the metadata

Schema was upgrated to 30 and a migration was added to change the flow ids and put the operation id in the flow metadata.

Fixes #5963