### PR TITLE
chore(ci): store docker images as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,11 @@ push_images: &push_images
         for image in ${IMAGES_TO_PUSH} ; do
           docker push syndesis/${image}:latest | cat -
         done
-      fi
-      if [[ "${CIRCLE_TAG}" =~ ^[0-9]+(\.[0-9]+){2} ]]; then
+      elif [ -n "${CIRCLE_PR_NUMBER}" ]; then
+        for image in ${IMAGES_TO_PUSH} ; do
+          docker save syndesis/${image}:${CIRCLE_TAG} |gzip > ${image}.tar.gz
+        done
+      elif [[ "${CIRCLE_TAG}" =~ ^[0-9]+(\.[0-9]+){2} ]]; then
         docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
         for image in ${IMAGES_TO_PUSH} ; do
           docker push syndesis/${image}:${CIRCLE_TAG} | cat -
@@ -121,6 +124,8 @@ jobs:
           paths:
             - ~/.m2
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
 
   ui-legacy:
     <<: *job_defaults
@@ -161,6 +166,8 @@ jobs:
           paths:
             - ~/.m2
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
 
   # All connectors job depends on integration, mount workspace .m2
   connectors:
@@ -293,6 +300,8 @@ jobs:
       - store_artifacts:
           path: build_log.txt
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
       - <<: *save_m2
       - save_cache:
           key: syndesis-mvn-meta-{{ checksum "app/meta/pom.xml" }}
@@ -393,6 +402,8 @@ jobs:
       - store_artifacts:
           path: build_log.txt
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
       - <<: *save_m2
       - save_cache:
           key: syndesis-mvn-s2i-{{ checksum "app/s2i/pom.xml" }}
@@ -432,6 +443,8 @@ jobs:
       - store_artifacts:
           path: build_log.txt
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
       - <<: *save_m2
       - save_cache:
           key: syndesis-mvn-server-{{ checksum "app/server/pom.xml" }}
@@ -454,6 +467,8 @@ jobs:
       - store_artifacts:
           path: build_log.txt
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
 
   upgrade:
     <<: *job_defaults
@@ -481,6 +496,8 @@ jobs:
           command: |
             ./tools/bin/syndesis build --batch-mode --module upgrade --docker
       - <<: *push_images
+      - store_artifacts:
+          path: "*.tar.gz"
 
   # Test support depends on integration, server, mount workspace .m2
   test-support:


### PR DESCRIPTION
The idea here is that the stored artifacts can be downloaded and then imported into quay.io

Ref #6306