### PR TITLE
fix(5883) - Replace of start/finish connection in integration - the old connection still showing up

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -160,6 +160,14 @@ export const AddStepPage: React.FunctionComponent<
                     getFirstPosition(state.integration, params.flowId) ||
                   position === getLastPosition(state.integration, params.flowId)
                 ) {
+                  setIsDeleting(true);
+                  const newInt = await removeStep(
+                    state.integration,
+                    params.flowId,
+                    position!
+                  );
+                  state.integration = newInt;
+                  setIsDeleting(false);
                   history.push(getDeleteEdgeStepHref(position!, params, state));
                 } else {
                   /**

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorSidebar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorSidebar.tsx
@@ -7,7 +7,11 @@ import {
 import * as React from 'react';
 import { EntityIcon } from '../../../../shared';
 import { IUIStep } from './interfaces';
-import { getDataShapeText, toUIStepCollection } from './utils';
+import {
+  getDataShapeText,
+  isPlaceholderEndpointStep,
+  toUIStepCollection,
+} from './utils';
 
 function makeActiveStep(
   position: number,
@@ -18,6 +22,7 @@ function makeActiveStep(
 ) {
   return activeStep ? (
     <IntegrationFlowStepWithOverview
+      key={position - 1}
       icon={
         <EntityIcon
           alt={activeStep.name}
@@ -41,6 +46,7 @@ function makeActiveStep(
     />
   ) : (
     <IntegrationFlowStepGeneric
+      key={position - 1}
       icon={<i className={'fa fa-plus'} />}
       i18nTitle={`${position}. ${title}`}
       i18nTooltip={tooltip}
@@ -48,6 +54,24 @@ function makeActiveStep(
       showDetails={expanded}
       description={tooltip}
     />
+  );
+}
+
+function getPlaceholderActiveStepComponent(
+  idx: number,
+  expanded: boolean,
+  activeStep?: IUIStep
+) {
+  if (idx === 0) {
+    return makeActiveStep(1, expanded, 'Start', 'Choose a step', activeStep);
+  }
+
+  return makeActiveStep(
+    idx + 1,
+    expanded,
+    'Finish',
+    'Choose a step',
+    activeStep
   );
 }
 
@@ -69,13 +93,7 @@ export const EditorSidebar: React.FunctionComponent<
         if (UISteps.length === 0) {
           return (
             <>
-              {makeActiveStep(
-                1,
-                expanded,
-                'Start',
-                'Choose a step',
-                activeStep
-              )}
+              {getPlaceholderActiveStepComponent(0, expanded, activeStep)}
               <IntegrationFlowStepGeneric
                 icon={<i className={'fa fa-plus'} />}
                 i18nTitle={'2. Finish'}
@@ -109,19 +127,21 @@ export const EditorSidebar: React.FunctionComponent<
                   startStep.outputDataShape
                 )}
               />
-              {makeActiveStep(
-                2,
-                expanded,
-                'Finish',
-                'Choose a step',
-                activeStep
-              )}
+              {getPlaceholderActiveStepComponent(1, expanded, activeStep)}
             </>
           );
         } else {
           return (
             <>
               {UISteps.map((s, idx) => {
+                if (isPlaceholderEndpointStep(UISteps, idx)) {
+                  return getPlaceholderActiveStepComponent(
+                    idx,
+                    expanded,
+                    activeStep
+                  );
+                }
+
                 const isActive = idx === activeIndex;
                 const hasAddStep = isAdding && activeIndex === idx + 1;
                 const isAfterActiveAddStep = activeIndex - 1 < idx;

--- a/app/ui-react/syndesis/src/shared/EntityIcon.tsx
+++ b/app/ui-react/syndesis/src/shared/EntityIcon.tsx
@@ -95,7 +95,12 @@ export function getStepIcon(
   if (typeof kind !== 'undefined') {
     const stepKind = step as Step;
     if (kind === ENDPOINT) {
-      return getConnectionIcon(apiUri, stepKind.connection!);
+      if (stepKind.connection) {
+        return getConnectionIcon(apiUri, stepKind.connection!);
+      }
+
+      // ENDPOINT kind is also used as placeholder for start and finish steps
+      return UNKNOWN_ICON;
     }
     // The step is an extension
     if ((step as Step).stepKind === EXTENSION) {


### PR DESCRIPTION
- See issue #5883
- `AddStepPage` was  not deleting the start or finish endpoint step (now it does)
- modified `EditorSidebar` to display a placeholder component when the start or finish step is missing


