### PR TITLE
fix(6085): Email verification needs to fail-fast to avoid request tim…

### DIFF
--- a/app/connector/email/src/main/java/io/syndesis/connector/email/EMailConstants.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/EMailConstants.java
@@ -64,6 +64,8 @@ public interface EMailConstants extends StringConstants {
 
     String PRIORITY = "priority";
 
+    String CONNECTION_TIMEOUT = "mail.connection.timeout";
+
     /**
      * Content types of email
      */
@@ -103,11 +105,29 @@ public interface EMailConstants extends StringConstants {
         }
 
         public Protocol toSecureProtocol() {
-            if (isSecure()) {
-                return this;
+            switch (this) {
+                case IMAP:
+                    return IMAPS;
+                case POP3:
+                    return POP3S;
+                case SMTP:
+                    return SMTPS;
+                default:
+                    return this;
             }
+        }
 
-            return getValueOf(id() + "s");
+        public Protocol toPlainProtocol() {
+            switch (this) {
+                case IMAPS:
+                    return IMAP;
+                case POP3S:
+                    return POP3;
+                case SMTPS:
+                    return SMTP;
+                default:
+                    return this;
+            }
         }
 
         public String id() {

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/receive/ReceiveEMailVerifierExtension.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/receive/ReceiveEMailVerifierExtension.java
@@ -34,7 +34,6 @@ public class ReceiveEMailVerifierExtension extends AbstractEMailVerifier {
         super(defaultScheme, context);
     }
 
-
     // *********************************
     // Parameters validation
     // *********************************
@@ -72,6 +71,14 @@ public class ReceiveEMailVerifierExtension extends AbstractEMailVerifier {
 
         try {
             MailConfiguration configuration = createConfiguration(parameters);
+
+            String timeoutVal = ConnectorOptions.extractOption(parameters, CONNECTION_TIMEOUT);
+            if (ObjectHelper.isEmpty(timeoutVal)) {
+                timeoutVal = Long.toString(DEFAULT_CONNECTION_TIMEOUT);
+            }
+
+            setConnectionTimeoutProperty(parameters, configuration, timeoutVal);
+
             JavaMailSender sender = createJavaMailSender(configuration);
             Session session = sender.getSession();
 

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/send/SendEMailVerifierExtension.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/send/SendEMailVerifierExtension.java
@@ -24,7 +24,9 @@ import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import org.apache.camel.component.mail.JavaMailSender;
 import org.apache.camel.component.mail.MailConfiguration;
+import org.apache.camel.util.ObjectHelper;
 import io.syndesis.connector.email.verifier.AbstractEMailVerifier;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class SendEMailVerifierExtension extends AbstractEMailVerifier {
 
@@ -65,6 +67,14 @@ public class SendEMailVerifierExtension extends AbstractEMailVerifier {
 
         try {
             MailConfiguration configuration = createConfiguration(parameters);
+
+            String timeoutVal = ConnectorOptions.extractOption(parameters, CONNECTION_TIMEOUT);
+            if (ObjectHelper.isEmpty(timeoutVal)) {
+                timeoutVal = Long.toString(DEFAULT_CONNECTION_TIMEOUT);
+            }
+
+            setConnectionTimeoutProperty(parameters, configuration, timeoutVal);
+
             JavaMailSender sender = createJavaMailSender(configuration);
             Session session = sender.getSession();
 


### PR DESCRIPTION
…eout

* When verifying email connections, the default timeout for such
  connections is 30 seconds. Unfortunately, the timeout for http requests
  is also 30 seconds hence by the time the email connection fails & returns
  the original http request has already returned with a "gateway time-out"

* Adds properties to the JavaMail configuration that reduces the connection
  timeouts to a default of 5 seconds. Also, provides for ability to set
  a new timeout value as an option (used by tests).

* Provides tests for checking the connection timeouts are respected.