### PR TITLE
Change phases of iltorb/node-sass download to generate-sources

### DIFF
--- a/app/ui-angular/pom.xml
+++ b/app/ui-angular/pom.xml
@@ -319,7 +319,7 @@
             <artifactId>download-maven-plugin</artifactId>
             <executions>
               <execution>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -286,7 +286,7 @@
             <executions>
               <execution>
                 <id>download-node-sass</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -298,7 +298,7 @@
               </execution>
               <execution>
                 <id>download-iltorb</id>
-                <phase>initialize</phase>
+                <phase>generate-sources</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>


### PR DESCRIPTION
I tested out the changes made in fa3cbe42637b33c1bf8015c2ac64862725224322 and would like to change the phases of the node-sass/iltorb download to generate-sources.     Keeping the phase as generate-sources makes debugging easier (all of the executions in the profile then happen back to back and the order that they are listed in the profile ensures that they execute correctly).    