### PR TITLE
Fix for TEIIDTOOLS-683 Initialization of the Import Datasource wizard flashes "No connections available"

### DIFF
--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionSkeleton.tsx
@@ -1,25 +1,23 @@
-import { Card, EmptyState } from 'patternfly-react';
+import { Card } from 'patternfly-react';
 import * as React from 'react';
 import ContentLoader from 'react-content-loader';
 
 export const DvConnectionSkeleton = (props: any) => (
   <Card matchHeight={true}>
     <Card.Body>
-      <EmptyState>
-        <ContentLoader
-          height={300}
-          width={200}
-          speed={2}
-          primaryColor="#f3f3f3"
-          secondaryColor="#ecebeb"
-          {...props}
-        >
-          <circle cx="100" cy="50" r="40" />
-          <rect x="5" y="125" rx="5" ry="5" width="190" height="30" />
-          <rect x="25" y="180" rx="5" ry="5" width="150" height="15" />
-          <rect x="40" y="205" rx="5" ry="5" width="120" height="15" />
-        </ContentLoader>
-      </EmptyState>
+      <ContentLoader
+        height={150}
+        width={150}
+        speed={2}
+        primaryColor="#f3f3f3"
+        secondaryColor="#ecebeb"
+        {...props}
+      >
+        <rect x="5" y="5" width="50" height="25" />
+        <circle cx="75" cy="65" r="25" />
+        <rect x="25" y="100" width="100" height="20" />
+        <rect x="15" y="130" width="120" height="15" />
+      </ContentLoader>
     </Card.Body>
   </Card>
 );

--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionsToolbarSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionsToolbarSkeleton.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import ContentLoader from 'react-content-loader';
+
+export const DvConnectionsToolbarSkeleton = () => (
+  <div>
+    <ContentLoader
+      height={50}
+      width={500}
+      speed={2}
+      primaryColor="#ffffff"
+      secondaryColor="#ecebeb"
+    >
+      <rect x="0" y="0" height="25" width="500" />
+    </ContentLoader>
+  </div>
+);

--- a/app/ui-react/packages/ui/src/Data/DvConnection/index.ts
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/index.ts
@@ -3,3 +3,4 @@ export * from './DvConnectionsGrid';
 export * from './DvConnectionsGridCell';
 export * from './DvConnectionSkeleton';
 export * from './DvConnectionsListView';
+export * from './DvConnectionsToolbarSkeleton';

--- a/app/ui-react/packages/ui/src/Data/index.ts
+++ b/app/ui-react/packages/ui/src/Data/index.ts
@@ -6,6 +6,7 @@ export * from './DvConnection/DvConnectionsGrid';
 export * from './DvConnection/DvConnectionsGridCell';
 export * from './DvConnection/DvConnectionSkeleton';
 export * from './DvConnection/DvConnectionsListView';
+export * from './DvConnection/DvConnectionsToolbarSkeleton';
 export * from './Virtualizations/Views/EmptyViewsState';
 export * from './Virtualizations/Views/SchemaNodeListItem';
 export * from './Virtualizations/Views/ViewEditContent';

--- a/app/ui-react/packages/ui/stories/Data/DvConnection/DvConnectionsWithToolbarSkeleton.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/DvConnection/DvConnectionsWithToolbarSkeleton.stories.tsx
@@ -1,0 +1,24 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import {
+  DvConnectionsGridCell,
+  DvConnectionSkeleton,
+  DvConnectionsToolbarSkeleton,
+} from '../../../src';
+
+const stories = storiesOf(
+  'Data/DvConnection/DvConnectionsWithToolbarSkeleton',
+  module
+);
+
+stories.add('render', () => (
+  <>
+    <DvConnectionsToolbarSkeleton />
+    {new Array(5).fill(0).map((_, index) => (
+      <DvConnectionsGridCell key={index}>
+        <DvConnectionSkeleton />
+      </DvConnectionsGridCell>
+    ))}
+  </>
+));

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
@@ -3,17 +3,12 @@ import {
   DvConnectionCard,
   DvConnectionsGrid,
   DvConnectionsGridCell,
-  DvConnectionSkeleton,
 } from '@syndesis/ui';
-import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
-import { ApiError, EntityIcon } from '../../../shared';
+import { EntityIcon } from '../../../shared';
 import { getDvConnectionStatus } from './VirtualizationUtils';
 
 export interface IDvConnectionsProps {
-  error: boolean;
-  errorMessage?: string;
-  loading: boolean;
   connections: Connection[];
   initialSelection: string; // Name of initially selected connection
   onConnectionSelectionChanged: (name: string, selected: boolean) => void;
@@ -22,47 +17,34 @@ export interface IDvConnectionsProps {
 export const DvConnections: React.FunctionComponent<
   IDvConnectionsProps
 > = props => {
+  const [selectedConnection, setSelectedConnection] = React.useState(
+    props.initialSelection
+  );
 
-  const [selectedConnection, setSelectedConnection] = React.useState(props.initialSelection);
-
-  const handleConnSourceSelectionChanged = (name: string, isSelected: boolean) => {
+  const handleConnSourceSelectionChanged = (
+    name: string,
+    isSelected: boolean
+  ) => {
     const newSelection = isSelected ? name : '';
     setSelectedConnection(newSelection);
-    
-    props.onConnectionSelectionChanged(name, isSelected);
-  }
 
-    return (
-      <DvConnectionsGrid>
-        <WithLoader
-          error={props.error}
-          loading={props.loading}
-          loaderChildren={
-            <>
-              {new Array(5).fill(0).map((_, index) => (
-                <DvConnectionsGridCell key={index}>
-                  <DvConnectionSkeleton />
-                </DvConnectionsGridCell>
-              ))}
-            </>
-          }
-          errorChildren={<ApiError error={props.errorMessage!} />}
-        >
-          {() =>
-            props.connections.map((c, index) => (
-              <DvConnectionsGridCell key={index}>
-                <DvConnectionCard
-                  name={c.name}
-                  description={c.description || ''}
-                  dvStatus={getDvConnectionStatus(c)}
-                  icon={<EntityIcon entity={c} alt={c.name} width={46} />}
-                  selected={selectedConnection === c.name}
-                  onSelectionChanged={handleConnSourceSelectionChanged}
-                />
-              </DvConnectionsGridCell>
-            ))
-          }
-        </WithLoader>
-      </DvConnectionsGrid>
-    );
-}
+    props.onConnectionSelectionChanged(name, isSelected);
+  };
+
+  return (
+    <DvConnectionsGrid>
+      {props.connections.map((c, index) => (
+        <DvConnectionsGridCell key={index}>
+          <DvConnectionCard
+            name={c.name}
+            description={c.description || ''}
+            dvStatus={getDvConnectionStatus(c)}
+            icon={<EntityIcon entity={c} alt={c.name} width={46} />}
+            selected={selectedConnection === c.name}
+            onSelectionChanged={handleConnSourceSelectionChanged}
+          />
+        </DvConnectionsGridCell>
+      ))}
+    </DvConnectionsGrid>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
@@ -1,51 +1,22 @@
 import { useConnections } from '@syndesis/api';
 import { Connection, VirtualizationSourceStatus } from '@syndesis/models';
 import {
+  DvConnectionsGridCell,
+  DvConnectionSkeleton,
   DvConnectionsListView,
+  DvConnectionsToolbarSkeleton,
   IActiveFilter,
   IFilterType,
   ISortType,
 } from '@syndesis/ui';
-import { WithListViewToolbarHelpers } from '@syndesis/utils';
+import { WithListViewToolbarHelpers, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import resolvers from '../../resolvers';
 import { DvConnections } from './DvConnections';
 import { generateDvConnections } from './VirtualizationUtils';
-
-function getFilteredAndSortedConnections(
-  connections: Connection[],
-  dvSourceStatuses: VirtualizationSourceStatus[],
-  selectedConn: string,
-  activeFilters: IActiveFilter[],
-  currentSortType: ISortType,
-  isSortAscending: boolean
-) {
-  // Connections are adjusted to supply dvStatus and selection
-  let filteredAndSortedConnections = generateDvConnections(
-    connections,
-    dvSourceStatuses,
-    selectedConn,
-    true
-  );
-  activeFilters.forEach((filter: IActiveFilter) => {
-    const valueToLower = filter.value.toLowerCase();
-    filteredAndSortedConnections = filteredAndSortedConnections.filter(
-      (c: Connection) => c.name.toLowerCase().includes(valueToLower)
-    );
-  });
-
-  filteredAndSortedConnections = filteredAndSortedConnections.sort(
-    (miA, miB) => {
-      const left = isSortAscending ? miA : miB;
-      const right = isSortAscending ? miB : miA;
-      return left.name.localeCompare(right.name);
-    }
-  );
-
-  return filteredAndSortedConnections;
-}
 
 const filterByName = {
   filterType: 'text',
@@ -79,6 +50,40 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
   const { t } = useTranslation(['data', 'shared']);
   const [selectedConnection, setSelectedConnection] = React.useState('');
 
+  function getFilteredAndSortedConnections(
+    connections: Connection[],
+    dvSourceStatuses: VirtualizationSourceStatus[],
+    selectedConn: string,
+    activeFilters: IActiveFilter[],
+    currentSortType: ISortType,
+    isSortAscending: boolean
+  ) {
+    // Connections are adjusted to supply dvStatus and selection
+    let filteredAndSortedConnections = generateDvConnections(
+      connections,
+      dvSourceStatuses,
+      selectedConn,
+      true
+    );
+    activeFilters.forEach((filter: IActiveFilter) => {
+      const valueToLower = filter.value.toLowerCase();
+      filteredAndSortedConnections = filteredAndSortedConnections.filter(
+        (c: Connection) => c.name.toLowerCase().includes(valueToLower)
+      );
+    });
+
+    filteredAndSortedConnections = filteredAndSortedConnections.sort(
+      (miA, miB) => {
+        const left = isSortAscending ? miA : miB;
+        const right = isSortAscending ? miB : miA;
+        return left.name.localeCompare(right.name);
+      }
+    );
+
+    // setLoaded(true);
+    return filteredAndSortedConnections;
+  }
+
   const handleConnectionSelectionChanged = (
     name: string,
     selected: boolean
@@ -87,7 +92,11 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
     setSelectedConnection(selected ? name : '');
   };
 
-  const { resource: connectionsData } = useConnections();
+  const {
+    resource: connectionsData,
+    hasData: hasConnectionsData,
+    error: connectionsError,
+  } = useConnections();
 
   return (
     <WithListViewToolbarHelpers
@@ -105,33 +114,56 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
         );
 
         return (
-          <DvConnectionsListView
-            i18nEmptyStateInfo={t(
-              'virtualization.activeConnectionsEmptyStateInfo'
-            )}
-            i18nEmptyStateTitle={t(
-              'virtualization.activeConnectionsEmptyStateTitle'
-            )}
-            linkToConnectionCreate={resolvers.connections.create.selectConnector()}
-            filterTypes={filterTypes}
-            sortTypes={sortTypes}
-            resultsCount={filteredAndSortedConnections.length}
-            {...helpers}
-            i18nLinkCreateConnection={t('shared:linkCreateConnection')}
-            i18nResultsCount={t('shared:resultsCount', {
-              count: filteredAndSortedConnections.length,
-            })}
+          <WithLoader
+            error={props.error || connectionsError !== false}
+            loading={props.loading || !hasConnectionsData}
+            loaderChildren={
+              <>
+                <DvConnectionsToolbarSkeleton />
+                {new Array(5).fill(0).map((_, index) => (
+                  <DvConnectionsGridCell key={index}>
+                    <DvConnectionSkeleton />
+                  </DvConnectionsGridCell>
+                ))}
+              </>
+            }
+            errorChildren={
+              <ApiError
+                error={props.errorMessage || (connectionsError as Error)}
+              />
+            }
           >
-            {props.children}
-            <DvConnections
-              error={props.error}
-              errorMessage={props.errorMessage}
-              loading={props.loading}
-              connections={filteredAndSortedConnections}
-              initialSelection={selectedConnection}
-              onConnectionSelectionChanged={handleConnectionSelectionChanged}
-            />
-          </DvConnectionsListView>
+            {() => (
+              <DvConnectionsListView
+                i18nEmptyStateInfo={t(
+                  'virtualization.activeConnectionsEmptyStateInfo'
+                )}
+                i18nEmptyStateTitle={t(
+                  'virtualization.activeConnectionsEmptyStateTitle'
+                )}
+                linkToConnectionCreate={resolvers.connections.create.selectConnector()}
+                filterTypes={filterTypes}
+                sortTypes={sortTypes}
+                resultsCount={filteredAndSortedConnections.length}
+                {...helpers}
+                i18nLinkCreateConnection={t('shared:linkCreateConnection')}
+                i18nResultsCount={t('shared:resultsCount', {
+                  count: filteredAndSortedConnections.length,
+                })}
+              >
+                {props.children}
+                {filteredAndSortedConnections.length > 0 && (
+                  <DvConnections
+                    connections={filteredAndSortedConnections}
+                    initialSelection={selectedConnection}
+                    onConnectionSelectionChanged={
+                      handleConnectionSelectionChanged
+                    }
+                  />
+                )}
+              </DvConnectionsListView>
+            )}
+          </WithLoader>
         );
       }}
     </WithListViewToolbarHelpers>


### PR DESCRIPTION
- see [TEIIDTOOLS-683](https://issues.jboss.org/browse/TEIIDTOOLS-683)
- added `DvConnectionsToolbarSkeleton` to the loader children that are displayed when the DV connections are being fetched
- moved the loader from `DvConnections` to `DvConnectionsWithToolbar`
- added story for the combined loader skeleton used by `DvConnectionsWithToolbar`
- redesigned `DvConnectionSkeleton` to look more like the DV connection card