### PR TITLE
Fix syndesis permissions and legacy mode

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
-    <camel.version>2.21.0.fuse-740028</camel.version>
+    <camel.version>2.21.0.fuse-740038</camel.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/integration/bom-camel-k/pom.xml
+++ b/app/integration/bom-camel-k/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <camel.version>2.21.0.fuse-740028</camel.version>
+    <camel.version>2.21.0.fuse-740038</camel.version>
     <atlasmap.version>1.39.5</atlasmap.version>
     <jackson.version>2.8.11</jackson.version>
     <jackson.databind.version>2.8.11.3</jackson.databind.version>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
-    <camel.version>2.21.0.fuse-740028</camel.version>
+    <camel.version>2.21.0.fuse-740038</camel.version>
     <atlasmap.version>1.40.2</atlasmap.version>
     <jackson.databind.version>2.8.11.3</jackson.databind.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -77,8 +77,8 @@
     <commons.compress.version>1.18</commons.compress.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.21.0.fuse-740028</camel.version>
-    <camel-k-runtime.version>0.3.4.fuse-740007</camel-k-runtime.version>
+    <camel.version>2.21.0.fuse-740038</camel.version>
+    <camel-k-runtime.version>0.3.4.fuse-740008</camel-k-runtime.version>
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
     <basepom.test.fork-count>1</basepom.test.fork-count>

--- a/install/generator/05-syndesis-security.yml.mustache
+++ b/install/generator/05-syndesis-security.yml.mustache
@@ -26,6 +26,17 @@
     - replicationcontrollers/scale
     verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
   - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    - statefulsets/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
     - extensions
     resources:
     - daemonsets
@@ -203,14 +214,6 @@
     - list
     - watch
   - apiGroups:
-    - ""
-    resources:
-    - namespaces
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
     - apps
     resources:
     - daemonsets
@@ -301,7 +304,6 @@
     - list
     - watch
   - apiGroups:
-    - ""
     - route.openshift.io
     resources:
     - routes

--- a/install/generator/05-syndesis-security.yml.mustache
+++ b/install/generator/05-syndesis-security.yml.mustache
@@ -22,26 +22,63 @@
   - apiGroups:
     - ""
     resources:
-    - pods/log
-    verbs: [ get ]
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - ingresses
+    - networkpolicies
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
   - apiGroups:
     - ""
     resources:
-    - replicationcontrollers
-    - replicationcontrollers/scale
+    - bindings
+    - events
+    - limitranges
+    - namespaces/status
+    - pods/log
+    - pods/status
     - replicationcontrollers/status
-    verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - resourcequotas
+    - resourcequotas/status
+    verbs: [ get, list, watch ]
   - apiGroups:
     - ""
     - build.openshift.io
     resources:
-    - builds
     - buildconfigs
-    - builds/details
     - buildconfigs/webhooks
+    - builds
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildconfigs/instantiate
     - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs: [ create ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - builds/details
+    verbs: [ update ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
     - builds/log
-    verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    verbs: [ get, list, watch ]
   - apiGroups:
     - ""
     - apps.openshift.io
@@ -78,8 +115,13 @@
     - ""
     - image.openshift.io
     resources:
-    - imagestreams/status
     - imagestreamimports
+    verbs: [ create ]
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreams/status
     verbs: [ get, list, watch ]
   - apiGroups:
     - route.openshift.io

--- a/install/generator/05-syndesis-security.yml.mustache
+++ b/install/generator/05-syndesis-security.yml.mustache
@@ -128,6 +128,21 @@
     resources:
     - routes
     verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - template.openshift.io
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templateinstances
+    - templates
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildlogs
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -144,4 +159,191 @@
   roleRef:
     kind: Role
     name: syndesis-editor
+    apiGroup: rbac.authorization.k8s.io
+
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: syndesis-viewer
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
+    - pods
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - bindings
+    - events
+    - limitranges
+    - namespaces/status
+    - pods/log
+    - pods/status
+    - replicationcontrollers/status
+    - resourcequotas
+    - resourcequotas/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    - statefulsets/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - ingresses
+    - networkpolicies
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - apps.openshift.io
+    resources:
+    - deploymentconfigs
+    - deploymentconfigs/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - apps.openshift.io
+    resources:
+    - deploymentconfigs/log
+    - deploymentconfigs/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreamimages
+    - imagestreammappings
+    - imagestreams
+    - imagestreamtags
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreams/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - template.openshift.io
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templateinstances
+    - templates
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildlogs
+    verbs:
+    - get
+    - list
+    - watch
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: syndesis-prometheus-viewer
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-prometheus
+  subjects:
+  - kind: ServiceAccount
+    name: syndesis-prometheus
+  roleRef:
+    kind: Role
+    name: syndesis-viewer
     apiGroup: rbac.authorization.k8s.io

--- a/install/operator/deploy/manifests/1.7.0/syndesisoperator.1.7.0.clusterserviceversion.yaml
+++ b/install/operator/deploy/manifests/1.7.0/syndesisoperator.1.7.0.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ spec:
           resources:
           - "*"
           - "*/finalizers"
-          verbs: [ get, list, create, update, delete, deletecollection, watch]
+          verbs: [ get, list, create, update, delete, deletecollection, watch ]
         - apiGroups:
           - ""
           resources:
@@ -97,30 +97,78 @@ spec:
           - configmaps
           - secrets
           - serviceaccounts
-          verbs: [ get, list, create, update, delete, deletecollection, watch]
-        - apiGroups:
-          - ""
-          resources:
-          - pods/log
-          verbs: [ get ]
+          verbs: [ get, list, create, update, delete, deletecollection, watch ]
         - apiGroups:
           - ""
           resources:
           - replicationcontrollers
           - replicationcontrollers/scale
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/rollback
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - events
+          - limitranges
+          - namespaces/status
+          - pods/log
+          - pods/status
           - replicationcontrollers/status
-          verbs: [ get, list, create, update, delete, deletecollection, watch ]
+          - resourcequotas
+          - resourcequotas/status
+          verbs: [ get, list, watch ]
         - apiGroups:
           - ""
           - build.openshift.io
           resources:
-          - builds
           - buildconfigs
-          - builds/details
           - buildconfigs/webhooks
+          - builds
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs/instantiate
           - buildconfigs/instantiatebinary
+          - builds/clone
+          verbs: [ create ]
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/details
+          verbs: [ update ]
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
           - builds/log
-          verbs: [ get, list, create, update, delete, deletecollection, watch ]
+          verbs: [ get, list, watch ]
         - apiGroups:
           - ""
           - apps.openshift.io
@@ -157,8 +205,13 @@ spec:
           - ""
           - image.openshift.io
           resources:
-          - imagestreams/status
           - imagestreamimports
+          verbs: [ create ]
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
           verbs: [ get, list, watch ]
         - apiGroups:
           - ""
@@ -170,7 +223,7 @@ spec:
           resources:
           - roles
           - rolebindings
-          verbs: [ get, list, create, update, delete, deletecollection, watch]
+          verbs: [ get, list, create, update, delete, deletecollection, watch ]
         - apiGroups:
           - ""
           - template.openshift.io
@@ -181,16 +234,22 @@ spec:
           - templates
           verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
         - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+        - apiGroups:
           - authorization.openshift.io
           resources:
           - rolebindings
-          verbs: [ get, list, create, update, delete, deletecollection, watch]
+          verbs: [ get, list, create, update, delete, deletecollection, watch ]
         - apiGroups:
           - route.openshift.io
           resources:
           - routes
           - routes/custom-host
-          verbs: [ get, list, create, update, delete, deletecollection, watch]
+          verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
         - apiGroups:
           - camel.apache.org
           resources:

--- a/install/operator/deploy/syndesis-operator.yml
+++ b/install/operator/deploy/syndesis-operator.yml
@@ -39,26 +39,74 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/log
-  verbs: [ get ]
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 - apiGroups:
   - ""
   resources:
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
   - replicationcontrollers/status
-  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+  - resourcequotas
+  - resourcequotas/status
+  verbs: [ get, list, watch ]
 - apiGroups:
   - ""
   - build.openshift.io
   resources:
-  - builds
   - buildconfigs
-  - builds/details
   - buildconfigs/webhooks
+  - builds
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs/instantiate
   - buildconfigs/instantiatebinary
+  - builds/clone
+  verbs: [ create ]
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds/details
+  verbs: [ update ]
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
   - builds/log
-  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+  verbs: [ get, list, watch ]
 - apiGroups:
   - ""
   - apps.openshift.io
@@ -95,8 +143,13 @@ rules:
   - ""
   - image.openshift.io
   resources:
-  - imagestreams/status
   - imagestreamimports
+  verbs: [ create ]
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/status
   verbs: [ get, list, watch ]
 - apiGroups:
   - ""
@@ -117,6 +170,12 @@ rules:
   - templateconfigs
   - templateinstances
   - templates
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildlogs
   verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 - apiGroups:
   - authorization.openshift.io

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -2450,6 +2450,21 @@ objects:
     resources:
     - routes
     verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - template.openshift.io
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templateinstances
+    - templates
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildlogs
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -2466,6 +2481,193 @@ objects:
   roleRef:
     kind: Role
     name: syndesis-editor
+    apiGroup: rbac.authorization.k8s.io
+
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: syndesis-viewer
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
+    - pods
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - bindings
+    - events
+    - limitranges
+    - namespaces/status
+    - pods/log
+    - pods/status
+    - replicationcontrollers/status
+    - resourcequotas
+    - resourcequotas/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    - statefulsets/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - ingresses
+    - networkpolicies
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - apps.openshift.io
+    resources:
+    - deploymentconfigs
+    - deploymentconfigs/scale
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - apps.openshift.io
+    resources:
+    - deploymentconfigs/log
+    - deploymentconfigs/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreamimages
+    - imagestreammappings
+    - imagestreams
+    - imagestreamtags
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreams/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - template.openshift.io
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templateinstances
+    - templates
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildlogs
+    verbs:
+    - get
+    - list
+    - watch
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: syndesis-prometheus-viewer
+    labels:
+      app: syndesis
+      syndesis.io/app: syndesis
+      syndesis.io/type: infrastructure
+      syndesis.io/component: syndesis-prometheus
+  subjects:
+  - kind: ServiceAccount
+    name: syndesis-prometheus
+  roleRef:
+    kind: Role
+    name: syndesis-viewer
     apiGroup: rbac.authorization.k8s.io
 - apiVersion: v1
   kind: ServiceAccount

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -2102,6 +2102,8 @@ objects:
             value: ${POSTGRESQL_USER}
           - name: POSTGRESQL_DATABASE
             value: ${POSTGRESQL_DATABASE}
+          - name: CONTROLLERS_EXPOSE_VIA3SCALE
+            value: ''            
           image: ' '
 
           imagePullPolicy: IfNotPresent
@@ -2342,26 +2344,63 @@ objects:
   - apiGroups:
     - ""
     resources:
-    - pods/log
-    verbs: [ get ]
+    - replicationcontrollers
+    - replicationcontrollers/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - ingresses
+    - networkpolicies
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
   - apiGroups:
     - ""
     resources:
-    - replicationcontrollers
-    - replicationcontrollers/scale
+    - bindings
+    - events
+    - limitranges
+    - namespaces/status
+    - pods/log
+    - pods/status
     - replicationcontrollers/status
-    verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - resourcequotas
+    - resourcequotas/status
+    verbs: [ get, list, watch ]
   - apiGroups:
     - ""
     - build.openshift.io
     resources:
-    - builds
     - buildconfigs
-    - builds/details
     - buildconfigs/webhooks
+    - builds
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - buildconfigs/instantiate
     - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs: [ create ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
+    - builds/details
+    verbs: [ update ]
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    resources:
     - builds/log
-    verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    verbs: [ get, list, watch ]
   - apiGroups:
     - ""
     - apps.openshift.io
@@ -2398,8 +2437,13 @@ objects:
     - ""
     - image.openshift.io
     resources:
-    - imagestreams/status
     - imagestreamimports
+    verbs: [ create ]
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    resources:
+    - imagestreams/status
     verbs: [ get, list, watch ]
   - apiGroups:
     - route.openshift.io

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -2348,6 +2348,17 @@ objects:
     - replicationcontrollers/scale
     verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
   - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    - statefulsets/scale
+    verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+  - apiGroups:
     - extensions
     resources:
     - daemonsets
@@ -2525,14 +2536,6 @@ objects:
     - list
     - watch
   - apiGroups:
-    - ""
-    resources:
-    - namespaces
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
     - apps
     resources:
     - daemonsets
@@ -2623,7 +2626,6 @@ objects:
     - list
     - watch
   - apiGroups:
-    - ""
     - route.openshift.io
     resources:
     - routes


### PR DESCRIPTION
Fix #6028
Fix #5914

When installing upstream version from template (or legacy mode), some errors are thrown but they are related to camel k and knative and you can ignore them. This is the same behavior it was present before on upstream template.
Those errors will not be present in the final product release.

I've added back the viewer role to let prometheus scrape pods.

This fixes the problem with previous version, that only worked  with full cluster-admin permissions, because it required permissions that are normally not allowed to standard users.