### PR TITLE
fix: don't require authentication for /config.json

### DIFF
--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -99,6 +99,7 @@
             - '--skip-auth-regex=/icons[^/]*'
             - '--skip-auth-regex=/static[^/]*'
             - '--skip-auth-regex=/precache-manifest.*.js'
+            - '--skip-auth-regex=/config.json'
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -1106,6 +1106,7 @@ objects:
             - '--skip-auth-regex=/icons[^/]*'
             - '--skip-auth-regex=/static[^/]*'
             - '--skip-auth-regex=/precache-manifest.*.js'
+            - '--skip-auth-regex=/config.json'
             - --skip-auth-preflight
             - --openshift-ca=/etc/pki/tls/certs/ca-bundle.crt
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -2404,7 +2405,7 @@ objects:
     - route.openshift.io
     resources:
     - routes
-    verbs: [ delete ]
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding


### PR DESCRIPTION
Seems that the request for `/config.json` is resulting in a 302 redirect to the HTML page served from oauth-proxy to authenticate. Parsing this response as JSON fails and we get an error in the UI.

This only seems to happen on a particular installation, and I think this should fix this issue. Having public `/config.json` doesn't seem like a security issue to me.

Fixes #5602