### PR TITLE
Changes to ui poms (phases, node-sass/iltorb) for proxies

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -99,6 +99,12 @@
 
     <maven-common-artifact-filters.version>1.4</maven-common-artifact-filters.version>
     <maven-shared-utils.version>3.1.0</maven-shared-utils.version>
+    <maven-download.version>1.3.0</maven-download.version>
+
+
+    <!-- UI dependencies -->
+    <iltorb-version>2.4.1</iltorb-version>
+    <node-sass-version>4.12.0</node-sass-version>
 
     <!-- Common dependencies -->
     <assertj-core.version>3.11.1</assertj-core.version>
@@ -963,6 +969,13 @@
           <artifactId>frontend-maven-plugin</artifactId>
           <version>1.6</version>
         </plugin>
+
+        <plugin>
+          <groupId>com.googlecode.maven-download-plugin</groupId>
+          <artifactId>download-maven-plugin</artifactId>
+          <version>${maven-download.version}</version>
+        </plugin>
+
 
       </plugins>
     </pluginManagement>

--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -93,6 +93,7 @@
         <executions>
           <execution>
             <id>install node and npm</id>
+            <phase>initialize</phase>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
@@ -102,6 +103,7 @@
           </execution>
           <execution>
             <id>install yarn</id>
+            <phase>initialize</phase>
             <goals>
               <goal>install-node-and-yarn</goal>
             </goals>
@@ -112,6 +114,7 @@
           </execution>
           <execution>
             <id>yarn install</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -121,30 +124,36 @@
           </execution>
           <execution>
             <id>yarn ng lint</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
             <configuration>
               <arguments>lint</arguments>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
           <execution>
             <id>yarn ng test</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
             <configuration>
               <arguments>test:ci</arguments>
               <skip>${skipTests}</skip>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
           <execution>
             <id>yarn cleanup</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
             <configuration>
               <arguments>cleanup</arguments>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
           <execution>
@@ -152,8 +161,10 @@
             <goals>
               <goal>yarn</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
               <arguments>build:ci</arguments>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
         </executions>
@@ -205,9 +216,9 @@
             <executions>
               <execution>
                 <id>set https proxy</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>yarn</goal>
+                  <goal>npm</goal>
                 </goals>
                 <configuration>
                   <arguments>config set https-proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
@@ -215,9 +226,9 @@
               </execution>
               <execution>
                 <id>set http proxy</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>yarn</goal>
+                  <goal>npm</goal>
                 </goals>
                 <configuration>
                   <arguments>config set proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
@@ -225,9 +236,9 @@
               </execution>
               <execution>
                 <id>set maxconn</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>yarn</goal>
+                  <goal>npm</goal>
                 </goals>
                 <configuration>
                   <arguments>config set maxsockets 30</arguments>
@@ -253,7 +264,7 @@
             <executions>
               <execution>
                 <id>set registry</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>npm</goal>
                 </goals>
@@ -263,7 +274,7 @@
               </execution>
               <execution>
                 <id>yarn set registry</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -278,6 +289,11 @@
     </profile>
     <profile>
       <id>insecure</id>
+      <activation>
+        <property>
+          <name>yarn-insecure</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -286,7 +302,7 @@
             <executions>
               <execution>
                 <id>yarn set no-strict ssl</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -309,27 +325,64 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <configuration>
+                  <url>${sass-binary-site}/v${node-sass-version}/linux-x64-64_binding.node</url>
+                  <outputFileName>binding.node</outputFileName>
+                  <outputDirectory>${project.build.directory}/linux-x64-64</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>yarn set sass binary url</id>
-                <phase>initialize</phase>
+                <id>yarn unset sass binary url</id>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>config set sass-binary-site ${sass-binary-site}</arguments>
+                  <arguments>config delete sass-binary-site</arguments>
                 </configuration>
               </execution>
               <execution>
-                <id>install node-sass</id>
-                <phase>initialize</phase>
+                <id>npm unset sass binary url</id>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>install --global-style node-sass@4.9.0 ${npm-verbose} --max-sockets=30 --fetch-retry-mintimeout=60000 --fetch-retries=10</arguments>
+                  <arguments>config delete sass-binary-site</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>npm set sass binary path</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>yarn set sass binary path</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
                 </configuration>
               </execution>
             </executions>

--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -124,7 +124,7 @@
           </execution>
           <execution>
             <id>yarn ng lint</id>
-            <phase>verify</phase>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -147,7 +147,7 @@
           </execution>
           <execution>
             <id>yarn cleanup</id>
-            <phase>generate-sources</phase>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -158,10 +158,10 @@
           </execution>
           <execution>
             <id>yarn ng build</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
-            <phase>compile</phase>
             <configuration>
               <arguments>build:ci</arguments>
               <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
@@ -324,9 +324,9 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>${sass-binary-site}/v${node-sass-version}/linux-x64-64_binding.node</url>
+                  <url>${sass-binary-site}/v${node-sass-version}/${os.type}-x64-64_binding.node</url>
                   <outputFileName>binding.node</outputFileName>
-                  <outputDirectory>${project.build.directory}/linux-x64-64</outputDirectory>
+                  <outputDirectory>${project.build.directory}/${os.type}-x64-64</outputDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -362,7 +362,7 @@
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
+                  <arguments>config set sass-binary-path ${project.build.directory}/${os.type}-x64-64/binding.node</arguments>
                 </configuration>
               </execution>
               <execution>
@@ -372,7 +372,7 @@
                   <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
+                  <arguments>config set sass-binary-path ${project.build.directory}/${os.type}-x64-64/binding.node</arguments>
                 </configuration>
               </execution>
             </executions>
@@ -479,6 +479,33 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>macosx</id>
+      <activation>
+        <os><family>mac</family></os>
+      </activation>
+      <properties>
+        <os.type>darwin</os.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os><name>Linux</name></os>
+      </activation>
+      <properties>
+        <os.type>linux</os.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os><name>Windows</name></os>
+      </activation>
+      <properties>
+        <os.type>win32</os.type>
+      </properties>
     </profile>
   </profiles>
 

--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -124,7 +124,7 @@
           </execution>
           <execution>
             <id>yarn ng lint</id>
-            <phase>compile</phase>
+            <phase>verify</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -135,7 +135,7 @@
           </execution>
           <execution>
             <id>yarn ng test</id>
-            <phase>compile</phase>
+            <phase>test</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -147,7 +147,7 @@
           </execution>
           <execution>
             <id>yarn cleanup</id>
-            <phase>compile</phase>
+            <phase>generate-sources</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -218,7 +218,7 @@
                 <id>set https proxy</id>
                 <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
                   <arguments>config set https-proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
@@ -228,7 +228,7 @@
                 <id>set http proxy</id>
                 <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
                   <arguments>config set proxy http://${proxy-user}:${proxy-password}@${proxy-server}:${proxy-port}</arguments>
@@ -238,7 +238,7 @@
                 <id>set maxconn</id>
                 <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
                   <arguments>config set maxsockets 30</arguments>
@@ -262,16 +262,6 @@
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
-              <execution>
-                <id>set registry</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <configuration>
-                  <arguments>config set registry ${custom-registry}</arguments>
-                </configuration>
-              </execution>
               <execution>
                 <id>yarn set registry</id>
                 <phase>generate-sources</phase>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -81,6 +81,7 @@
 
           <execution>
             <id>install-node-and-yarn</id>
+            <phase>initialize</phase>
             <goals>
               <goal>install-node-and-yarn</goal>
             </goals>
@@ -92,6 +93,7 @@
 
           <execution>
             <id>yarn-install</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -102,11 +104,13 @@
 
           <execution>
             <id>yarn-lint</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
             <configuration>
               <arguments>lint</arguments>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
 
@@ -115,8 +119,10 @@
             <goals>
               <goal>yarn</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
               <arguments>build</arguments>
+               <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
 
@@ -125,9 +131,11 @@
             <goals>
               <goal>yarn</goal>
             </goals>
+            <phase>test</phase>
             <configuration>
               <arguments>test</arguments>
               <skip>${skipTests}</skip>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
             </configuration>
           </execution>
         </executions>
@@ -179,7 +187,7 @@
             <executions>
               <execution>
                 <id>set https proxy</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -189,7 +197,7 @@
               </execution>
               <execution>
                 <id>set http proxy</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -199,7 +207,7 @@
               </execution>
               <execution>
                 <id>set maxconn</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -226,18 +234,8 @@
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>set registry</id>
-                <phase>initialize</phase>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <configuration>
-                  <arguments>config set registry ${custom-registry}</arguments>
-                </configuration>
-              </execution>
-              <execution>
                 <id>yarn set registry</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -260,7 +258,7 @@
             <executions>
               <execution>
                 <id>yarn set no-strict ssl</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
@@ -283,27 +281,58 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>1.3.0</version>
+            <executions>
+              <execution>
+                <id>download-node-sass</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <configuration>
+                  <url>${sass-binary-site}/v${node-sass-version}/linux-x64-64_binding.node</url>
+                  <outputFileName>binding.node</outputFileName>
+                  <outputDirectory>${project.build.directory}/linux-x64-64</outputDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>download-iltorb</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <configuration>
+                  <url>${iltorb-binary-site}/v${iltorb-version}/iltorb-v${iltorb-version}-node-v64-linux-x64.tar.gz</url>
+                  <outputFileName>45aa7d-iltorb-v${iltorb-version}-node-v64-linux-x64.tar.gz</outputFileName>
+                  <outputDirectory>${user.home}/.npm/_prebuilds/</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>yarn set sass binary url</id>
-                <phase>initialize</phase>
+                <id>yarn unset sass binary url</id>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>config set sass-binary-site ${sass-binary-site}</arguments>
+                  <arguments>config delete sass-binary-site</arguments>
                 </configuration>
               </execution>
               <execution>
-                <id>install node-sass</id>
-                <phase>initialize</phase>
+                <id>yarn set sass binary dir</id>
+                <phase>generate-sources</phase>
                 <goals>
-                  <goal>npm</goal>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>install --global-style node-sass@4.9.0 ${npm-verbose} --max-sockets=30 --fetch-retry-mintimeout=60000 --fetch-retries=10</arguments>
+                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
                 </configuration>
               </execution>
             </executions>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -104,7 +104,7 @@
 
           <execution>
             <id>yarn-lint</id>
-            <phase>compile</phase>
+            <phase>verify</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
@@ -116,10 +116,10 @@
 
           <execution>
             <id>yarn-build</id>
+            <phase>compile</phase>
             <goals>
               <goal>yarn</goal>
             </goals>
-            <phase>compile</phase>
             <configuration>
               <arguments>build</arguments>
                <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -291,9 +291,9 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>${sass-binary-site}/v${node-sass-version}/linux-x64-64_binding.node</url>
+                  <url>${sass-binary-site}/v${node-sass-version}/${os.type}-x64-64_binding.node</url>
                   <outputFileName>binding.node</outputFileName>
-                  <outputDirectory>${project.build.directory}/linux-x64-64</outputDirectory>
+                  <outputDirectory>${project.build.directory}/${os.type}-x64-64</outputDirectory>
                 </configuration>
               </execution>
               <execution>
@@ -303,8 +303,8 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>${iltorb-binary-site}/v${iltorb-version}/iltorb-v${iltorb-version}-node-v64-linux-x64.tar.gz</url>
-                  <outputFileName>45aa7d-iltorb-v${iltorb-version}-node-v64-linux-x64.tar.gz</outputFileName>
+                  <url>${iltorb-binary-site}/v${iltorb-version}/iltorb-v${iltorb-version}-node-v64-${os.type}-x64.tar.gz</url>
+                  <outputFileName>45aa7d-iltorb-v${iltorb-version}-node-v64-${os.type}-x64.tar.gz</outputFileName>
                   <outputDirectory>${user.home}/.npm/_prebuilds/</outputDirectory>
                 </configuration>
               </execution>
@@ -548,6 +548,33 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>macosx</id>
+      <activation>
+        <os><family>mac</family></os>
+      </activation>
+      <properties>
+        <os.type>darwin</os.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os><name>Linux</name></os>
+      </activation>
+      <properties>
+        <os.type>linux</os.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os><name>Windows</name></os>
+      </activation>
+      <properties>
+        <os.type>win32</os.type>
+      </properties>
     </profile>
   </profiles>
 

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -283,7 +283,6 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>download-node-sass</id>


### PR DESCRIPTION
Adding a number of changes here to support the build of the ui behind a proxy.      The execution phases needed to be changed so that yarn/npm install happened first, then downloads / config changes, and then the build.

yarnInheritsProxyConfigFromMaven needed to be added to a number of executions so that maven does not add in --proxy to yarn commands like lint where that option is not supported.

Some additional changes here to support the required downloads of node-sass and iltorb.

Similar changes need to go into master, but I will do them separately because I think there need to be other additions (cypress, etc).