### PR TITLE
fix: propagate data shape changes to all subsequent steps

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,7 +76,14 @@ public class StepActionHandler extends BaseHandler {
             if (metadataHandler.isPresent()) {
                 StepMetadataHandler handler = metadataHandler.get();
 
-                final DynamicActionMetadata metadata = handler.createMetadata(step, steps.subList(0, i), steps.subList(i + 1, steps.size()));
+                List<Step> previousSteps;
+                if (i == 0) {
+                    previousSteps = Collections.singletonList(step);
+                } else {
+                    previousSteps = enriched.subList(0, i);
+                }
+
+                final DynamicActionMetadata metadata = handler.createMetadata(step, previousSteps, steps.subList(i + 1, steps.size()));
                 final DynamicActionMetadata enrichedMetadata = handler.handle(metadata);
                 if (enrichedMetadata.equals(DynamicActionMetadata.NOTHING)) {
                     enriched.add(step);


### PR DESCRIPTION
… when doing a step shape meta lookup

So this PR fixes the auto data shape adaption for split/aggregate and other steps. In particular a data shape change needs to propagate to the complete list of subsequent steps. For instance when the data shape of the 1st step changes this should also propagate to the steps 3 or 4 in line if required.

In detail the step adaption needs to reuse the enriched shapes for further propagation when walking through the set of steps. Before the fix it always used the old shapes as base for adaption.

Fixes #5215