### PR TITLE
Rewrite of polling function

### DIFF
--- a/app/ui-react/packages/api/src/usePolling.tsx
+++ b/app/ui-react/packages/api/src/usePolling.tsx
@@ -1,37 +1,29 @@
-import * as React from 'react';
+import { useEffect, useRef } from 'react';
 
 export interface IUsePollingProps {
-  polling: number;
-  read: () => void;
+  delay: number;
+  callback: () => void;
 }
 
-export function usePolling({ polling, read }: IUsePollingProps) {
-  const [pollingTimer, setPollingTimer] = React.useState();
+export function usePolling({ delay, callback }: IUsePollingProps) {
+  const savedCallback = useRef<() => void>(callback);
 
-  const poller = () => {
-    read();
-  };
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
 
-  const stopPolling = () => {
-    if (pollingTimer) {
-      clearInterval(pollingTimer);
-      setPollingTimer(undefined);
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
     }
-  };
 
-  const startPolling = () => {
-    if (!pollingTimer && polling > 0) {
-      setPollingTimer(setInterval(poller, polling));
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
     }
-  };
 
-  React.useEffect(() => {
-    // mount
-    startPolling();
-
-    // unmount
-    return () => {
-      stopPolling();
-    };
-  });
+    return undefined;
+  }, [delay]);
 }

--- a/app/ui-react/packages/api/src/useVirtualization.tsx
+++ b/app/ui-react/packages/api/src/useVirtualization.tsx
@@ -2,7 +2,10 @@ import { RestDataService } from '@syndesis/models';
 import { useApiResource } from './useApiResource';
 import { usePolling } from './usePolling';
 
-export const useVirtualization = (virtualizationName: string, disableUpdates: boolean = false) => {
+export const useVirtualization = (
+  virtualizationName: string,
+  disableUpdates: boolean = false
+) => {
   const { read, ...rest } = useApiResource<RestDataService>({
     defaultValue: {
       connections: 0,
@@ -18,15 +21,14 @@ export const useVirtualization = (virtualizationName: string, disableUpdates: bo
       serviceVdbVersion: '1',
       serviceViewDefinitions: [],
       serviceViewModel: '',
-      tko__description: ''
-    
+      tko__description: '',
     },
     url: `workspace/dataservices/${virtualizationName}`,
     useDvApiUrl: true,
   });
 
   if (!disableUpdates) {
-    usePolling({ polling: 5000, read });
+    usePolling({ callback: read, delay: 5000 });
   }
 
   return {

--- a/app/ui-react/packages/api/src/useVirtualizations.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizations.tsx
@@ -10,7 +10,7 @@ export const useVirtualizations = (disableUpdates: boolean = false) => {
   });
 
   if (!disableUpdates) {
-    usePolling({ polling: 5000, read });
+    usePolling({ callback: read, delay: 5000 });
   }
 
   return {

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -84,15 +84,7 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
     handlePublishVirtualization,
     handleUnpublishServiceVdb,
   } = VirtualizationHandlers();
-  const [disableUpdates, setDisableUpdates] = React.useState(false);
-  const { resource: data, hasData, error } = useVirtualizations(disableUpdates);
-
-  // unmount: turn off polling
-  React.useEffect(() => {
-    return () => {
-      setDisableUpdates(true);
-    };
-  }, []);
+  const { resource: data, hasData, error } = useVirtualizations();
 
   // TODO: implement handleImportVirt
   // const handleImportVirt = (virtualizationName: string) => {


### PR DESCRIPTION
- renamed `usePolling` function properties to be `delay` and `callback`
- changed `useVirtualization` and `useVirtualizations` to the new property names of `usePolling`
- removed unnecessary React effect in `VirtualizationsPage`