### PR TITLE
fix(6141): FTP Verifier handles empty username & password properties

### DIFF
--- a/app/connector/ftp/pom.xml
+++ b/app/connector/ftp/pom.xml
@@ -37,6 +37,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
     </dependency>

--- a/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
+++ b/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
@@ -17,7 +17,6 @@ package io.syndesis.connector.ftp;
 
 import java.io.IOException;
 import java.util.Map;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
@@ -25,6 +24,7 @@ import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class FtpVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -58,12 +58,14 @@ public class FtpVerifierExtension extends DefaultComponentVerifierExtension {
     @SuppressWarnings("PMD.NPathComplexity")
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
-        final String host = (String) parameters.get("host");
-        final int port = Integer.parseInt((String) parameters.get("port"));
-        final String userName = (parameters.get("username") == null) ? "anonymous"
-                : (String) parameters.get("username");
-        final String password = (parameters.get("password") == null) || "anonymous".equals(userName) ? ""
-                : (String) parameters.get("password");
+        final String host = ConnectorOptions.extractOption(parameters, "host");
+        final int port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt);
+        final String userName = ConnectorOptions.extractOption(parameters, "username", "anonymous");
+
+        String password = "";
+        if (! "anonymous".equals(userName)) {
+            password = ConnectorOptions.extractOption(parameters, "password", password);
+        }
 
         int reply;
         FTPClient ftp = new FTPClient();

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
@@ -23,6 +23,22 @@ public final class ConnectorOptions {
 
     /**
      * Gets the value mapped to the given key & converts to {@link String} if present,
+     * or defaultValue otherwise.
+     *
+     * @param options
+     * @param key
+     * @param defaultValue
+     * @return {@link String} object belonging to the given key in the options map
+     */
+    public static String extractOption(Map<String, Object> options, String key, String defaultValue) {
+        return Optional.ofNullable(options.get(key))
+                        .map(Object::toString)
+                        .filter(v -> v.length() > 0)
+                        .orElse(defaultValue);
+    }
+
+    /**
+     * Gets the value mapped to the given key & converts to {@link String} if present,
      * or null otherwise.
      *
      * @param options
@@ -30,9 +46,7 @@ public final class ConnectorOptions {
      * @return {@link String} object belonging to the given key in the options map
      */
     public static String extractOption(Map<String, Object> options, String key) {
-        return Optional.ofNullable(options.get(key))
-                        .map(Object::toString)
-                        .orElse(null);
+        return extractOption(options, key, null);
     }
 
     /**


### PR DESCRIPTION
* ConnectorOptions
 * Provides function for returning a default value rather than null if
   property in options map is not present or if it is empty

* FtpVerifierExtension
 * Uses the ConnectorOptions to extract options and ensure they are either
   null or empty as required.