### PR TITLE
fix: Support unified json bodies with aggregate steps

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
@@ -189,8 +189,6 @@ public class IntegrationRouteBuilder extends RouteBuilder {
 
                 if (StepKind.aggregate.equals(step.getStepKind())) {
                     if (!splitStack.isEmpty()) {
-                        parent = handler.handle(step, parent, this, flowIndex, String.valueOf(stepIndex)).orElse(parent);
-
                         String splitStepId = splitStack.pop();
                         while (!getStepId(splitStepId).equals(parent.getId())) {
                             if (parent instanceof ExpressionNode) {
@@ -206,6 +204,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
                             parent = parent.endParent();
                         }
 
+                        parent = handler.handle(step, parent, this, flowIndex, String.valueOf(stepIndex)).orElse(parent);
                         parent = captureOutMessage(parent, stepId);
                     }
                 } else {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AggregateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AggregateStepHandlerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.DataShapeMetaData;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.action.StepAction;
+import io.syndesis.common.model.action.StepDescriptor;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.common.util.KeyGenerator;
+import io.syndesis.integration.runtime.IntegrationTestSupport;
+import io.syndesis.integration.runtime.logging.ActivityTracker;
+import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
+import io.syndesis.integration.runtime.logging.BodyLogger;
+import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
+import io.syndesis.integration.runtime.util.JsonSupport;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.SimpleRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+public class AggregateStepHandlerTest extends IntegrationTestSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AggregateStepHandlerTest.class);
+
+    private static final String START_STEP = "start-step";
+    private static final String SPLIT_STEP = "split-step";
+    private static final String AGGREGATE_STEP = "aggregate-step";
+    private static final String LOG_STEP = "log-step";
+    private static final String MOCK_STEP = "mock-step";
+
+    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+
+    @Before
+    public void setupMocks() {
+        reset(activityTracker);
+
+        doAnswer(invocation -> {
+            ActivityTracker.initializeTracking(invocation.getArgument(0));
+            return null;
+        }).when(activityTracker).startTracking(any(Exchange.class));
+
+        doAnswer(invocation -> {
+            LOGGER.debug(JsonSupport.toJsonObject(invocation.getArguments()));
+            return null;
+        }).when(activityTracker).track(any());
+    }
+
+    @Test
+    public void testAggregateUnifiedJsonStep() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        try {
+            final RouteBuilder routes = newIntegrationRouteBuilder(activityTracker,
+                    new Step.Builder()
+                            .id(START_STEP)
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("direct")
+                                            .putConfiguredProperty("name", "expression")
+                                            .build())
+                                    .build())
+                            .build(),
+                    new Step.Builder()
+                            .id(SPLIT_STEP)
+                            .stepKind(StepKind.split)
+                            .build(),
+                    new Step.Builder()
+                            .id(LOG_STEP)
+                            .stepKind(StepKind.log)
+                            .putConfiguredProperty("bodyLoggingEnabled", "true")
+                            .putConfiguredProperty("customText", "Log me baby one more time")
+                            .build(),
+                    new Step.Builder()
+                            .id(AGGREGATE_STEP)
+                            .stepKind(StepKind.aggregate)
+                            .action(new StepAction.Builder()
+                                    .descriptor(new StepDescriptor.Builder()
+                                            .outputDataShape(new DataShape.Builder()
+                                                    .kind(DataShapeKinds.JSON_SCHEMA)
+                                                    .putMetadata(DataShapeMetaData.UNIFIED, "true")
+                                                    .specification("{" +
+                                                            "\"$schema\": \"http://json-schema.org/schema#\"," +
+                                                            "\"id\": \"io:syndesis:webhook\"," +
+                                                            "\"type\": \"object\"," +
+                                                            "\"properties\": {" +
+                                                                "\"body\": {" +
+                                                                    "\"type\": \"array\"," +
+                                                                    "\"items\": {" +
+                                                                        "\"type\": \"object\"," +
+                                                                        "\"properties\": {" +
+                                                                            "\"id\":{\"type\":\"string\",\"required\":true}" +
+                                                                            "\"name\":{\"type\":\"string\",\"required\":true}" +
+                                                                        "}" +
+                                                                    "}" +
+                                                                "}" +
+                                                            "}" +
+                                                        "}")
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build(),
+                    new Step.Builder()
+                            .id(MOCK_STEP)
+                            .stepKind(StepKind.endpoint)
+                            .action(new ConnectorAction.Builder()
+                                    .descriptor(new ConnectorDescriptor.Builder()
+                                            .componentScheme("mock")
+                                            .putConfiguredProperty("name", "expression")
+                                            .build())
+                                    .build())
+                            .build()
+            );
+
+            // Set up the camel context
+            context.setUuidGenerator(KeyGenerator::createKey);
+            context.addLogListener(new IntegrationLoggingListener(activityTracker));
+            context.addInterceptStrategy(new ActivityTrackingInterceptStrategy(activityTracker));
+            context.addRoutes(routes);
+
+            SimpleRegistry beanRegistry = new SimpleRegistry();
+            beanRegistry.put("bodyLogger", new BodyLogger.Default());
+            context.setRegistry(beanRegistry);
+
+            context.start();
+
+            // Dump routes as XML for troubleshooting
+            dumpRoutes(context);
+
+            final ProducerTemplate template = context.createProducerTemplate();
+            final MockEndpoint result = context.getEndpoint("mock:expression", MockEndpoint.class);
+            final List<String> body = Arrays.asList("{\"body\": {\"id\":1,\"name\":\"a\"}}",
+                                                    "{\"body\": {\"id\":2,\"name\":\"b\"}}",
+                                                    "{\"body\": {\"id\":3,\"name\":\"c\"}}");
+
+            result.expectedMessageCount(1);
+            result.expectedBodiesReceived("{" +
+                        "\"body\":[" +
+                            "{\"id\":1,\"name\":\"a\"}," +
+                            "{\"id\":2,\"name\":\"b\"}," +
+                            "{\"id\":3,\"name\":\"c\"}" +
+                        "]" +
+                    "}");
+
+            template.sendBody("direct:expression", body);
+
+            result.assertIsSatisfied();
+
+            verify(activityTracker).startTracking(any(Exchange.class));
+            verifyActivityStepTracking(SPLIT_STEP, 0);
+            verifyActivityStepTracking(LOG_STEP, body.size());
+            verifyActivityStepTracking(AGGREGATE_STEP, 0);
+            verifyActivityStepTracking(MOCK_STEP, 1);
+            verify(activityTracker).finishTracking(any(Exchange.class));
+        } finally {
+            context.stop();
+        }
+    }
+
+    private void verifyActivityStepTracking(String stepId, int times) {
+        verify(activityTracker, times(times)).track(eq("exchange"), anyString(), eq("step"), eq(stepId), eq("id"), anyString(), eq("duration"), anyLong(), eq("failure"), isNull());
+    }
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -72,7 +72,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
                                             .decompress()
                                             .build();
 
-                if (isUnifiedJsonSchemaShape(dataShape)) {
+                if (StepMetadataHelper.isUnifiedJsonSchemaShape(dataShape)) {
                     dataShape = new DataShape.Builder()
                                         .createFrom(dataShape)
                                         .specification(extractUnifiedJsonBodySpec(dataShape.getSpecification()))
@@ -156,22 +156,6 @@ class SplitMetadataHandler implements StepMetadataHandler {
         }
 
         return DynamicActionMetadata.NOTHING;
-    }
-
-    /**
-     * Checks if given shape is a unified Json schema shape.
-     * @param dataShape
-     * @return
-     */
-    private boolean isUnifiedJsonSchemaShape(DataShape dataShape) {
-        if (dataShape.getKind() == DataShapeKinds.JSON_SCHEMA) {
-            return dataShape.getMetadata()
-                    .entrySet()
-                    .stream()
-                    .anyMatch(entry -> entry.getKey().equals(DataShapeMetaData.UNIFIED));
-        }
-
-        return false;
     }
 
     /**

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
@@ -103,4 +103,20 @@ final class StepMetadataHelper {
             return variants;
         }
     }
+
+    /**
+     * Checks if given shape is a unified Json schema shape.
+     * @param dataShape
+     * @return
+     */
+    static boolean isUnifiedJsonSchemaShape(DataShape dataShape) {
+        if (dataShape.getKind() == DataShapeKinds.JSON_SCHEMA) {
+            return dataShape.getMetadata()
+                    .entrySet()
+                    .stream()
+                    .anyMatch(entry -> entry.getKey().equals(DataShapeMetaData.UNIFIED));
+        }
+
+        return false;
+    }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -530,6 +530,48 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(DataShapeMetaData.VARIANT));
     }
 
+    @Test
+    public void shouldAutoConvertAndExtractJsonUnifiedSchemaVariants() throws IOException {
+        DynamicActionMetadata metadata = new DynamicActionMetadata.Builder()
+                .inputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-list-unified-response-schema.json"))
+                        .putMetadata(DataShapeMetaData.UNIFIED, "true")
+                        .description("person-list-schema")
+                        .collectionType("List")
+                        .type(Person.class.getName())
+                        .collectionClassName(List.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .outputShape(new DataShape.Builder()
+                        .kind(DataShapeKinds.JSON_SCHEMA)
+                        .specification(getSpecification("person-unified-response-schema.json"))
+                        .putMetadata(DataShapeMetaData.UNIFIED, "true")
+                        .description("person-schema")
+                        .type(Person.class.getName())
+                        .addVariant(dummyShape(DataShapeKinds.JAVA))
+                        .build())
+                .build();
+
+        DynamicActionMetadata enrichedMetadata = metadataHandler.handle(metadata);
+
+        Assert.assertNotNull(enrichedMetadata.inputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.inputShape().getKind());
+        Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-unified-response-schema.json")), enrichedMetadata.inputShape().getSpecification());
+        Assert.assertEquals(DataShapeMetaData.VARIANT_ELEMENT, enrichedMetadata.inputShape().getMetadata().get(DataShapeMetaData.VARIANT));
+        Assert.assertEquals("true", enrichedMetadata.inputShape().getMetadata().get(DataShapeMetaData.UNIFIED));
+        Assert.assertEquals(1, enrichedMetadata.inputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.inputShape().getVariants().get(0).getMetadata().get(DataShapeMetaData.VARIANT));
+
+        Assert.assertNotNull(enrichedMetadata.outputShape());
+        Assert.assertEquals(DataShapeKinds.JSON_SCHEMA, enrichedMetadata.outputShape().getKind());
+        Assert.assertEquals(StringUtils.trimAllWhitespace(getSpecification("person-list-unified-response-schema.json")), enrichedMetadata.outputShape().getSpecification());
+        Assert.assertEquals(DataShapeMetaData.VARIANT_COLLECTION, enrichedMetadata.outputShape().getMetadata().get(DataShapeMetaData.VARIANT));
+        Assert.assertEquals("true", enrichedMetadata.outputShape().getMetadata().get(DataShapeMetaData.UNIFIED));
+        Assert.assertEquals(1, enrichedMetadata.outputShape().getVariants().size());
+        Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(DataShapeMetaData.VARIANT));
+    }
+
     private DataShape dummyShape(DataShapeKinds kind) {
         return new DataShape.Builder()
                 .kind(kind)

--- a/app/server/endpoint/src/test/resources/io/syndesis/server/endpoint/v1/handler/meta/person-list-unified-response-schema.json
+++ b/app/server/endpoint/src/test/resources/io/syndesis/server/endpoint/v1/handler/meta/person-list-unified-response-schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "id": "io:syndesis:webhook",
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "body": {
+      "type": "array",
+      "$schema": "http://json-schema.org/schema#",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/server/endpoint/src/test/resources/io/syndesis/server/endpoint/v1/handler/meta/person-unified-response-schema.json
+++ b/app/server/endpoint/src/test/resources/io/syndesis/server/endpoint/v1/handler/meta/person-unified-response-schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "id": "io:syndesis:webhook",
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "body": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Relates to #6118 

Dynamic data shape adaption for aggregate step now supports unified json body shapes where in this special case the collection of the unified body element is adapted to single elements.

In addition to that added an aggregation post processor that is added for unified json body shapes. The post processor is added after the aggregation and takes care on aggregating the unified json body elements to a single unified body collection.

## aggregated bodies before post processing
```json
[
  {"body": {"id":1,"name":"a"}},
  {"body": {"id":2,"name":"b"}},
  {"body": {"id":3,"name":"c"}},
]
```

## after post processing
```json
{
  "body": [
    {"id":1,"name":"a"},
    {"id":2,"name":"b"},
    {"id":3,"name":"c"},
  ]
}
```