### PR TITLE
user doc: add xref from general json def file info to ui details

### DIFF
--- a/doc/integrating-applications/topics/c_about-extension-definitions.adoc
+++ b/doc/integrating-applications/topics/c_about-extension-definitions.adoc
@@ -113,13 +113,15 @@ Syndesis version 1.3, the following extension types are supported:
 ** `Connectors`
 ** `Libraries`
 
-* *properties* defines the global configuration options that are
-supported by the extension. Only connector extensions use 
-properties that you specify. For example: 
+* *properties* at the top level in a connector extension controls 
+what {prodname} displays when a {prodname} user selects the connector
+to create a connection. This `properties` object contains a set 
+of properties for each form control for creating a connection.
+For example: 
 +
 [source,json]
 ----
-"propertyName": {
+"myControlName": {
   "deprecated": true|false,
   "description": "",
   "displayName": "",
@@ -135,6 +137,13 @@ properties that you specify. For example:
   }
 }
 ----
++
+In connector extensions, nested `properties` objects define HTML form controls for 
+configuring connection actions. 
+In step extensions, the `actions` object contains a `properties`
+object. The `properties` object defines a set of properties for 
+each form control for configuring the step. See also:  
+link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 
 * *actions* defines the operations that a connector can perform or the
 operation that a step between connections can perform. Only connector

--- a/doc/integrating-applications/topics/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
+++ b/doc/integrating-applications/topics/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
@@ -219,7 +219,7 @@ that you specify in the form control’s `enum` property.
 |Description
 
 |`type`
-| 
+|string 
 |Controls the kind of form control that {prodname} displays. See 
 the previous table for details. 
 


### PR DESCRIPTION
This just adds a cross-reference from the topic that talks about the requirements in the extension definition json file to the topic that describes the user interface properties that the json file needs to specify. 