### PR TITLE
TTOOLS-715 Adapt to backend changes

### DIFF
--- a/app/ui-react/packages/api/src/useViewEditorStates.tsx
+++ b/app/ui-react/packages/api/src/useViewEditorStates.tsx
@@ -1,10 +1,10 @@
 import { ViewEditorState } from '@syndesis/models';
 import { useApiResource } from './useApiResource';
 
-export const useViewEditorStates = (idPattern?: string) => {
+export const useViewEditorStates = (virtualization: string) => {
   const url =
     'service/userProfile/viewEditorState' +
-    (idPattern ? '?pattern=' + idPattern : '');
+    (virtualization ? '?virtualization=' + virtualization : '');
   return useApiResource<ViewEditorState[]>({
     defaultValue: [],
     url,

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
@@ -44,7 +44,7 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
   const { resource: virtualization } = useVirtualization(params.virtualizationId);
 
   const { resource: editorStates } = useViewEditorStates(
-    virtualization.serviceVdbName + '*'
+    virtualization.keng__id
   );
   const publishingDetails = getPublishingDetails(
     appContext.config.consoleUrl,

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -106,7 +106,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
     hasData: hasEditorStates,
     error: editorStatesError,
     read,
-  } = useViewEditorStates(virtualization.serviceVdbName + '*');
+  } = useViewEditorStates(params.virtualizationId);
 
   const publishingDetails = getPublishingDetails(
     appContext.config.consoleUrl,

--- a/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
@@ -70,7 +70,7 @@ export const SelectViewsPage: React.FunctionComponent = () => {
 
   const virtualization = state.virtualization;
   const { resource: editorStates } = useViewEditorStates(
-    virtualization.serviceVdbName + '*'
+    virtualization.keng__id
   );
 
   const handleCreateViews = async () => {


### PR DESCRIPTION
Adapting to backend service change.  Editor states service now accepts a virtualizationId, rather than a name pattern.