### PR TITLE
Fixes #6069 Add ui and server config map migration from 1.6.x to 1.7.x

### DIFF
--- a/tools/upgrade/migration/resource/02_ui_config_map_upgrade.sh
+++ b/tools/upgrade/migration/resource/02_ui_config_map_upgrade.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Add new datavirt parameters to ui ConfigMap
+# fetch the config.json and append the new parameters for datavirt
+CONFIG_JSON=$(python - <<EOF
+import json
+import os
+
+with os.popen("oc get configmap syndesis-ui-config -o jsonpath='{.data.config\.json}'") as stream:
+  out = stream.read().strip()
+  config = json.loads(out)
+  config["datavirt"] = config.get("datavirt", dict())
+  config["datavirt"]["dvUrl"] = "/vdb-builder/v1/"
+  config["datavirt"]["enabled"] = 0
+  updated = json.dumps(config, indent=4)
+  print updated.replace('\n', "\\\n").replace('\"', '\\\"')
+EOF
+)
+CONFIG_JSON_PATCH="{ \"data\": { \"config.json\": \"$CONFIG_JSON\" } }"
+oc patch configmap syndesis-ui-config -p "$CONFIG_JSON_PATCH"

--- a/tools/upgrade/migration/resource/03_server_config_map_upgrade.sh
+++ b/tools/upgrade/migration/resource/03_server_config_map_upgrade.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Add the new parameter to server ConfigMap
+# fetch the application.yml and append the new parameter
+APP_YAML=$(python - <<EOF
+import yaml
+import os
+
+def quoted_presenter(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"')
+
+yaml.add_representer(str, quoted_presenter)
+
+with os.popen("oc get configmap syndesis-server-config -o jsonpath='{.data.application\.yml}'") as stream:
+  config = yaml.load(stream)
+  config["knative"] = config.get("knative", dict())
+  config["knative"]["enabled"] = False
+  config["integrationLivenessProbeInitialDelaySeconds"] = config.get("integrationLivenessProbeInitialDelaySeconds", dict())
+  config["integrationLivenessProbeInitialDelaySeconds"] = 120
+  updated = yaml.dump(config, default_flow_style=False)
+  print updated.replace('\n', "\\\n").replace('\"', '\\\"')
+EOF
+)
+APP_YAML_PATCH="{ \"data\": { \"application.yml\": \"$APP_YAML\" } }"
+oc patch configmap syndesis-server-config -p "$APP_YAML_PATCH"
+


### PR DESCRIPTION
YAY! my first adventure in python! 

Add missing config map migration scripts adding following entries to config maps:

- syndesis-ui-config
```
"datavirt": {
  "dvUrl": "/vdb-builder/v1/",
  "enabled": 0
}
```

- syndesis-server-config
```
knative:
     enabled: false
integrationLivenessProbeInitialDelaySeconds: 120
```

Not sure about idem potency for these scripts. At the moment the script will just overwrite existing values with these defaults.