### PR TITLE
Fix #6292 : exclude org.json:json from openshift-client

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2462,8 +2462,18 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${kubernetes.client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
-
   </dependencyManagement>
 
   <!-- Metadata need to publish to central -->


### PR DESCRIPTION
https://github.com/syndesisio/syndesis/issues/6292

Excluding org.json:json from openshift-client.    I believe the reason that I'm seeing this in the dev build and it's not seen in syndesis ci is that we're building and aligning to a newer version of kubernetes-client (which produces io.fabric:openshift-client)