### PR TITLE
fix: Do not use SQL batch update mode by default

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
@@ -38,6 +38,10 @@ public class SqlConnectorMetaDataExtension extends AbstractMetaDataExtension {
     @Override
     public Optional<MetaData> meta(final Map<String, Object> properties) {
         final String sqlStatement = (String) properties.get("query");
+        final boolean batch = Optional.ofNullable(properties.get("batch"))
+                                        .map(Object::toString)
+                                        .map(Boolean::valueOf)
+                                        .orElse(false);
 
         MetaData metaData = EMPTY_METADATA;
 
@@ -48,6 +52,8 @@ public class SqlConnectorMetaDataExtension extends AbstractMetaDataExtension {
                 final String schemaPattern = (String) properties.getOrDefault("schema", defaultSchema);
                 final SqlStatementParser parser = new SqlStatementParser(connection, schemaPattern, sqlStatement);
                 final SqlStatementMetaData sqlStatementMetaData = parseStatement(parser);
+
+                sqlStatementMetaData.setBatch(batch);
 
                 metaData = new DefaultMetaData(null, null, sqlStatementMetaData);
             } catch (final SQLException e) {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
@@ -35,7 +35,6 @@ import io.syndesis.common.model.DataShapeMetaData;
 import io.syndesis.common.util.Json;
 import io.syndesis.connector.sql.common.SqlParam;
 import io.syndesis.connector.sql.common.SqlStatementMetaData;
-import io.syndesis.connector.sql.common.StatementType;
 import io.syndesis.connector.sql.common.stored.ColumnMode;
 import io.syndesis.connector.sql.common.stored.StoredProcedureColumn;
 import io.syndesis.connector.sql.common.stored.StoredProcedureMetadata;
@@ -86,16 +85,12 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
         if (sqlStatementMetaData != null) {
             enrichedProperties.put(QUERY, Collections.singletonList(new PropertyPair(sqlStatementMetaData.getSqlStatement(), QUERY)));
 
-
             // build the input and output schemas
             final JsonSchema specIn;
             final ObjectSchema builderIn = new ObjectSchema();
             builderIn.setTitle("SQL_PARAM_IN");
 
-            boolean batch = sqlStatementMetaData.hasInputParams() &&
-                            sqlStatementMetaData.getStatementType() != StatementType.SELECT;
-
-            if (batch) {
+            if (sqlStatementMetaData.isVerifiedBatchUpdateMode()) {
                 ArraySchema arraySpec = new ArraySchema();
                 arraySpec.set$schema(JSON_SCHEMA_ORG_SCHEMA);
                 arraySpec.setItemsSchema(builderIn);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
@@ -23,9 +23,12 @@ import java.util.Locale;
 import java.util.Set;
 
 import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Data
 public class SqlStatementMetaData {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlStatementMetaData.class);
 
     private Enum<StatementType> statementType;
     private List<SqlParam> inParams = new ArrayList<>();
@@ -37,6 +40,7 @@ public class SqlStatementMetaData {
     private String schema;
     private String defaultedSqlStatement;
     private String autoIncrementColumnName;
+    private boolean batch;
 
     public SqlStatementMetaData(String sqlStatement, String schema) {
         super();
@@ -94,6 +98,22 @@ public class SqlStatementMetaData {
             }
         }
         return defaultedSqlStatement;
+    }
+
+    public boolean isVerifiedBatchUpdateMode() {
+        if (batch) {
+            if (!hasInputParams()) {
+                LOGGER.warn("Batch update mode set but no input params specified - automatically using non batch update mode");
+                return false;
+            }
+
+            if (statementType == StatementType.SELECT) {
+                LOGGER.warn("Batch update mode not supported on SELECT statement - automatically using non batch update mode");
+                return false;
+            }
+        }
+
+        return batch;
     }
 
 }

--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -27,6 +27,30 @@
                 "kind": "path",
                 "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
                 "placeholder": "for example ':#MYPARAMNAME'",
+                "order": 1,
+                "required": true,
+                "secret": false,
+                "type": "string"
+              },
+              "batch": {
+                "defaultValue": false,
+                "deprecated": false,
+                "displayName": "Batch update",
+                "enum": [
+                  {
+                    "label": "No",
+                    "value": "false"
+                  },
+                  {
+                    "label": "Yes",
+                    "value": "true"
+                  }
+                ],
+                "group": "common",
+                "javaType": "java.lang.String",
+                "kind": "property",
+                "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                "order": 2,
                 "required": true,
                 "secret": false,
                 "type": "string"

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
@@ -161,6 +161,26 @@ public class SqlMetadataAdapterTest {
     }
 
     @Test
+    public void adaptForSqlBatchUpdateTest() throws IOException, JSONException {
+        CamelContext camelContext = new DefaultCamelContext();
+        SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
+        Map<String,Object> parameters = new HashMap<>();
+        for (final String name: props.stringPropertyNames()) {
+            parameters.put(name.substring(name.indexOf('.') + 1), props.getProperty(name));
+        }
+        parameters.put("query", "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)");
+        parameters.put("batch", true);
+        Optional<MetaData> metadata = ext.meta(parameters);
+        SqlMetadataRetrieval adapter = new SqlMetadataRetrieval();
+
+        SyndesisMetadata syndesisMetaData2 = adapter.adapt(camelContext, "sql", "sql-connector", parameters, metadata.get());
+        String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_batch_update_metadata.json"), StandardCharsets.UTF_8).trim();
+        ObjectWriter writer = Json.writer();
+        String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
+        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+    }
+
+    @Test
     public void adaptForSqlUpdateNoParamTest() throws IOException, JSONException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);

--- a/app/connector/sql/src/test/resources/sql/name_sql_batch_update_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_batch_update_metadata.json
@@ -4,10 +4,10 @@
     "type" : "SQL_PARAM_IN",
     "name" : "SQL Parameter",
     "metadata": {
-      "variant": "element"
+      "variant": "collection"
     },
     "description" : "Parameters of SQL [INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)]",
-    "specification" : "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"firstname\":{\"type\":\"string\",\"required\":true},\"lastname\":{\"type\":\"string\",\"required\":true}}}"
+    "specification" : "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"firstname\":{\"type\":\"string\",\"required\":true},\"lastname\":{\"type\":\"string\",\"required\":true}}}}"
   },
   "outputShape" : {
     "kind" : "none",
@@ -20,4 +20,3 @@
     } ]
   }
 }
-


### PR DESCRIPTION
... as it breaks existing data mappings in integrations

Introduced new configuration property `batch` (which is `false` by default) so existing integrations keep working with existing data mappings as the data shape is then still using single element parameters like before.

The user needs to enable the batch update support and then is provided with a collection of SQL input parameters as data shape.

Related to #6118 