### PR TITLE
feat: expand any extended properties into the property definition

### DIFF
--- a/app/ui-react/packages/utils/src/autoformHelpers.ts
+++ b/app/ui-react/packages/utils/src/autoformHelpers.ts
@@ -34,6 +34,7 @@ export function toFormDefinition(properties: IConfigurationProperties) {
 export function toFormDefinitionProperty(property: IConfigurationProperty) {
   const {
     cols,
+    extendedProperties,
     max,
     min,
     multiple,
@@ -46,6 +47,7 @@ export function toFormDefinitionProperty(property: IConfigurationProperty) {
   } = property as any; // needed, ConfigurationProperty is a lie
   return {
     ...formDefinitionProperty,
+    ...(extendedProperties || {}),
     controlHint: controlHint || controlTooltip,
     fieldAttributes: {
       cols,


### PR DESCRIPTION
For controls that need additional properties that ConfigurationProperty doesn't provide for in it's interface.

@KurtStam FYI