### PR TITLE
chore(cards): replace dashboard/connection pf3 cards/layout with pf4

### DIFF
--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -72,7 +72,7 @@
     "react-router-dom": "^4.3.1"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^2.8.1",
+    "@patternfly/patternfly": "^2.23.2",
     "@patternfly/react-core": "^3.32.9",
     "@patternfly/react-icons": "^3.9.2",
     "@patternfly/react-styles": "^3.2.0",

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
@@ -74,10 +74,10 @@ a.connection-card__content:focus {
   text-decoration: none;
 }
 
-.connection-card__footer--config-required {
+.pf-c-card__footer.connection-card__footer--config-required {
   background-color: #fdf2e5;
   border-color: #ec7a08;
   font-size: smaller;
   text-align: center;
-  padding: 15px;
+  padding: 16px;
 }

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -1,5 +1,8 @@
 import {
   Button,
+  Card,
+  CardBody,
+  CardFooter,
   Dropdown,
   DropdownPosition,
   KebabToggle,
@@ -9,7 +12,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Card, Icon } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { toValidHtmlId } from '../helpers';
@@ -128,7 +131,6 @@ export class ConnectionCard extends React.PureComponent<
         )}
         <Card
           data-testid={`connection-card-${toValidHtmlId(this.props.name)}-card`}
-          matchHeight={true}
           className={'connection-card'}
         >
           {this.props.isTechPreview && (
@@ -229,7 +231,7 @@ export class ConnectionCard extends React.PureComponent<
             to={this.props.href}
             className={'connection-card__content'}
           >
-            <Card.Body>
+            <CardBody>
               <div className={'connection-card__body'}>
                 <div className="connection-card__icon">{this.props.icon}</div>
                 <Title
@@ -246,9 +248,9 @@ export class ConnectionCard extends React.PureComponent<
                   {this.props.description}
                 </Text>
               </div>
-            </Card.Body>
+            </CardBody>
             {this.props.isConfigRequired && (
-              <Card.Footer
+              <CardFooter
                 className={
                   'connection-card__footer--config-required alert alert-warning'
                 }
@@ -256,7 +258,7 @@ export class ConnectionCard extends React.PureComponent<
               >
                 <Icon type={'pf'} name={'warning-triangle-o'} size={'2x'} />
                 {this.props.i18nConfigRequired}
-              </Card.Footer>
+              </CardFooter>
             )}
           </Link>
         </Card>

--- a/app/ui-react/packages/ui/src/Connection/ConnectionsGrid.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionsGrid.tsx
@@ -1,12 +1,8 @@
-import { CardGrid } from 'patternfly-react';
+import { Gallery } from '@patternfly/react-core';
 import * as React from 'react';
 
 export class ConnectionsGrid extends React.Component {
   public render() {
-    return (
-      <CardGrid fluid={true} matchHeight={true}>
-        <CardGrid.Row>{this.props.children}</CardGrid.Row>
-      </CardGrid>
-    );
+    return <Gallery gutter={'sm'}>{this.props.children}</Gallery>;
   }
 }

--- a/app/ui-react/packages/ui/src/Connection/ConnectionsGridCell.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionsGridCell.tsx
@@ -1,12 +1,7 @@
-import { CardGrid } from 'patternfly-react';
 import * as React from 'react';
 
 export class ConnectionsGridCell extends React.Component {
   public render() {
-    return (
-      <CardGrid.Col xs={6} md={3}>
-        {this.props.children}
-      </CardGrid.Col>
-    );
+    return <>{this.props.children}</>;
   }
 }

--- a/app/ui-react/packages/ui/src/Dashboard/ConnectionsMetric.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/ConnectionsMetric.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@patternfly/react-core';
-import { Card } from 'patternfly-react';
+import { Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
 import './ConnectionsMetric.css';
 
@@ -12,10 +12,10 @@ export class ConnectionsMetric extends React.PureComponent<
 > {
   public render() {
     return (
-      <Card accented={true} aggregated={true} matchHeight={true}>
-        <Card.Body className={'connections-metric__body'}>
+      <Card className="aggregate-status">
+        <CardBody className={'connections-metric__body'}>
           <Text>{this.props.i18nTitle}</Text>
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
@@ -11,16 +11,6 @@
   padding: 0 10px;
 }
 
-/* .dashboard__metrics .pf-l-grid__item {
-  margin-bottom: var(--pf-global--spacer--md);
-}
-
-@media screen and (min-width: 768px) {
-  .dashboard__metrics .pf-l-grid__item {
-    margin-bottom: 0;
-  }
-} */
-
 .dashboard__metrics .pf-c-card.aggregate-status {
   padding: 10px 10px 16px 10px;
   text-align: center;
@@ -39,18 +29,3 @@
   --pf-c-card__body--FontSize: var(--pf-global--icon--FontSize--lg);
   font-weight: var(--pf-global--FontWeight--light);
 }
-
-
-/* .dashboard__connections__actions,
-.dashboard__integrations__actions,
-.dashboard__metrics,
-.dashboard__integrations,
-.dashboard__integrations .pf-l-grid__item {
-  margin-bottom: var(--pf-global--spacer--lg);
-}
-
-@media screen and (min-width: 1200px) {
-  .dashboard__integrations .pf-l-grid__item {
-    margin-bottom: 0;
-  }
-} */

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
@@ -11,7 +11,7 @@
   padding: 0 10px;
 }
 
-.dashboard__metrics .pf-l-grid__item {
+/* .dashboard__metrics .pf-l-grid__item {
   margin-bottom: var(--pf-global--spacer--md);
 }
 
@@ -19,7 +19,7 @@
   .dashboard__metrics .pf-l-grid__item {
     margin-bottom: 0;
   }
-}
+} */
 
 .dashboard__metrics .pf-c-card.aggregate-status {
   padding: 10px 10px 16px 10px;
@@ -41,7 +41,7 @@
 }
 
 
-.dashboard__connections__actions,
+/* .dashboard__connections__actions,
 .dashboard__integrations__actions,
 .dashboard__metrics,
 .dashboard__integrations,
@@ -53,4 +53,4 @@
   .dashboard__integrations .pf-l-grid__item {
     margin-bottom: 0;
   }
-}
+} */

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
@@ -3,19 +3,54 @@
   padding: 0.3em 0.8em;
 }
 
+.dashboard__integrations .pf-c-card__header {
+  border-bottom: 1px solid #d1d1d1;
+}
+
 .dashboard__connections__actions {
   padding: 0 10px;
 }
 
-.dashboard__metrics .card-pf.card-pf-aggregate-status {
-  padding: 0 10px 24px 10px;
+.dashboard__metrics .pf-l-grid__item {
+  margin-bottom: var(--pf-global--spacer--md);
 }
 
-.dashboard__metrics .card-pf-title .card-pf-aggregate-status-count {
+@media screen and (min-width: 768px) {
+  .dashboard__metrics .pf-l-grid__item {
+    margin-bottom: 0;
+  }
+}
+
+.dashboard__metrics .pf-c-card.aggregate-status {
+  padding: 10px 10px 16px 10px;
+  text-align: center;
+  min-height: 118px;
+}
+
+.dashboard__metrics .aggregate-status .pf-c-card__body {
+  margin-top: var(--pf-global--spacer--md);
+}
+
+.dashboard__metrics .pf-c-card .pf-c-title .card-pf-aggregate-status-count {
   font-size: 14px;
 }
 
 .dashboard__metrics .metrics-uptime {
-  font-size: 24px;
-  font-weight: 300;
+  --pf-c-card__body--FontSize: var(--pf-global--icon--FontSize--lg);
+  font-weight: var(--pf-global--FontWeight--light);
+}
+
+
+.dashboard__connections__actions,
+.dashboard__integrations__actions,
+.dashboard__metrics,
+.dashboard__integrations,
+.dashboard__integrations .pf-l-grid__item {
+  margin-bottom: var(--pf-global--spacer--lg);
+}
+
+@media screen and (min-width: 1200px) {
+  .dashboard__integrations .pf-l-grid__item {
+    margin-bottom: 0;
+  }
 }

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
       <>
         <SimplePageHeader i18nTitle={this.props.i18nTitle} titleSize={'xl'} />
         <PageSection>
-          <Stack>
+          <Stack gutter={'md'}>
             <StackItem
               className="dashboard__integrations__actions"
               isFilled={false}

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
@@ -1,6 +1,11 @@
-import { Title } from '@patternfly/react-core';
+import {
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { CardGrid, Grid } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { ButtonLink, PageSection } from '../Layout';
@@ -35,70 +40,59 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
       <>
         <SimplePageHeader i18nTitle={this.props.i18nTitle} titleSize={'xl'} />
         <PageSection>
-          <Grid fluid={true}>
-            <Grid.Row className={'show-grid dashboard__integrations__actions'}>
-              <Grid.Col xs={6} xsOffset={6}>
-                <ButtonLink
-                  data-testid={'dashboard-create-integration-button'}
-                  href={this.props.linkToIntegrationCreation}
-                  as={'primary'}
-                  className={'pull-right'}
-                >
-                  {this.props.i18nLinkCreateIntegration}
-                </ButtonLink>
-                <Link
-                  data-testid={'dashboard-integrations-link'}
-                  to={this.props.linkToIntegrations}
-                  className={'pull-right view'}
-                >
-                  {this.props.i18nLinkToIntegrations}
-                </Link>
-              </Grid.Col>
-            </Grid.Row>
-
-            <Grid.Row className={'dashboard__metrics'}>
-              <CardGrid fluid={true} matchHeight={true}>
-                <CardGrid.Row>
-                  <CardGrid.Col sm={6} md={3}>
-                    {this.props.integrationsOverview}
-                  </CardGrid.Col>
-                  <CardGrid.Col sm={6} md={3}>
-                    {this.props.connectionsOverview}
-                  </CardGrid.Col>
-                  <CardGrid.Col sm={6} md={3}>
-                    {this.props.messagesOverview}
-                  </CardGrid.Col>
-                  <CardGrid.Col sm={6} md={3}>
-                    {this.props.uptimeOverview}
-                  </CardGrid.Col>
-                </CardGrid.Row>
-              </CardGrid>
-            </Grid.Row>
-
-            <Grid.Row className={'dashboard__integrations'}>
+          <Stack>
+            <StackItem
+              className="dashboard__integrations__actions"
+              isFilled={false}
+            >
+              <ButtonLink
+                data-testid={'dashboard-create-integration-button'}
+                href={this.props.linkToIntegrationCreation}
+                as={'primary'}
+                className={'pull-right'}
+              >
+                {this.props.i18nLinkCreateIntegration}
+              </ButtonLink>
+              <Link
+                data-testid={'dashboard-integrations-link'}
+                to={this.props.linkToIntegrations}
+                className={'pull-right view'}
+              >
+                {this.props.i18nLinkToIntegrations}
+              </Link>
+            </StackItem>
+            <StackItem className="dashboard__metrics" isFilled={false}>
+              <Grid md={6} xl={3} gutter={'sm'}>
+                <GridItem>{this.props.integrationsOverview}</GridItem>
+                <GridItem>{this.props.connectionsOverview}</GridItem>
+                <GridItem>{this.props.messagesOverview}</GridItem>
+                <GridItem>{this.props.uptimeOverview}</GridItem>
+              </Grid>
+            </StackItem>
+            <StackItem className="dashboard__integrations" isFilled={false}>
               {/* TODO last minute empty state hack with minimal changes, this needs a revisit */
               this.props.noIntegrations ? (
-                <>
-                  <Grid.Col sm={12} md={12}>
-                    {this.props.topIntegrations}
-                  </Grid.Col>
-                </>
+                <>{this.props.topIntegrations}</>
               ) : (
                 <>
-                  <Grid.Col sm={12} md={7}>
-                    {this.props.topIntegrations}
-                  </Grid.Col>
-                  <Grid.Col sm={12} md={5}>
-                    {this.props.integrationBoard}
-                  </Grid.Col>
-                  <Grid.Col sm={12} md={5}>
-                    {this.props.integrationUpdates}
-                  </Grid.Col>
+                  <Grid gutter={'lg'}>
+                    <GridItem xl={7} xlRowSpan={12}>
+                      {this.props.topIntegrations}
+                    </GridItem>
+                    <GridItem lg={6} xl={5} xlRowSpan={6}>
+                      {this.props.integrationBoard}
+                    </GridItem>
+                    <GridItem lg={6} xl={5} xlRowSpan={6}>
+                      {this.props.integrationUpdates}
+                    </GridItem>
+                  </Grid>
                 </>
               )}
-            </Grid.Row>
-
-            <Grid.Row className={'dashboard__connections__actions'}>
+            </StackItem>
+            <StackItem
+              className="dashboard__connections__actions"
+              isFilled={false}
+            >
               <Title size={'lg'} className={'pull-left'}>
                 {this.props.i18nConnections}
               </Title>
@@ -117,14 +111,14 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
               >
                 {this.props.i18nLinkToConnections}
               </Link>
-            </Grid.Row>
-
-            <Grid.Row>
-              <CardGrid fluid={true} matchHeight={true}>
-                <CardGrid.Row>{this.props.connections}</CardGrid.Row>
-              </CardGrid>
-            </Grid.Row>
-          </Grid>
+            </StackItem>
+            <StackItem
+              className="dashboard__connections__grid"
+              isFilled={false}
+            >
+              {this.props.connections}
+            </StackItem>
+          </Stack>
         </PageSection>
       </>
     );

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
@@ -61,6 +61,7 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
                 {this.props.i18nLinkToIntegrations}
               </Link>
             </StackItem>
+
             <StackItem className="dashboard__metrics" isFilled={false}>
               <Grid md={6} xl={3} gutter={'sm'}>
                 <GridItem>{this.props.integrationsOverview}</GridItem>
@@ -69,6 +70,7 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
                 <GridItem>{this.props.uptimeOverview}</GridItem>
               </Grid>
             </StackItem>
+
             <StackItem className="dashboard__integrations" isFilled={false}>
               {/* TODO last minute empty state hack with minimal changes, this needs a revisit */
               this.props.noIntegrations ? (
@@ -89,6 +91,7 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
                 </>
               )}
             </StackItem>
+
             <StackItem
               className="dashboard__connections__actions"
               isFilled={false}
@@ -112,6 +115,7 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
                 {this.props.i18nLinkToConnections}
               </Link>
             </StackItem>
+
             <StackItem
               className="dashboard__connections__grid"
               isFilled={false}

--- a/app/ui-react/packages/ui/src/Dashboard/IntegrationBoard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/IntegrationBoard.tsx
@@ -1,4 +1,5 @@
-import { Card, DonutChart, patternfly } from 'patternfly-react';
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
+import { DonutChart, patternfly } from 'patternfly-react';
 import * as React from 'react';
 
 export interface IIntegrationBoardProps {
@@ -42,10 +43,10 @@ export class IntegrationBoard extends React.PureComponent<
 
     return (
       <Card>
-        <Card.Heading>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
-        </Card.Heading>
-        <Card.Body>
+        <CardHeader>
+          <Title size={'md'}>{this.props.i18nTitle}</Title>
+        </CardHeader>
+        <CardBody>
           <DonutChart
             id="integration-board"
             size={{ height: 120 }}
@@ -60,7 +61,7 @@ export class IntegrationBoard extends React.PureComponent<
             }}
             legend={{ show: true, position: 'right' }}
           />
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesCard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesCard.tsx
@@ -1,4 +1,4 @@
-import { Card } from 'patternfly-react';
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IRecentUpdatesProps {
@@ -8,11 +8,13 @@ export interface IRecentUpdatesProps {
 export class RecentUpdatesCard extends React.Component<IRecentUpdatesProps> {
   public render() {
     return (
-      <Card accented={false}>
-        <Card.Heading>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
-        </Card.Heading>
-        <Card.Body>{this.props.children}</Card.Body>
+      <Card>
+        <CardHeader>
+          <Title size="md" headingLevel="h2">
+            {this.props.i18nTitle}
+          </Title>
+        </CardHeader>
+        <CardBody>{this.props.children}</CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Dashboard/TopIntegrations.css
+++ b/app/ui-react/packages/ui/src/Dashboard/TopIntegrations.css
@@ -1,7 +1,3 @@
-.top-integrations .card-pf-body {
-  margin-left: -20px;
-  margin-right: -20px;
-}
 .top-integrations .integration-list-item {
   padding-left: 20px;
   padding-right: 20px;

--- a/app/ui-react/packages/ui/src/Dashboard/TopIntegrationsCard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/TopIntegrationsCard.tsx
@@ -1,5 +1,5 @@
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Card } from 'patternfly-react';
 import * as React from 'react';
 import { IntegrationsEmptyState } from '../Integration';
 
@@ -20,14 +20,14 @@ export class TopIntegrationsCard extends React.Component<
 > {
   public render() {
     return (
-      <Card accented={false} className={'top-integrations'}>
-        <Card.Heading className={'top-integrations__heading'}>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
+      <Card className={'top-integrations'}>
+        <CardHeader className={'top-integrations__heading'}>
+          <Title size={'md'}>{this.props.i18nTitle}</Title>
           <div className={'top-integrations__heading-daterange'}>
             {this.props.i18nLast30Days}
           </div>
-        </Card.Heading>
-        <Card.Body>
+        </CardHeader>
+        <CardBody>
           {this.props.children ? (
             this.props.children
           ) : (
@@ -39,7 +39,7 @@ export class TopIntegrationsCard extends React.Component<
               linkCreateIntegration={this.props.linkCreateIntegration}
             />
           )}
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
@@ -1,4 +1,4 @@
-import { Card } from 'patternfly-react';
+import { Card, CardBody, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import './UptimeMetric.css';
 
@@ -13,19 +13,14 @@ export class UptimeMetric extends React.PureComponent<IUptimeMetricProps> {
     const startAsDate = new Date(this.props.start);
     const startAsHuman = startAsDate.toLocaleString();
     return (
-      <Card
-        className="metrics-uptime"
-        accented={true}
-        aggregated={true}
-        matchHeight={true}
-      >
-        <Card.Title className="metrics-uptime__header">
+      <Card className="metrics-uptime aggregate-status">
+        <Title size="md" className="metrics-uptime__header">
           <div>{this.props.i18nTitle}</div>
           <div className="metrics-uptime__uptime">since {startAsHuman}</div>
-        </Card.Title>
-        <Card.Body>
+        </Title>
+        <CardBody>
           <span>{this.props.durationDifference}</span>
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Shared/AggregatedMetricCard.tsx
+++ b/app/ui-react/packages/ui/src/Shared/AggregatedMetricCard.tsx
@@ -1,8 +1,8 @@
+import { Card, CardBody, Title } from '@patternfly/react-core';
 import {
   AggregateStatusCount,
   AggregateStatusNotification,
   AggregateStatusNotifications,
-  Card,
   Icon,
 } from 'patternfly-react';
 import * as React from 'react';
@@ -23,8 +23,8 @@ export class AggregatedMetricCard extends React.PureComponent<
 
   public render() {
     return (
-      <Card accented={true} aggregated={true} matchHeight={true}>
-        <Card.Title>
+      <Card className="aggregate-status">
+        <Title size="md">
           <AggregateStatusCount>
             <span data-testid={'aggregated-metric-card-total-count'}>
               {this.formatNumber(this.props.total)}
@@ -34,8 +34,8 @@ export class AggregatedMetricCard extends React.PureComponent<
               {this.props.title}
             </span>
           </AggregateStatusCount>
-        </Card.Title>
-        <Card.Body>
+        </Title>
+        <CardBody>
           <AggregateStatusNotifications>
             <AggregateStatusNotification>
               <Icon type="pf" name="ok" />
@@ -50,7 +50,7 @@ export class AggregatedMetricCard extends React.PureComponent<
               </span>
             </AggregateStatusNotification>
           </AggregateStatusNotifications>
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -12,6 +12,8 @@
 @import url('~@patternfly/patternfly/utilities/Spacing/spacing.css');
 @import url('~@patternfly/patternfly/layouts/Level/level.css');
 @import url('~@patternfly/patternfly/layouts/Split/split.css');
+/* @import url('~@patternfly/patternfly/layouts/Stack/stack.css'); */
+/* @import url('~@patternfly/patternfly/layouts/Gallery/gallery.css'); */
 @import url('~@patternfly/patternfly/utilities/Display/display.css');
 
 :root {

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -12,8 +12,6 @@
 @import url('~@patternfly/patternfly/utilities/Spacing/spacing.css');
 @import url('~@patternfly/patternfly/layouts/Level/level.css');
 @import url('~@patternfly/patternfly/layouts/Split/split.css');
-/* @import url('~@patternfly/patternfly/layouts/Stack/stack.css'); */
-/* @import url('~@patternfly/patternfly/layouts/Gallery/gallery.css'); */
 @import url('~@patternfly/patternfly/utilities/Display/display.css');
 
 :root {
@@ -23,6 +21,7 @@
   --pf-global--link--Color--hover: #00659c;
   --pf-c-backdrop--Color: rgba(3,3,3,.62);
   --pf-c-popover__content--PaddingRight: 3rem;
+  --pf-global--gutter--md: 1.5rem;
 }
 
 .pf-c-page__header-brand-link .pf-c-brand {

--- a/app/ui-react/syndesis/src/app/App.css
+++ b/app/ui-react/syndesis/src/app/App.css
@@ -1,2 +1,6 @@
 @import url('~@syndesis/ui/dist/ui.css');
 @import url('~@syndesis/auto-form/dist/auto-form.css');
+
+body {
+  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+}

--- a/app/ui-react/syndesis/src/app/App.tsx
+++ b/app/ui-react/syndesis/src/app/App.tsx
@@ -33,10 +33,6 @@ export const App: React.FunctionComponent<IAppBaseProps> = ({
   config,
   routes,
 }) => {
-  const logout = () => {
-    // do nothing
-  };
-
   const getPodLogUrl = (
     monitoring: IntegrationMonitoring | undefined
   ): string | undefined => {
@@ -69,7 +65,6 @@ export const App: React.FunctionComponent<IAppBaseProps> = ({
           value={{
             config,
             getPodLogUrl,
-            logout,
             user: data,
           }}
         >

--- a/app/ui-react/syndesis/src/index.css
+++ b/app/ui-react/syndesis/src/index.css
@@ -1,5 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: "Open Sans", Helvetica, Arial, sans-serif;
-}

--- a/app/ui-react/syndesis/src/index.tsx
+++ b/app/ui-react/syndesis/src/index.tsx
@@ -14,7 +14,6 @@ import * as ReactDOM from 'react-dom';
 import { I18nextProvider, Translation } from 'react-i18next';
 import { Router } from 'react-router-dom';
 import i18n from './i18n';
-import './index.css';
 import { ApiClientConnectorsModule } from './modules/apiClientConnectors';
 import { ConnectionsModule } from './modules/connections';
 import { DashboardModule } from './modules/dashboard';

--- a/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
@@ -57,88 +57,95 @@ export class Connections extends React.Component<IConnectionsProps> {
                     };
 
                     return (
-                      <ConnectionsGrid>
-                        <WithLoader
-                          error={this.props.error}
-                          loading={this.props.loading}
-                          loaderChildren={
-                            <>
-                              {new Array(5).fill(0).map((_, index) => (
-                                <ConnectionsGridCell key={index}>
-                                  <ConnectionSkeleton />
-                                </ConnectionsGridCell>
-                              ))}
-                            </>
-                          }
-                          errorChildren={
-                            <ApiError error={this.props.errorMessage!} />
-                          }
-                        >
-                          {() =>
-                            this.props.connections.map((c, index) => {
-                              const handleDelete = (): void => {
-                                doDelete(c.id!, c.name); // must have an ID if deleting
-                              };
-
-                              return (
-                                <ConnectionsGridCell key={index}>
-                                  <ConnectionCard
-                                    name={c.name}
-                                    description={c.description || ''}
-                                    icon={
-                                      <EntityIcon
-                                        entity={c}
-                                        alt={c.name}
-                                        width={46}
-                                      />
-                                    }
-                                    href={this.props.getConnectionHref(c)}
-                                    i18nCannotDelete={t('cannotDelete')}
-                                    i18nConfigRequired={t(
-                                      'configurationRequired'
-                                    )}
-                                    i18nTechPreview={t('shared:techPreview')}
-                                    isConfigRequired={c.isConfigRequired}
-                                    isTechPreview={c.isTechPreview}
-                                    menuProps={
-                                      this.props.includeConnectionMenu
-                                        ? {
-                                            editHref: this.props
-                                              .getConnectionEditHref!(c),
-                                            i18nCancelLabel: t('shared:Cancel'),
-                                            i18nDeleteLabel: t('shared:Delete'),
-                                            i18nDeleteModalMessage: t(
-                                              'deleteModalMessage',
-                                              { connectionName: c.name }
+                      <WithLoader
+                        error={this.props.error}
+                        loading={this.props.loading}
+                        loaderChildren={
+                          <>
+                            {new Array(5).fill(0).map((_, index) => (
+                              <ConnectionsGridCell key={index}>
+                                <ConnectionSkeleton />
+                              </ConnectionsGridCell>
+                            ))}
+                          </>
+                        }
+                        errorChildren={
+                          <ApiError error={this.props.errorMessage!} />
+                        }
+                      >
+                        {() => {
+                          return (
+                            <ConnectionsGrid>
+                              {this.props.connections.map((c, index) => {
+                                const handleDelete = (): void => {
+                                  doDelete(c.id!, c.name); // must have an ID if deleting
+                                };
+                                return (
+                                  <ConnectionsGridCell key={index}>
+                                    <ConnectionCard
+                                      name={c.name}
+                                      description={c.description || ''}
+                                      icon={
+                                        <EntityIcon
+                                          entity={c}
+                                          alt={c.name}
+                                          width={46}
+                                        />
+                                      }
+                                      href={this.props.getConnectionHref(c)}
+                                      i18nCannotDelete={t('cannotDelete')}
+                                      i18nConfigRequired={t(
+                                        'configurationRequired'
+                                      )}
+                                      i18nTechPreview={t('shared:techPreview')}
+                                      isConfigRequired={c.isConfigRequired}
+                                      isTechPreview={c.isTechPreview}
+                                      menuProps={
+                                        this.props.includeConnectionMenu
+                                          ? {
+                                              editHref: this.props
+                                                .getConnectionEditHref!(c),
+                                              i18nCancelLabel: t(
+                                                'shared:Cancel'
+                                              ),
+                                              i18nDeleteLabel: t(
+                                                'shared:Delete'
+                                              ),
+                                              i18nDeleteModalMessage: t(
+                                                'deleteModalMessage',
+                                                { connectionName: c.name }
+                                              ),
+                                              i18nDeleteModalTitle: t(
+                                                'deleteModalTitle'
+                                              ),
+                                              i18nEditLabel: t('shared:Edit'),
+                                              i18nMenuTitle: t(
+                                                'connectionCardMenuTitle'
+                                              ),
+                                              i18nViewLabel: t('shared:View'),
+                                              isDeleteEnabled:
+                                                (c.uses as number) === 0,
+                                              onDelete: handleDelete,
+                                            }
+                                          : undefined
+                                      }
+                                      techPreviewPopoverHtml={
+                                        <span
+                                          dangerouslySetInnerHTML={{
+                                            __html: t(
+                                              'shared:techPreviewPopoverHtml'
                                             ),
-                                            i18nDeleteModalTitle: t(
-                                              'deleteModalTitle'
-                                            ),
-                                            i18nEditLabel: t('shared:Edit'),
-                                            i18nMenuTitle: t(
-                                              'connectionCardMenuTitle'
-                                            ),
-                                            i18nViewLabel: t('shared:View'),
-                                            isDeleteEnabled:
-                                              (c.uses as number) === 0,
-                                            onDelete: handleDelete,
-                                          }
-                                        : undefined
-                                    }
-                                    techPreviewPopoverHtml={
-                                      <span
-                                        dangerouslySetInnerHTML={{
-                                          __html: t('shared:techPreviewPopoverHtml'),
-                                        }}
-                                      />
-                                    }
-                                  />
-                                </ConnectionsGridCell>
-                              );
-                            })
-                          }
-                        </WithLoader>
-                      </ConnectionsGrid>
+                                          }}
+                                        />
+                                      }
+                                    />
+                                  </ConnectionsGridCell>
+                                );
+                              })}
+                            </ConnectionsGrid>
+                          );
+                        }}
+                      </WithLoader>
                     );
                   }}
                 </WithConnectionHelpers>

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2614,7 +2614,7 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@patternfly/patternfly@1.0.250", "@patternfly/patternfly@2.6.6", "@patternfly/patternfly@^2.8.1":
+"@patternfly/patternfly@1.0.250", "@patternfly/patternfly@2.6.6", "@patternfly/patternfly@^2.23.2":
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.6.6.tgz#d4ba153f0b1470fbc91ea308c8c7260c9bcb0d28"
   integrity sha512-lKbsTE/VlU1BiVzeo0BhfDe/qeqIqheejBz0qAm3CYuHyfUXd4+Uu+/9lfEB2EMb+wXpK4Np74OHtYCC82fP0Q==


### PR DESCRIPTION
This PR upgrades several Card views from PF3 to PF4. I also swapped out any usages of PF3 Card Grid while I was in there. There's a little bit of fine-tuning to do regarding spacing in the main dashboard layout but wanted to go ahead and raise this PR so we can start getting any feedback people may have.

It's an incremental step toward https://github.com/syndesisio/syndesis/issues/6240

Addresses card views in the following components.

- ConnectionCard
- ConnectionsGrid
- ConnectionsGridCell
- ConnectionsMetric
- Dashboard
- IntegrationBoard
- RecentUpdatesCard
- TopIntegrationsCard
- UptimeMetric
- AggregatedMetricCard

<img width="559" alt="Screen Shot 2019-07-30 at 12 51 08 PM" src="https://user-images.githubusercontent.com/5942899/62149092-fa0efb80-b2c8-11e9-8f35-e6b4e2bd292c.png">

<img width="776" alt="Screen Shot 2019-07-30 at 12 51 32 PM" src="https://user-images.githubusercontent.com/5942899/62149093-faa79200-b2c8-11e9-8e6b-7434b0cb7b61.png">

<img width="1241" alt="Screen Shot 2019-07-30 at 12 51 46 PM" src="https://user-images.githubusercontent.com/5942899/62149094-faa79200-b2c8-11e9-8be2-bedb88b373d0.png">

