### PR TITLE
fix(6316): Removes acceptance criteria on template editor file upload

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/template/TemplateStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/template/TemplateStepPage.tsx
@@ -117,7 +117,6 @@ export const TemplateStepPage: React.FunctionComponent<
   );
 
   const { getRootProps, getInputProps } = useDropzone({
-    accept: 'text/*',
     disabled: false,
     maxSize: 1024 * 1000,
     multiple: false,


### PR DESCRIPTION
* Such an accept is problematic as there is no guarantee that files even
  have a file-type property despite being 'text'. Thus, false-positives
  are being generated resulting in legitimate files being rejected.

* Removal restores functionality of allowing files to be uploaded and
  handled by the editor.