### PR TITLE
fix: add connector-parent module to connector-support job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       - run:
           name: Build Connector Support
           command: |
-            ./tools/bin/syndesis build --batch-mode --module :connector-support-util,:connector-support-verifier,:connector-support-maven-plugin,:connector-support-processor,:connector-support-test | tee build_log.txt
+            ./tools/bin/syndesis build --batch-mode --module :connector-parent,:connector-support-util,:connector-support-verifier,:connector-support-maven-plugin,:connector-support-processor,:connector-support-test | tee build_log.txt
       - <<: *save_junit
       - store_test_results:
           path: /workspace/junit


### PR DESCRIPTION
Seems that the individual connector jobs fail on CI because of missing connector-parent artifact in the local Maven repository. This adds it to the list of modules being build in the connector-support job that precedes the individual connector jobs.