### PR TITLE
chore: enable strict checksums for integration builds

### DIFF
--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftConfigurationProperties.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftConfigurationProperties.java
@@ -39,6 +39,7 @@ public class OpenShiftConfigurationProperties {
     private String deploymentMemoryRequestMi = "280";
     private String deploymentMemoryLimitMi = "512";
     private String mavenOptions = "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx300m";
+    private String additionalMavenArguments = "--strict-checksums";
 
     private String apiBaseUrl;
 
@@ -142,6 +143,14 @@ public class OpenShiftConfigurationProperties {
 
     public void setMavenOptions(String mavenOptions) {
         this.mavenOptions = mavenOptions;
+    }
+
+    public String getAdditionalMavenArguments() {
+        return additionalMavenArguments;
+    }
+
+    public void setAdditionalMavenArguments(String additionalMavenArguments) {
+        this.additionalMavenArguments = additionalMavenArguments;
     }
 
     public String getIntegrationDataPath() {

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -339,6 +339,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
                     // https://github.com/syndesisio/syndesis-rest/issues/682
                     .withEnv(
                         new EnvVar("MAVEN_OPTS", config.getMavenOptions(), null),
+                        new EnvVar("MAVEN_ARGS_APPEND", config.getAdditionalMavenArguments(), null),
                         new EnvVar("BUILD_LOGLEVEL", config.isDebug() ? "5" : "1", null)
                     )
                   .endSourceStrategy()


### PR DESCRIPTION
This seems to be an issue when using flaky networks or Maven repositories with issues. At least this way the integrationbuild will fail instead of the integration failing at runtime.