### PR TITLE
user doc: Conditionalize text that applies only downstream

### DIFF
--- a/doc/integrating-applications/topics/as_copying-integrations-to-other-environments.adoc
+++ b/doc/integrating-applications/topics/as_copying-integrations-to-other-environments.adoc
@@ -10,6 +10,19 @@ To run integrations across development, staging and
 production environments, you can export and import integrations.
 The environments can all be on a single OpenShift cluster,
 or they can be spread out across multiple OpenShift clusters.
+
+The procedures described here instruct you to export 
+and import integrations in the {prodname} web interface. 
+
+ifeval::["{location}"=="downstream"]
+If you are running {prodname} 
+on OpenShift Container Platform on-site, you might have 
+Continuous Integration/Continuous Deployment (CI/CD) pipelines 
+that need to export and import certain integrations. For 
+information about doing that, see 
+link:{LinkFuseOnlineOnOCP}#using-external-tools-to-export-import-integrations_ocp[Using external tools to export/import integrations for CI/CD].
+endif::[]
+
 See the following topics:
 
 * xref:about-copying-integrations_{context}[]

--- a/doc/integrating-applications/topics/as_managing-integrations.adoc
+++ b/doc/integrating-applications/topics/as_managing-integrations.adoc
@@ -7,8 +7,13 @@
 = Managing integrations
 :context: manage
 
-Each {prodname} environment is hosted on OpenShift Online or
-OpenShift Container Platform (OCP). A common set up is to have
+
+ifeval::["{location}" == "downstream"]
+Each {prodname} environment is hosted on OpenShift Online, OpenShift Dedicated or
+OpenShift Container Platform (OCP). 
+endif::[]
+
+A common set up is to have
 a {prodname} development environment, a {prodname} test environment, 
 and a {prodname} deployment environment. 
 

--- a/doc/integrating-applications/topics/p_importing-integrations.adoc
+++ b/doc/integrating-applications/topics/p_importing-integrations.adoc
@@ -45,6 +45,7 @@ See the appropriate topic:
 
 * link:{LinkFuseOnlineConnectorGuide}#register-with-dropbox_dropbox[Registering with Dropbox]
 * link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering with Google]
+* link:{LinkFuseOnlineConnectorGuide}#register-with-jira[Registering with Jira]
 * link:{LinkFuseOnlineConnectorGuide}#register-with-rest-api_rest[Registering with a REST API]
 * link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Registering with Salesforce]
 * link:{LinkFuseOnlineConnectorGuide}#connecting-to-concur_connectors[Connecting to SAP Concur]


### PR DESCRIPTION
I updated the doc about export/import integrations to clarify the difference between using the UI and using environment tags. Some  content is relevant and correct only downstream, so I conditionalized it to render only downstream. Of course, it still appears in upstream source. At some point, we need to publish Syndesis user doc to the Syndesis community site. There, the content that is relevant only downstream, will not appear. Next release maybe. 

In the doc for importing integrations, I also added a link to the doc for the Jira connector. That doc does not yet exist, but it will. 