### PR TITLE
fix: InlineTextEdit shows the controlled value in read mode

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/InlineTextEdit.tsx
+++ b/app/ui-react/packages/ui/src/Shared/InlineTextEdit.tsx
@@ -242,7 +242,7 @@ export const InlineTextEdit: React.FunctionComponent<IInlineTextEditProps> = ({
       {...attrs}
       valid={valid}
       saving={saving}
-      value={v}
+      value={currentValue}
       errorMsg={errorMsg}
       asTextarea={isTextArea}
       onChange={handleChange}
@@ -256,7 +256,7 @@ export const InlineTextEdit: React.FunctionComponent<IInlineTextEditProps> = ({
   return (
     <InlineEdit
       className={className}
-      value={currentValue}
+      value={value}
       isEditing={isEditing}
       renderValue={renderValue}
       renderEdit={renderEdit}


### PR DESCRIPTION
Also, `useApiResource` re-fetches data when its default value or initial value changes

Fixes #6147