### PR TITLE
[chore] Add --nodev flag to syndesis minishift --install

### DIFF
--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -45,6 +45,7 @@ minishift::usage() {
     --datavirt                Install Data Virtualizations.
     --maven-mirror            Install Maven Mirror to be used with --maven-mirror when building.
     --deploy-latest           Deploy latest tags from dockerhub.
+    --nodev                   Do not set the devImages flag in CR (deploys all images)
 EOT
 }
 
@@ -161,7 +162,13 @@ minishift::run() {
         if [ -z "$route" ]; then
             route="syndesis.$(minishift ip).nip.io"
         fi
-        result=$(create_syndesis "$route" "https://$(minishift ip):8443/console" "with_dev_images")
+
+        local dev_images="with_dev_images"
+        if [ $(hasflag --nodev) ] ; then
+            dev_images=""
+        fi
+
+        result=$(create_syndesis "$route" "https://$(minishift ip):8443/console" "$dev_images")
         check_error "$result"
 
         # Wait until everything's up and finally patch imagestreams for triggers


### PR DESCRIPTION
Often the easiest way for QE to deploy latest syndesis is with `syndesis minishift --install`. With the recent addition of the `devImages` flag (#6348 ), it would now also mean we'd have to build the images ourselves. 

Adding a `--nodev` flag to `syndesis minishift` that will restore the original behaviour.