### PR TITLE
chore: update UI setup against local Syndesis

### DIFF
--- a/app/ui-react/syndesis/src/setupProxy.js
+++ b/app/ui-react/syndesis/src/setupProxy.js
@@ -28,6 +28,7 @@ module.exports = function(app) {
       headers: {
         'X-Forwarded-Origin': 'for=127.0.0.1;host=localhost:3000;proto=https',
         'X-Forwarded-Access-Token': 'supersecret',
+        'X-Forwarded-User': 'user',
         Cookie: process.env.BACKEND_COOKIE || '',
       },
     });

--- a/doc/sdh/development/local.adoc
+++ b/doc/sdh/development/local.adoc
@@ -82,13 +82,14 @@ The backend is started once you see the a line containing this in the output:
 Started Application in 28.9 seconds (JVM running for 29.615)
 ```
 
-After that UI can be started by running:
+After that UI can be started by running (in two separate terminal sessions):
 
 ```
-$ (cd app/ui && yarn start:local)
+$ (cd app/ui-react && watch:packages)
+$ (cd app/ui-react && BACKEND=http://localhost:8080 yarn watch:app:proxy)
 ```
 
-You can now access a running instance at https://localhost:4200[https://localhost:4200].
+You can now access a running instance at https://localhost:3000[https://localhost:3000].
 
 === Day-to-Day
 


### PR DESCRIPTION
Adds the additional header set by oauth-proxy required by the server when proxying via middleware. Updates the documentation on how to run the React UI against the locally started server.