### PR TITLE
TEIIDTOOLS-726 Adapt to teiid backend changes

### DIFF
--- a/app/ui-react/packages/api/src/useViewDefinition.tsx
+++ b/app/ui-react/packages/api/src/useViewDefinition.tsx
@@ -6,13 +6,11 @@ export const useViewDefinition = (
 ) => {
   return useApiResource<ViewDefinition>({
     defaultValue: {
-      compositions: [],
       dataVirtualizationName: '',
       isComplete: false,
       isUserDefined: false,
       keng__description: '',
       name: '',
-      projectedColumns: [],
       sourcePaths: [],
     },
     initialValue: initialDefn,

--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -83,32 +83,6 @@ export const useVirtualizationHelpers = () => {
   }
 
   /**
-   * Deletes the specified virtualization view.
-   * @param virtualizationName the virtualization name
-   * @param viewId the id of the view being deleted
-   */
-  const deleteView = async (
-    virtualizationName: string,
-    viewId: string
-  ): Promise<void> => {
-    // Delete view definition and refresh views
-    await deleteViewDefinition(viewId);
-    const response = await callFetch({
-      headers: {},
-      method: 'POST',
-      url: `${apiContext.dvApiUri}workspace/dataservices/refreshViews/${
-        virtualizationName
-      }`,
-    });
-
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
-
-    return Promise.resolve();
-  }
-
-  /**
    * Deletes the virtualization with the specified name.
    * @param virtualizationName the name of the virtualization being deleted
    */
@@ -351,12 +325,12 @@ export const useVirtualizationHelpers = () => {
 
     return Promise.resolve();
   }
-
+  
   /**
-   * Saves ViewDefinition in the komodo user profile
+   * Saves the ViewDefinition
    * @param viewDefinition the view definition
    */
-  const updateViewDefinitions = async (
+  const saveViewDefinition = async (
     viewDefinition: ViewDefinition
   ): Promise<void> => {
     const response = await callFetch({
@@ -365,47 +339,21 @@ export const useVirtualizationHelpers = () => {
       method: 'PUT',
       url: `${apiContext.dvApiUri}service/userProfile/viewEditorState`,
     });
-
     if (!response.ok) {
       throw new Error(response.statusText);
     }
-
     return Promise.resolve();
   }
-
-  /**
-   * Saves ViewDefinition in the komodo user profile, then updates the virtualizations
-   * @param viewDefinition the view definition
-   */
-  const refreshVirtualizationViews = async (
-    virtualizationName: string,
-    viewDefinition: ViewDefinition
-  ): Promise<void> => {
-    // Updates the view editor states
-    await updateViewDefinitions(viewDefinition);
-    const response = await callFetch({
-      headers: {},
-      method: 'POST',
-      url: `${
-        apiContext.dvApiUri
-      }workspace/dataservices/refreshViews/${virtualizationName}`,
-    });
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
-
-    return Promise.resolve();
-  }
-
+  
   return {
     createVirtualization,
-    deleteView,
+    deleteViewDefinition,
     deleteVirtualization,
     getViewDefinition,
     importSource,
     publishVirtualization,
     queryVirtualization,
-    refreshVirtualizationViews,
+    saveViewDefinition,
     unpublishServiceVdb,
     updateVirtualizationDescription,
     validateViewDefinition,

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -66,12 +66,6 @@ export interface VirtualizationSourceStatus {
   schemaModelName?: string;
 }
 
-export interface ProjectedColumn {
-  name: string;
-  type: string;
-  selected: boolean;
-}
-
 export interface ViewDefinitionDescriptor {
   id: string;
   name: string;
@@ -86,8 +80,6 @@ export interface ViewDefinition {
   isComplete: boolean;
   isUserDefined: boolean;
   sourcePaths: string[];
-  compositions: string[];
-  projectedColumns: ProjectedColumn[];
   ddl?: string;
 }
 

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -99,7 +99,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
     IVirtualizationViewsPageRouteState
   >();
   const {
-    deleteView,
+    deleteViewDefinition,
     updateVirtualizationDescription,
   } = useVirtualizationHelpers();
   const {
@@ -155,8 +155,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   ) => {
     // Delete the view
     try {
-      await deleteView(
-        params.virtualizationId,
+      await deleteViewDefinition(
         viewId
       );
 

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectNamePage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectNamePage.tsx
@@ -39,13 +39,13 @@ export interface ISelectNameRouteState {
 
 export const SelectNamePage: React.FunctionComponent = () => {
   const { t } = useTranslation(['data', 'shared']);
-  const { state, history } = useRouteData<
+  const { params, state, history } = useRouteData<
     ISelectNameRouteParams,
     ISelectNameRouteState
   >();
   const { pushNotification } = useContext(UIContext);
   const {
-    refreshVirtualizationViews,
+    saveViewDefinition,
     validateViewName,
   } = useVirtualizationHelpers();
 
@@ -55,8 +55,6 @@ export const SelectNamePage: React.FunctionComponent = () => {
     }
     return '';
   };
-
-  const virtualization = state.virtualization;
 
   /**
    * Backend name validation only occurs when attempting to create
@@ -69,7 +67,7 @@ export const SelectNamePage: React.FunctionComponent = () => {
     }
 
     const response: IDvNameValidationResult = await validateViewName(
-      virtualization.serviceVdbName,
+      state.virtualization.serviceVdbName,
       'views',
       proposedName
     );
@@ -92,14 +90,12 @@ export const SelectNamePage: React.FunctionComponent = () => {
       // ViewDefinition for the source
       const viewDefinition = generateViewDefinition(
         state.schemaNodeInfo,
-        state.virtualization.keng__id,
+        params.virtualizationId,
         value.name,
         value.description
       );
       try {
-        await refreshVirtualizationViews(state.virtualization.keng__id,
-          viewDefinition
-        );
+        await saveViewDefinition(viewDefinition);
         pushNotification(
           t('virtualization.createViewSuccess', {
             name: viewDefinition.name,
@@ -117,7 +113,7 @@ export const SelectNamePage: React.FunctionComponent = () => {
       }
       history.push(
         resolvers.data.virtualizations.views.root({
-          virtualization,
+          virtualization: state.virtualization,
         })
       );
     } else {
@@ -175,10 +171,10 @@ export const SelectNamePage: React.FunctionComponent = () => {
             </>
           }
           cancelHref={resolvers.data.virtualizations.views.root({
-            virtualization,
+            virtualization: state.virtualization,
           })}
           backHref={resolvers.data.virtualizations.views.createView.selectSources(
-            { virtualization }
+            { virtualization: state.virtualization }
           )}
           onNext={submitForm}
           isNextDisabled={!isValid}

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -50,7 +50,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
   const { params, state, history } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
-  const { refreshVirtualizationViews, validateViewDefinition } = useVirtualizationHelpers();
+  const { saveViewDefinition, validateViewDefinition } = useVirtualizationHelpers();
   const [previewExpanded, setPreviewExpanded] = React.useState(state.previewExpanded);
   const { resource: virtualization } = useVirtualization(params.virtualizationId);
   const { resource: viewDefn, loading, error } = useViewDefinition(params.viewDefinitionId, state.viewDefinition);
@@ -82,7 +82,6 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     setIsSaving(true);
     // View Definition
     const view: ViewDefinition = {
-      compositions: viewDefn.compositions,
       dataVirtualizationName: viewDefn.dataVirtualizationName,
       ddl: ddlValue,
       id: viewDefn.id,
@@ -90,15 +89,11 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
       isUserDefined: true,
       keng__description: viewDefn.keng__description,
       name: viewDefn.name,
-      projectedColumns: viewDefn.projectedColumns,
       sourcePaths: viewDefn.sourcePaths,
     };
 
     try {
-      await refreshVirtualizationViews(
-        virtualization.keng__id,
-        view
-      );
+      await saveViewDefinition(view);
       setIsSaving(false);
       pushNotification(
         t(
@@ -130,7 +125,6 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
 
     // View Definition
     const view: ViewDefinition = {
-      compositions: viewDefn.compositions,
       dataVirtualizationName: viewDefn.dataVirtualizationName,
       ddl: ddlValue,
       id: viewDefn.id,
@@ -138,7 +132,6 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
       isUserDefined: true,
       keng__description: viewDefn.keng__description,
       name: viewDefn.name,
-      projectedColumns: viewDefn.projectedColumns,
       sourcePaths: viewDefn.sourcePaths,
     };
 

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -1,6 +1,5 @@
 import {
   Connection,
-  ProjectedColumn,
   RestDataService,
   SchemaNode,
   SchemaNodeInfo,
@@ -12,9 +11,6 @@ import {
 
 const PREVIEW_VDB_NAME = 'PreviewVdb';
 const SCHEMA_MODEL_SUFFIX = 'schemamodel';
-const PROJECTED_COLS_ALL = [
-  { name: 'ALL', selected: true, type: 'ALL' } as ProjectedColumn,
-];
 
 export enum DvConnectionStatus {
   ACTIVE = 'ACTIVE',
@@ -154,7 +150,6 @@ export function generateViewDefinition(
   return getViewDefinition(
     vwName,
     dataVirtName,
-    PROJECTED_COLS_ALL,
     srcPaths,
     false,
     vwDescription
@@ -178,7 +173,6 @@ function loadPaths(schemaNodeInfo: SchemaNodeInfo[]): string[] {
  * Generate a ViewDefinition for the supplied values.
  * @param name the view name
  * @param dataVirtName the name of the virtualization
- * @param projectedCols projected columns for the view
  * @param srcPaths paths for the sources used in the view
  * @param userDefined specifies if the ddl has been altered from defaults
  * @param description the (optional) view description
@@ -187,7 +181,6 @@ function loadPaths(schemaNodeInfo: SchemaNodeInfo[]): string[] {
 function getViewDefinition(
   name: string,
   dataVirtName: string,
-  projectedCols: ProjectedColumn[],
   srcPaths: string[],
   userDefined: boolean,
   description?: string,
@@ -195,14 +188,12 @@ function getViewDefinition(
 ) {
   // View Definition
   const viewDefn: ViewDefinition = {
-    compositions: [],
     dataVirtualizationName: dataVirtName,
     ddl: viewDdl ? viewDdl : '',
     isComplete: true,
     isUserDefined: userDefined,
     keng__description: description ? description : '',
     name,
-    projectedColumns: projectedCols,
     sourcePaths: srcPaths,
   };
 


### PR DESCRIPTION
Adapting UI to further changes in teiid server interface
- removes need to explicitly refresh ViewDefinitions.  The views are refreshed upon save or import.  This removes the 'deleteView' and 'refreshVirtualizationViews' functions from useVirtualizationHelpers. 'updateViewDefinitions' was also renamed to 'saveViewDefinition'
- pages were modified to utilize the updated functions
- projectedColumns and compositions were removed from the ViewDefinition model.  compositions were not utilized and projectedColumns only minimally.  Design of projectedColumns for future release will be coordinated with teiid team.