### PR TITLE
fix(server): handle unsupported security definitions

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/PropertyGenerators.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/PropertyGenerators.java
@@ -83,8 +83,7 @@ enum PropertyGenerators {
             return (swagger, template, settings) -> {
                 final Map<String, SecuritySchemeDefinition> securityDefinitions = swagger.getSecurityDefinitions();
                 if (securityDefinitions == null || securityDefinitions.isEmpty()) {
-                    return Optional
-                        .of(new ConfigurationProperty.Builder().createFrom(template).defaultValue("none").addEnum(NO_SECURITY).build());
+                    return Optional.of(NO_SECURITY.apply(template));
                 }
 
                 final ConfigurationProperty.PropertyValue[] enums = securityDefinitions.entrySet().stream()
@@ -92,7 +91,12 @@ enum PropertyGenerators {
                     .map(e -> SupportedAuthenticationTypes.asPropertyValue(e.getKey(), e.getValue()))
                     .toArray(l -> new ConfigurationProperty.PropertyValue[l]);
 
-                final ConfigurationProperty.Builder authenticationType = new ConfigurationProperty.Builder().createFrom(template)
+                if (enums.length == 0) {
+                    return Optional.of(NO_SECURITY.apply(template));
+                }
+
+                final ConfigurationProperty.Builder authenticationType = new ConfigurationProperty.Builder()
+                    .createFrom(template)
                     .addEnum(enums);
 
                 if (enums.length == 1) {
@@ -189,8 +193,11 @@ enum PropertyGenerators {
         }
     };
 
-    private static final ConfigurationProperty.PropertyValue NO_SECURITY = new ConfigurationProperty.PropertyValue.Builder().value("none")
-        .label("No Security").build();
+    private static final Function<ConfigurationProperty, ConfigurationProperty> NO_SECURITY = template -> new ConfigurationProperty.Builder()
+        .createFrom(template)
+        .defaultValue("none")
+        .addEnum(ConfigurationProperty.PropertyValue.Builder.of("none", "No Security"))
+        .build();
 
     @FunctionalInterface
     interface PropertyGenerator {

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/PropertyGeneratorsTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/PropertyGeneratorsTest.java
@@ -66,6 +66,25 @@ public class PropertyGeneratorsTest {
     }
 
     @Test
+    public void shouldDefaultToNoSecurityIfNoSupportedSecurityDefinitionsFound() {
+        final Swagger swagger = new Swagger()
+            .securityDefinition("oauth-username-password", new OAuth2Definition().password("https://api.example.com/token"))
+            .securityDefinition("oauth-implicit", new OAuth2Definition().implicit("https://api.example.com/authz"));
+
+        final ConfigurationProperty template = new ConfigurationProperty.Builder().build();
+        final ConnectorSettings settings = new ConnectorSettings.Builder().build();
+        final Optional<ConfigurationProperty> authenticationTypes = PropertyGenerators.authenticationType
+            .propertyGenerator()
+            .generate(swagger, template, settings);
+
+        assertThat(authenticationTypes)
+            .contains(new ConfigurationProperty.Builder()
+                .defaultValue("none")
+                .addEnum(ConfigurationProperty.PropertyValue.Builder.of("none", "No Security"))
+                .build());
+    }
+
+    @Test
     public void shouldDetermineFromHostsContainingPorts() {
         assertThat(determineHost(new Swagger().host("54.152.43.92:8080").scheme(Scheme.HTTPS))).isEqualTo("https://54.152.43.92:8080");
     }


### PR DESCRIPTION
Makes sure to return `No Security` when no supported security definitions are found.

Fixes #6123