### PR TITLE
GMail and Google Calendar connector OAuth fixes

### DIFF
--- a/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
+++ b/app/connector/gmail/src/main/resources/META-INF/syndesis/connector/gmail.json
@@ -188,7 +188,8 @@
     "authenticationType": "oauth2",
     "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
     "googleScopes": "https://mail.google.com/",
-    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token"
+    "tokenUrl": "https://www.googleapis.com/oauth2/v4/token",
+    "userId": "me"
   },
   "dependencies": [
     {

--- a/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
+++ b/app/connector/google-calendar/src/main/resources/META-INF/syndesis/connector/calendar.json
@@ -659,19 +659,6 @@
         "oauth-access-token-url"
       ],
       "type": "hidden"
-    },
-    "userId": {
-      "deprecated": false,
-      "displayName": "User ID",
-      "group": "common",
-      "javaType": "java.lang.String",
-      "kind": "parameter",
-      "labelHint": "Google calendar account name that is associated with this registration.",
-      "order": "6",
-      "raw": true,
-      "required": true,
-      "secret": false,
-      "type": "string"
     }
   },
   "tags": [


### PR DESCRIPTION
In GMail connector, sets the configured property to `"me"`: to be on the safe side as the `userId` property can be used from the Camel component in some weird way. It's used in the verifier, though there it could be replaced with a constant of `"me"`.

In Google Calendar coonector, removes the `userId` property: the underlying Camel component doesn't have a `userId` property and it's not used in the connector.

Fixes #5891 