### PR TITLE
fix: when updating a connection, check if the previous step exist and has a valid id, else create a new one

### DIFF
--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -345,7 +345,7 @@ export const useIntegrationHelpers = () => {
           action,
           configuredProperties,
           connection,
-          id: originalStep ? originalStep.id : key(),
+          id: originalStep && originalStep.id ? originalStep.id : key(),
           metadata: {
             ...(originalStep ? originalStep.metadata : {}),
             ...{ configured: true },


### PR DESCRIPTION
Fixes a bug introduced with #6138
Part of #6118