### PR TITLE
chore(6199): Refactor connector options handling

### DIFF
--- a/app/connector/activemq/pom.xml
+++ b/app/connector/activemq/pom.xml
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis.integration</groupId>

--- a/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnectorVerifierExtension.java
+++ b/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnectorVerifierExtension.java
@@ -28,6 +28,7 @@ import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class ActiveMQConnectorVerifierExtension extends DefaultComponentVerifierExtension {
     private static final Logger LOG = LoggerFactory.getLogger(ActiveMQConnectorVerifierExtension.class);
@@ -64,12 +65,13 @@ public class ActiveMQConnectorVerifierExtension extends DefaultComponentVerifier
     }
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
-        final String brokerUrl = (String) parameters.get("brokerUrl");
-        final String username = (String) parameters.get("username");
-        final String password = (String) parameters.get("password");
-        final boolean skipCertificateCheck = "true".equals(parameters.get("skipCertificateCheck"));
-        final String brokerCertificate = (String) parameters.get("brokerCertificate");
-        final String clientCertificate = (String) parameters.get("clientCertificate");
+        final String brokerUrl = ConnectorOptions.extractOption(parameters, "brokerUrl");
+        final String username = ConnectorOptions.extractOption(parameters, "username");
+        final String password = ConnectorOptions.extractOption(parameters, "password");
+        final boolean skipCertificateCheck = ConnectorOptions.extractOptionAndMap(parameters,
+            "skipCertificateCheck", Boolean::parseBoolean, false);
+        final String brokerCertificate = ConnectorOptions.extractOption(parameters, "brokerCertificate");
+        final String clientCertificate = ConnectorOptions.extractOption(parameters, "clientCertificate");
 
         LOG.debug("Validating AMQ connection to {}", brokerUrl);
 

--- a/app/connector/amqp/pom.xml
+++ b/app/connector/amqp/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
@@ -29,6 +29,7 @@ import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * Component verifier for AMQP Connector.
@@ -69,12 +70,13 @@ public class AMQPVerifierExtension extends DefaultComponentVerifierExtension {
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
-        final String connectionUri = (String) parameters.get("connectionUri");
-        final String username = (String) parameters.get("username");
-        final String password = (String) parameters.get("password");
-        final boolean skipCertificateCheck = "true".equals(parameters.get("skipCertificateCheck"));
-        final String brokerCertificate = (String) parameters.get("brokerCertificate");
-        final String clientCertificate = (String) parameters.get("clientCertificate");
+        final String connectionUri = ConnectorOptions.extractOption(parameters, "connectionUri");
+        final String username = ConnectorOptions.extractOption(parameters, "username");
+        final String password = ConnectorOptions.extractOption(parameters, "password");
+        final boolean skipCertificateCheck = ConnectorOptions.extractOptionAndMap(parameters,
+            "skipCertificateCheck", Boolean::parseBoolean, false);
+        final String brokerCertificate = ConnectorOptions.extractOption(parameters, "brokerCertificate");
+        final String clientCertificate = ConnectorOptions.extractOption(parameters, "clientCertificate");
 
         LOG.debug("Validating AMQP connection to {}", connectionUri);
         final AMQPUtil.ConnectionParameters connectionParameters = new AMQPUtil.ConnectionParameters(connectionUri,

--- a/app/connector/aws-s3/pom.xml
+++ b/app/connector/aws-s3/pom.xml
@@ -57,6 +57,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/aws-s3/src/main/java/io/syndesis/connector/aws/s3/AWSS3CopyObjectCustomizer.java
+++ b/app/connector/aws-s3/src/main/java/io/syndesis/connector/aws/s3/AWSS3CopyObjectCustomizer.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.aws.s3.S3Constants;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -31,7 +31,7 @@ public class AWSS3CopyObjectCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        filenameKey = (String) options.get("fileName");
+        filenameKey = ConnectorOptions.extractOption(options, "fileName");
 
         component.setBeforeProducer(this::beforeProducer);
     }

--- a/app/connector/aws-s3/src/main/java/io/syndesis/connector/aws/s3/AWSS3DeleteObjectCustomizer.java
+++ b/app/connector/aws-s3/src/main/java/io/syndesis/connector/aws/s3/AWSS3DeleteObjectCustomizer.java
@@ -22,7 +22,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.aws.s3.S3Operations;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -32,7 +32,7 @@ public class AWSS3DeleteObjectCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        filenameKey = (String) options.get("fileName");
+        filenameKey = ConnectorOptions.extractOption(options, "fileName");
 
         component.setBeforeProducer(this::beforeProducer);
     }

--- a/app/connector/aws-sns/pom.xml
+++ b/app/connector/aws-sns/pom.xml
@@ -57,6 +57,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/aws-sns/src/main/java/io/syndesis/connector/aws/sns/AWSSNSMetaDataExtension.java
+++ b/app/connector/aws-sns/src/main/java/io/syndesis/connector/aws/sns/AWSSNSMetaDataExtension.java
@@ -19,11 +19,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.MetaDataBuilder;
-
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -33,6 +31,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.amazonaws.services.sns.model.ListTopicsResult;
 import com.amazonaws.services.sns.model.Topic;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class AWSSNSMetaDataExtension extends AbstractMetaDataExtension {
 
@@ -42,9 +41,9 @@ public class AWSSNSMetaDataExtension extends AbstractMetaDataExtension {
 
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
-        final String accessKey = (String)parameters.get("accessKey");
-        final String secretKey = (String)parameters.get("secretKey");
-        final String region = (String)parameters.get("region");
+        final String accessKey = ConnectorOptions.extractOption(parameters, "accessKey");
+        final String secretKey = ConnectorOptions.extractOption(parameters, "secretKey");
+        final String region = ConnectorOptions.extractOption(parameters, "region");
         AmazonSNSClientBuilder clientBuilder;
         AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
         AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentials);

--- a/app/connector/aws-sns/src/main/java/io/syndesis/connector/aws/sns/AWSSNSVerifierExtension.java
+++ b/app/connector/aws-sns/src/main/java/io/syndesis/connector/aws/sns/AWSSNSVerifierExtension.java
@@ -33,6 +33,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class AWSSNSVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -53,7 +54,7 @@ public class AWSSNSVerifierExtension extends DefaultComponentVerifierExtension {
 
         // Validate using the catalog
 
-        if (ObjectHelper.isEmpty(parameters.get("secretKey")) || ObjectHelper.isEmpty(parameters.get("accessKey"))) {
+        if (ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "secretKey")) || ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "accessKey"))) {
             builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.GENERIC,
                     "You must specify a secretKey and an accessKey").parameterKey("secretKey").parameterKey("accessKey").build());
         }

--- a/app/connector/aws-sqs/pom.xml
+++ b/app/connector/aws-sqs/pom.xml
@@ -57,6 +57,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/aws-sqs/src/main/java/io/syndesis/connector/aws/sqs/AWSSQSMetaDataExtension.java
+++ b/app/connector/aws-sqs/src/main/java/io/syndesis/connector/aws/sqs/AWSSQSMetaDataExtension.java
@@ -37,6 +37,7 @@ import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
 import com.amazonaws.services.sqs.model.QueueAttributeName;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class AWSSQSMetaDataExtension extends AbstractMetaDataExtension {
 
@@ -46,9 +47,9 @@ public class AWSSQSMetaDataExtension extends AbstractMetaDataExtension {
 
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
-        final String accessKey = (String)parameters.get("accessKey");
-        final String secretKey = (String)parameters.get("secretKey");
-        final String region = (String)parameters.get("region");
+        final String accessKey = ConnectorOptions.extractOption(parameters, "accessKey");
+        final String secretKey = ConnectorOptions.extractOption(parameters, "secretKey");
+        final String region = ConnectorOptions.extractOption(parameters, "region");
         AmazonSQSClientBuilder clientBuilder;
         AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
         AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(credentials);

--- a/app/connector/aws-sqs/src/main/java/io/syndesis/connector/aws/sqs/AWSSQSVerifierExtension.java
+++ b/app/connector/aws-sqs/src/main/java/io/syndesis/connector/aws/sqs/AWSSQSVerifierExtension.java
@@ -33,6 +33,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class AWSSQSVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -53,7 +54,7 @@ public class AWSSQSVerifierExtension extends DefaultComponentVerifierExtension {
 
         // Validate using the catalog
 
-        if (ObjectHelper.isEmpty(parameters.get("secretKey")) || ObjectHelper.isEmpty(parameters.get("accessKey"))) {
+        if (ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "secretKey")) || ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "accessKey"))) {
             builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.GENERIC,
                     "You must specify a secretKey and an accessKey").parameterKey("secretKey").parameterKey("accessKey").build());
         }

--- a/app/connector/box/pom.xml
+++ b/app/connector/box/pom.xml
@@ -53,6 +53,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/box/src/main/java/io/syndesis/connector/box/BoxConnector.java
+++ b/app/connector/box/src/main/java/io/syndesis/connector/box/BoxConnector.java
@@ -16,14 +16,13 @@
 package io.syndesis.connector.box;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
-
-import io.syndesis.integration.component.proxy.ComponentDefinition;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import org.apache.camel.Component;
 import org.apache.camel.component.box.BoxComponent;
 import org.apache.camel.component.box.BoxConfiguration;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentDefinition;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 public class BoxConnector extends ComponentProxyComponent {
 
@@ -55,11 +54,9 @@ public class BoxConnector extends ComponentProxyComponent {
     @Override
     protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
         Map<String, String> endpointOptions = super.buildEndpointOptions(remaining, options);
-        Stream.of("parentFolderId", "fileId").forEach(key ->
-                Optional.ofNullable(options.get(key))
-                        .map(String.class::cast)
-                        .ifPresent(value -> endpointOptions.put(key, value))
-        );
+        Stream.of("parentFolderId", "fileId").forEach(key -> {
+                ConnectorOptions.extractOptionAndConsume(options, key, (String value) -> endpointOptions.put(key, value));
+        });
         return endpointOptions;
     }
 

--- a/app/connector/box/src/main/java/io/syndesis/connector/box/customizer/BoxDownloadCustomizer.java
+++ b/app/connector/box/src/main/java/io/syndesis/connector/box/customizer/BoxDownloadCustomizer.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import io.syndesis.connector.box.BoxFile;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -36,8 +37,8 @@ public class BoxDownloadCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        fileId = (String) options.get("fileId");
-        encoding = (String) options.get("encoding");
+        fileId = ConnectorOptions.extractOption(options, "fileId");
+        encoding = ConnectorOptions.extractOption(options, "encoding");
         component.setBeforeProducer(this::beforeProducer);
         component.setAfterProducer(this::afterProducer);
     }

--- a/app/connector/dropbox/pom.xml
+++ b/app/connector/dropbox/pom.xml
@@ -29,6 +29,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/dropbox/src/main/java/io/syndesis/connector/dropbox/DropBoxVerifierExtension.java
+++ b/app/connector/dropbox/src/main/java/io/syndesis/connector/dropbox/DropBoxVerifierExtension.java
@@ -27,6 +27,7 @@ import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.v2.DbxClientV2;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class DropBoxVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -57,8 +58,8 @@ public class DropBoxVerifierExtension extends DefaultComponentVerifierExtension 
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
-        String token = (String) parameters.get("accessToken");
-        String clientId = (String) parameters.get("clientIdentifier");
+        String token = ConnectorOptions.extractOption(parameters, "accessToken");
+        String clientId = ConnectorOptions.extractOption(parameters, "clientIdentifier");
 
         try {
             // Create Dropbox client

--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -57,7 +57,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis.common</groupId>

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
@@ -65,7 +65,7 @@ public class EMailSendCustomizer implements ComponentProxyCustomizer, EMailConst
         //
         // Will return injected data if not set
         //
-        priority = ConnectorOptions.extractOptionAndMap(options, PRIORITY, Priority::priorityFromId);
+        priority = ConnectorOptions.extractOptionAndMap(options, PRIORITY, Priority::priorityFromId, null);
     }
 
     private Object updateMail(String inputValue, Object dataValue) {

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
@@ -48,12 +48,14 @@ public abstract class AbstractEMailVerifier extends DefaultComponentVerifierExte
     }
 
     protected void secureProtocol(Map<String, Object> parameters) {
-        Protocol protocol = ConnectorOptions.extractOptionAndMap(parameters, PROTOCOL, Protocol::getValueOf);
+        Protocol protocol = ConnectorOptions.extractOptionAndMap(parameters,
+            PROTOCOL, Protocol::getValueOf, null);
         if (ObjectHelper.isEmpty(protocol)) {
             return;
         }
 
-        SecureType secureType = ConnectorOptions.extractOptionAndMap(parameters, SECURE_TYPE, SecureType::secureTypeFromId);
+        SecureType secureType = ConnectorOptions.extractOptionAndMap(parameters,
+            SECURE_TYPE, SecureType::secureTypeFromId, null);
         if (ObjectHelper.isEmpty(secureType) || protocol.isSecure()) {
             return;
         }
@@ -88,7 +90,8 @@ public abstract class AbstractEMailVerifier extends DefaultComponentVerifierExte
      */
     protected void setConnectionTimeoutProperty(Map<String, Object> parameters,
                                                 MailConfiguration configuration, String timeoutValue) {
-        Protocol protocol = ConnectorOptions.extractOptionAndMap(parameters, PROTOCOL, Protocol::getValueOf);
+        Protocol protocol = ConnectorOptions.extractOptionAndMap(parameters,
+            PROTOCOL, Protocol::getValueOf, null);
         Protocol plainProtocol = protocol.toPlainProtocol();
         Protocol secureProtocol = protocol.toSecureProtocol();
 

--- a/app/connector/fhir/pom.xml
+++ b/app/connector/fhir/pom.xml
@@ -34,6 +34,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetaDataExtension.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetaDataExtension.java
@@ -16,6 +16,7 @@
 package io.syndesis.connector.fhir;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.MetaDataBuilder;
@@ -31,11 +32,11 @@ public class FhirMetaDataExtension extends AbstractMetaDataExtension {
         super(context);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
-        String fhirVersion = (String) parameters.get("fhirVersion");
-        FhirVersionEnum fhirVersionEnum = fhirVersion == null ? FhirVersionEnum.DSTU3 : FhirVersionEnum.valueOf(fhirVersion);
+        FhirVersionEnum fhirVersionEnum = ConnectorOptions.extractOptionAndMap(
+            parameters, "fhirVersion",
+            FhirVersionEnum::valueOf, FhirVersionEnum.DSTU3);
 
         Set<String> resources = getResources(fhirVersionEnum);
 

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetadataRetrieval.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetadataRetrieval.java
@@ -29,6 +29,7 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.Resources;
 import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.PropertyPair;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
@@ -79,7 +80,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         enrichedProperties.put("resourceType",resourceTypeResult);
         enrichedProperties.put("containedResourceTypes", resourceTypeResult);
 
-        if (ObjectHelper.isNotEmpty(properties.get("resourceType"))) {
+        if (ObjectHelper.isNotEmpty(ConnectorOptions.extractOption(properties, "resourceType"))) {
             return createSyndesisMetadata(actionId, properties, enrichedProperties);
         } else {
             return SyndesisMetadata.of(enrichedProperties);
@@ -87,8 +88,8 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
     }
 
     private SyndesisMetadata createSyndesisMetadata(String actionId, Map<String, Object> properties, Map<String, List<PropertyPair>> enrichedProperties) {
-        String containedResourceTypes = (String) properties.get("containedResourceTypes");
-        String type = (String) properties.get("resourceType");
+        String containedResourceTypes = ConnectorOptions.extractOption(properties, "containedResourceTypes");
+        String type = ConnectorOptions.extractOption(properties, "resourceType");
 
         if (actionId.contains("read")) {
             return new SyndesisMetadata(
@@ -126,7 +127,8 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
                     .description("FHIR " + actionId)
                     .name(actionId).build());
         } else if (actionId.contains("patch")) {
-            Integer operationNumber = Integer.valueOf((String) properties.get("operationNumber"));
+            Integer operationNumber = ConnectorOptions.extractOptionAndMap(
+                properties, "operationNumber", Integer::valueOf, 0);
             return new SyndesisMetadata(
                 enrichedProperties,
                 new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA)//

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirCustomizerHelper.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirCustomizerHelper.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.fhir.customizer;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.component.fhir.internal.FhirApiCollection;
 import org.apache.camel.util.component.ApiMethod;
 
@@ -29,8 +30,8 @@ public final class FhirCustomizerHelper {
     }
 
     public static FhirContext newFhirContext(Map<String, Object> options) {
-        String fhirVersion = (String) options.get("fhirVersion");
-        FhirVersionEnum fhirVersionEnum = FhirVersionEnum.valueOf(fhirVersion);
+        FhirVersionEnum fhirVersionEnum = ConnectorOptions.extractOptionAndMap(
+            options, "fhirVersion", FhirVersionEnum::valueOf, null);
         return new FhirContext(fhirVersionEnum);
     }
 

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirPatchCustomizer.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirPatchCustomizer.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.fhir.customizer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.CamelExecutionException;
@@ -47,9 +48,9 @@ public class FhirPatchCustomizer implements ComponentProxyCustomizer {
         options.put("apiName", FhirCustomizerHelper.getFhirApiName(FhirPatchApiMethod.class));
         options.put("methodName", "patchById");
 
-        resourceType = (String) options.get("resourceType");
-        id = (String) options.get("id");
-        patch = (String) options.get("patch");
+        resourceType = ConnectorOptions.extractOption(options, "resourceType");
+        id = ConnectorOptions.extractOption(options, "id");
+        patch = ConnectorOptions.extractOption(options, "patch");
 
         component.setBeforeProducer(this::beforeProducer);
     }
@@ -74,7 +75,7 @@ public class FhirPatchCustomizer implements ComponentProxyCustomizer {
                     } else if (entry.getValue() instanceof Map) {
                         @SuppressWarnings("unchecked")
                         Map<String, String> operation = (Map<String, String>) entry.getValue();
-                        if (ObjectHelper.isEmpty(operation.get("op"))) {
+                        if (ObjectHelper.isEmpty(ConnectorOptions.extractOption(operation, "op"))) {
                             operation.put("op", "replace"); //'replace' by default
                         }
                         list.add(operation);

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirReadDeleteBaseCustomizer.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirReadDeleteBaseCustomizer.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.fhir.customizer;
 
 import ca.uhn.fhir.context.FhirContext;
 import io.syndesis.connector.fhir.FhirResourceId;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -36,9 +37,9 @@ public abstract class FhirReadDeleteBaseCustomizer implements ComponentProxyCust
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         fhirContext = FhirCustomizerHelper.newFhirContext(options);
 
-        resourceType = (String) options.get("resourceType");
-        id = (String) options.get("id");
-        version = (String) options.get("version");
+        resourceType = ConnectorOptions.extractOption(options, "resourceType");
+        id = ConnectorOptions.extractOption(options, "id");
+        version = ConnectorOptions.extractOption(options, "version");
 
         options.put("apiName", FhirCustomizerHelper.getFhirApiName(getApiMethodClass()));
         options.put("methodName", "resourceById");

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirSearchCustomizer.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirSearchCustomizer.java
@@ -16,6 +16,7 @@
 package io.syndesis.connector.fhir.customizer;
 
 import io.syndesis.connector.fhir.FhirResourceQuery;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -41,7 +42,7 @@ public class FhirSearchCustomizer  extends FhirReadCustomizer {
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         super.customize(component, options);
 
-        query = (String) options.get("query");
+        query = ConnectorOptions.extractOption(options, "query");
 
         options.put("methodName", "searchByUrl?inBody=url");
     }

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/verifier/FhirVerifierExtension.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/verifier/FhirVerifierExtension.java
@@ -21,6 +21,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
@@ -64,11 +65,11 @@ public class FhirVerifierExtension extends DefaultComponentVerifierExtension {
     }
 
     private void verifyFhirVersion(ResultBuilder builder, Map<String, Object> parameters) {
-        final String fhirVersion = (String) parameters.get("fhirVersion");
         try {
-            FhirVersionEnum fhirVersionEnum = FhirVersionEnum.valueOf(fhirVersion);
+            final FhirVersionEnum fhirVersionEnum = ConnectorOptions.extractOptionAndMap(
+                parameters, "fhirVersion", FhirVersionEnum::valueOf);
             parameters.put("fhirVersion", fhirVersionEnum);
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             builder.error(
                 ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.ILLEGAL_PARAMETER_VALUE, "Invalid FHIR version")
                     .parameterKey("fhirVersion")
@@ -80,11 +81,12 @@ public class FhirVerifierExtension extends DefaultComponentVerifierExtension {
         if (!builder.build().getErrors().isEmpty()) {
             return;
         }
-        final String serverUrl = (String) parameters.get("serverUrl");
-        final FhirVersionEnum fhirVersion = (FhirVersionEnum) parameters.get("fhirVersion");
-        final String username = (String) parameters.get("username");
-        final String password = (String) parameters.get("password");
-        final String accessToken = (String) parameters.get("accessToken");
+        final String serverUrl = ConnectorOptions.extractOption(parameters, "serverUrl");
+        final FhirVersionEnum fhirVersion = ConnectorOptions.extractOptionAsType(
+            parameters, "fhirVersion", FhirVersionEnum.class);
+        final String username = ConnectorOptions.extractOption(parameters, "username");
+        final String password = ConnectorOptions.extractOption(parameters, "password");
+        final String accessToken = ConnectorOptions.extractOption(parameters, "accessToken");
 
         LOG.debug("Validating FHIR connection to {} with FHIR version {}", serverUrl, fhirVersion);
 

--- a/app/connector/ftp/pom.xml
+++ b/app/connector/ftp/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
+++ b/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
@@ -59,7 +59,7 @@ public class FtpVerifierExtension extends DefaultComponentVerifierExtension {
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
         final String host = ConnectorOptions.extractOption(parameters, "host");
-        final int port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt);
+        final Integer port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt, 21);
         final String userName = ConnectorOptions.extractOption(parameters, "username", "anonymous");
 
         String password = "";

--- a/app/connector/gmail/pom.xml
+++ b/app/connector/gmail/pom.xml
@@ -51,6 +51,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailSendEmailCustomizer.java
+++ b/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailSendEmailCustomizer.java
@@ -20,14 +20,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import javax.mail.Address;
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
@@ -36,10 +34,9 @@ import org.apache.camel.component.google.mail.internal.GoogleMailApiCollection;
 import org.apache.camel.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.api.client.util.Base64;
 import com.google.common.base.Splitter;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -61,12 +58,12 @@ public class GmailSendEmailCustomizer implements ComponentProxyCustomizer {
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        to = (String) options.get("to");
-        subject = (String) options.get("subject");
-        text = (String) options.get("text");
+        to = ConnectorOptions.extractOption(options, "to");
+        subject = ConnectorOptions.extractOption(options, "subject");
+        text = ConnectorOptions.extractOption(options, "text");
         userId = "me";
-        cc = (String) options.get("cc");
-        bcc = (String) options.get("bcc");
+        cc = ConnectorOptions.extractOption(options, "cc");
+        bcc = ConnectorOptions.extractOption(options, "bcc");
         options.put("apiName",
                 GoogleMailApiCollection.getCollection().getApiName(GmailUsersMessagesApiMethod.class).getName());
         options.put("methodName", "send");

--- a/app/connector/google-calendar/pom.xml
+++ b/app/connector/google-calendar/pom.xml
@@ -51,6 +51,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarGetEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarGetEventCustomizer.java
@@ -15,22 +15,21 @@
  */
 package io.syndesis.connector.calendar;
 
+import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
-
-import com.google.api.services.calendar.model.Event;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.calendar.internal.CalendarEventsApiMethod;
 import org.apache.camel.component.google.calendar.internal.GoogleCalendarApiCollection;
 import org.apache.camel.util.ObjectHelper;
-
-import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
+import com.google.api.services.calendar.model.Event;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class GoogleCalendarGetEventCustomizer implements ComponentProxyCustomizer {
 
@@ -45,8 +44,8 @@ public class GoogleCalendarGetEventCustomizer implements ComponentProxyCustomize
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        calendarId = (String) options.get("calendarId");
-        eventId = (String) options.get("eventId");
+        calendarId = ConnectorOptions.extractOption(options, "calendarId");
+        eventId = ConnectorOptions.extractOption(options, "eventId");
 
         options.put("apiName",
                 GoogleCalendarApiCollection.getCollection().getApiName(CalendarEventsApiMethod.class).getName());

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarMetaDataExtension.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarMetaDataExtension.java
@@ -25,6 +25,7 @@ import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.CalendarList;
 import com.google.api.services.calendar.model.CalendarListEntry;
 import com.google.common.base.Splitter;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.MetaDataBuilder;
@@ -40,16 +41,15 @@ public class GoogleCalendarMetaDataExtension extends AbstractMetaDataExtension {
         super(context);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
 
-        String clientId = (String) parameters.get("clientId");
-        String clientSecret = (String) parameters.get("clientSecret");
+        String clientId = ConnectorOptions.extractOption(parameters, "clientId");
+        String clientSecret = ConnectorOptions.extractOption(parameters, "clientSecret");
         String googleScopes = "https://www.googleapis.com/auth/calendar";
-        String applicationName = (String) parameters.get("applicationName");
-        String accessToken = (String) parameters.get("accessToken");
-        String refreshToken = (String) parameters.get("refreshToken");
+        String applicationName = ConnectorOptions.extractOption(parameters, "applicationName");
+        String accessToken = ConnectorOptions.extractOption(parameters, "accessToken");
+        String refreshToken = ConnectorOptions.extractOption(parameters, "refreshToken");
 
         if (clientId != null) {
             try {

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarSendEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarSendEventCustomizer.java
@@ -15,26 +15,25 @@
  */
 package io.syndesis.connector.calendar;
 
+import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesList;
+import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
-
-import com.google.api.client.util.DateTime;
-import com.google.api.services.calendar.model.Event;
-import com.google.api.services.calendar.model.EventDateTime;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.calendar.internal.CalendarEventsApiMethod;
 import org.apache.camel.component.google.calendar.internal.GoogleCalendarApiCollection;
 import org.apache.camel.util.ObjectHelper;
-
-import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesList;
-import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class GoogleCalendarSendEventCustomizer implements ComponentProxyCustomizer {
 
@@ -56,16 +55,15 @@ public class GoogleCalendarSendEventCustomizer implements ComponentProxyCustomiz
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        description = (String)options.get("description");
-        summary = (String)options.get("summary");
-        calendarId = (String)options.get("calendarId");
-        attendees = (String)options.get("attendees");
-        calendarId = (String)options.get("calendarId");
-        startDate = (String)options.get("startDate");
-        endDate = (String)options.get("endDate");
-        startTime = (String)options.get("startTime");
-        endTime = (String)options.get("endTime");
-        location = (String)options.get("location");
+        description = ConnectorOptions.extractOption(options, "description");
+        summary = ConnectorOptions.extractOption(options, "summary");
+        calendarId = ConnectorOptions.extractOption(options, "calendarId");
+        attendees = ConnectorOptions.extractOption(options, "attendees");
+        startDate = ConnectorOptions.extractOption(options, "startDate");
+        endDate = ConnectorOptions.extractOption(options, "endDate");
+        startTime = ConnectorOptions.extractOption(options, "startTime");
+        endTime = ConnectorOptions.extractOption(options, "endTime");
+        location = ConnectorOptions.extractOption(options, "location");
         options.put("apiName", GoogleCalendarApiCollection.getCollection().getApiName(CalendarEventsApiMethod.class).getName());
         options.put("methodName", "insert");
     }

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarUpdateEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarUpdateEventCustomizer.java
@@ -15,26 +15,25 @@
  */
 package io.syndesis.connector.calendar;
 
+import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesList;
+import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
-
-import com.google.api.client.util.DateTime;
-import com.google.api.services.calendar.model.Event;
-import com.google.api.services.calendar.model.EventDateTime;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.calendar.internal.CalendarEventsApiMethod;
 import org.apache.camel.component.google.calendar.internal.GoogleCalendarApiCollection;
 import org.apache.camel.util.ObjectHelper;
-
-import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesList;
-import static io.syndesis.connector.calendar.utils.GoogleCalendarUtils.getAttendeesString;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class GoogleCalendarUpdateEventCustomizer implements ComponentProxyCustomizer {
 
@@ -57,16 +56,16 @@ public class GoogleCalendarUpdateEventCustomizer implements ComponentProxyCustom
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        description = (String)options.get("description");
-        summary = (String)options.get("summary");
-        calendarId = (String)options.get("calendarId");
-        eventId = (String)options.get("eventId");
-        attendees = (String)options.get("attendees");
-        startDate = (String)options.get("startDate");
-        endDate = (String)options.get("endDate");
-        startTime = (String)options.get("startTime");
-        endTime = (String)options.get("endTime");
-        location = (String)options.get("location");
+        description = ConnectorOptions.extractOption(options, "description");
+        summary = ConnectorOptions.extractOption(options, "summary");
+        calendarId = ConnectorOptions.extractOption(options, "calendarId");
+        eventId = ConnectorOptions.extractOption(options, "eventId");
+        attendees = ConnectorOptions.extractOption(options, "attendees");
+        startDate = ConnectorOptions.extractOption(options, "startDate");
+        endDate = ConnectorOptions.extractOption(options, "endDate");
+        startTime = ConnectorOptions.extractOption(options, "startTime");
+        endTime = ConnectorOptions.extractOption(options, "endTime");
+        location = ConnectorOptions.extractOption(options, "location");
         options.put("apiName", GoogleCalendarApiCollection.getCollection().getApiName(CalendarEventsApiMethod.class).getName());
         options.put("methodName", "update");
     }

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -55,6 +55,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
@@ -42,6 +42,7 @@ import com.google.api.services.sheets.v4.model.Request;
 import io.syndesis.connector.sheets.model.CellCoordinate;
 import io.syndesis.connector.sheets.model.GoogleChart;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -65,9 +66,9 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
-        title = (String) options.get("title");
-        subtitle = (String) options.get("subtitle");
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
+        title = ConnectorOptions.extractOption(options, "title");
+        subtitle = ConnectorOptions.extractOption(options, "subtitle");
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
@@ -36,6 +36,7 @@ import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 import io.syndesis.connector.sheets.model.CellCoordinate;
 import io.syndesis.connector.sheets.model.GooglePivotTable;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -57,7 +58,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
@@ -21,13 +21,12 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Map;
-import java.util.Optional;
-
-import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.services.sheets.v4.Sheets;
 import org.apache.camel.component.google.sheets.BatchGoogleSheetsClientFactory;
 import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
 import org.apache.camel.util.ObjectHelper;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.services.sheets.v4.Sheets;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * @author Christoph Deppisch
@@ -79,20 +78,12 @@ public final class GoogleSheetsConnectorHelper {
      * @return
      */
     public static Sheets makeClient(GoogleSheetsClientFactory clientFactory, Map<String, Object> properties) {
-        final String clientId = Optional.ofNullable(properties.get("clientId"))
-                                        .map(Object::toString)
-                                        .orElse(null);
-
-        final String clientSecret = Optional.ofNullable(properties.get("clientSecret"))
-                                        .map(Object::toString)
-                                        .orElse(null);
-
-        final String applicationName = Optional.ofNullable(properties.get("applicationName"))
-                                        .map(Object::toString)
-                                        .orElse(null);
+        final String clientId = ConnectorOptions.extractOption(properties, "clientId");
+        final String clientSecret = ConnectorOptions.extractOption(properties, "clientSecret");
+        final String applicationName = ConnectorOptions.extractOption(properties, "applicationName");
 
         return clientFactory.makeClient(clientId, clientSecret, applicationName,
-                                properties.getOrDefault("refreshToken", "").toString(),
-                                properties.getOrDefault("accessToken", "").toString());
+                                ConnectorOptions.extractOption(properties, "refreshToken", ""),
+                                ConnectorOptions.extractOption(properties, "accessToken", ""));
     }
 }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
@@ -25,6 +25,7 @@ import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -48,9 +49,9 @@ public class GoogleSheetsCreateSpreadsheetCustomizer implements ComponentProxyCu
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        title = (String) options.get("title");
-        timeZone = (String) options.get("timeZone");
-        locale = (String) options.get("locale");
+        title = ConnectorOptions.extractOption(options, "title");
+        timeZone = ConnectorOptions.extractOption(options, "timeZone");
+        locale = ConnectorOptions.extractOption(options, "locale");
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizer.java
@@ -15,26 +15,25 @@
  */
 package io.syndesis.connector.sheets;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.common.util.Json;
-import io.syndesis.connector.sheets.model.CellCoordinate;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
 import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
 import org.apache.camel.util.ObjectHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer {
 
@@ -53,20 +52,14 @@ public class GoogleSheetsGetValuesCustomizer implements ComponentProxyCustomizer
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
-        range = (String) options.get("range");
-        majorDimension = (String) Optional.ofNullable(options.get("majorDimension"))
-                                          .orElse(RangeCoordinate.DIMENSION_ROWS);
-        columnNames = Optional.ofNullable(options.get("columnNames"))
-                                .map(Object::toString)
-                                .map(names -> names.split(","))
-                                .orElse(new String[]{});
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
+        range = ConnectorOptions.extractOption(options, "range");
+        majorDimension = ConnectorOptions.extractOption(options, "majorDimension", RangeCoordinate.DIMENSION_ROWS);
+        columnNames = ConnectorOptions.extractOptionAndMap(options, "columnNames",
+            names -> names.split(","), new String[]{});
         Arrays.parallelSetAll(columnNames, (i) -> columnNames[i].trim());
 
-        splitResults = Optional.ofNullable(options.get("splitResults"))
-                                                .map(Object::toString)
-                                                .map(Boolean::valueOf)
-                                                .orElse(false);
+        splitResults = ConnectorOptions.extractOptionAndMap(options, "splitResults", Boolean::valueOf, false);
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetaDataExtension.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import io.syndesis.connector.sheets.meta.GoogleValueRangeMetaData;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.DefaultMetaData;
@@ -35,22 +36,12 @@ public class GoogleSheetsMetaDataExtension extends AbstractMetaDataExtension {
 
     @Override
     public Optional<MetaData> meta(final Map<String, Object> properties) {
-        final String spreadsheetId = Optional.ofNullable(properties.get("spreadsheetId"))
-                                     .map(Object::toString)
-                                     .orElse("");
+        final String spreadsheetId = ConnectorOptions.extractOption(properties, "spreadsheetId", "");
+        final String range = ConnectorOptions.extractOption(properties, "range", "");
+        final String headerRow = ConnectorOptions.extractOption(properties, "headerRow");
 
-        final String range = Optional.ofNullable(properties.get("range"))
-                                     .map(Object::toString)
-                                     .orElse("");
-
-        final String headerRow = Optional.ofNullable(properties.get("headerRow"))
-                                     .map(Object::toString)
-                                     .orElse(null);
-
-        final String[] columnNames = Optional.ofNullable(properties.get("columnNames"))
-                                             .map(Object::toString)
-                                             .map(names -> names.split(","))
-                                             .orElse(new String[]{});
+        final String[] columnNames = ConnectorOptions.extractOptionAndMap(properties, "columnNames",
+            names -> names.split(","), new String[]{});
 
         Arrays.parallelSetAll(columnNames, (i) -> columnNames[i].trim());
 
@@ -61,16 +52,12 @@ public class GoogleSheetsMetaDataExtension extends AbstractMetaDataExtension {
             valueRangeMetaData.setHeaderRow(headerRow);
             valueRangeMetaData.setColumnNames(columnNames);
 
-            final String majorDimension = Optional.ofNullable(properties.get("majorDimension"))
-                    .map(Object::toString)
-                    .orElse(RangeCoordinate.DIMENSION_ROWS);
+            final String majorDimension = ConnectorOptions.extractOption(properties, "majorDimension", RangeCoordinate.DIMENSION_ROWS);
 
             valueRangeMetaData.setMajorDimension(majorDimension);
 
-            final boolean split = Optional.ofNullable(properties.get("splitResults"))
-                    .map(Object::toString)
-                    .map(Boolean::valueOf)
-                    .orElse(false);
+            final boolean split = ConnectorOptions.extractOptionAndMap(properties, "splitResults",
+                    Boolean::valueOf, false);
 
             valueRangeMetaData.setSplit(split);
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizer.java
@@ -20,21 +20,20 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.common.util.Json;
-import io.syndesis.connector.sheets.model.CellCoordinate;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
 import org.apache.camel.util.ObjectHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.sheets.model.CellCoordinate;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class GoogleSheetsRetrieveValuesCustomizer implements ComponentProxyCustomizer {
 
@@ -53,14 +52,11 @@ public class GoogleSheetsRetrieveValuesCustomizer implements ComponentProxyCusto
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
-        range = (String) options.get("range");
-        majorDimension = (String) Optional.ofNullable(options.get("majorDimension"))
-                .orElse(RangeCoordinate.DIMENSION_ROWS);
-        columnNames = Optional.ofNullable(options.get("columnNames"))
-                .map(Object::toString)
-                .map(names -> names.split(","))
-                .orElse(new String[]{});
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
+        range = ConnectorOptions.extractOption(options, "range");
+        majorDimension = ConnectorOptions.extractOption(options, "majorDimension", RangeCoordinate.DIMENSION_ROWS);
+        columnNames = ConnectorOptions.extractOptionAndMap(options, "columnNames",
+            names -> names.split(","), new String[]{});
         Arrays.parallelSetAll(columnNames, (i) -> columnNames[i].trim());
 
         options.put("apiName",

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
@@ -29,6 +29,7 @@ import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest;
 import com.google.api.services.sheets.v4.model.UpdateSpreadsheetPropertiesRequest;
 import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -54,10 +55,10 @@ public class GoogleSheetsUpdateSpreadsheetCustomizer implements ComponentProxyCu
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
-        title = (String) options.get("title");
-        timeZone = (String) options.get("timeZone");
-        locale = (String) options.get("locale");
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
+        title = ConnectorOptions.extractOption(options, "title");
+        timeZone = ConnectorOptions.extractOption(options, "timeZone");
+        locale = ConnectorOptions.extractOption(options, "locale");
 
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -32,6 +32,7 @@ import io.syndesis.common.util.Json;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.connector.sheets.meta.GoogleSheetsMetaDataHelper;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -57,20 +58,14 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
     }
 
     private void setApiMethod(Map<String, Object> options) {
-        spreadsheetId = (String) options.get("spreadsheetId");
-        range = (String) options.get("range");
+        spreadsheetId = ConnectorOptions.extractOption(options, "spreadsheetId");
+        range = ConnectorOptions.extractOption(options, "range");
 
-        majorDimension = Optional.ofNullable(options.get("majorDimension"))
-                                  .map(Object::toString)
-                                  .orElse(RangeCoordinate.DIMENSION_ROWS);
-        valueInputOption = Optional.ofNullable(options.get("valueInputOption"))
-                                   .map(Object::toString)
-                                   .orElse("USER_ENTERED");
+        majorDimension = ConnectorOptions.extractOption(options, "majorDimension", RangeCoordinate.DIMENSION_ROWS);
+        valueInputOption = ConnectorOptions.extractOption(options, "valueInputOption", "USER_ENTERED");
 
-        columnNames = Optional.ofNullable(options.get("columnNames"))
-                .map(Object::toString)
-                .map(names -> names.split(","))
-                .orElse(new String[]{});
+        columnNames = ConnectorOptions.extractOptionAndMap(options, "columnNames",
+            names -> names.split(","), new String[]{});
 
         Arrays.parallelSetAll(columnNames, (i) -> columnNames[i].trim());
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
@@ -19,9 +19,11 @@ package io.syndesis.connector.sheets.meta;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.StringJoiner;
-
+import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
+import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
 import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
@@ -31,10 +33,7 @@ import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.connector.sheets.GoogleSheetsConnectorHelper;
 import io.syndesis.connector.sheets.model.CellCoordinate;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
-import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
-import org.apache.camel.util.ObjectHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * @author Christoph Deppisch
@@ -94,14 +93,12 @@ public final class GoogleSheetsMetaDataHelper {
                     .append(CellCoordinate.getColumnName(rangeCoordinate.getColumnEndIndex()))
                     .append(headerRow);
 
-        final String rootUrl = properties.getOrDefault("rootUrl", Sheets.DEFAULT_ROOT_URL).toString();
+        final String rootUrl = ConnectorOptions.extractOption(properties, "rootUrl", Sheets.DEFAULT_ROOT_URL);
 
-        final boolean validateCertificates = Optional.ofNullable(properties.get("validateCertificates"))
-                                                .map(Object::toString)
-                                                .map(Boolean::valueOf)
-                                                .orElse(false);
+        final boolean validateCertificates = ConnectorOptions.extractOptionAndMap(
+            properties, "validateCertificates", Boolean::valueOf, false);
 
-        final String serverCertificate = properties.getOrDefault("serverCertificate", "").toString();
+        final String serverCertificate = ConnectorOptions.extractOption(properties, "serverCertificate", "");
 
         try {
             final GoogleSheetsClientFactory clientFactory = GoogleSheetsConnectorHelper.createClientFactory(rootUrl, serverCertificate, validateCertificates);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
@@ -28,6 +28,7 @@ import com.google.api.services.sheets.v4.model.EmbeddedChart;
 import com.google.api.services.sheets.v4.model.GridRange;
 import com.google.api.services.sheets.v4.model.PieChartSpec;
 import io.syndesis.connector.sheets.model.GoogleChart;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -62,8 +63,8 @@ public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCust
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("batchUpdate", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("batchUpdate", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
@@ -19,11 +19,6 @@ package io.syndesis.connector.sheets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
-import com.google.api.services.sheets.v4.model.PivotTable;
-import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
-import io.syndesis.connector.sheets.model.GooglePivotTable;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -33,6 +28,11 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
+import com.google.api.services.sheets.v4.model.PivotTable;
+import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
+import io.syndesis.connector.sheets.model.GooglePivotTable;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * @author Christoph Deppisch
@@ -56,8 +56,8 @@ public class GoogleSheetsAddPivotTableCustomizerTest extends AbstractGoogleSheet
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("batchUpdate", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("batchUpdate", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAppendValuesCustomizerTest.java
@@ -20,9 +20,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -32,6 +29,9 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -54,8 +54,8 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("append", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("append", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
@@ -84,8 +84,8 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("append", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("append", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1:B1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
@@ -117,8 +117,8 @@ public class GoogleSheetsAppendValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("append", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("append", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1:A2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
@@ -19,13 +19,6 @@ package io.syndesis.connector.sheets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.Sheet;
-import com.google.api.services.sheets.v4.model.SheetProperties;
-import com.google.api.services.sheets.v4.model.Spreadsheet;
-import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
-import io.syndesis.connector.sheets.model.GoogleSheet;
-import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -34,6 +27,13 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.api.services.sheets.v4.model.Sheet;
+import com.google.api.services.sheets.v4.model.SheetProperties;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
+import io.syndesis.connector.sheets.model.GoogleSheet;
+import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * @author Christoph Deppisch
@@ -59,8 +59,8 @@ public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleS
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("create", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("create", ConnectorOptions.extractOption(options, "methodName"));
 
         Spreadsheet spreadsheet = (Spreadsheet) inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "content");
         Assert.assertNull(spreadsheet.getSpreadsheetId());

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizerTest.java
@@ -19,12 +19,6 @@ package io.syndesis.connector.sheets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.Sheet;
-import com.google.api.services.sheets.v4.model.SheetProperties;
-import com.google.api.services.sheets.v4.model.Spreadsheet;
-import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
-import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
@@ -32,6 +26,12 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.api.services.sheets.v4.model.Sheet;
+import com.google.api.services.sheets.v4.model.SheetProperties;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
+import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class GoogleSheetsGetSpreadsheetCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -71,8 +71,8 @@ public class GoogleSheetsGetSpreadsheetCustomizerTest extends AbstractGoogleShee
         inbound.getIn().setBody(spreadsheet);
         getComponent().getBeforeConsumer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         GoogleSpreadsheet model = (GoogleSpreadsheet) inbound.getIn().getBody();
         Assert.assertEquals(getSpreadsheetId(), model.getSpreadsheetId());

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
@@ -23,9 +23,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -37,6 +34,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -105,8 +105,8 @@ public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCus
         inbound.getIn().setBody(valueRange);
         getComponent().getBeforeConsumer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         @SuppressWarnings("unchecked")
         List<String> model = inbound.getIn().getBody(List.class);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsValuesApiMethod;
@@ -36,6 +34,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -94,8 +94,8 @@ public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoo
         inbound.getIn().setBody(values);
         getComponent().getBeforeConsumer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         String model = inbound.getIn().getBody(String.class);
         JSONAssert.assertEquals(String.format(expectedValueModel, getSpreadsheetId()), model, JSONCompareMode.STRICT);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
@@ -23,9 +23,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -39,6 +36,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsNamedColumnsTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -92,8 +92,8 @@ public class GoogleSheetsNamedColumnsTest extends AbstractGoogleSheetsCustomizer
         inbound.getIn().setBody(valueRange);
         getComponent().getBeforeConsumer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         @SuppressWarnings("unchecked")
         List<String> body = inbound.getIn().getBody(List.class);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
@@ -22,9 +22,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -35,6 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -57,8 +57,8 @@ public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleShee
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "spreadsheetId"));
         Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "range"));
@@ -101,8 +101,8 @@ public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleShee
         inbound.getIn().setBody(valueRange);
         getComponent().getAfterProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         @SuppressWarnings("unchecked")
         List<String> model = inbound.getIn().getBody(List.class);
@@ -139,8 +139,8 @@ public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleShee
         inbound.getIn().setBody(valueRange);
         getComponent().getAfterProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("get", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         @SuppressWarnings("unchecked")
         List<String> model = inbound.getIn().getBody(List.class);

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
@@ -20,7 +20,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
+import org.apache.camel.Exchange;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
+import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
+import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
+import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
 import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetResponse;
 import com.google.api.services.sheets.v4.model.Sheet;
@@ -31,15 +39,7 @@ import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest;
 import com.google.api.services.sheets.v4.model.UpdateSpreadsheetPropertiesRequest;
 import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
-import org.apache.camel.Exchange;
-import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
-import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
-import org.apache.camel.component.google.sheets.internal.SheetsSpreadsheetsApiMethod;
-import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamConstants;
-import org.apache.camel.impl.DefaultExchange;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * @author Christoph Deppisch
@@ -66,8 +66,8 @@ public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleS
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("batchUpdate", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("batchUpdate", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertNotNull(inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -20,9 +20,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.api.services.sheets.v4.model.ValueRange;
-import io.syndesis.connector.sheets.model.RangeCoordinate;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsApiCollection;
 import org.apache.camel.component.google.sheets.internal.GoogleSheetsConstants;
@@ -32,6 +29,9 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import io.syndesis.connector.sheets.model.RangeCoordinate;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -54,8 +54,8 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Exchange inbound = new DefaultExchange(createCamelContext());
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("update", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("update", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
@@ -84,8 +84,8 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("update", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("update", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1:B1", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));
@@ -117,8 +117,8 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
 
         getComponent().getBeforeProducer().process(inbound);
 
-        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), options.get("apiName"));
-        Assert.assertEquals("update", options.get("methodName"));
+        Assert.assertEquals(GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsValuesApiMethod.class).getName(), ConnectorOptions.extractOption(options, "apiName"));
+        Assert.assertEquals("update", ConnectorOptions.extractOption(options, "methodName"));
 
         Assert.assertEquals(getSpreadsheetId(), inbound.getIn().getHeader(GoogleSheetsStreamConstants.SPREADSHEET_ID));
         Assert.assertEquals("A1:A2", inbound.getIn().getHeader(GoogleSheetsStreamConstants.RANGE));

--- a/app/connector/irc/pom.xml
+++ b/app/connector/irc/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>integration-component-proxy</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
@@ -16,7 +16,7 @@
 package io.syndesis.connector.irc;
 
 import java.util.Map;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 public class IrcConnector extends ComponentProxyComponent {
@@ -27,8 +27,9 @@ public class IrcConnector extends ComponentProxyComponent {
     @Override
     protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
         Map<String, String> endpointOptions = super.buildEndpointOptions(remaining, options);
-        if (options.get("channels") != null) {
-            endpointOptions.put("channels", (String)options.get("channels"));
+        String channels = ConnectorOptions.extractOption(options, "channels");
+        if (channels != null) {
+            endpointOptions.put("channels", channels);
         }
         return endpointOptions;
     }

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierExtension.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcVerifierExtension.java
@@ -19,7 +19,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -33,8 +33,8 @@ public class IrcVerifierExtension extends DefaultComponentVerifierExtension {
 
     @Override
     public Result verify(Scope scope, Map<String, Object> parameters) {
-        final String hostname = (String) parameters.get("hostname");
-        final int port = Integer.parseInt((String) parameters.get("port"));
+        final String hostname = ConnectorOptions.extractOption(parameters, "hostname");
+        final int port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt, 7000);
         final Socket s = new Socket();
         try {
             s.connect(new InetSocketAddress(hostname,port), 5000);

--- a/app/connector/jira/pom.xml
+++ b/app/connector/jira/pom.xml
@@ -78,6 +78,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.syndesis.connector</groupId>
+            <artifactId>connector-support-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>connector-support-verifier</artifactId>
             <version>${project.version}</version>

--- a/app/connector/jira/src/main/java/io/syndesis/connector/jira/JiraVerifierExtension.java
+++ b/app/connector/jira/src/main/java/io/syndesis/connector/jira/JiraVerifierExtension.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.ServerInfo;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
@@ -57,7 +58,7 @@ public class JiraVerifierExtension extends DefaultComponentVerifierExtension {
 
         JiraRestClient client = null;
         try {
-            String privateKey = parameters.get(PRIVATE_KEY).toString();
+            String privateKey = ConnectorOptions.extractOption(parameters, PRIVATE_KEY);
             boolean isRawEnvloped = privateKey != null && privateKey.length() > 4 && "RAW(".equals(privateKey.substring(0, 4));
             if (isRawEnvloped) {
                 // remove the RAW envelope

--- a/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/AddIssueCustomizer.java
+++ b/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/AddIssueCustomizer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.google.common.base.Splitter;
 import io.syndesis.connector.jira.JiraIssue;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -42,30 +43,38 @@ public class AddIssueCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         jiraIssue = new JiraIssue();
-        if (options.get(ISSUE_PROJECT_KEY) != null) {
-            jiraIssue.setProjectKey(options.get(ISSUE_PROJECT_KEY).toString());
+        String issueProjectKey = ConnectorOptions.extractOption(options, ISSUE_PROJECT_KEY);
+        if (issueProjectKey != null) {
+            jiraIssue.setProjectKey(issueProjectKey);
         }
-        if (options.get(ISSUE_SUMMARY) != null) {
-            jiraIssue.setSummary(options.get(ISSUE_SUMMARY).toString());
+        String issueSummary = ConnectorOptions.extractOption(options, ISSUE_SUMMARY);
+        if (issueSummary != null) {
+            jiraIssue.setSummary(issueSummary);
         }
-        if (options.get(ISSUE_ASSIGNEE) != null) {
-            jiraIssue.setAssignee(options.get(ISSUE_ASSIGNEE).toString());
+        String issueAssignee = ConnectorOptions.extractOption(options, ISSUE_ASSIGNEE);
+        if (issueAssignee != null) {
+            jiraIssue.setAssignee(issueAssignee);
         }
-        if (options.get("description") != null) {
-            jiraIssue.setDescription(options.get("description").toString());
+        String description = ConnectorOptions.extractOption(options, "description");
+        if (description != null) {
+            jiraIssue.setDescription(description);
         }
-        if (options.get(ISSUE_WATCHERS_ADD) != null) {
-            String watc = options.get(ISSUE_WATCHERS_ADD).toString();
-            List<String> watchers = Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watc);
-            jiraIssue.setWatchers(watchers);
+
+        List<String> addWatchers = ConnectorOptions.extractOptionAndMap(options, ISSUE_WATCHERS_ADD,
+            (String watchers) -> Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watchers), null);
+        if (addWatchers != null) {
+            jiraIssue.setWatchers(addWatchers);
         }
-        if (options.get(ISSUE_COMPONENTS) != null) {
-            String comps = options.get(ISSUE_COMPONENTS).toString();
-            List<String> components = Splitter.on(",").omitEmptyStrings().trimResults().splitToList(comps);
-            jiraIssue.setComponents(components);
+
+        List<String> issueComponents = ConnectorOptions.extractOptionAndMap(options, ISSUE_COMPONENTS,
+            (String comps) -> Splitter.on(",").omitEmptyStrings().trimResults().splitToList(comps), null);
+        if (issueComponents != null) {
+            jiraIssue.setComponents(issueComponents);
         }
-        if (options.get(ISSUE_TYPE_ID) != null) {
-            String issueTypeName = options.get(ISSUE_TYPE_ID).toString();
+
+        String issueTypeId = ConnectorOptions.extractOption(options, ISSUE_TYPE_ID);
+        if (issueTypeId != null) {
+            String issueTypeName = issueTypeId;
             try {
                 int issueType = Integer.parseInt(issueTypeName);
                 jiraIssue.setIssueTypeId((long) issueType);
@@ -74,8 +83,10 @@ public class AddIssueCustomizer implements ComponentProxyCustomizer {
                 jiraIssue.setIssueTypeName(issueTypeName);
             }
         }
-        if (options.get(ISSUE_PRIORITY_ID) != null) {
-            String issuePriorityName = options.get(ISSUE_PRIORITY_ID).toString();
+
+        String issuePriorityId = ConnectorOptions.extractOption(options, ISSUE_PRIORITY_ID);
+        if (issuePriorityId != null) {
+            String issuePriorityName = issuePriorityId;
             try {
                 int prio = Integer.parseInt(issuePriorityName);
                 jiraIssue.setPriorityId((long) prio);

--- a/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/UpdateIssueCustomizer.java
+++ b/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/UpdateIssueCustomizer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.google.common.base.Splitter;
 import io.syndesis.connector.jira.JiraIssue;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -51,8 +52,9 @@ public class UpdateIssueCustomizer implements ComponentProxyCustomizer {
         if (options.get(ISSUE_ASSIGNEE) != null) {
             jiraIssue.setAssignee(options.get(ISSUE_ASSIGNEE).toString());
         }
-        if (options.get("description") != null) {
-            jiraIssue.setDescription(options.get("description").toString());
+        String description = ConnectorOptions.extractOption(options, "description");
+        if (description != null) {
+            jiraIssue.setDescription(description);
         }
         if (options.get(ISSUE_COMPONENTS) != null) {
             String comps = options.get(ISSUE_COMPONENTS).toString();

--- a/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/WatchersCustomizer.java
+++ b/app/connector/jira/src/main/java/io/syndesis/connector/jira/customizer/WatchersCustomizer.java
@@ -18,7 +18,9 @@ package io.syndesis.connector.jira.customizer;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.RuntimeCamelException;
 import com.google.common.base.Splitter;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -38,14 +40,17 @@ public class WatchersCustomizer implements ComponentProxyCustomizer {
         if (options.get(ISSUE_KEY) != null) {
             issueKey = options.get(ISSUE_KEY).toString();
         }
-        if (options.get("addWatchers") != null) {
-            String watchers = options.get("addWatchers").toString();
-            addWatchers = Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watchers);
+
+        try {
+            addWatchers = ConnectorOptions.extractOptionAndMap(options, "addWatchers",
+                (String watchers) -> Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watchers));
+
+            removeWatchers = ConnectorOptions.extractOptionAndMap(options, "removeWatchers",
+                (String watchers) -> Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watchers));
+        } catch (Exception ex) {
+            throw new RuntimeCamelException(ex);
         }
-        if (options.get("removeWatchers") != null) {
-            String watchers = options.get("removeWatchers").toString();
-            removeWatchers = Splitter.on(",").omitEmptyStrings().trimResults().splitToList(watchers);
-        }
+
         component.setBeforeProducer(this::beforeProducer);
     }
 

--- a/app/connector/kafka/pom.xml
+++ b/app/connector/kafka/pom.xml
@@ -30,6 +30,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataExtension.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataExtension.java
@@ -24,7 +24,7 @@ import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,8 +42,8 @@ public class KafkaMetaDataExtension extends AbstractMetaDataExtension {
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
 
-        final String brokers = (String) parameters.get("brokers");
-        final String topic = (String) parameters.get("topic");
+        final String brokers = ConnectorOptions.extractOption(parameters, "brokers");
+        final String topic = ConnectorOptions.extractOption(parameters, "topic");
 
         if( topic == null) {
             LOG.debug("Retrieving Kafka topics for connection to {}", brokers);

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
@@ -27,7 +27,7 @@ import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import java.util.Map;
 import java.util.Properties;
 
@@ -66,7 +66,7 @@ public class KafkaVerifierExtension extends DefaultComponentVerifierExtension {
     }
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
-        final String brokers = (String) parameters.get("brokers");
+        final String brokers = ConnectorOptions.extractOption(parameters, "brokers");
 
         LOG.debug("Validating Kafka connection to {}", brokers);
         if (ObjectHelper.isNotEmpty(brokers)) {

--- a/app/connector/knative/pom.xml
+++ b/app/connector/knative/pom.xml
@@ -30,6 +30,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
       <scope>provided</scope>

--- a/app/connector/knative/src/main/java/io/syndesis/connector/knative/meta/KnativeMetaDataExtension.java
+++ b/app/connector/knative/src/main/java/io/syndesis/connector/knative/meta/KnativeMetaDataExtension.java
@@ -20,7 +20,7 @@ import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.MetaDataBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,7 +40,7 @@ public class KnativeMetaDataExtension extends AbstractMetaDataExtension {
     @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
     public Optional<MetaData> meta(Map<String, Object> parameters) {
 
-        String type = (String) parameters.get("type");
+        String type = ConnectorOptions.extractOption(parameters, "type");
         if (type == null) {
             type = TYPE_CHANNEL;
         }

--- a/app/connector/kudu/pom.xml
+++ b/app/connector/kudu/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.syndesis.connector</groupId>
+            <artifactId>connector-support-util</artifactId>
+        </dependency>
+
+        <dependency>
           <groupId>io.syndesis.connector</groupId>
           <artifactId>connector-support-verifier</artifactId>
         </dependency>

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduCreateTableCustomizer.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduCreateTableCustomizer.java
@@ -17,6 +17,7 @@
 package io.syndesis.connector.kudu;
 
 import io.syndesis.connector.kudu.model.KuduTable;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -48,7 +49,8 @@ public class KuduCreateTableCustomizer implements ComponentProxyCustomizer {
         }
 
         if (!options.isEmpty()) {
-            String[] columns = ((String) options.get("columns")).split(";", -1);
+            String[] columns = ConnectorOptions.extractOptionAndMap(options, "columns",
+                names -> names.split(";", -1), new String[]{});
             KuduTable.ColumnSchema[] columnSchemas = new KuduTable.ColumnSchema[columns.length];
 
             for (int i = 0; i < columns.length; i++) {

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduMetaDataExtension.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduMetaDataExtension.java
@@ -16,14 +16,14 @@
 
 package io.syndesis.connector.kudu;
 
-import io.syndesis.connector.kudu.meta.KuduMetaData;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
 import org.apache.camel.component.extension.metadata.DefaultMetaData;
 import org.apache.camel.util.ObjectHelper;
-
-import java.util.Map;
-import java.util.Optional;
+import io.syndesis.connector.kudu.meta.KuduMetaData;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class KuduMetaDataExtension extends AbstractMetaDataExtension {
     private static final MetaData EMPTY_METADATA = new DefaultMetaData(null, null, null);
@@ -34,9 +34,7 @@ public class KuduMetaDataExtension extends AbstractMetaDataExtension {
 
     @Override
     public Optional<MetaData> meta(final Map<String, Object> properties) {
-        final String tableName = Optional.ofNullable(properties.get("tableName"))
-                .map(Object::toString)
-                .orElse("");
+        final String tableName = ConnectorOptions.extractOption(properties, "tableName", "");
 
         MetaData metaData = EMPTY_METADATA;
 
@@ -44,14 +42,10 @@ public class KuduMetaDataExtension extends AbstractMetaDataExtension {
             KuduMetaData kuduInsertMetaData = new KuduMetaData();
             kuduInsertMetaData.setTableName(tableName);
 
-            final String host = Optional.ofNullable(properties.get("host"))
-                    .map(Object::toString)
-                    .orElse("localhost");
+            final String host = ConnectorOptions.extractOption(properties, "host", "localhost");
             kuduInsertMetaData.setHost(host);
 
-            final String port = Optional.ofNullable(properties.get("port"))
-                    .map(Object::toString)
-                    .orElse("7051");
+            final String port = ConnectorOptions.extractOption(properties, "port", "7051");
             kuduInsertMetaData.setPort(port);
 
             metaData = new DefaultMetaData(null, null, kuduInsertMetaData);

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/common/KuduSupport.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/common/KuduSupport.java
@@ -19,6 +19,7 @@ package io.syndesis.connector.kudu.common;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.kudu.client.KuduClient;
 import org.apache.camel.util.ObjectHelper;
 import java.util.HashMap;
@@ -32,13 +33,15 @@ public final class KuduSupport {
 
     public static KuduClient createConnection(Map<String, Object> options) {
 
-        if(ObjectHelper.isNotEmpty(options.get("host")) && ObjectHelper.isNotEmpty(options.get("port"))) {
+        String host = ConnectorOptions.extractOption(options, "host");
+        String port = ConnectorOptions.extractOption(options, "port");
+        if(ObjectHelper.isNotEmpty(host) && ObjectHelper.isNotEmpty(port)) {
 
-            Long socketTimeout = options.containsKey("socketTimeout") ? (Long) options.get("socketTimeout") : 3000;
-            Long operationTimeout = options.containsKey("operationTimeout") ? (Long) options.get("socketTimeout") : 10000;
-            Long adminOperationTimeout = options.containsKey("operationTimeout") ? (Long) options.get("socketTimeout") : 10000;
+            Long socketTimeout = ConnectorOptions.extractOptionAndMap(options, "socketTimeout", Long::valueOf, 3000L);
+            Long operationTimeout = ConnectorOptions.extractOptionAndMap(options, "operationTimeout", Long::valueOf, 10000L);
+            Long adminOperationTimeout = ConnectorOptions.extractOptionAndMap(options, "operationTimeout", Long::valueOf, 10000L);
 
-            return new KuduClient.KuduClientBuilder((String)options.get("host") + ":" + (String)options.get("port"))
+            return new KuduClient.KuduClientBuilder(host + ":" + port)
                     .defaultSocketReadTimeoutMs(socketTimeout)
                     .defaultOperationTimeoutMs(operationTimeout)
                     .defaultAdminOperationTimeoutMs(adminOperationTimeout)

--- a/app/connector/mqtt/pom.xml
+++ b/app/connector/mqtt/pom.xml
@@ -41,6 +41,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/mqtt/src/main/java/io/syndesis/connector/mqtt/MqttVerifierExtension.java
+++ b/app/connector/mqtt/src/main/java/io/syndesis/connector/mqtt/MqttVerifierExtension.java
@@ -26,6 +26,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class MqttVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -56,9 +57,9 @@ public class MqttVerifierExtension extends DefaultComponentVerifierExtension {
     }
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
-        String brokerUrl = (String) parameters.get("brokerUrl");
-        String username = (String) parameters.get("userName");
-        String password = (String) parameters.get("password");
+        String brokerUrl = ConnectorOptions.extractOption(parameters, "brokerUrl");
+        String username = ConnectorOptions.extractOption(parameters, "userName");
+        String password = ConnectorOptions.extractOption(parameters, "password");
 
         if (ObjectHelper.isNotEmpty(brokerUrl)) {
             try {

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -88,7 +88,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.syndesis.common</groupId>

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-http-common</artifactId>
     </dependency>

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessor.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessor.java
@@ -16,12 +16,7 @@
 package io.syndesis.connector.rest.swagger.auth.oauth;
 
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
-import io.syndesis.connector.rest.swagger.Configuration;
-import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -36,10 +31,12 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.syndesis.connector.rest.swagger.Configuration;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
 
 /**
  * Refreshes the OAuth token based on the expiry time of the token.
@@ -56,7 +53,8 @@ class OAuthRefreshTokenProcessor implements Processor {
 
     private static final Logger LOG = LoggerFactory.getLogger(OAuthRefreshTokenProcessor.class);
 
-    Optional<Long> expiresInOverride = Optional.ofNullable(System.getenv().get("AUTHTOKEN_EXPIRES_IN_OVERRIDE")).map(Long::valueOf);
+    Long expiresInOverride = ConnectorOptions.extractOptionAndMap(System.getenv(),
+        "AUTHTOKEN_EXPIRES_IN_OVERRIDE", Long::valueOf, null);
 
     // Always refresh on (re)start
     final AtomicReference<Boolean> isFirstTime = new AtomicReference<>(Boolean.TRUE);
@@ -124,8 +122,8 @@ class OAuthRefreshTokenProcessor implements Processor {
             LOG.info("Successful access token refresh");
 
             Long expiresInSeconds = null;
-            if (expiresInOverride.isPresent()) {
-                expiresInSeconds = expiresInOverride.get();
+            if (expiresInOverride != null) {
+                expiresInSeconds = expiresInOverride;
             } else {
                 final JsonNode expiresIn = body.get("expires_in");
                 if (isPresentAndHasValue(expiresIn)) {

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizerTest.java
@@ -18,7 +18,7 @@ package io.syndesis.connector.rest.swagger;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 import org.junit.Test;
@@ -40,6 +40,6 @@ public class SpecificationResourceCustomizerTest {
 
         assertThat(options).containsKey("specificationUri");
         assertThat(options).doesNotContainKey("specification");
-        assertThat(new File((String) options.get("specificationUri"))).hasContent("the specification is here");
+        assertThat(new File(ConnectorOptions.extractOption(options, "specificationUri"))).hasContent("the specification is here");
     }
 }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessorTest.java
@@ -15,15 +15,13 @@
  */
 package io.syndesis.connector.rest.swagger.auth.oauth;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-
-import io.syndesis.connector.rest.swagger.Configuration;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.http.common.HttpOperationFailedException;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -37,10 +35,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import io.syndesis.connector.rest.swagger.Configuration;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class OAuthRefreshTokenProcessorTest {
     private final long currentTime = 1000000000;
@@ -59,7 +55,7 @@ public class OAuthRefreshTokenProcessorTest {
             "{\"access_token\": \"new-access-token\", \"refresh_token\": \"new-refresh-token\", \"expires_in\": 3600}");
         processor.state.update("access-token", currentTime, null);
         processor.isFirstTime.set(Boolean.FALSE);
-        processor.expiresInOverride = Optional.of(1800L);
+        processor.expiresInOverride = 1800L;
 
         processor.process(exchange);
 

--- a/app/connector/salesforce/pom.xml
+++ b/app/connector/salesforce/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>jackson-module-jsonSchema</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <optional>true</optional>

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrieval.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrieval.java
@@ -28,6 +28,7 @@ import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.SyndesisServerException;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.PropertyPair;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
@@ -94,7 +95,7 @@ public final class SalesforceMetadataRetrieval extends ComponentMetadataRetrieva
 
         if (isPresentAndNonNull(properties, SalesforceEndpointConfig.SOBJECT_NAME)) {
             try {
-                final String objectName = (String) properties.get(SalesforceEndpointConfig.SOBJECT_NAME);
+                final String objectName = ConnectorOptions.extractOption(properties, SalesforceEndpointConfig.SOBJECT_NAME);
                 final ObjectSchema inputOutputSchema = inputOutputSchemaFor(schemasToConsider, objectName);
                 final String specification = Json.writer().writeValueAsString(inputOutputSchema);
 
@@ -185,7 +186,7 @@ public final class SalesforceMetadataRetrieval extends ComponentMetadataRetrieva
     }
 
     static boolean isPresentAndNonNull(final Map<String, Object> properties, final String property) {
-        return isPresent(properties, property) && properties.get(property) != null;
+        return ConnectorOptions.extractOption(properties, property) != null;
     }
 
     static PropertyPair nameAndTitlePropertyPairOf(final ObjectSchema schema) {

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceUtil.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceUtil.java
@@ -16,8 +16,8 @@
 package io.syndesis.connector.salesforce;
 
 import java.util.Map;
-
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public final class SalesforceUtil {
     private static final String TOPIC_PREFIX = "syndesis_";
@@ -29,13 +29,13 @@ public final class SalesforceUtil {
     public static String topicNameFor(final Map<String, String> options) {
         final String sObjectName = options.get(SalesforceEndpointConfig.SOBJECT_NAME);
         final String topicSuffix;
-        if (Boolean.valueOf(options.get("notifyForOperationCreate"))) {
+        if (ConnectorOptions.extractOptionAndMap(options, "notifyForOperationCreate", Boolean::valueOf, false)) {
             topicSuffix = "_c";
-        } else if (Boolean.valueOf(options.get("notifyForOperationUpdate"))) {
+        } else if (ConnectorOptions.extractOptionAndMap(options, "notifyForOperationUpdate", Boolean::valueOf, false)) {
             topicSuffix = "_up";
-        } else if (Boolean.valueOf(options.get("notifyForOperationDelete"))) {
+        } else if (ConnectorOptions.extractOptionAndMap(options, "notifyForOperationDelete", Boolean::valueOf, false)) {
             topicSuffix = "_d";
-        } else if (Boolean.valueOf(options.get("notifyForOperationUndelete"))) {
+        } else if (ConnectorOptions.extractOptionAndMap(options, "notifyForOperationUndelete", Boolean::valueOf, false)) {
             topicSuffix = "_un";
         } else {
             topicSuffix = "_a";

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/customizer/ForUpdateCustomizer.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/customizer/ForUpdateCustomizer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import io.syndesis.common.util.Json;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
@@ -36,7 +37,7 @@ public class ForUpdateCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        idPropertyName = (String) options.getOrDefault(SalesforceEndpointConfig.SOBJECT_EXT_ID_NAME, "Id");
+        idPropertyName = ConnectorOptions.extractOption(options, SalesforceEndpointConfig.SOBJECT_EXT_ID_NAME, "Id");
 
         component.setBeforeProducer(this::beforeProducer);
     }

--- a/app/connector/servicenow/pom.xml
+++ b/app/connector/servicenow/pom.xml
@@ -46,6 +46,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetaDataExtension.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetaDataExtension.java
@@ -54,6 +54,7 @@ import org.apache.camel.util.ObjectHelper;
 import org.apache.camel.util.StringHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * An implementation of the MetaData extension {@link MetaDataExtension} that
@@ -75,8 +76,8 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
 
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
-        final String objectType = (String)parameters.get("objectType");
-        final String metaType = (String)parameters.getOrDefault("metaType", "definition");
+        final String objectType = ConnectorOptions.extractOption(parameters, "objectType");
+        final String metaType = ConnectorOptions.extractOption(parameters, "metaType", "definition");
 
         // Retrieve the table definition as json-scheme
         if (ObjectHelper.equalIgnoreCase(objectType, ServiceNowConstants.RESOURCE_TABLE) && ObjectHelper.equalIgnoreCase(metaType, "definition")) {
@@ -128,7 +129,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
     private Optional<MetaData> tableDefinition(MetaContext context) throws Exception {
         final List<String> names = getObjectHierarchy(context);
         final ObjectNode root = context.getConfiguration().getOrCreateMapper().createObjectNode();
-        final String baseUrn = (String)context.getParameters().getOrDefault("baseUrn", "org:apache:camel:component:servicenow");
+        final String baseUrn = ConnectorOptions.extractOption(context.getParameters(), "baseUrn", "org:apache:camel:component:servicenow");
 
         // Schema
         root.put("$schema", "http://json-schema.org/schema#");
@@ -150,8 +151,8 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
             context.getStack().pop();
         }
 
-        final String dateFormat = properties.getOrDefault("glide.sys.date_format", "yyyy-MM-dd");
-        final String timeFormat = properties.getOrDefault("glide.sys.time_format", "HH:mm:ss");
+        final String dateFormat = ConnectorOptions.extractOption(properties, "glide.sys.date_format", "yyyy-MM-dd");
+        final String timeFormat = ConnectorOptions.extractOption(properties, "glide.sys.time_format", "HH:mm:ss");
 
         return Optional.of(
             MetaDataBuilder.on(getCamelContext())
@@ -579,9 +580,9 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
                 throw new IllegalStateException(e);
             }
 
-            this.instanceName = (String)parameters.get("instanceName");
-            this.objectType = (String)parameters.getOrDefault("objectType", ServiceNowConstants.RESOURCE_TABLE);
-            this.objectName = (String)parameters.getOrDefault("objectName", configuration.getTable());
+            this.instanceName = ConnectorOptions.extractOption(parameters, "instanceName");
+            this.objectType = ConnectorOptions.extractOption(parameters, "objectType", ServiceNowConstants.RESOURCE_TABLE);
+            this.objectName = ConnectorOptions.extractOption(parameters, "objectName", configuration.getTable());
 
             ObjectHelper.notNull(instanceName, "instanceName");
 

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.Json;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.PropertyPair;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
@@ -47,7 +48,7 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
 
     @Override
     public SyndesisMetadata fetch(CamelContext context, String componentId, String actionId, Map<String, Object> properties) {
-        final Object table = properties.get("table");
+        final Object table = ConnectorOptions.extractOption(properties, "table");
 
         if (table == null) {
             Map<String, Object> props = new HashMap<>(properties);
@@ -93,8 +94,8 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
     @Override
     protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
         if (metadata.getPayload() != null) {
-            final String objectType = (String)properties.get("objectType");
-            final String metaType = (String)properties.get("metaType");
+            final String objectType = ConnectorOptions.extractOption(properties, "objectType");
+            final String metaType = ConnectorOptions.extractOption(properties, "metaType");
 
             if (ServiceNowConstants.RESOURCE_TABLE.equalsIgnoreCase(objectType) && "definition".equals(metaType)) {
                 return adaptTableDefinitionMetadata(actionId, properties, metadata);
@@ -112,7 +113,7 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
 
     private SyndesisMetadata adaptTableDefinitionMetadata(String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
         try {
-            final Object table = properties.get("table");
+            final Object table = ConnectorOptions.extractOption(properties, "table");
             final ObjectNode schema = (ObjectNode) metadata.getPayload();
 
             DataShape.Builder shapeBuilder = new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA)

--- a/app/connector/sftp/pom.xml
+++ b/app/connector/sftp/pom.xml
@@ -30,6 +30,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
+++ b/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.extension.verifier.ResultErrorHelper;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class SftpVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -60,10 +61,10 @@ public class SftpVerifierExtension extends DefaultComponentVerifierExtension {
 
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
-        final String host = (String) parameters.get("host");
-        final int port = Integer.parseInt((String) parameters.get("port"));
-        final String userName = (String) parameters.get("username");
-        final String password = (parameters.get("password") == null) ? "" : (String) parameters.get("password");
+        final String host = ConnectorOptions.extractOption(parameters, "host");
+        final Integer port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt, 22);
+        final String userName = ConnectorOptions.extractOption(parameters, "username");
+        final String password = ConnectorOptions.extractOption(parameters, "password", "");
 
         JSch jsch = new JSch();
         Session session = null;

--- a/app/connector/slack/pom.xml
+++ b/app/connector/slack/pom.xml
@@ -48,6 +48,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <version>${project.version}</version>

--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackChannelCustomizer.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackChannelCustomizer.java
@@ -16,7 +16,7 @@
 package io.syndesis.connector.slack;
 
 import java.util.Map;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -31,8 +31,8 @@ public class SlackChannelCustomizer implements ComponentProxyCustomizer {
     }
 
     private void sanitizeUserOrChannel(Map<String, Object> options) {
-        String username = (String) options.get("receiver");
-        String channel = (String) options.remove("channel");
+        String username = ConnectorOptions.extractOption(options, "receiver");
+        String channel = ConnectorOptions.popOption(options, "channel");
 
         if (channel != null) {
             if (channel.trim().charAt(0) == '#') {

--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackMetaDataExtension.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackMetaDataExtension.java
@@ -36,7 +36,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import io.syndesis.connector.support.util.ConnectorOptions;
 import static io.syndesis.connector.slack.utils.SlackUtils.readResponse;
 
 public class SlackMetaDataExtension extends AbstractMetaDataExtension {
@@ -50,7 +50,7 @@ public class SlackMetaDataExtension extends AbstractMetaDataExtension {
     @SuppressWarnings("unchecked")
     @Override
     public Optional<MetaData> meta(Map<String, Object> parameters) {
-        final String token = (String) parameters.get("token");
+        final String token = ConnectorOptions.extractOption(parameters, "token");
 
         if (token != null) {
             LOG.debug("Retrieving channels for connection to slack with token {}", token);

--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackVerifierExtension.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackVerifierExtension.java
@@ -15,13 +15,12 @@
  */
 package io.syndesis.connector.slack;
 
+import static io.syndesis.connector.slack.utils.SlackUtils.readResponse;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.camel.CamelContext;
-import org.apache.camel.component.extension.ComponentVerifierExtension.VerificationError;
 import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExtension;
 import org.apache.camel.component.extension.verifier.ResultBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
@@ -36,8 +35,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-
-import static io.syndesis.connector.slack.utils.SlackUtils.readResponse;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public class SlackVerifierExtension extends DefaultComponentVerifierExtension {
 
@@ -52,7 +50,7 @@ public class SlackVerifierExtension extends DefaultComponentVerifierExtension {
     protected Result verifyParameters(Map<String, Object> parameters) {
         ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.PARAMETERS);
 
-        if (ObjectHelper.isEmpty(parameters.get("token")) || ObjectHelper.isEmpty(parameters.get("webhookUrl"))) {
+        if (ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "token")) || ObjectHelper.isEmpty(ConnectorOptions.extractOption(parameters, "webhookUrl"))) {
             builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.GENERIC,
                     "You must specify a webhookUrl and a token").parameterKey("webhookUrl").parameterKey("token").build());
         }
@@ -70,8 +68,7 @@ public class SlackVerifierExtension extends DefaultComponentVerifierExtension {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
-        String webhookUrl = (String)parameters.get("webhookUrl");
-
+        String webhookUrl = ConnectorOptions.extractOption(parameters, "webhookUrl");
         if (ObjectHelper.isNotEmpty(webhookUrl)) {
 
             try {
@@ -101,9 +98,9 @@ public class SlackVerifierExtension extends DefaultComponentVerifierExtension {
                 builder.error(ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION, "Invalid webhookUrl").parameterKey("webhookUrl").build());
             }
         }
-        if (ObjectHelper.isNotEmpty((String)parameters.get("token"))) {
-            String token = (String)parameters.get("token");
 
+        String token = ConnectorOptions.extractOption(parameters, "token");
+        if (ObjectHelper.isNotEmpty(token)) {
             try {
                 HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
                 HttpPost httpPost = new HttpPost("https://slack.com/api/channels.list");

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -31,6 +31,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
     </dependency>

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
@@ -21,7 +21,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
@@ -39,12 +41,10 @@ import io.syndesis.connector.sql.common.stored.ColumnMode;
 import io.syndesis.connector.sql.common.stored.StoredProcedureColumn;
 import io.syndesis.connector.sql.common.stored.StoredProcedureMetadata;
 import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.PropertyPair;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
-import org.apache.camel.CamelContext;
-import org.apache.camel.component.extension.MetaDataExtension;
-import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 
 @SuppressWarnings("PMD.GodClass")
 public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
@@ -163,7 +163,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
             @SuppressWarnings("unchecked")
             final Map<String, StoredProcedureMetadata> procedureMap = (Map<String, StoredProcedureMetadata>) metadata
                 .getPayload();
-            final String procedureName = (String) properties.get(PROCEDURE_NAME);
+            final String procedureName = ConnectorOptions.extractOption(properties, PROCEDURE_NAME);
             final StoredProcedureMetadata storedProcedure = procedureMap.get(procedureName);
             ppList.add(new PropertyPair(storedProcedure.getTemplate(), PROCEDURE_TEMPLATE));
             enrichedProperties.put(PROCEDURE_TEMPLATE, ppList);
@@ -219,7 +219,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
         // return list of stored procedures in the database
         @SuppressWarnings("unchecked")
         final Map<String, StoredProcedureMetadata> procedureMap = (Map<String, StoredProcedureMetadata>) metadata.getPayload();
-        if (isPresentAndNonNull(properties, PATTERN) && FROM_PATTERN.equalsIgnoreCase(String.valueOf(properties.get(PATTERN)))) {
+        if (isPresentAndNonNull(properties, PATTERN) && FROM_PATTERN.equalsIgnoreCase(ConnectorOptions.extractOption(properties, PATTERN))) {
             enrichedProperties.put(PROCEDURE_NAME, obtainFromProcedureList(procedureMap));
         } else {
             enrichedProperties.put(PROCEDURE_NAME, obtainToProcedureList(procedureMap));
@@ -279,7 +279,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
     }
 
     static boolean isPresentAndNonNull(final Map<String, Object> properties, final String property) {
-        return isPresent(properties, property) && properties.get(property) != null;
+        return ConnectorOptions.extractOption(properties, property) != null;
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
@@ -30,6 +30,7 @@ import io.syndesis.connector.sql.common.DbMetaDataHelper;
 import io.syndesis.connector.sql.common.stored.ColumnMode;
 import io.syndesis.connector.sql.common.stored.StoredProcedureColumn;
 import io.syndesis.connector.sql.common.stored.StoredProcedureMetadata;
+import io.syndesis.connector.support.util.ConnectorOptions;
 
 public final class SqlSupport {
     private SqlSupport() {
@@ -37,9 +38,9 @@ public final class SqlSupport {
 
     public static Connection createConnection(final Map<String, Object> properties) throws SQLException {
         return DriverManager.getConnection(
-            String.valueOf(properties.get("url")),
-            String.valueOf(properties.get("user")),
-            String.valueOf(properties.get("password"))
+            ConnectorOptions.extractOption(properties, "url"),
+            ConnectorOptions.extractOption(properties, "user"),
+            ConnectorOptions.extractOption(properties, "password")
         );
     }
 
@@ -78,14 +79,16 @@ public final class SqlSupport {
 
         final Map<String, StoredProcedureMetadata> storedProcedures = new HashMap<>();
 
-        try (Connection connection = DriverManager.getConnection(String.valueOf(parameters.get("url")),
-            String.valueOf(parameters.get("user")), String.valueOf(parameters.get("password")));) {
+        try (Connection connection = DriverManager.getConnection(
+                    ConnectorOptions.extractOption(parameters, "url"),
+                    ConnectorOptions.extractOption(parameters, "user"),
+                    ConnectorOptions.extractOption(parameters, "password"));) {
 
             final DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
-            final String catalog = (String) parameters.getOrDefault("catalog", null);
-            final String defaultSchema = dbHelper.getDefaultSchema((String) parameters.getOrDefault("user", ""));
-            final String schemaPattern = (String) parameters.getOrDefault("schema", defaultSchema);
-            final String procedurePattern = (String) parameters.getOrDefault("procedure-pattern", null);
+            final String catalog = ConnectorOptions.extractOption(parameters, "catalog");
+            final String defaultSchema = dbHelper.getDefaultSchema(ConnectorOptions.extractOption(parameters, "user", ""));
+            final String schemaPattern = ConnectorOptions.extractOption(parameters, "schema", defaultSchema);
+            final String procedurePattern = ConnectorOptions.extractOption(parameters, "procedure-pattern");
 
             try (ResultSet procedureSet = dbHelper.fetchProcedures(catalog, schemaPattern, procedurePattern)) {
                 while (procedureSet.next()) {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
@@ -26,6 +26,7 @@ import javax.sql.DataSource;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.common.SqlStatementMetaData;
 import io.syndesis.connector.sql.common.SqlStatementParser;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
@@ -75,8 +76,8 @@ public final class SqlStartConnectorCustomizer implements ComponentProxyCustomiz
 
     private void init(Map<String, Object> options) {
         if (isInit) {
-            final String sql =  String.valueOf(options.get("query"));
-            final DataSource dataSource = (DataSource) options.get("dataSource");
+            final String sql =  ConnectorOptions.extractOption(options, "query");
+            final DataSource dataSource = ConnectorOptions.extractOptionAsType(options, "dataSource", DataSource.class);
             try (Connection connection = dataSource.getConnection()) {
                 SqlStatementMetaData statementInfo = new SqlStatementParser(connection, null, sql).parse();
                 if (statementInfo.getAutoIncrementColumnName() != null) {

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.connector.sql;
 
+import static org.assertj.core.api.Assertions.fail;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -26,12 +28,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-
-import com.fasterxml.jackson.databind.ObjectWriter;
-import io.syndesis.connector.sql.common.DbEnum;
-import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
-import io.syndesis.common.util.Json;
-import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -41,9 +37,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-
-import static org.assertj.core.api.Assertions.fail;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.sql.common.DbEnum;
+import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
 
 public class SqlMetadataAdapterTest {
     private static final String DERBY_DEMO_ADD2_SQL =
@@ -69,9 +67,9 @@ public class SqlMetadataAdapterTest {
     public static void setUpBeforeClass() throws IOException {
         try (InputStream is = SqlMetadataAdapterTest.class.getClassLoader().getResourceAsStream("test-options.properties")) {
             props.load(is);
-            String user     = String.valueOf(props.get("sql-connector.user"));
-            String password = String.valueOf(props.get("sql-connector.password"));
-            String url      = String.valueOf(props.get("sql-connector.url"));
+            String user     = props.getProperty("sql-connector.user");
+            String password = props.getProperty("sql-connector.password");
+            String url      = props.getProperty("sql-connector.url");
 
             conn = DriverManager.getConnection(url,user,password);
             String dbProductName = conn.getMetaData().getDatabaseProductName();

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlConnectionRule.java
@@ -52,9 +52,9 @@ public final class SqlConnectionRule extends ExternalResource {
             throw new AssertionError("Unable to read application.properties", e);
         }
 
-        final String user = String.valueOf(properties.get("sql-connector.user"));
-        final String password = String.valueOf(properties.get("sql-connector.password"));
-        final String url = String.valueOf(properties.get("sql-connector.url"));
+        final String user = properties.getProperty("sql-connector.user");
+        final String password = properties.getProperty("sql-connector.password");
+        final String url = properties.getProperty("sql-connector.url");
 
         try {
             connection = DriverManager.getConnection(url, user, password);

--- a/app/connector/support/util/pom.xml
+++ b/app/connector/support/util/pom.xml
@@ -31,6 +31,11 @@
   <packaging>jar</packaging>
 
   <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
@@ -17,24 +17,35 @@ package io.syndesis.connector.support.util;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ConnectorOptions {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorOptions.class);
+
     /**
-     * Gets the value mapped to the given key & converts to {@link String} if present,
-     * or defaultValue otherwise.
+     * Gets the value mapped to the given key,
+     * converts to {@link String} & returns or defaultValue otherwise.
+     *
+     * Note. Don't use this if the value is not expected to a {@link String}
      *
      * @param options
      * @param key
      * @param defaultValue
      * @return {@link String} object belonging to the given key in the options map
      */
-    public static String extractOption(Map<String, Object> options, String key, String defaultValue) {
+    public static String extractOption(Map<String, ?> options, String key, String defaultValue) {
+        if (options == null) {
+            return defaultValue;
+        }
+
         return Optional.ofNullable(options.get(key))
-                        .map(Object::toString)
-                        .filter(v -> v.length() > 0)
-                        .orElse(defaultValue);
+            .map(Object::toString)
+            .filter(v -> v.length() > 0)
+            .orElse(defaultValue);
     }
 
     /**
@@ -45,8 +56,57 @@ public final class ConnectorOptions {
      * @param key
      * @return {@link String} object belonging to the given key in the options map
      */
-    public static String extractOption(Map<String, Object> options, String key) {
+    public static String extractOption(Map<String, ?> options, String key) {
         return extractOption(options, key, null);
+    }
+
+    /**
+     * Gets & removes the value mapped to the given key & converts to {@link String} if present,
+     * or null otherwise.
+     *
+     * @param options
+     * @param key
+     * @return {@link String} object that used to belong to the given key in the options map
+     */
+    public static String popOption(Map<String, ?> options, String key) {
+        if (options == null) {
+            return null;
+        }
+
+        return Optional.ofNullable(options.remove(key))
+            .map(Object::toString)
+            .filter(v -> v.length() > 0)
+            .orElse(null);
+    }
+
+    /**
+     * Gets the value mapped to the given key, converts to {@link String} if present,
+     * then applies the given mapping function to the {@link String} value. Either
+     * returns the resulting mapped object or null.
+     *
+     * Note. This will only work for values that can be converted to strings so Strings and primitives.
+     *            The mappingFn should be able to handle null values.
+     *
+     * @param options
+     * @param key
+     * @return Mapped object converted from value belonging to the given key in the options map
+     */
+    public static <T> T extractOptionAndMap(Map<String, ?> options, String key,
+                                                                    Function<? super String, T> mappingFn, T defaultValue) {
+        if (options == null) {
+            return defaultValue;
+        }
+
+        try {
+            return Optional.ofNullable(options.get(key))
+                        .map(Object::toString)
+                        .filter(v -> v.length() > 0)
+                        .map(mappingFn)
+                        .orElse(defaultValue);
+        } catch (Exception ex) {
+            LOG.error("Evaluation of option '" + key + "' failed. Returning default value.", ex);
+            return defaultValue;
+        }
     }
 
     /**
@@ -59,13 +119,75 @@ public final class ConnectorOptions {
      * @param options
      * @param key
      * @return Mapped object converted from value belonging to the given key in the options map
+     * @throws any exception that may result from the mapping function
      */
     public static <T> T extractOptionAndMap(Map<String, ?> options, String key,
-                                                                    Function<? super String, ? extends T> mappingFn) {
-        return Optional.ofNullable(options.get(key))
+                                                                    Function<? super String, T> mappingFn) throws IllegalArgumentException {
+        if (options == null) {
+            return null;
+        }
+
+        try {
+            return Optional.ofNullable(options.get(key))
                         .map(Object::toString)
+                        .filter(v -> v.length() > 0)
                         .map(mappingFn)
                         .orElse(null);
+        } catch (Exception ex) {
+            LOG.error("Evaluation of option '" + key + "' failed.", ex);
+            throw new IllegalArgumentException(ex);
+        }
     }
 
+    public static void extractOptionAndConsume(Map<String, ?> options, String key,
+                                                                   Consumer<String> consumer) {
+        if (options == null) {
+            return;
+        }
+
+        try {
+            Optional.ofNullable(options.get(key))
+                .map(Object::toString)
+                .ifPresent(consumer);
+        } catch (Exception ex) {
+            LOG.error("Evaluation of option '" + key + "' failed.", ex);
+        }
+    }
+
+    /**
+     * Gets the value mapped to the given key, checks it is the required class
+     * and returns. Otherwise return defaultValue.
+     *
+     * @param options
+     * @param key
+     * @param requiredClass
+     * @param defaultValue
+     *
+     * @return value from options
+     */
+    public static <T> T extractOptionAsType(Map<String, ?> options,
+                                                            String key, Class<T> requiredClass, T defaultValue) {
+        if (options == null) {
+            return defaultValue;
+        }
+
+        return Optional.ofNullable(options.get(key))
+            .filter(requiredClass::isInstance)
+            .map(requiredClass::cast)
+            .orElse(defaultValue);
+    }
+
+    /**
+     * Gets the value mapped to the given key, checks it is the required class
+     * and returns. Otherwise return null.
+     *
+     * @param options
+     * @param key
+     * @param requiredClass
+     * @return value from options
+     */
+    public static <T> T extractOptionAsType(Map<String, ?> options,
+                                                            String key, Class<T> requiredClass) {
+        return extractOptionAsType(options, key, requiredClass, null);
+    }
 }

--- a/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/ConnectorOptionsTest.java
+++ b/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/ConnectorOptionsTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConnectorOptionsTest {
+
+    private String key = "myKey";
+    private String missingKey = "missingKey";
+    private String value = "myValue";
+
+    private enum Colours {
+        RED,
+        BLUE,
+        GREEN,
+        YELLOW;
+    }
+
+    private Map<String, Object> parameters;
+
+    @Before
+    public void setup() {
+        parameters = new HashMap<String, Object>();
+    }
+
+    private void put(String key, Object value) {
+        parameters.put(key, value);
+    }
+
+    private Long convertLong(Object someObject) {
+        return value.equals(someObject) ? 1L : 0L;
+    }
+
+    public boolean isEmpty(Object value) {
+        return !isNotEmpty(value);
+    }
+
+    public boolean isNotEmpty(Object value) {
+        if (value == null) {
+            return false;
+        } else if (value instanceof String) {
+            String text = (String) value;
+            return text.trim().length() > 0;
+        } else if (value instanceof Collection) {
+            return !((Collection<?>)value).isEmpty();
+        } else if (value instanceof Map) {
+            return !((Map<?, ?>)value).isEmpty();
+        } else {
+            return true;
+        }
+    }
+
+    @Test
+    public void testNoMap() throws Exception {
+        String defaultString = "defaultString";
+        Long defaultLong = 2L;
+        parameters = null;
+
+        assertNull(ConnectorOptions.extractOption(parameters, key));
+        assertEquals(defaultString, ConnectorOptions.extractOption(parameters, key, defaultString));
+        assertNull(ConnectorOptions.extractOptionAndMap(parameters, key, this::convertLong));
+        assertEquals(defaultLong, ConnectorOptions.extractOptionAndMap(parameters, key, this::convertLong, defaultLong));
+        assertNull(ConnectorOptions.extractOptionAsType(parameters, key, String.class));
+        assertEquals(defaultString, ConnectorOptions.extractOptionAsType(parameters, key, String.class, defaultString));
+        assertNull(ConnectorOptions.popOption(parameters, key));
+
+        Consumer<String> c = (String v) -> fail("This should never be executed");
+        ConnectorOptions.extractOptionAndConsume(parameters, key, c);
+    }
+
+    @Test
+    public void testStringValue() {
+        put(key, value);
+
+        assertEquals(value, ConnectorOptions.extractOption(parameters, key));
+        assertNull(ConnectorOptions.extractOption(parameters, missingKey));
+    }
+
+    @Test
+    public void testStringValueWithDefault() {
+        String defaultValue = "defaultValue";
+        put(key, value);
+
+        assertEquals(value, ConnectorOptions.extractOption(parameters, key, defaultValue));
+        assertEquals(defaultValue, ConnectorOptions.extractOption(parameters, missingKey, defaultValue));
+    }
+
+    @Test
+    public void testStringValueAndMap() throws Exception {
+        put(key, value);
+
+        assertEquals((Long) 1L, ConnectorOptions.extractOptionAndMap(parameters, key, this::convertLong));
+        assertNull(ConnectorOptions.extractOptionAndMap(parameters, missingKey, this::convertLong));
+    }
+
+    @Test
+    public void testStringValueAndMapWithDefault() {
+        Long defaultValue = 2L;
+        put(key, value);
+
+        assertEquals((Long) 1L, ConnectorOptions.extractOptionAndMap(parameters, key, this::convertLong, defaultValue));
+        assertEquals(defaultValue, ConnectorOptions.extractOptionAndMap(parameters, missingKey, this::convertLong, defaultValue));
+    }
+
+    @Test
+    public void testStringValueAndMapToArrayWithDefault() {
+        String vToSplit = "hello,bonjour,salve,hiya";
+
+        put(key, vToSplit);
+
+        String[] exp = {"hello", "bonjour", "salve", "hiya"};
+        String[] defaultValue = new String[]{};
+        String[] result = ConnectorOptions.extractOptionAndMap(parameters, key,
+                                                                     names -> names.split(","), defaultValue);
+        assertArrayEquals(exp, result);
+        assertArrayEquals(defaultValue, ConnectorOptions.extractOptionAndMap(parameters, missingKey,
+                                                                    names -> names.split(","), defaultValue));
+
+        String[] columns = ConnectorOptions.extractOption(parameters, key).split(",", -1);
+        assertArrayEquals(columns, result);
+    }
+
+    @Test
+    public void testStringValueAndMapToBooleanWithDefault() {
+        put(key, Boolean.toString(true));
+        assertEquals(Boolean.TRUE, ConnectorOptions.extractOptionAndMap(parameters, key, Boolean::valueOf, false));
+        assertEquals(Boolean.FALSE, ConnectorOptions.extractOptionAndMap(parameters, missingKey, Boolean::valueOf, false));
+
+        put(key, "NotABoolean");
+        assertEquals(Boolean.FALSE, ConnectorOptions.extractOptionAndMap(parameters, key, Boolean::valueOf, false));
+    }
+
+    @Test
+    public void testStringValueAndMapToIntWithDefault() throws Exception {
+        put(key, 2);
+        assertTrue(2 == ConnectorOptions.extractOptionAndMap(parameters, key, Integer::parseInt, 3));
+        assertTrue(3 == ConnectorOptions.extractOptionAndMap(parameters, missingKey, Integer::parseInt, 3));
+
+        put(key, "NotAnInt");
+        assertTrue(-1 == ConnectorOptions.extractOptionAndMap(parameters, key, Integer::parseInt, -1));
+    }
+
+    @Test
+    public void testValueAndConsumer() {
+        put(key, value);
+
+        final int[] cRun = new int[1];
+        final int[] success = new int[1];
+        Consumer<String> c = (String v) -> {
+            cRun[0] = 1;
+            if (v.equals(value)) {
+                success[0] = 1;
+            }
+        };
+
+        cRun[0] = 0;
+        success[0] = 0;
+        ConnectorOptions.extractOptionAndConsume(parameters, key, c);
+        assertEquals(1, cRun[0]);
+        assertEquals(1, success[0]);
+
+        //
+        // Consumer not executed if key not present
+        //
+        cRun[0] = 0;
+        success[0] = 0;
+        ConnectorOptions.extractOptionAndConsume(parameters, missingKey, c);
+        assertEquals(0, cRun[0]);
+        assertEquals(0, success[0]);
+    }
+
+    @Test
+    public void testTypedValue() {
+        Colours redValue = Colours.RED;
+        put(key, redValue);
+
+        assertEquals(redValue, ConnectorOptions.extractOptionAsType(parameters, key, Colours.class));
+        assertNull(ConnectorOptions.extractOptionAsType(parameters, missingKey, Colours.class));
+    }
+}

--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -32,6 +32,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>

--- a/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
+++ b/app/connector/telegram/src/main/java/io/syndesis/connector/telegram/TelegramSendMessageCustomizer.java
@@ -15,21 +15,20 @@
  */
 package io.syndesis.connector.telegram;
 
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
-import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.telegram.model.OutgoingTextMessage;
-
-import java.util.Map;
-import java.util.Optional;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 
 public class TelegramSendMessageCustomizer implements ComponentProxyCustomizer {
 
-    private Optional<String> configuredChatId;
+    private String configuredChatId;
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        this.configuredChatId = Optional.ofNullable(options.get("chatId")).map(String.class::cast);
+        this.configuredChatId = ConnectorOptions.extractOption(options, "chatId");
         component.setBeforeProducer(this::beforeProducer);
     }
 
@@ -37,9 +36,9 @@ public class TelegramSendMessageCustomizer implements ComponentProxyCustomizer {
         OutgoingTextMessage message = exchange.getIn().getBody(OutgoingTextMessage.class);
 
         // Chat ID priority (in Syndesis) should be: chatId field in the message, chatId at action level, TelegramChatId header
-        if (message != null && message.getChatId() == null && this.configuredChatId.isPresent()) {
+        if (message != null && message.getChatId() == null && this.configuredChatId != null) {
             // Overriding Camel default priority giving action configuration higher priority than header
-            message.setChatId(this.configuredChatId.get());
+            message.setChatId(this.configuredChatId);
         }
     }
 }

--- a/app/connector/twitter/pom.xml
+++ b/app/connector/twitter/pom.xml
@@ -48,6 +48,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.syndesis.connector</groupId>
+            <artifactId>connector-support-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>connector-support-verifier</artifactId>
             <version>${project.version}</version>

--- a/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/SendDirectMessageCustomizer.java
+++ b/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/SendDirectMessageCustomizer.java
@@ -16,17 +16,17 @@
 package io.syndesis.connector.twitter;
 
 import java.util.Map;
-
+import org.apache.camel.Message;
+import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
-import org.apache.camel.Message;
 
 public class SendDirectMessageCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         component.setBeforeProducer(exchange -> {
-            Object defaultMessage = options.get("message");
+            String defaultMessage = ConnectorOptions.extractOption(options, "message");
             final Message in = exchange.getIn();
             final DirectMessageText message = in.getBody(DirectMessageText.class);
             // only set the default message if there is no message in the body

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1306,6 +1306,12 @@
 
       <dependency>
         <groupId>io.syndesis.connector</groupId>
+        <artifactId>connector-support-util</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.syndesis.connector</groupId>
         <artifactId>connector-support-verifier</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
* Refactors connectors to extract values from options map using the
  ConnectorOptions class. This handles checking for null or empty, maps
  to alternative types if required and returns as String or other type.

* Ensures uniform methodology for accessing key/values from map,
  simplifying boilerplate code.

* Provides unit tests for testing possible option extraction use-cases.