### PR TITLE
chore(tool): configure devImages: true

### DIFF
--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -161,7 +161,7 @@ minishift::run() {
         if [ -z "$route" ]; then
             route="syndesis.$(minishift ip).nip.io"
         fi
-        result=$(create_syndesis "$route" "https://$(minishift ip):8443/console")
+        result=$(create_syndesis "$route" "https://$(minishift ip):8443/console" "with_dev_images")
         check_error "$result"
 
         # Wait until everything's up and finally patch imagestreams for triggers

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -224,6 +224,7 @@ deploy_syndesis_operator() {
 create_syndesis() {
     local route="${1:-}"
     local console="${2:-}"
+    local force_dev="${3:-}"
 
     local syndesis_installed=$(oc get syndesis -o name | wc -l)
     local force=$(hasflag --force)
@@ -241,6 +242,16 @@ metadata:
 spec:
 EOT
 )
+    if [ $(hasflag --dev) ] || [ -n "$force_dev" ]; then
+        extra=$(cat <<EOT
+
+  devImages: true
+EOT
+)
+
+        syndesis="${syndesis}${extra}"
+    fi
+
     local extra=""
     if [ -n "$console" ]; then
         extra=$(cat <<EOT


### PR DESCRIPTION
This configures Syndesis custom resource option `devImages` to `true`, to configure that the images for meta, server and ui are not pulled from Docker Hub but from the internal OpenShift registry.

When running `syndesis minishift --install` or `syndesis install --dev` this will result in no meta, server or ui pods being deployed as they first need to be built.

This is a start, perhaps a good follow up would be to import images from the Docker Hub initially, not sure where would that code be, seems natural that it would be in the operator.