### PR TITLE
#5992: Correcting the ENV variable BUILD_IMAGE_STREAM in deploymentco…

### DIFF
--- a/install/generator/04-teiid-komodo-server.yml.mustache
+++ b/install/generator/04-teiid-komodo-server.yml.mustache
@@ -62,7 +62,7 @@
           - name: GC_MAX_METASPACE_SIZE
             value: "512"
           - name: BUILD_IMAGE_STREAM
-            value: {{ Images.Syndesis.S2i }}:latest
+            value: {{ Images.Syndesis.S2i }}:{{ Tags.Syndesis }}
           - name: POSTGRESQL_PASSWORD
             value: ${POSTGRESQL_PASSWORD}
           - name: POSTGRESQL_USER


### PR DESCRIPTION
…nfig of komodo-server to point to correct tag version of the build image stream