### PR TITLE
TTOOLS-688 Enable tables for SQL auto complete

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -124,6 +124,11 @@ export interface QueryResults {
   rows: RowData[];
 }
 
+export interface TableColumns {
+  name: string;
+  columnNames: string[];
+}
+
 export interface ViewDefinitionStatus {
   status: string;
   message: string;

--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.css
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.css
@@ -15,3 +15,9 @@
 .dv-connection-card__status {
   margin-bottom: 10px;
 }
+
+.dv-connection-card .card-pf.card-pf-accented {
+  border-width: 2px;
+  border-style: solid;
+  border-color: #39a5dc;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
@@ -10,6 +10,11 @@ export interface IViewEditValidationResult {
   type: 'error' | 'success';
 }
 
+interface ITableInfo {
+  name: string;
+  columnNames: string[];
+}
+
 export interface IViewEditContentProps {
   viewDdl: string;
 
@@ -52,6 +57,11 @@ export interface IViewEditContentProps {
    * View validationResults
    */
   validationResults: IViewEditValidationResult[];
+
+  /**
+   * Source table-columns for code completion
+   */
+  sourceTableInfos: ITableInfo[];
 
   /**
    * The callback for when the save button is clicked
@@ -116,18 +126,30 @@ export class ViewEditContent extends React.Component<
     this.props.onSave(currentDdl);
   };
 
+  /**
+   * reformats the tableInfo into the format expected by hintOptions
+   * Example - 
+   *   tables: {
+   *     countries: ['name', 'population', 'size'],
+   *     users: ['name', 'score', 'birthDate'],
+   *   }
+   * @param tableInfos the table infos
+   */
+  public getHintOptions(tableInfos: ITableInfo[]) {
+    const result = {tables: {}};
+
+    for (const tableInfo of tableInfos) {
+      result.tables[tableInfo.name] = tableInfo.columnNames;
+    }
+    return result;
+  }
+
   public render() {
     const editorOptions = {
       autofocus: true,
       extraKeys: { 'Ctrl-Space': 'autocomplete' },
       gutters: ['CodeMirror-lint-markers'],
-      // TODO: dynamically generate the table - column hints
-      // hintOptions: {
-      //   tables: {
-      //     countries: ['name', 'population', 'size'],
-      //     users: ['name', 'score', 'birthDate'],
-      //   },
-      // },
+      hintOptions: this.getHintOptions(this.props.sourceTableInfos),
       lineNumbers: true,
       lineWrapping: true,
       matchBrackets: true,

--- a/app/ui-react/packages/ui/stories/Data/Views/ViewEditContent.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ViewEditContent.stories.tsx
@@ -8,6 +8,14 @@ const stories = storiesOf('Data/Virtualizations/Views/ViewEditContent', module);
 const viewDdl =
   'CREATE VIEW PgCustomer_account (\n\tRowId long,\n\taccount_id integer,\n\tssn string,\n\tstatus string,\n\ttype string,\n\tdateopened timestamp,\n\tdateclosed timestamp,\n\tPRIMARY KEY(RowId)\n)\nAS\nSELECT ROW_NUMBER() OVER (ORDER BY account_id), account_id, ssn, status, type, dateopened, dateclosed FROM pgcustomerschemamodel.account;';
 
+const sourceTables = [
+  { 'columnNames': ['name', 'population', 'size'], // column names
+    'name': 'countries' },                         // table name
+  { 'columnNames': ['name','score', 'birthDate'],  
+    'name': 'users' 
+  }
+];
+
 stories.add('render', () => {
   return (
     <ViewEditContent
@@ -19,6 +27,7 @@ stories.add('render', () => {
       i18nValidateLabel={'Validate'}
       isValid={true}
       isWorking={false}
+      sourceTableInfos={sourceTables}
       onCancel={action('cancel')}
       onValidate={action('validate')}
       onSave={action('save')}

--- a/app/ui-react/syndesis/src/modules/data/pages/ViewEditPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/ViewEditPage.tsx
@@ -1,4 +1,5 @@
 import { useVirtualizationHelpers } from '@syndesis/api';
+import { TableColumns } from '@syndesis/models';
 import {
   RestDataService,
   ViewDefinition,
@@ -149,6 +150,18 @@ export const ViewEditPage: React.FunctionComponent = () => {
   const initialView = state.viewDefinition.ddl ? state.viewDefinition.ddl : '';
   const virtualization = state.virtualization;
 
+  const getSourceTableInfos = (): TableColumns[] => {
+    // TODO: replace this hardcoded data with server call (or table-column info on the virtualization)
+    const sourceTables = [
+      { 'columnNames': ['name', 'population', 'size'], // column names
+        'name': 'countries' },                         // table name
+      { 'columnNames': ['name','score', 'birthDate'],  
+        'name': 'users' 
+      }
+    ];
+    return sourceTables;
+  };
+
   return (
     <>
       <Breadcrumb>
@@ -178,6 +191,7 @@ export const ViewEditPage: React.FunctionComponent = () => {
         i18nValidateLabel={t('shared:Validate')}
         isValid={viewValid}
         isWorking={isWorking}
+        sourceTableInfos={getSourceTableInfos()}
         onCancel={handleCancel}
         onValidate={handleValidateView}
         onSave={handleSaveView}


### PR DESCRIPTION
- Adds sourceTableInfos property to ViewEditContent component.  This allows user to supply the SQL source table/column info to the editor
- ViewEditPage supplies the source table/column info to the ViewEditContent component - there is a TODO to complete this once a service is available
- DvConnectionCard.css - added style changes so that the selected DV card accent is around the whole card.  (TEIIDTOOLS-677)