### PR TITLE
fix: No artifact attached build error for test module

### DIFF
--- a/app/test/pom.xml
+++ b/app/test/pom.xml
@@ -34,8 +34,26 @@
     <basepom.test.reuse-vm>false</basepom.test.reuse-vm>
   </properties>
 
-  <dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
+  <dependencies>
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>


### PR DESCRIPTION
Fixes #6173 

Skipping maven install and deploy executions for test module that only has test sources and no artifacts. This prevents the build to fail because no artifact has been attached in this module.