### PR TITLE
Changes the pod names in the templates to match the actual container names

### DIFF
--- a/install/generator/03-syndesis-ui.yml.mustache
+++ b/install/generator/03-syndesis-ui.yml.mustache
@@ -91,7 +91,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-ui
+        - {{ProductName}}-ui
         from:
           kind: ImageStreamTag
           name: {{ Images.Syndesis.Ui }}:{{ Tags.Syndesis }}

--- a/install/generator/04-syndesis-meta.yml.mustache
+++ b/install/generator/04-syndesis-meta.yml.mustache
@@ -135,7 +135,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-meta
+        - {{ProductName}}-meta
         from:
           kind: ImageStreamTag
           name: {{ Images.Syndesis.Verifier }}:{{ Tags.Syndesis }}

--- a/install/generator/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/generator/04-syndesis-oauth-proxy.yml.mustache
@@ -148,7 +148,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-oauthproxy
+        - {{ProductName}}-oauthproxy
         from:
           kind: ImageStreamTag
           name: {{ Images.Support.OAuthProxy }}:{{ Tags.OAuthProxy }}

--- a/install/generator/04-syndesis-server.yml.mustache
+++ b/install/generator/04-syndesis-server.yml.mustache
@@ -159,7 +159,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-server
+        - {{ProductName}}-server
         from:
           kind: ImageStreamTag
           name: {{ Images.Syndesis.Rest }}:{{ Tags.Syndesis }}

--- a/install/generator/07-syndesis-upgrade.yml.mustache
+++ b/install/generator/07-syndesis-upgrade.yml.mustache
@@ -19,7 +19,7 @@
       app: syndesis
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
-    name: syndesis-upgrade
+    name: {{ProductName}}-upgrade
     annotations:
       openshift.io/display-name: "Syndesis Upgrade"
       description: |-
@@ -54,7 +54,7 @@
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-{{ Tags.Upgrade }}
+      name: {{ProductName}}-upgrade-{{ Tags.Upgrade }}
     spec:
       serviceAccountName: syndesis-operator
       containers:

--- a/install/generator/syndesis-template.go
+++ b/install/generator/syndesis-template.go
@@ -79,6 +79,7 @@ type tags struct {
 
 type Context struct {
 	Name             string
+    ProductName      string
 	AllowLocalHost   bool
 	WithDockerImages bool
 	Productized      bool
@@ -182,6 +183,8 @@ func init() {
 }
 
 func install(cmd *cobra.Command, args []string) {
+
+    context.ProductName = context.Name
 
 	if context.Oso || context.Ocp {
 		context.Productized = true

--- a/install/operator/build/conf/template-config.yaml
+++ b/install/operator/build/conf/template-config.yaml
@@ -1,3 +1,4 @@
+ProductName: syndesis
 AllowLocalHost: false
 Debug: false
 EarlyAccess: false

--- a/install/operator/pkg/generator/assets/install/03-syndesis-ui.yml.mustache
+++ b/install/operator/pkg/generator/assets/install/03-syndesis-ui.yml.mustache
@@ -91,7 +91,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-ui
+        - {{ProductName}}-ui
         from:
           kind: ImageStreamTag
           name: '{{ Images.Syndesis.Ui }}:{{ Tags.Syndesis }}'

--- a/install/operator/pkg/generator/assets/install/04-syndesis-meta.yml.mustache
+++ b/install/operator/pkg/generator/assets/install/04-syndesis-meta.yml.mustache
@@ -135,7 +135,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-meta
+        - {{ProductName}}-meta
         from:
           kind: ImageStreamTag
           name: {{ Images.Syndesis.Verifier }}:{{ Tags.Syndesis }}

--- a/install/operator/pkg/generator/assets/install/04-syndesis-oauth-proxy.yml.mustache
+++ b/install/operator/pkg/generator/assets/install/04-syndesis-oauth-proxy.yml.mustache
@@ -140,7 +140,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-oauthproxy
+        - {{ProductName}}-oauthproxy
         from:
           kind: ImageStreamTag
           name: {{ Images.Support.OAuthProxy }}:{{ Tags.OAuthProxy }}

--- a/install/operator/pkg/generator/assets/install/04-syndesis-server.yml.mustache
+++ b/install/operator/pkg/generator/assets/install/04-syndesis-server.yml.mustache
@@ -159,7 +159,7 @@
     - imageChangeParams:
         automatic: true
         containerNames:
-        - syndesis-server
+        - {{ProductName}}-server
         from:
           kind: ImageStreamTag
           name: '{{ Images.Syndesis.Rest }}:{{ Tags.Syndesis }}'

--- a/install/operator/pkg/generator/assets/upgrade/07-syndesis-upgrade.yml.mustache
+++ b/install/operator/pkg/generator/assets/upgrade/07-syndesis-upgrade.yml.mustache
@@ -15,7 +15,7 @@
 - apiVersion: v1
   kind: Pod
   metadata:
-    name: syndesis-upgrade-{{ Tags.Upgrade }}
+    name: {{ProductName}}-upgrade-{{ Tags.Upgrade }}
   spec:
     serviceAccountName: syndesis-operator
     containers:

--- a/install/operator/pkg/generator/generator.go
+++ b/install/operator/pkg/generator/generator.go
@@ -59,6 +59,7 @@ type tags struct {
 }
 
 type Context struct {
+	ProductName      string
 	AllowLocalHost   bool
 	WithDockerImages bool
 	Productized      bool


### PR DESCRIPTION
Sending this as a proposed fix for https://issues.jboss.org/browse/ENTESB-11030. 

Doing it on the template generator is, IMHO, easier to maintain than implementing a bunch of regex on the productization scripts.