### PR TITLE
fix(6149): Improve the robustness of template step pre-processor

### DIFF
--- a/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestVelocityTemplatePreProcessor.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestVelocityTemplatePreProcessor.java
@@ -15,10 +15,9 @@
  */
 package io.syndesis.common.model.integration.step.template;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.After;
 import org.junit.Test;
 import io.syndesis.common.util.StringConstants;
@@ -147,6 +146,24 @@ public class TestVelocityTemplatePreProcessor implements StringConstants {
     }
 
     /**
+     * Velocity does not allow numbers at the start of its symbols
+     * @throws Exception
+     */
+    @Test
+    public void testTemplateSymbolBeginningWithNumber() throws Exception {
+        String template = EMPTY_STRING +
+            "At ${1the time}, ${the name}" + NEW_LINE +
+            "submitted the following message:" + NEW_LINE +
+            "${the text}";
+
+        assertThatThrownBy(() -> {
+            processor.preProcess(template);
+        })
+            .isInstanceOf(TemplateProcessingException.class)
+            .hasMessageContaining("not valid syntactically");
+    }
+
+    /**
      * Velocity does not allow spaces in its symbols
      *
      * @throws Exception
@@ -157,11 +174,11 @@ public class TestVelocityTemplatePreProcessor implements StringConstants {
             "At ${the time}, ${the name}" + NEW_LINE +
             "submitted the following message:" + NEW_LINE +
             "${the text}";
-        try {
+
+        assertThatThrownBy(() -> {
             processor.preProcess(template);
-            fail("Should not allow spaces in template");
-        } catch (TemplateProcessingException ex) {
-            assertTrue(ex.getMessage().contains("invalid"));
-        }
+        })
+            .isInstanceOf(TemplateProcessingException.class)
+            .hasMessageContaining("not valid syntactically");
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/FreeMarkerTemplateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/FreeMarkerTemplateStepHandlerTest.java
@@ -15,8 +15,7 @@
  */
 package io.syndesis.integration.runtime.template;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Test;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage.SymbolSyntax;
@@ -31,7 +30,6 @@ public class FreeMarkerTemplateStepHandlerTest extends AbstractTemplateStepHandl
 
     @Test
     public void testTemplateStepBasicWithPrefix() throws Exception {
-
         Symbol[] symbols = {
             new Symbol("body.time", "string"),
             new Symbol("body.name", "string"),
@@ -43,7 +41,6 @@ public class FreeMarkerTemplateStepHandlerTest extends AbstractTemplateStepHandl
 
     @Test
     public void testTemplateStepBasicWithoutPrefix() throws Exception {
-
         Symbol[] symbols = {
             new Symbol("time", "string"),
             new Symbol("name", "string"),
@@ -73,11 +70,10 @@ public class FreeMarkerTemplateStepHandlerTest extends AbstractTemplateStepHandl
             new Symbol("text", "string", mustacheSyntax)
         };
 
-        try {
+        assertThatThrownBy(() -> {
             testTemplateStepBasic(symbols);
-            fail("Should throw exception since wrong language");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("invalid"));
-        }
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid");
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/MustacheTemplateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/MustacheTemplateStepHandlerTest.java
@@ -15,15 +15,12 @@
  */
 package io.syndesis.integration.runtime.template;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.Test;
 import io.syndesis.common.model.integration.step.template.TemplateStepConstants;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage;
@@ -39,7 +36,6 @@ public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandler
 
     @Test
     public void testTemplateStepBasicWithPrefix() throws Exception {
-
         Symbol[] symbols = {
             new Symbol("body.time", "string"),
             new Symbol("body.name", "string"),
@@ -51,7 +47,6 @@ public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandler
 
     @Test
     public void testTemplateStepBasicWithoutPrefix() throws Exception {
-
         Symbol[] symbols = {
             new Symbol("time", "string"),
             new Symbol("name", "string"),
@@ -63,8 +58,6 @@ public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandler
 
     @Test
     public void testTemplateStepDanglingSection() throws Exception {
-        CamelContext context = new DefaultCamelContext();
-
         Symbol[] symbols = {
             new Symbol("id", "string"),
             new Symbol("course", "array", "{{#", getSymbolSyntax().close()),
@@ -77,24 +70,19 @@ public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandler
             "\t* {{name}}" + NEW_LINE +
             symbols[2];
 
-        try {
+        assertThatThrownBy(() -> {
             IntegrationWithRouteBuilder irb = generateRoute(template, Arrays.asList(symbols));
-            final RouteBuilder routes = irb.routeBuilder();
+            RouteBuilder routes = irb.routeBuilder();
 
             // Set up the camel context
             context.addRoutes(routes);
-            fail("Should not allow dangling section");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("invalid"));
-        } finally {
-            context.stop();
-        }
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid");
      }
 
     @Test
     public void testTemplateStepIterate() throws Exception {
-        CamelContext context = new DefaultCamelContext();
-
         List<String> testMessages = new ArrayList<>();
         testMessages.add(
             data(
@@ -207,11 +195,10 @@ public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandler
             new Symbol("text", "string", velocitySyntax)
         };
 
-        try {
+        assertThatThrownBy(() -> {
             testTemplateStepBasic(symbols);
-            fail("Should throw exception since wrong language");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("invalid"));
-        }
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid");
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/AbstractVelocityTemplateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/AbstractVelocityTemplateStepHandlerTest.java
@@ -15,9 +15,11 @@
  */
 package io.syndesis.integration.runtime.template.velocity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Test;
 import io.syndesis.common.model.integration.step.template.TemplateStepConstants;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage;
+import io.syndesis.common.model.integration.step.template.TemplateStepLanguage.SymbolSyntax;
 import io.syndesis.integration.runtime.handlers.AbstractTemplateStepHandlerTest;
 
 public abstract class AbstractVelocityTemplateStepHandlerTest extends AbstractTemplateStepHandlerTest
@@ -56,4 +58,19 @@ public abstract class AbstractVelocityTemplateStepHandlerTest extends AbstractTe
         testTemplateStepBasic(symbols);
      }
 
+    @Test
+    public void testInvalidTemplate() throws Exception {
+        SymbolSyntax mustacheSyntax = TemplateStepLanguage.MUSTACHE.getDefaultSymbolSyntax();
+        Symbol[] symbols = {
+            new Symbol("time", "string", mustacheSyntax),
+            new Symbol("name", "string", mustacheSyntax),
+            new Symbol("text", "string", mustacheSyntax)
+        };
+
+        assertThatThrownBy(() -> {
+            testTemplateStepBasic(symbols);
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid");
+    }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityFormalSyntaxTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityFormalSyntaxTest.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.integration.runtime.template.velocity;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Arrays;
+import org.apache.camel.builder.RouteBuilder;
 import org.junit.Test;
 
 /**
@@ -34,4 +37,44 @@ public class VelocityFormalSyntaxTest extends AbstractVelocityTemplateStepHandle
 
         testTemplateStepNoSpacesInSymbolAllowed(symbols);
      }
+
+    @Test
+    public void testTemplateStepNoClosingTag() throws Exception {
+        Symbol[] symbols = {
+            new Symbol("name", "string")
+        };
+
+        String template = EMPTY_STRING +
+            "Hello ${name, how are you?";
+
+        assertThatThrownBy(() -> {
+            IntegrationWithRouteBuilder irb = generateRoute(template, Arrays.asList(symbols));
+            RouteBuilder routes = irb.routeBuilder();
+
+            // Set up the camel context
+            context.addRoutes(routes);
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("due to an incomplete symbol");
+    }
+
+    @Test
+    public void testTemplateStepNoClosingEndTag() throws Exception {
+        Symbol[] symbols = {
+            new Symbol("name", "string")
+        };
+
+        String template = EMPTY_STRING +
+            "Hello this is your name: ${name";
+
+        assertThatThrownBy(() -> {
+            IntegrationWithRouteBuilder irb = generateRoute(template, Arrays.asList(symbols));
+            final RouteBuilder routes = irb.routeBuilder();
+
+            // Set up the camel context
+            context.addRoutes(routes);
+        })
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid due to an incomplete symbol");
+    }
 }


### PR DESCRIPTION
* Better handles parsing the template syntax prior to passing it to the
  camel-template components.
 * Specifically:
  * Identifies the named parts of a literal so the opening & closing tags,
    symbol identifier and any leading text
  * Allows for text to enclose the symbol, eg. brackets

* More tests trying out different syntax variations and mistakes