### PR TITLE
fix: AcquisitionMethod JSON serialization

### DIFF
--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -226,6 +226,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin.external.google</groupId>
+      <artifactId>android-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/AcquisitionMethod.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/AcquisitionMethod.java
@@ -17,6 +17,7 @@ package io.syndesis.server.credential;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
@@ -42,5 +43,6 @@ public interface AcquisitionMethod {
 
     Type getType();
 
-    boolean isConfigured();
+    @JsonProperty("configured")
+    boolean configured();
 }

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1CredentialProvider.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1CredentialProvider.java
@@ -61,7 +61,7 @@ public final class OAuth1CredentialProvider<A> extends BaseCredentialProvider {
             .icon(iconFor(id))
             .type(Type.OAUTH1)
             .description(descriptionFor(id))
-            .isConfigured(configured)
+            .configured(configured)
             .build();
     }
 

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
@@ -67,7 +67,7 @@ public final class OAuth2CredentialProvider<S> extends BaseCredentialProvider {
             .icon(iconFor(id))
             .type(Type.OAUTH2)
             .description(descriptionFor(id))
-            .isConfigured(configured)
+            .configured(configured)
             .build();
     }
 

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/AcquisitionMethodTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/AcquisitionMethodTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.credential;
+
+import io.syndesis.common.util.Json;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class AcquisitionMethodTest {
+
+    @Test
+    public void shouldSerializeAsExpected() throws JsonProcessingException, JSONException {
+        final AcquisitionMethod acquisitionMethod = new AcquisitionMethod.Builder()
+            .description("description")
+            .icon("icon")
+            .label("label")
+            .type(Type.OAUTH2)
+            .build();
+
+        final String json = Json.writer().writeValueAsString(acquisitionMethod);
+        final String expected = "{\"description\":\"description\",\"icon\":\"icon\",\"label\":\"label\",\"type\":\"OAUTH2\",\"configured\":false}";
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
+    }
+}

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth1CredentialProviderTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth1CredentialProviderTest.java
@@ -34,7 +34,7 @@ public class OAuth1CredentialProviderTest {
             .label("provider1")
             .icon("provider1")
             .type(Type.OAUTH1)
-            .isConfigured(true)
+            .configured(true)
             .build();
 
         assertThat(oauth1.acquisitionMethod()).isEqualTo(method1);

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth2CredentialProviderTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/OAuth2CredentialProviderTest.java
@@ -36,7 +36,7 @@ public class OAuth2CredentialProviderTest {
             .label("provider2")
             .icon("provider2")
             .type(Type.OAUTH2)
-            .isConfigured(true)
+            .configured(true)
             .build();
 
         assertThat(oauth2.acquisitionMethod()).isEqualTo(method2);

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/SetupITCase.java
@@ -109,7 +109,7 @@ public class SetupITCase extends BaseITCase {
 
             final AcquisitionMethod acquisitionMethod = twitterProvider.acquisitionMethod();
 
-            return acquisitionMethod.isConfigured();
+            return acquisitionMethod.configured();
         });
 
         delete("/api/v1/setup/oauth-apps/twitter");
@@ -120,7 +120,7 @@ public class SetupITCase extends BaseITCase {
 
                 final AcquisitionMethod acquisitionMethod = twitterProvider.acquisitionMethod();
 
-                return !acquisitionMethod.isConfigured();
+                return !acquisitionMethod.configured();
             } catch (final IllegalArgumentException e) {
                 return e.getMessage().startsWith("No property tagged with `oauth-client-id` on connector");
             }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/credential/CredentialITCase.java
@@ -218,7 +218,7 @@ public class CredentialITCase extends BaseITCase {
             .icon("test-provider")
             .label("test-provider")
             .description("test-provider")
-            .isConfigured(true)
+            .configured(true)
             .build();
 
         assertThat(acquisitionMethod).isEqualTo(salesforce);

--- a/app/ui-react/packages/models/swagger.internal.json
+++ b/app/ui-react/packages/models/swagger.internal.json
@@ -2194,13 +2194,13 @@
         "description": {
           "type": "string"
         },
-        "warnings": {
+        "errors": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Violation"
           }
         },
-        "errors": {
+        "warnings": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Violation"
@@ -2236,14 +2236,15 @@
           "type": "string",
           "enum": ["OAUTH1", "OAUTH2"]
         },
-        "label": {
-          "type": "string"
-        },
         "description": {
           "type": "string"
         },
+        "label": {
+          "type": "string"
+        },
         "configured": {
-          "type": "boolean"
+          "type": "boolean",
+          "readOnly": true
         }
       }
     },
@@ -2289,17 +2290,17 @@
     "ActionDescriptor": {
       "type": "object",
       "properties": {
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         }
       }
     },
@@ -2330,22 +2331,25 @@
     "ActionsSummary": {
       "type": "object",
       "properties": {
-        "totalActions": {
-          "type": "integer",
-          "format": "int32"
-        },
         "actionCountByTags": {
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "int32"
           }
+        },
+        "totalActions": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },
     "ConfigurationProperty": {
       "type": "object",
       "properties": {
+        "secret": {
+          "type": "boolean"
+        },
         "raw": {
           "type": "boolean"
         },
@@ -2358,13 +2362,10 @@
         "displayName": {
           "type": "string"
         },
-        "label": {
-          "type": "string"
-        },
         "description": {
           "type": "string"
         },
-        "kind": {
+        "label": {
           "type": "string"
         },
         "deprecated": {
@@ -2373,28 +2374,31 @@
         "group": {
           "type": "string"
         },
+        "kind": {
+          "type": "string"
+        },
         "enum": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PropertyValue"
           }
         },
-        "componentProperty": {
-          "type": "boolean"
-        },
-        "connectorValue": {
+        "generator": {
           "type": "string"
         },
-        "placeholder": {
+        "required": {
+          "type": "boolean"
+        },
+        "controlHint": {
+          "type": "string"
+        },
+        "connectorValue": {
           "type": "string"
         },
         "multiple": {
           "type": "boolean"
         },
-        "labelHint": {
-          "type": "string"
-        },
-        "controlHint": {
+        "javaType": {
           "type": "string"
         },
         "relation": {
@@ -2403,16 +2407,13 @@
             "$ref": "#/definitions/PropertyRelation"
           }
         },
-        "javaType": {
+        "placeholder": {
           "type": "string"
         },
-        "generator": {
+        "labelHint": {
           "type": "string"
         },
-        "required": {
-          "type": "boolean"
-        },
-        "secret": {
+        "componentProperty": {
           "type": "boolean"
         },
         "tags": {
@@ -2456,9 +2457,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -2471,6 +2469,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -2507,10 +2508,10 @@
         "id": {
           "type": "string"
         },
-        "warnings": {
+        "errors": {
           "$ref": "#/definitions/OptionalInt"
         },
-        "errors": {
+        "warnings": {
           "$ref": "#/definitions/OptionalInt"
         },
         "notices": {
@@ -2573,9 +2574,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -2588,6 +2586,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -2632,6 +2633,9 @@
           "readOnly": true,
           "$ref": "#/definitions/OptionalInt"
         },
+        "connectorGroup": {
+          "$ref": "#/definitions/ConnectorGroup"
+        },
         "connectorGroupId": {
           "type": "string"
         },
@@ -2649,9 +2653,6 @@
         },
         "actionsSummary": {
           "$ref": "#/definitions/ActionsSummary"
-        },
-        "connectorGroup": {
-          "$ref": "#/definitions/ConnectorGroup"
         },
         "id": {
           "type": "string"
@@ -2749,9 +2750,6 @@
     "ConnectorDescriptor": {
       "type": "object",
       "properties": {
-        "camelConnectorPrefix": {
-          "type": "string"
-        },
         "camelConnectorGAV": {
           "type": "string"
         },
@@ -2770,17 +2768,20 @@
         "connectorId": {
           "type": "string"
         },
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
+        "camelConnectorPrefix": {
+          "type": "string"
         },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         },
         "configuredProperties": {
           "type": "object",
@@ -2812,11 +2813,11 @@
         "description": {
           "type": "string"
         },
-        "componentScheme": {
-          "type": "string"
-        },
         "connectorGroup": {
           "$ref": "#/definitions/ConnectorGroup"
+        },
+        "componentScheme": {
+          "type": "string"
         },
         "connectorProperties": {
           "type": "object",
@@ -2848,6 +2849,13 @@
       "type": "object",
       "required": ["name"],
       "properties": {
+        "releaseTag": {
+          "type": "string"
+        },
+        "lastTaggedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
         "lastExportedAt": {
           "type": "string",
           "format": "date-time"
@@ -2855,13 +2863,6 @@
         "lastImportedAt": {
           "type": "string",
           "format": "date-time"
-        },
-        "lastTaggedAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "releaseTag": {
-          "type": "string"
         },
         "name": {
           "type": "string"
@@ -2875,6 +2876,13 @@
       "type": "object",
       "required": ["name"],
       "properties": {
+        "exemplar": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "byte"
+          }
+        },
         "name": {
           "type": "string"
         },
@@ -2890,6 +2898,12 @@
         "description": {
           "type": "string"
         },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "kind": {
           "type": "string",
           "enum": [
@@ -2903,12 +2917,6 @@
             "NONE"
           ]
         },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "collectionType": {
           "type": "string"
         },
@@ -2917,13 +2925,6 @@
         },
         "specification": {
           "type": "string"
-        },
-        "exemplar": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "byte"
-          }
         }
       }
     },
@@ -3078,14 +3079,14 @@
         "description": {
           "type": "string"
         },
-        "scheduler": {
-          "$ref": "#/definitions/Scheduler"
-        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
+        },
+        "scheduler": {
+          "$ref": "#/definitions/Scheduler"
         },
         "name": {
           "type": "string"
@@ -3248,14 +3249,14 @@
             "$ref": "#/definitions/Step"
           }
         },
+        "deleted": {
+          "type": "boolean"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "deleted": {
-          "type": "boolean"
         },
         "continuousDeliveryState": {
           "type": "object",
@@ -3308,10 +3309,10 @@
     "IntegrationBulletinBoard": {
       "type": "object",
       "properties": {
-        "warnings": {
+        "errors": {
           "$ref": "#/definitions/OptionalInt"
         },
-        "errors": {
+        "warnings": {
           "$ref": "#/definitions/OptionalInt"
         },
         "notices": {
@@ -3360,10 +3361,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -3372,6 +3369,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -3438,10 +3439,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -3450,6 +3447,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -3491,6 +3492,13 @@
           "type": "string",
           "format": "date-time"
         },
+        "topIntegrations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
         "metricsProvider": {
           "type": "string"
         },
@@ -3498,13 +3506,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/IntegrationDeploymentMetrics"
-          }
-        },
-        "topIntegrations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "integer",
-            "format": "int64"
           }
         },
         "id": {
@@ -3522,6 +3523,16 @@
         "board": {
           "$ref": "#/definitions/IntegrationBulletinBoard"
         },
+        "deploymentVersion": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "deployments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntegrationDeploymentOverview"
+          }
+        },
         "draft": {
           "type": "boolean"
         },
@@ -3529,19 +3540,9 @@
           "type": "string",
           "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
-        "deploymentVersion": {
-          "type": "integer",
-          "format": "int32"
-        },
         "targetState": {
           "type": "string",
           "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
-        "deployments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IntegrationDeploymentOverview"
-          }
         },
         "id": {
           "type": "string"
@@ -3561,14 +3562,14 @@
             "$ref": "#/definitions/Step"
           }
         },
+        "deleted": {
+          "type": "boolean"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "deleted": {
-          "type": "boolean"
         },
         "continuousDeliveryState": {
           "type": "object",
@@ -3965,16 +3966,16 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Environment"
-          }
-        },
         "users": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/User"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Environment"
           }
         },
         "id": {
@@ -4021,6 +4022,10 @@
     "Quota": {
       "type": "object",
       "properties": {
+        "maxDeploymentsPerUser": {
+          "type": "integer",
+          "format": "int32"
+        },
         "usedIntegrationsPerUser": {
           "type": "integer",
           "format": "int32"
@@ -4030,10 +4035,6 @@
           "format": "int32"
         },
         "maxIntegrationsPerUser": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "maxDeploymentsPerUser": {
           "type": "integer",
           "format": "int32"
         }
@@ -4129,14 +4130,14 @@
     "Step": {
       "type": "object",
       "properties": {
-        "connection": {
-          "$ref": "#/definitions/Connection"
-        },
         "name": {
           "type": "string"
         },
         "extension": {
           "$ref": "#/definitions/Extension"
+        },
+        "connection": {
+          "$ref": "#/definitions/Connection"
         },
         "action": {
           "$ref": "#/definitions/Action"
@@ -4194,17 +4195,17 @@
         "entrypoint": {
           "type": "string"
         },
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         }
       }
     },
@@ -4235,6 +4236,12 @@
         "organizationId": {
           "type": "string"
         },
+        "lastName": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
         "integrations": {
           "type": "array",
           "items": {
@@ -4242,12 +4249,6 @@
           }
         },
         "roleId": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "firstName": {
           "type": "string"
         },
         "id": {

--- a/app/ui-react/packages/models/swagger.json
+++ b/app/ui-react/packages/models/swagger.json
@@ -733,17 +733,17 @@
     "ActionDescriptor": {
       "type": "object",
       "properties": {
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         }
       }
     },
@@ -774,22 +774,25 @@
     "ActionsSummary": {
       "type": "object",
       "properties": {
-        "totalActions": {
-          "type": "integer",
-          "format": "int32"
-        },
         "actionCountByTags": {
           "type": "object",
           "additionalProperties": {
             "type": "integer",
             "format": "int32"
           }
+        },
+        "totalActions": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },
     "ConfigurationProperty": {
       "type": "object",
       "properties": {
+        "secret": {
+          "type": "boolean"
+        },
         "raw": {
           "type": "boolean"
         },
@@ -802,13 +805,10 @@
         "displayName": {
           "type": "string"
         },
-        "label": {
-          "type": "string"
-        },
         "description": {
           "type": "string"
         },
-        "kind": {
+        "label": {
           "type": "string"
         },
         "deprecated": {
@@ -817,28 +817,31 @@
         "group": {
           "type": "string"
         },
+        "kind": {
+          "type": "string"
+        },
         "enum": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PropertyValue"
           }
         },
-        "componentProperty": {
-          "type": "boolean"
-        },
-        "connectorValue": {
+        "generator": {
           "type": "string"
         },
-        "placeholder": {
+        "required": {
+          "type": "boolean"
+        },
+        "controlHint": {
+          "type": "string"
+        },
+        "connectorValue": {
           "type": "string"
         },
         "multiple": {
           "type": "boolean"
         },
-        "labelHint": {
-          "type": "string"
-        },
-        "controlHint": {
+        "javaType": {
           "type": "string"
         },
         "relation": {
@@ -847,16 +850,13 @@
             "$ref": "#/definitions/PropertyRelation"
           }
         },
-        "javaType": {
+        "placeholder": {
           "type": "string"
         },
-        "generator": {
+        "labelHint": {
           "type": "string"
         },
-        "required": {
-          "type": "boolean"
-        },
-        "secret": {
+        "componentProperty": {
           "type": "boolean"
         },
         "tags": {
@@ -900,9 +900,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -915,6 +912,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -951,10 +951,10 @@
         "id": {
           "type": "string"
         },
-        "warnings": {
+        "errors": {
           "$ref": "#/definitions/OptionalInt"
         },
-        "errors": {
+        "warnings": {
           "$ref": "#/definitions/OptionalInt"
         },
         "notices": {
@@ -1017,9 +1017,6 @@
         "userId": {
           "type": "string"
         },
-        "organizationId": {
-          "type": "string"
-        },
         "connector": {
           "$ref": "#/definitions/Connector"
         },
@@ -1032,6 +1029,9 @@
         },
         "derived": {
           "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
         },
         "tags": {
           "type": "array",
@@ -1076,6 +1076,9 @@
           "readOnly": true,
           "$ref": "#/definitions/OptionalInt"
         },
+        "connectorGroup": {
+          "$ref": "#/definitions/ConnectorGroup"
+        },
         "connectorGroupId": {
           "type": "string"
         },
@@ -1093,9 +1096,6 @@
         },
         "actionsSummary": {
           "$ref": "#/definitions/ActionsSummary"
-        },
-        "connectorGroup": {
-          "$ref": "#/definitions/ConnectorGroup"
         },
         "id": {
           "type": "string"
@@ -1193,9 +1193,6 @@
     "ConnectorDescriptor": {
       "type": "object",
       "properties": {
-        "camelConnectorPrefix": {
-          "type": "string"
-        },
         "camelConnectorGAV": {
           "type": "string"
         },
@@ -1214,17 +1211,20 @@
         "connectorId": {
           "type": "string"
         },
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
+        "camelConnectorPrefix": {
+          "type": "string"
         },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         },
         "configuredProperties": {
           "type": "object",
@@ -1250,6 +1250,13 @@
       "type": "object",
       "required": ["name"],
       "properties": {
+        "releaseTag": {
+          "type": "string"
+        },
+        "lastTaggedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
         "lastExportedAt": {
           "type": "string",
           "format": "date-time"
@@ -1257,13 +1264,6 @@
         "lastImportedAt": {
           "type": "string",
           "format": "date-time"
-        },
-        "lastTaggedAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "releaseTag": {
-          "type": "string"
         },
         "name": {
           "type": "string"
@@ -1292,6 +1292,13 @@
       "type": "object",
       "required": ["name"],
       "properties": {
+        "exemplar": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "byte"
+          }
+        },
         "name": {
           "type": "string"
         },
@@ -1307,6 +1314,12 @@
         "description": {
           "type": "string"
         },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "kind": {
           "type": "string",
           "enum": [
@@ -1320,12 +1333,6 @@
             "NONE"
           ]
         },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "collectionType": {
           "type": "string"
         },
@@ -1334,13 +1341,6 @@
         },
         "specification": {
           "type": "string"
-        },
-        "exemplar": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "byte"
-          }
         }
       }
     },
@@ -1467,14 +1467,14 @@
         "description": {
           "type": "string"
         },
-        "scheduler": {
-          "$ref": "#/definitions/Scheduler"
-        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
+        },
+        "scheduler": {
+          "$ref": "#/definitions/Scheduler"
         },
         "name": {
           "type": "string"
@@ -1657,14 +1657,14 @@
             "$ref": "#/definitions/Step"
           }
         },
+        "deleted": {
+          "type": "boolean"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "deleted": {
-          "type": "boolean"
         },
         "continuousDeliveryState": {
           "type": "object",
@@ -1717,10 +1717,10 @@
     "IntegrationBulletinBoard": {
       "type": "object",
       "properties": {
-        "warnings": {
+        "errors": {
           "$ref": "#/definitions/OptionalInt"
         },
-        "errors": {
+        "warnings": {
           "$ref": "#/definitions/OptionalInt"
         },
         "notices": {
@@ -1769,10 +1769,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -1781,6 +1777,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -1823,10 +1823,6 @@
         "userId": {
           "type": "string"
         },
-        "currentState": {
-          "type": "string",
-          "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
         "stepsDone": {
           "type": "object",
           "additionalProperties": {
@@ -1835,6 +1831,10 @@
         },
         "statusMessage": {
           "type": "string"
+        },
+        "currentState": {
+          "type": "string",
+          "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
         "targetState": {
           "type": "string",
@@ -1867,19 +1867,19 @@
           "type": "integer",
           "format": "int32"
         },
-        "integrationId": {
-          "type": "string"
-        },
-        "podName": {
-          "type": "string"
-        },
         "detailedState": {
           "type": "string",
           "enum": ["ASSEMBLING", "BUILDING", "DEPLOYING", "STARTING"]
         },
+        "podName": {
+          "type": "string"
+        },
         "linkType": {
           "type": "string",
           "enum": ["EVENTS", "LOGS"]
+        },
+        "integrationId": {
+          "type": "string"
         },
         "id": {
           "type": "string"
@@ -1896,6 +1896,16 @@
         "board": {
           "$ref": "#/definitions/IntegrationBulletinBoard"
         },
+        "deploymentVersion": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "deployments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntegrationDeploymentOverview"
+          }
+        },
         "draft": {
           "type": "boolean"
         },
@@ -1903,19 +1913,9 @@
           "type": "string",
           "enum": ["Published", "Unpublished", "Error", "Pending"]
         },
-        "deploymentVersion": {
-          "type": "integer",
-          "format": "int32"
-        },
         "targetState": {
           "type": "string",
           "enum": ["Published", "Unpublished", "Error", "Pending"]
-        },
-        "deployments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IntegrationDeploymentOverview"
-          }
         },
         "id": {
           "type": "string"
@@ -1935,14 +1935,14 @@
             "$ref": "#/definitions/Step"
           }
         },
+        "deleted": {
+          "type": "boolean"
+        },
         "connections": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Connection"
           }
-        },
-        "deleted": {
-          "type": "boolean"
         },
         "continuousDeliveryState": {
           "type": "object",
@@ -2104,16 +2104,16 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "environments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Environment"
-          }
-        },
         "users": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/User"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Environment"
           }
         },
         "id": {
@@ -2208,14 +2208,14 @@
     "Step": {
       "type": "object",
       "properties": {
-        "connection": {
-          "$ref": "#/definitions/Connection"
-        },
         "name": {
           "type": "string"
         },
         "extension": {
           "$ref": "#/definitions/Extension"
+        },
+        "connection": {
+          "$ref": "#/definitions/Connection"
         },
         "action": {
           "$ref": "#/definitions/Action"
@@ -2273,17 +2273,17 @@
         "entrypoint": {
           "type": "string"
         },
-        "inputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
-        "outputDataShape": {
-          "$ref": "#/definitions/DataShape"
-        },
         "propertyDefinitionSteps": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ActionDescriptorStep"
           }
+        },
+        "inputDataShape": {
+          "$ref": "#/definitions/DataShape"
+        },
+        "outputDataShape": {
+          "$ref": "#/definitions/DataShape"
         }
       }
     },
@@ -2305,6 +2305,12 @@
         "organizationId": {
           "type": "string"
         },
+        "lastName": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
         "integrations": {
           "type": "array",
           "items": {
@@ -2312,12 +2318,6 @@
           }
         },
         "roleId": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "firstName": {
           "type": "string"
         },
         "id": {


### PR DESCRIPTION
With #5924 the `configured` was refactored to `isConfigured` so that the Swagger core JAX-RS support recognizes the property. This made the serialization to JSON serialize it as `isConfigured` instead of `configured` as declared in the internal OpenAPI document.

This reverts that refactor, and the adds `@JsonProperty` annotation to explicitly name the property as `configured`.

Fixes #6005