### PR TITLE
user doc: Updates to doc for API key security based on QA review

### DIFF
--- a/doc/integrating-applications/topics/c_guidelines-for-openapi-documents.adoc
+++ b/doc/integrating-applications/topics/c_guidelines-for-openapi-documents.adoc
@@ -19,7 +19,7 @@ immediately after an API connection that performs a typeless action.
 One remedy for this is to add more information to the OpenAPI document.
 Identify the OpenAPI resource operations that
 will map to the actions you want the API connection to perform. In the
-OpenAPI document, ensure that there is a JSON schema that specifies
+OpenAPI document, ensure that there is a YAML or JSON schema that specifies
 each operation's request and response types.
 
 After you upload the schema, {prodname} gives you an opportunity 
@@ -27,6 +27,9 @@ to review and edit it in Apicurito, which is a visual editor for
 designing APIs based on the OpenAPI document. You can add more detail, 
 save  your updates, and {prodname} creates an API client connector that 
 incorporates your updates. 
+After {prodname} creates the client connector, you can no longer edit 
+the OpenAPI document. To implement a change, you must create a new 
+client connector. 
 
 If the OpenAPI document for the API declares support for
 `application/json` content type and also `application/xml` content type

--- a/doc/integrating-applications/topics/p_creating-api-connectors.adoc
+++ b/doc/integrating-applications/topics/p_creating-api-connectors.adoc
@@ -100,14 +100,17 @@ If you do not upload an icon, {prodname} generates one.
 You can upload an icon at a later time. When {prodname} displays
 the flow of an integration, it displays a connector's icon
 to represent connections that are created from that connector.
-+
-To override a value obtained from
+
+. To override a value obtained from
 the OpenAPI file, edit the field value that you want to change.
++
+[IMPORTANT]
 After {prodname} creates a connector,
-you cannot change it. To effect a change, you need to upload an updated
+*you cannot change it*. To effect a change, you need to upload an updated
 OpenAPI document so that {prodname} can create a new connector
 or you can upload the same schema and then edit it in Apicurito. 
 You then continue the process for creating a new API client connector. 
+
 . When you are satisfied with the connector details, click *Create API Connector*.
 {prodname} displays the new connector with the other connectors. 
 

--- a/doc/integrating-applications/topics/r_refreshing-access-tokens.adoc
+++ b/doc/integrating-applications/topics/r_refreshing-access-tokens.adoc
@@ -6,7 +6,7 @@
 
 If an access token has an expiration date, then {prodname} integrations 
 that use that token to connect to an application stop running successfully 
-when the taken expires. To obtain a new access token, you must 
+when the token expires. To obtain a new access token, you must 
 either reconnect to the application or re-register with the application. 
 
 If you need to, you can change this default behavior so that


### PR DESCRIPTION
Makes it clear that you cannot change an api client connector after Syndesis creates it. 