### PR TITLE
fix(5955): Error after change of template step language type

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/template/useTemplater.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/template/useTemplater.tsx
@@ -43,7 +43,7 @@ function createSpecification(symbols: TemplateSymbol[]): string {
     type: 'object',
   };
   if (symbols.length === 0) {
-    return spec;
+    return JSON.stringify(spec);
   }
   const properties: any = {};
   for (const symbol of symbols) {
@@ -78,7 +78,7 @@ export function useTemplater(props: IUseTemplaterProps) {
 
   const handleTemplateTypeChange = (newType: TemplateType) => {
     setLanguage(newType);
-    linter.current = TemplateStepLinters[language];
+    linter.current = TemplateStepLinters[newType];
   };
 
   const handleEditorChange = (e: ITextEditor, data: any, text: string) => {


### PR DESCRIPTION
* Bad request caused by no JSON.stringify when symbols length is 0

* Symbols length is being left as 0 since linter is not being changed back
  due to language not being immediately updated during the function
  handleTemplateTypeChange
 * By adding a useEffect dependent on language, the linter is correctly
   updated once language has been changed.