### PR TITLE
fix(server): activity logging performance improvements

### DIFF
--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/NativeJsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/NativeJsonDB.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.common.model;
+package io.syndesis.server.jsondb;
 
-/**
- * This class is used to track the current model schema version.
- */
-public class Schema {
-    // changing this will reset all the DB data.
-    public static final int VERSION = 31;
+import org.skife.jdbi.v2.DBI;
+
+public interface NativeJsonDB extends CloseableJsonDB {
+
+    DBI database();
+
 }

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/MemorySqlJsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/MemorySqlJsonDB.java
@@ -27,13 +27,14 @@ import org.skife.jdbi.v2.DBI;
 import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.server.jsondb.CloseableJsonDB;
 import io.syndesis.server.jsondb.JsonDBException;
+import io.syndesis.server.jsondb.NativeJsonDB;
 
 /**
  * Used to create in memory version impl of JsonDB
  */
 public class MemorySqlJsonDB {
 
-    private static class ClosableSqlJsonDB extends SqlJsonDB implements CloseableJsonDB {
+    private static class ClosableSqlJsonDB extends SqlJsonDB implements NativeJsonDB {
 
         private final Connection keepsDBOpen;
         private final AtomicBoolean closed = new AtomicBoolean();
@@ -52,6 +53,11 @@ public class MemorySqlJsonDB {
                     throw new IOException(e);
                 }
             }
+        }
+
+        @Override
+        public DBI database() {
+            return dbi;
         }
     }
 

--- a/app/server/runtime/src/main/resources/migrations/up-31.js
+++ b/app/server/runtime/src/main/resources/migrations/up-31.js
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.common.model;
 
-/**
- * This class is used to track the current model schema version.
- */
-public class Schema {
-    // changing this will reset all the DB data.
-    public static final int VERSION = 31;
-}
+internal.jsondb.executeNative('CREATE INDEX IF NOT EXISTS jsondb_activity_idx ON jsondb (path DESC)');
+
+console.log('Migrated to schema 31 completed');

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion31Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion31Test.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.runtime.migrations;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import io.syndesis.server.jsondb.NativeJsonDB;
+import io.syndesis.server.jsondb.dao.Migrator;
+import io.syndesis.server.jsondb.impl.MemorySqlJsonDB;
+import io.syndesis.server.runtime.DefaultMigrator;
+
+import org.junit.Test;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpgradeVersion31Test {
+
+    private static class FetchIndex implements HandleCallback<Set<String>> {
+
+        private static final FetchIndex INSTANCE = new FetchIndex();
+
+        @Override
+        public Set<String> withHandle(final Handle handle) throws Exception {
+            try (Connection con = handle.getConnection()) {
+                final DatabaseMetaData metaData = con.getMetaData();
+                try (ResultSet rs = metaData.getIndexInfo(con.getCatalog(), con.getSchema(), "JSONDB", false, false)) {
+                    final Set<String> indexes = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+                    while (rs.next()) {
+                        final String indexName = rs.getString("INDEX_NAME");
+                        indexes.add(indexName);
+                    }
+
+                    return indexes;
+                }
+            }
+        }
+
+    }
+
+    @Test
+    public void shouldPerformSchemaUpgrade() throws IOException {
+        try (final NativeJsonDB jsondb = (NativeJsonDB) MemorySqlJsonDB.create(Collections.emptyList())) {
+            assertThat(jsondb.database().withHandle(FetchIndex.INSTANCE)).doesNotContain("jsondb_activity_idx");
+
+            final Migrator migrator = new DefaultMigrator(new DefaultResourceLoader());
+            migrator.migrate(jsondb, 31);
+
+            assertThat(jsondb.database().withHandle(FetchIndex.INSTANCE)).contains("jsondb_activity_idx");
+        }
+    }
+
+}


### PR DESCRIPTION
Tries to improve performance of activity tracking persistence by:

 - adding a ordered index on the JSONDB table, in order to help with
   purging of old activity tracking entries during which we order the
   rows by the PATH column
 - explicitly trying to avoid locking when fetching the rows that need
   to be deleted from the database by adding `FOR KEY SHARE SKIP LOCKED`
   to the SELECT statement that's fetching the rows to be deleted

I'm mainly concerned about the change of `NOT IN` to `IN`, the subselect in the `NOT IN` variant will return 50 rows which will be checked against a the rows matching the `LIKE`, so we have a intersection of 50 against N; the changed version has an intersection of N-50 against N, but it doesn't have a `WHERE path LIKE ?` bit so the starting query could be N against N against 50 in some cases. Hope this makes some sense to someone.

Fixes #6052