### PR TITLE
[Upgrade] Link the secret back to SAs after re-creation

### DIFF
--- a/tools/upgrade/steps/upgrade_40_update_resources
+++ b/tools/upgrade/steps/upgrade_40_update_resources
@@ -53,6 +53,7 @@ update_resources::run() {
 
     run_update_scripts "$backupdir" "$workdir" "$tag" "$migrationdir"
     apply_resources "$workdir/resources" "$DONT_TOUCH_RESOURCES"
+    link_pull_secret
 }
 
 update_resources::rollback() {
@@ -117,6 +118,22 @@ apply_resources() {
     done
 }
 
+link_pull_secret() {
+  if oc get secret syndesis-pull-secret -o name >/dev/null 2>&1; then
+    # Add pull secrets to every service account specific to syndesis
+    for sa in $(oc get sa -o jsonpath='{.items[*].metadata.name}'); do
+      # For all sa's which start with "syndesis-" + the camel k operator
+      if [ ${sa/#syndesis-/} != $sa ] || [ $sa == "camel-k-operator" ]; then
+        echo "       ### Linking syndesis-pull-secret --> SA $sa (pull)"
+        oc secrets link $sa syndesis-pull-secret --for=pull
+      fi
+    done
+
+    # Add pull and push secrets to the builder account
+    echo "       ### Linking syndesis-pull-secret --> SA builder (pull + mount)"
+    oc secrets link builder syndesis-pull-secret --for=pull,mount
+  fi
+}
 
 # Just as reference, not currently used
 remove_rcs_for_dc() {


### PR DESCRIPTION
@nicolaferraro the problem is that the migration script never worked (my bad at 7.3 times), because first the migration scripts are executed and then the SA are re-created, effectively reverting the change back:

```
=== * Update resources (upgrade_40_update_resources)
<migration scripts>
      - Executing 01_server_config_map_upgrade.sh
configmap/syndesis-server-config patched
      - Executing 02_ui_config_map_upgrade.sh
configmap/syndesis-ui-config patched
      - Executing 03_server_config_map_upgrade.sh
configmap/syndesis-server-config patched
      - BuildConfig: update (replace)
        * todo
      - ConfigMap: skipped
      - DeploymentConfig: update (replace)
        * broker-amq
        * komodo-server
          not existing --> trying to create
deploymentconfig.apps.openshift.io/komodo-server created
        * syndesis-db
        * syndesis-meta
        * syndesis-oauthproxy
        * syndesis-prometheus
        * syndesis-server
        * syndesis-ui
        * todo
      - ImageStream: update (replace)
        * jboss-amq-63
        * todo
      - PersistentVolumeClaim: skipped
      - Role: skipped
      - RoleBinding: skipped
      - Route: force update (delete/create)
        * syndesis
        * todo
      - Secret: skipped
      - Service: force update (delete/create)
        * broker-amq-tcp
        * komodo-server
        * syndesis-db
        * syndesis-meta
        * syndesis-oauthproxy
        * syndesis-prometheus
        * syndesis-server
        * syndesis-ui
        * todo
<sa recreated>
      - ServiceAccount: force update (delete/create)
        * syndesis-default
        * syndesis-integration
        * syndesis-prometheus
        * syndesis-server
      - Template: update (replace)
        * syndesis-upgrade
<my change>
       ### Linking syndesis-pull-secret --> SA syndesis-default (pull)
       ### Linking syndesis-pull-secret --> SA syndesis-integration (pull)
       ### Linking syndesis-pull-secret --> SA syndesis-oauth-client (pull)
       ### Linking syndesis-pull-secret --> SA syndesis-operator (pull)
       ### Linking syndesis-pull-secret --> SA syndesis-prometheus (pull)
       ### Linking syndesis-pull-secret --> SA syndesis-server (pull)
       ### Linking syndesis-pull-secret --> SA builder (pull + mount)

```