### PR TITLE
Fixes view header display issue when navigating back and forth from view output tab to SQL tab

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContentSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContentSkeleton.tsx
@@ -1,0 +1,91 @@
+// import { Split, SplitItem } from '@patternfly/react-core';
+import * as React from 'react';
+import ContentLoader from 'react-content-loader';
+
+export const SqlClientContentSkeleton: React.FunctionComponent<{}> = props => {
+  const inputWidth = 200;
+  const rectHeight = 20;
+  const spacing = 30;
+  const startY = 50;
+  const xPos = 30;
+  let yPos = startY;
+
+  const colWidth = 75;
+  const gap = 1;
+  const rowHeight = 25;
+  const tableX = xPos + inputWidth + 40;
+  const tableY = 25;
+
+  return (
+    <ContentLoader
+      height={600}
+      width={800}
+      speed={2}
+      primaryColor="#f3f3f3"
+      secondaryColor="#ecebeb"
+      {...props}
+    >
+      <rect key={0} x={xPos} y={yPos} width={50} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      <rect key={1} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      <rect key={2} x={xPos} y={yPos} width={60} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      <rect key={3} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      <rect key={4} x={xPos} y={yPos} width={40} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      <rect key={5} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      {(yPos = yPos + spacing)}
+      // border left
+      <rect key={6} x={xPos - 5} y={startY} width={1} height={yPos - startY} />
+      // border bottom
+      <rect
+        key={7}
+        x={xPos - 5}
+        y={yPos}
+        width={5 + inputWidth + 5}
+        height={1}
+      />
+      // border right
+      <rect
+        key={8}
+        x={inputWidth + xPos + 5}
+        y={startY}
+        width={1}
+        height={yPos - startY}
+      />
+      // button
+      {(yPos = yPos + 10)}
+      <rect key={9} x={xPos + 10} y={yPos} width={40} height={20} />
+      // table
+      {[
+        tableY,
+        tableY + rowHeight + gap,
+        tableY + 2 * (rowHeight + gap),
+        tableY + 3 * (rowHeight + gap),
+        tableY + 4 * (rowHeight + gap),
+        tableY + 5 * (rowHeight + gap),
+        tableY + 6 * (rowHeight + gap),
+        tableY + 7 * (rowHeight + gap),
+      ].map((y: number) => {
+        return (
+          // create columns for each row
+          <>
+            {[0, 1, 2, 3, 4, 5].map((colNum: number) => {
+              return (
+                <rect
+                  key={colNum}
+                  x={tableX + colNum * (colWidth + gap)}
+                  y={y}
+                  width={colWidth}
+                  height={rowHeight}
+                />
+              );
+            })}
+          </>
+        );
+      })}
+    </ContentLoader>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
@@ -2,6 +2,7 @@ export * from './Views';
 export * from './ViewEditor';
 export * from './PublishStatusWithProgress';
 export * from './SqlClientContent';
+export * from './SqlClientContentSkeleton';
 export * from './SqlClientForm';
 export * from './VirtualizationDetailsHeader';
 export * from './VirtualizationList';

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/SqlClientContentSkeleton.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/SqlClientContentSkeleton.stories.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { SqlClientContentSkeleton } from '../../../src';
+
+const stories = storiesOf(
+  'Data/Virtualizations/SqlClientContentSkeleton',
+  module
+);
+
+stories.add('render', () => <SqlClientContentSkeleton />);

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -1,7 +1,11 @@
-import { useViewEditorStates, useVirtualization, useVirtualizationHelpers } from '@syndesis/api';
+import { useViewEditorStates, useVirtualizationHelpers } from '@syndesis/api';
 import { ViewDefinition, ViewEditorState } from '@syndesis/models';
 import { RestDataService } from '@syndesis/models';
-import { PageSection, ViewHeaderBreadcrumb, VirtualizationDetailsHeader } from '@syndesis/ui';
+import {
+  PageSection,
+  ViewHeaderBreadcrumb,
+  VirtualizationDetailsHeader,
+} from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import { useContext } from 'react';
 import * as React from 'react';
@@ -10,7 +14,10 @@ import i18n from '../../../i18n';
 import { ApiError } from '../../../shared';
 import { VirtualizationNavBar } from '../shared';
 import { VirtualizationHandlers } from '../shared/VirtualizationHandlers';
-import { getOdataUrl, getPublishingDetails } from '../shared/VirtualizationUtils';
+import {
+  getOdataUrl,
+  getPublishingDetails,
+} from '../shared/VirtualizationUtils';
 
 import {
   IActiveFilter,
@@ -87,18 +94,23 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   const appContext = React.useContext(AppContext);
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
-  const { params, history } = useRouteData<
+  const { params, state, history } = useRouteData<
     IVirtualizationViewsPageRouteParams,
     IVirtualizationViewsPageRouteState
   >();
-  const { deleteView, updateVirtualizationDescription } = useVirtualizationHelpers();
-  const { handleDeleteVirtualization, handlePublishVirtualization, handleUnpublishServiceVdb } = VirtualizationHandlers();
+  const {
+    deleteView,
+    updateVirtualizationDescription,
+  } = useVirtualizationHelpers();
+  const {
+    handleDeleteVirtualization,
+    handlePublishVirtualization,
+    handleUnpublishServiceVdb,
+  } = VirtualizationHandlers();
 
   const filterUndefinedId = (view: ViewDefinition): boolean => {
     return view.viewName !== undefined;
   };
-
-  const { resource: virtualization } = useVirtualization(params.virtualizationId);
 
   const {
     resource: editorStates,
@@ -109,30 +121,21 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
 
   const publishingDetails = getPublishingDetails(
     appContext.config.consoleUrl,
-    virtualization
+    state.virtualization
   );
 
-  const doDelete = async (
-    pVirtualizationId: string
-  ) => {
+  const doDelete = async (pVirtualizationId: string) => {
     const success = await handleDeleteVirtualization(pVirtualizationId);
-    if(success) {
-      history.push(
-        resolvers.data.virtualizations.list()
-      );
+    if (success) {
+      history.push(resolvers.data.virtualizations.list());
     }
   };
-  
-  const doPublish = async (
-    pVirtualizationId: string,
-    hasViews: boolean
-  ) => {
-    await handlePublishVirtualization(pVirtualizationId,hasViews);
-  }
 
-  const doUnpublish = async (
-    serviceVdbName: string
-  ) => {
+  const doPublish = async (pVirtualizationId: string, hasViews: boolean) => {
+    await handlePublishVirtualization(pVirtualizationId, hasViews);
+  };
+
+  const doUnpublish = async (serviceVdbName: string) => {
     await handleUnpublishServiceVdb(serviceVdbName);
   };
 
@@ -142,42 +145,29 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
       params.virtualizationId,
       newDescription
     );
-    virtualization.tko__description = newDescription;
+    state.virtualization.tko__description = newDescription;
     return true;
   };
 
-  const handleDeleteView = async (
-    viewName: string
-  ) => {
+  const handleDeleteView = async (viewName: string) => {
     try {
-      await deleteView(
-        virtualization,
-        viewName
-      );
+      await deleteView(state.virtualization, viewName);
 
       pushNotification(
-        t(
-          'virtualization.deleteViewSuccess',
-          {
-            name: viewName,
-          }
-        ),
+        t('virtualization.deleteViewSuccess', {
+          name: viewName,
+        }),
         'success'
       );
 
       await read();
     } catch (error) {
-      const details = error.message
-        ? error.message
-        : '';
+      const details = error.message ? error.message : '';
       pushNotification(
-        t(
-          'virtualization.deleteViewFailed',
-          {
-            details,
-            name: viewName,
-          }
-        ),
+        t('virtualization.deleteViewFailed', {
+          details,
+          name: viewName,
+        }),
         'error'
       );
     }
@@ -199,93 +189,92 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
           helpers.isSortAscending
         );
         return (
-          <PageSection variant={'light'} noPadding={true}>
-            <WithLoader
-              error={editorStatesError !== false}
-              loading={!hasEditorStates}
-              loaderChildren={
-                <ViewListSkeleton
-                  width={800}
-                  style={{
-                    backgroundColor: '#FFF',
-                    marginTop: 30,
-                  }}
-                />
-              }
-              errorChildren={<ApiError error={editorStatesError as Error} />}
-            >
-              {() => (
-                <>
-                  <PageSection variant={'light'} noPadding={true}>
-                    <ViewHeaderBreadcrumb
-                      currentPublishedState={publishingDetails.state}
-                      virtualizationName={virtualization.keng__id}
-                      dashboardHref={resolvers.dashboard.root()}
-                      dashboardString={t('shared:Home')}
-                      dataHref={resolvers.data.root()}
-                      dataString={t('shared:Virtualizations')}
-                      i18nCancelText={t('shared:Cancel')}
-                      i18nDelete={t('shared:Delete')}
-                      i18nDeleteModalMessage={t(
-                        'virtualization.deleteModalMessage',
-                        {
-                          name: virtualization.keng__id,
-                        }
-                      )}
-                      i18nDeleteModalTitle={t(
-                        'virtualization.deleteModalTitle'
-                      )}
-                      /* TD-636: Commented out for TP
-                              i18nExport={t('shared:Export')}
-                      */
-                      i18nPublish={t('shared:Publish')}
-                      i18nUnpublish={t('shared:Unpublish')}
-                      i18nUnpublishModalMessage={t(
-                        'virtualization.unpublishModalMessage',
-                        {
-                          name: virtualization.keng__id,
-                        }
-                      )}
-                      i18nUnpublishModalTitle={t(
-                        'virtualization.unpublishModalTitle'
-                      )}
-                      onDelete={doDelete}
-                      /* TD-636: Commented out for TP
-                          onExport={
-                          this.handleExportVirtualization
-                    } */
-                      onUnpublish={doUnpublish}
-                      onPublish={doPublish}
-                      serviceVdbName={virtualization.serviceVdbName}
-                      hasViews={viewDefns.length > 0}
-                    />
-                    <VirtualizationDetailsHeader
-                      i18nDescriptionPlaceholder={t('virtualization.descriptionPlaceholder')}
-                      i18nDraft={t('shared:Draft')}
-                      i18nError={t('shared:Error')}
-                      i18nPublished={t(
-                        'virtualization.publishedDataVirtualization'
-                      )}
-                      i18nPublishInProgress={t(
-                        'virtualization.publishInProgress'
-                      )}
-                      i18nUnpublishInProgress={t(
-                        'virtualization.unpublishInProgress'
-                      )}
-                      i18nPublishLogUrlText={t('shared:viewLogs')}
-                      odataUrl={getOdataUrl(virtualization)}
-                      publishedState={publishingDetails.state}
-                      publishingCurrentStep={publishingDetails.stepNumber}
-                      publishingLogUrl={publishingDetails.logUrl}
-                      publishingTotalSteps={publishingDetails.stepTotal}
-                      publishingStepText={publishingDetails.stepText}
-                      virtualizationDescription={virtualization.tko__description}
-                      virtualizationName={virtualization.keng__id}
-                      isWorking={false}
-                      onChangeDescription={doSetDescription}
-                    />
-                    <VirtualizationNavBar virtualization={virtualization} />
-                  </PageSection>
+          <>
+            <PageSection variant={'light'} noPadding={true}>
+              <ViewHeaderBreadcrumb
+                currentPublishedState={publishingDetails.state}
+                virtualizationName={state.virtualization.keng__id}
+                dashboardHref={resolvers.dashboard.root()}
+                dashboardString={t('shared:Home')}
+                dataHref={resolvers.data.root()}
+                dataString={t('shared:Virtualizations')}
+                i18nCancelText={t('shared:Cancel')}
+                i18nDelete={t('shared:Delete')}
+                i18nDeleteModalMessage={t('virtualization.deleteModalMessage', {
+                  name: state.virtualization.keng__id,
+                })}
+                i18nDeleteModalTitle={t('virtualization.deleteModalTitle')}
+                /* TD-636: Commented out for TP
+                        i18nExport={t('shared:Export')}
+                */
+                i18nPublish={t('shared:Publish')}
+                i18nUnpublish={t('shared:Unpublish')}
+                i18nUnpublishModalMessage={t(
+                  'virtualization.unpublishModalMessage',
+                  {
+                    name: state.virtualization.keng__id,
+                  }
+                )}
+                i18nUnpublishModalTitle={t(
+                  'virtualization.unpublishModalTitle'
+                )}
+                onDelete={doDelete}
+                /* TD-636: Commented out for TP
+                    onExport={
+                    this.handleExportVirtualization
+              } */
+                onUnpublish={doUnpublish}
+                onPublish={doPublish}
+                serviceVdbName={state.virtualization.serviceVdbName}
+                hasViews={viewDefns.length > 0}
+              />
+            </PageSection>
+            <PageSection variant={'light'} noPadding={true}>
+              <VirtualizationDetailsHeader
+                i18nDescriptionPlaceholder={t(
+                  'virtualization.descriptionPlaceholder'
+                )}
+                i18nDraft={t('shared:Draft')}
+                i18nError={t('shared:Error')}
+                i18nPublished={t('virtualization.publishedDataVirtualization')}
+                i18nPublishInProgress={t('virtualization.publishInProgress')}
+                i18nUnpublishInProgress={t(
+                  'virtualization.unpublishInProgress'
+                )}
+                i18nPublishLogUrlText={t('shared:viewLogs')}
+                odataUrl={getOdataUrl(state.virtualization)}
+                publishedState={publishingDetails.state}
+                publishingCurrentStep={publishingDetails.stepNumber}
+                publishingLogUrl={publishingDetails.logUrl}
+                publishingTotalSteps={publishingDetails.stepTotal}
+                publishingStepText={publishingDetails.stepText}
+                virtualizationDescription={
+                  state.virtualization.tko__description
+                }
+                virtualizationName={state.virtualization.keng__id}
+                isWorking={false}
+                onChangeDescription={doSetDescription}
+              />
+            </PageSection>
+            <PageSection variant={'light'} noPadding={true}>
+              <VirtualizationNavBar virtualization={state.virtualization} />
+            </PageSection>
+            <PageSection variant={'light'} noPadding={true}>
+              <WithLoader
+                error={editorStatesError !== false}
+                loading={!hasEditorStates}
+                loaderChildren={
+                  <ViewListSkeleton
+                    width={800}
+                    style={{
+                      backgroundColor: '#FFF',
+                      marginTop: 30,
+                    }}
+                  />
+                }
+                errorChildren={<ApiError error={editorStatesError as Error} />}
+              >
+                {() => (
                   <ViewList
                     filterTypes={filterTypes}
                     sortTypes={sortTypes}
@@ -315,12 +304,12 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                     })}
                     linkCreateViewHRef={resolvers.data.virtualizations.views.createView.selectSources(
                       {
-                        virtualization,
+                        virtualization: state.virtualization,
                       }
                     )}
                     linkImportViewsHRef={resolvers.data.virtualizations.views.importSource.selectConnection(
                       {
-                        virtualization,
+                        virtualization: state.virtualization,
                       }
                     )}
                     hasListData={editorStates.length > 0}
@@ -336,10 +325,10 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                           viewDescription={viewDefinition.keng__description}
                           viewEditPageLink={resolvers.data.virtualizations.views.edit.sql(
                             {
-                              virtualization,
+                              virtualization: state.virtualization,
                               // tslint:disable-next-line: object-literal-sort-keys
                               viewDefinition,
-                              previewExpanded:true,
+                              previewExpanded: true,
                             }
                           )}
                           i18nCancelText={t('shared:Cancel')}
@@ -359,10 +348,10 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                         />
                       ))}
                   </ViewList>
-                </>
-              )}
-            </WithLoader>
-          </PageSection>
+                )}
+              </WithLoader>
+            </PageSection>
+          </>
         );
       }}
     </WithListViewToolbarHelpers>


### PR DESCRIPTION
- removed the not needed `useVirtualization` call as the virtualization is available from the route state
- added a loader for when the SQL tab is loading
- created SqlClientContentSkeleton and story