### PR TITLE
fix(basicfilter): rework condition set form UI

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
@@ -82,8 +82,7 @@ export class FormArrayComponent extends React.Component<
                           htmlFor={toValidHtmlId(`${controlGroupName}-control`)}
                           className="control-label"
                           {...controlLabelAttributes}
-                        >
-                        </label>
+                        />
                         <div id={toValidHtmlId(`${controlGroupName}-control`)}>
                           <div className="form-array-control__array-controls">
                             {options.showSortControls && (

--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
@@ -50,70 +50,70 @@ export class FormArrayComponent extends React.Component<
                 const controlGroupName = `${fieldName}-array-controls`;
                 return (
                   <fieldset>
-                    {options.rowTitle && (
-                      <div key={titleKey} {...arrayRowTitleAttributes}>
-                        <h5 className="form-array-control__row-title">
-                          <strong>{`${index + 1}. ${options.rowTitle}`}</strong>
-                        </h5>
-                      </div>
-                    )}
-                    {propertiesArray.map(property =>
-                      getField({
-                        allFieldsRequired:
-                          this.props.allFieldsRequired || false,
-                        key: `${fieldName}.${property.name}`,
-                        name: `${fieldName}.${property.name}`,
-                        property: {
-                          controlLabelAttributes,
-                          fieldAttributes,
-                          formGroupAttributes,
-                          ...property,
-                        },
-                        value: rowValue[property.name],
-                      })
-                    )}
-                    <div
-                      key={controlGroupName}
-                      {...formGroupAttributes}
-                      {...arrayControlAttributes}
-                    >
-                      <label
-                        htmlFor={toValidHtmlId(`${controlGroupName}-control`)}
-                        className="control-label"
-                        {...controlLabelAttributes}
-                      >
-                        &nbsp;
-                      </label>
-                      <div id={toValidHtmlId(`${controlGroupName}-control`)}>
-                        <div className="form-array-control__array-controls">
-                          {options.showSortControls && (
-                            <>
-                              <TextButton
-                                onClick={() => {
-                                  this.props.move(index, index - 1);
-                                }}
-                                enable={index > 0}
-                              >
-                                <i className="fa fa-arrow-circle-o-up" />
-                              </TextButton>
-                              <TextButton
-                                onClick={() => {
-                                  this.props.move(index, index + 1);
-                                }}
-                                enable={index < values.length - 1}
-                              >
-                                <i className="fa fa-arrow-circle-o-down" />
-                              </TextButton>
-                            </>
-                          )}
-                          <TextButton
-                            onClick={() => this.props.remove(index)}
-                            enable={values.length > minElements}
-                          >
-                            <i className="fa fa-trash-o" />
-                          </TextButton>
+                    <div className="form-array-fields">
+                      {options.rowTitle && (
+                        <div key={titleKey} {...arrayRowTitleAttributes}>
+                          <h5 className="form-array-control__row-title">
+                            <strong>{`${index + 1}. ${options.rowTitle}`}</strong>
+                          </h5>
                         </div>
-                        <div className="help-block">&nbsp;</div>
+                      )}
+                      {propertiesArray.map(property =>
+                        getField({
+                          allFieldsRequired:
+                            this.props.allFieldsRequired || false,
+                          key: `${fieldName}.${property.name}`,
+                          name: `${fieldName}.${property.name}`,
+                          property: {
+                            controlLabelAttributes,
+                            fieldAttributes,
+                            formGroupAttributes,
+                            ...property,
+                          },
+                          value: rowValue[property.name],
+                        })
+                      )}
+                      <div
+                        key={controlGroupName}
+                        {...formGroupAttributes}
+                        {...arrayControlAttributes}
+                      >
+                        <label
+                          htmlFor={toValidHtmlId(`${controlGroupName}-control`)}
+                          className="control-label"
+                          {...controlLabelAttributes}
+                        >
+                        </label>
+                        <div id={toValidHtmlId(`${controlGroupName}-control`)}>
+                          <div className="form-array-control__array-controls">
+                            {options.showSortControls && (
+                              <>
+                                <TextButton
+                                  onClick={() => {
+                                    this.props.move(index, index - 1);
+                                  }}
+                                  enable={index > 0}
+                                >
+                                  <i className="fa fa-arrow-circle-o-up" />
+                                </TextButton>
+                                <TextButton
+                                  onClick={() => {
+                                    this.props.move(index, index + 1);
+                                  }}
+                                  enable={index < values.length - 1}
+                                >
+                                  <i className="fa fa-arrow-circle-o-down" />
+                                </TextButton>
+                              </>
+                            )}
+                            <TextButton
+                              onClick={() => this.props.remove(index)}
+                              enable={values.length > minElements}
+                            >
+                              <i className="fa fa-trash-o" />
+                            </TextButton>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </fieldset>

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -182,26 +182,3 @@ body {
   white-space: normal;
   word-break: break-word;
 }
-
-/* basic filter styles */
-.with-rule-filter-form fieldset {
-  position: relative;
-  margin-top: 40px;
-  margin-bottom: 40px;
-}
-
-.with-rule-filter-form__group {
-  width: 80%;
-}
-
-.with-rule-filter-form__action {
-  position: absolute;
-  top: 50%;
-  left: calc(85% + 6px);
-  width: 20%;
-  border-left: 1px solid var(--pf-global--BorderColor--100);
-  transform: translateY(-50%);
-  padding-top: 20px;
-  padding-bottom: 20px;
-  padding-left: 5%;
-}

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -182,3 +182,26 @@ body {
   white-space: normal;
   word-break: break-word;
 }
+
+/* basic filter styles */
+.with-rule-filter-form fieldset {
+  position: relative;
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
+.with-rule-filter-form__group {
+  width: 80%;
+}
+
+.with-rule-filter-form__action {
+  position: absolute;
+  top: 50%;
+  left: calc(85% + 6px);
+  width: 20%;
+  border-left: 1px solid var(--pf-global--BorderColor--100);
+  transform: translateY(-50%);
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-left: 5%;
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.css
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.css
@@ -1,21 +1,37 @@
-.with-rule-filter-form fieldset {
-  position: relative;
-  margin-top: 40px;
+.with-rule-filter-form,
+.with-rule-filter-form .pf-c-page__main-section {
+  flex-grow: 1;
+}
+
+.with-rule-filter-form {
+  display: flex;
+}
+
+.with-rule-filter-form .form-array-fields {
   margin-bottom: 40px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: repeat(3, auto);
+}
+
+.with-rule-filter-form fieldset:first-of-type .form-array-fields {
+  margin-top: 40px;
 }
 
 .with-rule-filter-form__group {
-  width: 80%;
+  grid-column: 1 / 2;
 }
 
 .with-rule-filter-form__action {
-  position: absolute;
-  top: 50%;
-  left: calc(85% + 6px);
-  width: 20%;
+  align-self: center;
+  grid-column: 2 / 3;
+  grid-row: 1 / -1;
   border-left: 1px solid var(--pf-global--BorderColor--100);
-  transform: translateY(-50%);
-  padding-top: 20px;
-  padding-bottom: 20px;
-  padding-left: 5%;
+  padding-top: 30px;
+  padding-bottom: 30px;
+  padding-left: 25px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0;
+  margin-left: 31px;
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.css
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.css
@@ -1,0 +1,21 @@
+.with-rule-filter-form fieldset {
+  position: relative;
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
+.with-rule-filter-form__group {
+  width: 80%;
+}
+
+.with-rule-filter-form__action {
+  position: absolute;
+  top: 50%;
+  left: calc(85% + 6px);
+  width: 20%;
+  border-left: 1px solid var(--pf-global--BorderColor--100);
+  transform: translateY(-50%);
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-left: 5%;
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
@@ -132,8 +132,7 @@ export const WithRuleFilterForm: React.FunctionComponent<
   const validator = (values: IRuleFilterConfig) =>
     validateRequiredProperties(
       definition,
-      (field: string) =>
-        t('integrations:editor:ruleForm:fieldRequired', { field }),
+      (field: string) => '', // return an empty string here so the help text isn't replaced
       values
     );
   return (

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
@@ -103,13 +103,15 @@ export const WithRuleFilterForm: React.FunctionComponent<
       },
       arrayDefinitionOptions: {
         arrayControlAttributes: {
-          className: 'col-md-3 form-group',
+          className: 'form-group with-rule-filter-form__action',
         },
+        /*
         controlLabelAttributes: {
           style: { display: 'none' },
         },
+        */
         formGroupAttributes: {
-          className: 'col-md-3',
+          className: 'with-rule-filter-form__group',
         },
         i18nAddElementText: t('integrations:editor:ruleForm:addRule'),
         minElements: 1,
@@ -139,23 +141,25 @@ export const WithRuleFilterForm: React.FunctionComponent<
       values
     );
   return (
-    <AutoForm<IRuleFilterConfig>
-      definition={toFormDefinition(definition)}
-      i18nRequiredProperty={t('shared:requiredFieldMessage')}
-      initialValue={initialValue}
-      onSave={onSave}
-      validate={validator}
-      validateInitial={validator}
-      key={step.id}
-    >
-      {({ fields, handleSubmit, isSubmitting, isValid, submitForm }) =>
-        children({
-          form: <>{fields}</>,
-          isSubmitting,
-          isValid,
-          submitForm,
-        })
-      }
-    </AutoForm>
+    <div className="with-rule-filter-form">
+      <AutoForm<IRuleFilterConfig>
+        definition={toFormDefinition(definition)}
+        i18nRequiredProperty={t('shared:requiredFieldMessage')}
+        initialValue={initialValue}
+        onSave={onSave}
+        validate={validator}
+        validateInitial={validator}
+        key={step.id}
+      >
+        {({ fields, handleSubmit, isSubmitting, isValid, submitForm }) =>
+          children({
+            form: <>{fields}</>,
+            isSubmitting,
+            isValid,
+            submitForm,
+          })
+        }
+      </AutoForm>
+    </div>
   );
 };

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
@@ -106,16 +106,11 @@ export const WithRuleFilterForm: React.FunctionComponent<
         arrayControlAttributes: {
           className: 'form-group with-rule-filter-form__action',
         },
-        /*
-        controlLabelAttributes: {
-          style: { display: 'none' },
-        },
-        */
         formGroupAttributes: {
           className: 'with-rule-filter-form__group',
         },
         i18nAddElementText: t('integrations:editor:ruleForm:addRule'),
-        minElements: 1,
+        minElements: 1
       },
       required: true,
       type: 'array',

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
@@ -3,6 +3,7 @@ import { FilterOptions, Op, StepKind } from '@syndesis/models';
 import { toFormDefinition, validateRequiredProperties } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import './WithRuleFilterForm.css';
 
 export interface IWithRuleFilterFormChildrenProps {
   form: JSX.Element;


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/6222

@gashcrumb this is as close as I could get while working with the existing markup. I couldn't figure out the auto form components to be able to modify the markup to make this layout easier/better. I'm also not sure where to inject the paragraph of description text that goes above the form fields.

In a perfect world, each of the `<fieldset>` elements would have a nested `<div>` that wraps the form groups so that I could give that a `grid` layout to place the the form groups inside of it.

A more flexible route would be to then wrap the 3 form group elements that create the condition in a `<div>`, then wrap the action/array controls in another element, that would allow me to use `flex` layout, which works in IE (since `grid` does not).

But what's there works, too, I just had to use `absolute` positioning for the delete action button, and %/relative spacing between the form groups and the delete action so it scales properly down to mobile.

Does this look ok, or can you (or point me in the right direction to) change the markup? And the same for injecting the description text before the form fields?