### PR TITLE
fix(ci): nightly CircleCi integration test execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,38 +645,7 @@ jobs:
           destination: /images/syndesis-upgrade.tar.gz
       - <<: *quay_transfer
 
-  # Test support depends on integration, server, mount workspace .m2
-  test-support:
-    <<: *job_defaults
-    environment:
-      <<: *common_env
-    steps:
-      - checkout
-      - restore_cache:
-          key: syndesis-mvn-test-{{ checksum "app/test/pom.xml" }}
-      - <<: *checkout_git_mvn_repo
-      - <<: *attach_m2_workspace
-      - run:
-          name: Build Test Support
-          command: |
-            if [[  "$SYNDESIS_GIT_MVN_REPO" != "" ]] ; then
-              GOAL_ARGS="-g deploy"
-            fi
-            ./tools/bin/syndesis build ${GOAL_ARGS} ${INCREMENTAL} --batch-mode --module :test-parent,:test-support | tee build_log.txt
-      - <<: *save_junit
-      - store_test_results:
-          path: /workspace/junit
-      - store_artifacts:
-          path: build_log.txt
-      - <<: *persist_m2_workspace
-      - <<: *checkin_git_mvn_repo
-      - <<: *scrub_m2_cache
-      - save_cache:
-          key: syndesis-mvn-test-{{ checksum "app/test/pom.xml" }}
-          paths:
-            - ~/.m2
-
-  # Integration test depends on test-support
+  # Integration test
   integration-test:
     environment:
       <<: *common_env
@@ -689,14 +658,22 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            mkdir -p /tmp/src
+            mkdir -p ~/integrations/
             mkdir -p ~/junit/
-            ./tools/bin/syndesis integration-test | tee ~/test_log.txt
+            mkdir -p ~/logs/
+            ./tools/bin/syndesis integration-test --output /home/circleci/integrations | tee ~/logs/test_log.txt
+            cp ./app/test/integration-test/target/integration-runtime.log ~/logs/
+      - run:
+          name: Collect test results
+          when: always
+          command: |
             find . -type f -regextype posix-extended -regex ".*target/.*TESTS?-.*xml" | xargs -i cp --backup --suffix=.xml {} ~/junit
       - store_test_results:
           path: ~/junit
       - store_artifacts:
-          path: ~/test_log.txt
+          path: ~/logs
+      - store_artifacts:
+          path: ~/integrations
 
   system-test:
     <<: *job_defaults
@@ -1192,10 +1169,6 @@ workflows:
       - s2i:
           requires:
             - server
-      - test-support:
-          requires:
-            - s2i
       - integration-test:
           requires:
             - s2i
-            - test-support

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -36,13 +36,14 @@
 
     <syndesis.integration.runtime>spring-boot</syndesis.integration.runtime>
     <syndesis.camel.k.customizers>health,logging,syndesis</syndesis.camel.k.customizers>
-    <syndesis.logging.enabled>false</syndesis.logging.enabled>
+    <syndesis.logging.enabled>true</syndesis.logging.enabled>
     <syndesis.server.port>8080</syndesis.server.port>
     <syndesis.management.port>8081</syndesis.management.port>
     <syndesis.debug.port>5005</syndesis.debug.port>
     <syndesis.debug.enabled>false</syndesis.debug.enabled>
     <syndesis.s2i.build.enabled>false</syndesis.s2i.build.enabled>
     <syndesis.output.directory>${project.build.directory}/integrations</syndesis.output.directory>
+    <syndesis.project.mount.path>/tmp/src</syndesis.project.mount.path>
     <syndesis.image.tag>${syndesis.version}</syndesis.image.tag>
   </properties>
 
@@ -199,13 +200,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <!-- Required only for CircleCi build as the used JVM to run the tests has limited cryptography -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -225,6 +219,7 @@
             <syndesis.debug.enabled>${syndesis.debug.enabled}</syndesis.debug.enabled>
             <syndesis.s2i.build.enabled>${syndesis.s2i.build.enabled}</syndesis.s2i.build.enabled>
             <syndesis.output.directory>${syndesis.output.directory}</syndesis.output.directory>
+            <syndesis.project.mount.path>${syndesis.project.mount.path}</syndesis.project.mount.path>
             <syndesis.image.tag>${syndesis.image.tag}</syndesis.image.tag>
           </systemProperties>
         </configuration>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
@@ -66,7 +66,7 @@ public class WebHookToFtp_IT extends FtpTestSupport {
     @ClassRule
     public static SyndesisIntegrationRuntimeContainer integrationContainer = new SyndesisIntegrationRuntimeContainer.Builder()
             .name("webhook-to-ftp")
-            .fromExport(WebHookToFtp_IT.class.getResource("WebHookToFtp-export"))
+            .fromExport(WebHookToFtp_IT.class.getResource("WebhookToFtp-export"))
             .customize("$..configuredProperties.contextPath", "contact")
             .customize("$..configuredProperties.directoryName", "public")
             .customize("$..configuredProperties.host", GenericContainer.INTERNAL_HOST_HOSTNAME)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
@@ -53,7 +53,7 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
     @ClassRule
     public static SyndesisIntegrationRuntimeContainer integrationContainer = new SyndesisIntegrationRuntimeContainer.Builder()
                             .name("webhook-to-db")
-                            .fromExport(Webhook2DB_IT.class.getResource("Webhook2DB-export"))
+                            .fromExport(Webhook2DB_IT.class.getResource("Webhook2Db-export"))
                             .customize("$..configuredProperties.contextPath", "quickstart")
                             .build()
                             .withNetwork(getSyndesisDb().getNetwork())

--- a/app/test/pom.xml
+++ b/app/test/pom.xml
@@ -32,6 +32,18 @@
 
   <name>Test</name>
 
+  <build>
+    <plugins>
+      <!-- Required only for CircleCi build as the used JVM to run the tests has limited cryptography -->
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencyManagement>
     <dependencies>
       <!-- Redefine Activemq deps -->

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -28,6 +28,22 @@
   <artifactId>test-support</artifactId>
   <name>Test :: Support</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.syndesis.server</groupId>
+        <artifactId>server-endpoint</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.github.mikegirard</groupId>
+            <artifactId>spring-social-salesforce</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- === Internal dependencies (don't touch without discussion) ========================== -->
     <dependency>

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -28,7 +28,7 @@ import io.syndesis.test.model.IntegrationRuntime;
 public final class SyndesisTestEnvironment {
 
     private static final String SYNDESIS_PREFIX = "syndesis.";
-    private static final String SYNDESIS_ENV_PREFIX = "SYNDESIS";
+    private static final String SYNDESIS_ENV_PREFIX = "SYNDESIS_";
 
     /** System property names */
     private static final String CAMEL_VERSION = "camel.version";
@@ -81,6 +81,10 @@ public final class SyndesisTestEnvironment {
     private static final String SYNDESIS_OUTPUT_DIRECTORY_DEFAULT = "target/integrations";
     private static final String SYNDESIS_OUTPUT_DIRECTORY = SYNDESIS_PREFIX + "output.directory";
     private static final String SYNDESIS_OUTPUT_DIRECTORY_ENV = SYNDESIS_ENV_PREFIX + "OUTPUT_DIRECTORY";
+
+    private static final String SYNDESIS_PROJECT_MOUNT_PATH_DEFAULT = "/tmp/src";
+    private static final String SYNDESIS_PROJECT_MOUNT_PATH = SYNDESIS_PREFIX + "project.mount.path";
+    private static final String SYNDESIS_PROJECT_MOUNT_PATH_ENV = SYNDESIS_ENV_PREFIX + "PROJECT_MOUNT_PATH";
 
     /**
      * Prevent instantiation of utility class.
@@ -169,5 +173,10 @@ public final class SyndesisTestEnvironment {
                 System.getenv(SYNDESIS_CAMEL_K_CUSTOMIZERS_ENV) : SYNDESIS_CAMEL_K_CUSTOMIZERS_DEFAULT)
                 .split(",", -1))
                 .collect(Collectors.toList());
+    }
+
+    public static String getProjectMountPath() {
+        return System.getProperty(SYNDESIS_PROJECT_MOUNT_PATH, System.getenv(SYNDESIS_PROJECT_MOUNT_PATH_ENV) != null ?
+                System.getenv(SYNDESIS_PROJECT_MOUNT_PATH_ENV) : SYNDESIS_PROJECT_MOUNT_PATH_DEFAULT);
     }
 }

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.test.container.dockerfile;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+import io.syndesis.test.SyndesisTestEnvironment;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * Special on the fly Dockerfile builder that automatically adds project sources as directory of jar file to the image.
+ * Also takes care on proper file permissions and user settings in the container.
+ *
+ * @author Christoph Deppisch
+ */
+public class SyndesisDockerfileBuilder extends ImageFromDockerfile {
+
+    private static final String ROOT = "0";
+    private static final String JBOSS = "jboss";
+
+    private String from;
+    private String runCommand;
+    private String projectSrc;
+    private String projectDest;
+    private Path projectPath;
+    private Map<String, String> envProperties = Collections.singletonMap("SYNDESIS_VERSION",
+                                                                         SyndesisTestEnvironment.getSyndesisVersion());
+
+    public SyndesisDockerfileBuilder(String dockerImageName, boolean deleteOnExit) {
+        super(dockerImageName, deleteOnExit);
+    }
+
+    public SyndesisDockerfileBuilder build() {
+        return (SyndesisDockerfileBuilder)
+                withFileFromPath(projectSrc, projectPath)
+                .withDockerfileFromBuilder(builder -> builder.from(from)
+                    .env(envProperties)
+                    .user(ROOT)
+                    .copy(projectSrc, projectDest)
+                    .run(fixGroupsCommand())
+                    .run(fixPermissionsCommand())
+                    .user(JBOSS)
+                    .expose(SyndesisTestEnvironment.getDebugPort())
+                    .cmd(runCommand)
+                .build());
+    }
+
+    private String[] fixGroupsCommand() {
+        return  new String [] { "chgrp", "-R", "0", projectDest };
+    }
+
+    private String[] fixPermissionsCommand() {
+        return new String [] { "chmod", "-R", "g=u", projectDest };
+    }
+
+    public SyndesisDockerfileBuilder from(String image, String tag) {
+        this.from = String.format("%s:%s", image, tag);
+        return this;
+    }
+
+    public SyndesisDockerfileBuilder env(Map<String, String> envProperties) {
+        this.envProperties = envProperties;
+        return this;
+    }
+
+    public SyndesisDockerfileBuilder cmd(String runCommand) {
+        this.runCommand = runCommand;
+        return this;
+    }
+
+    /**
+     * Adds the Syndesis integration project as directory of jar file resource.
+     * @param projectSrc the source marker as key added to the Dockerfile context.
+     * @param projectDest the destination path in the container.
+     * @param projectPath the actual path to the project sources on the host.
+     * @return
+     */
+    public SyndesisDockerfileBuilder project(String projectSrc, String projectDest, Path projectPath) {
+        this.projectSrc = projectSrc;
+        this.projectDest = projectDest;
+        this.projectPath = projectPath;
+        return this;
+    }
+}

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
@@ -37,6 +37,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAssemblyContainer> {
 
     private static final String S2I_ASSEMBLE_SCRIPT = "/usr/local/s2i/assemble";
+    private static final String SRC_DIR = "/tmp/src";
 
     public SyndesisS2iAssemblyContainer(String integrationName, Path projectDir, String imageTag) {
         super(new ImageFromDockerfile(integrationName + "-s2i", true)
@@ -44,7 +45,8 @@ public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAs
                         .cmd(S2I_ASSEMBLE_SCRIPT)
                         .build()));
 
-        withFileSystemBind(projectDir.toAbsolutePath().toString(), "/tmp/src", BindMode.READ_WRITE);
+        withFileSystemBind(projectDir.toAbsolutePath().toString(), SRC_DIR, BindMode.READ_WRITE);
+
         waitingFor(new LogMessageWaitStrategy().withRegEx(".*\\.\\.\\. done.*\\s")
                                                .withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
     }

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/project/AbstractMavenProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/project/AbstractMavenProjectBuilder.java
@@ -40,11 +40,16 @@ import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.integration.source.IntegrationSource;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christoph Deppisch
  */
 public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProjectBuilder<T>> implements ProjectBuilder {
+
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractMavenProjectBuilder.class);
 
     private final String name;
     private final String syndesisVersion;
@@ -63,6 +68,9 @@ public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProject
     public Path build(IntegrationSource source) {
         try {
             Path projectDir = Files.createTempDirectory(outputDir, name);
+
+            LOG.info(String.format("Building integration project in directory: '%s'", projectDir.toAbsolutePath()));
+
             ProjectGenerator projectGenerator = new ProjectGenerator(projectGeneratorConfiguration,
                     new StaticIntegrationResourceManager(source),
                     mavenProperties);

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
@@ -30,11 +30,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.common.util.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christoph Deppisch
  */
 public class IntegrationExportSource implements IntegrationSource {
+
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(IntegrationExportSource.class);
 
     private final JsonNode model;
 
@@ -44,6 +49,8 @@ public class IntegrationExportSource implements IntegrationSource {
 
     public IntegrationExportSource(Path pathToExport) {
         try {
+            LOG.info(String.format("Reading integration export source: '%s'", pathToExport.toAbsolutePath()));
+
             if (pathToExport.toFile().isDirectory()) {
                 this.model = readModel(pathToExport);
             } else {

--- a/tools/bin/commands/integration-test
+++ b/tools/bin/commands/integration-test
@@ -8,14 +8,19 @@ integration-test::usage() {
     cat - <<EOT
 -t  --test <test_name>         The test to run
 -c  --clean                    Run clean builds (mvn clean)
-    --release                  Syndesis version to use
+    --release <version>        Syndesis version to use
+    --image <tag>              Syndesis S2i image tag to use
+    --logging                  Container logging enabled
+    --s2i                      S2i build enabled
+    --mount-path <path>        Container mount path for integration projects
+-o  --output <directory_path>  Integration project output directory
 EOT
 }
 
 integration-test::run() {
     source "$(basedir)/commands/util/maven_funcs"
 
-    call_maven "$(maven_args)" ":integration-test"
+    call_maven "$(maven_args)" ":test-parent,:test-support,:integration-test"
 }
 
 maven_args() {
@@ -35,6 +40,29 @@ maven_args() {
     local release_version="$(readopt --release)"
     if [ -n "${release_version}" ]; then
         args="$args -Dsyndesis.version=${release_version}"
+    fi
+
+    local image_tag="$(readopt --image)"
+    if [ -n "${image_tag}" ]; then
+        args="$args -Dsyndesis.image.tag=${image_tag}"
+    fi
+
+    if [ "$(hasflag --logging)" ]; then
+        args="$args -Dsyndesis.logging.enabled=true"
+    fi
+
+    if [ "$(hasflag --s2i)" ]; then
+        args="$args -Dsyndesis.s2i.build.enabled=true"
+    fi
+
+    local output_directory="$(readopt --output -o)"
+    if [ -n "${output_directory}" ]; then
+        args="$args -Dsyndesis.output.directory=${output_directory}"
+    fi
+
+    local mount_path="$(readopt --mount-path)"
+    if [ -n "${mount_path}" ]; then
+        args="$args -Dsyndesis.project.mount.path=${mount_path}"
     fi
 
     args="$args -Dskip.integration.tests=false"


### PR DESCRIPTION
PR fixes integration test execution on CircleCi

The issues were related to copying/mounting files (the Syndesis integration project) to the S2i image. The file permissions got messed up as the container is run with another user that is not the owner of the files copied/mounted.

For some reason this is not an issue on MacOS with Docker for desktop but it was on CircleCi. That made error analysis a bit more complicated.

I solved the issue with taking care of file permissions as recommended by S2i best practices.