### PR TITLE
Dont use the same file that is used by template install

### DIFF
--- a/install/operator/cmd/syndesis-operator/main.go
+++ b/install/operator/cmd/syndesis-operator/main.go
@@ -39,6 +39,7 @@ func main() {
 	configuration.AddonsDirLocation = pflag.StringP("addons", "a", "", "Path to the addons directory used for installation")
 	configuration.Registry = pflag.StringP("registry", "r", "docker.io", "Registry to use for loading images like the upgrade pod")
 	configuration.ReleaseVersion = pflag.StringP("release-version", "v", "", "Alternatively, download resources based on the release version")
+	configuration.UpstreamOrg = pflag.StringP("upstream-org", "u", "syndesisio", "If Release Version is set, optionally set the github org where the template file is hosted")
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will

--- a/install/operator/pkg/syndesis/configuration/configuration.go
+++ b/install/operator/pkg/syndesis/configuration/configuration.go
@@ -21,6 +21,9 @@ var Registry *string
 // Release version to download resources from
 var ReleaseVersion *string
 
+// Github organization used to download the fuse-online template, useful for testing scenarios
+var UpstreamOrg *string
+
 const (
 	EnvRouteHostname SyndesisEnvVar = "ROUTE_HOSTNAME"
 	//EnvOpenshiftMaster 					SyndesisEnvVar = "OPENSHIFT_MASTER"

--- a/install/operator/pkg/syndesis/template/install.go
+++ b/install/operator/pkg/syndesis/template/install.go
@@ -49,7 +49,8 @@ func GetInstallResources(scheme *runtime.Scheme, syndesis *v1alpha1.Syndesis, pa
 	var templateLocation string
 
 	if releaseVersion := *configuration.ReleaseVersion; len(releaseVersion) > 0 {
-		fileUrl := fmt.Sprintf("https://raw.githubusercontent.com/syndesisio/fuse-online-install/%s/resources/fuse-online-template.yml", releaseVersion)
+		upstreamOrg := *configuration.UpstreamOrg
+		fileUrl := fmt.Sprintf("https://raw.githubusercontent.com/%s/fuse-online-install/%s/resources/fuse-online-template-oh.yml", upstreamOrg, releaseVersion)
 
 		log.V(0).Info("Downloading template from", "template", fileUrl)
 		if err := util.DownloadFile("/tmp/fuse-online-template.yml", fileUrl); err != nil {


### PR DESCRIPTION
Use a different file for upstream installation, dont mess around the template installation file

Add a option to target a new github user, for testing purposes mainly, default to _syndesisio_

Fixes https://github.com/syndesisio/syndesis/issues/5925