### PR TITLE
Remove cypress from dev-dependencies

### DIFF
--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -82,7 +82,6 @@
     "babel-loader": "^8.0.4",
     "babel-plugin-named-asset-import": "^0.3.1",
     "babel-preset-react-app": "^8.0.0",
-    "cypress": "^3.2.0",
     "cpr": "^3.0.1",
     "jest-dom": "^3.1.3",
     "my-local-ip": "^1.0.0",


### PR DESCRIPTION
Remove cypress from dev-dependencies - it requires external binaries that are unavailable inside the proxy.  

Talked to @riccardo-forina about this and he said it was not used currently but would be in the future and that it would be okay in 1.7.x to build without the dependency on cypress.    I'll figure out how to get cypress installed for 1.8, but if we could remove it for 1.7.x that would be helpful.