### PR TITLE
Fix(TEIIDTOOLS-699) Fixes issues with inline edit of Virtualization descriptions

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContentSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContentSkeleton.tsx
@@ -25,31 +25,24 @@ export const SqlClientContentSkeleton: React.FunctionComponent<{}> = props => {
       secondaryColor="#ecebeb"
       {...props}
     >
-      <rect key={0} x={xPos} y={yPos} width={50} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={50} height={rectHeight} />
       {(yPos = yPos + spacing)}
-      <rect key={1} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
       {(yPos = yPos + spacing)}
-      <rect key={2} x={xPos} y={yPos} width={60} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={60} height={rectHeight} />
       {(yPos = yPos + spacing)}
-      <rect key={3} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
       {(yPos = yPos + spacing)}
-      <rect key={4} x={xPos} y={yPos} width={40} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={40} height={rectHeight} />
       {(yPos = yPos + spacing)}
-      <rect key={5} x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
+      <rect x={xPos} y={yPos} width={inputWidth} height={rectHeight} />
       {(yPos = yPos + spacing)}
       // border left
-      <rect key={6} x={xPos - 5} y={startY} width={1} height={yPos - startY} />
+      <rect x={xPos - 5} y={startY} width={1} height={yPos - startY} />
       // border bottom
-      <rect
-        key={7}
-        x={xPos - 5}
-        y={yPos}
-        width={5 + inputWidth + 5}
-        height={1}
-      />
+      <rect x={xPos - 5} y={yPos} width={5 + inputWidth + 5} height={1} />
       // border right
       <rect
-        key={8}
         x={inputWidth + xPos + 5}
         y={startY}
         width={1}
@@ -57,7 +50,7 @@ export const SqlClientContentSkeleton: React.FunctionComponent<{}> = props => {
       />
       // button
       {(yPos = yPos + 10)}
-      <rect key={9} x={xPos + 10} y={yPos} width={40} height={20} />
+      <rect x={xPos + 10} y={yPos} width={40} height={20} />
       // table
       {[
         tableY,
@@ -71,11 +64,11 @@ export const SqlClientContentSkeleton: React.FunctionComponent<{}> = props => {
       ].map((y: number) => {
         return (
           // create columns for each row
-          <>
+          <React.Fragment key={y}>
             {[0, 1, 2, 3, 4, 5].map((colNum: number) => {
               return (
                 <rect
-                  key={colNum}
+                  key={y + ':' + colNum}
                   x={tableX + colNum * (colWidth + gap)}
                   y={y}
                   width={colWidth}
@@ -83,7 +76,7 @@ export const SqlClientContentSkeleton: React.FunctionComponent<{}> = props => {
                 />
               );
             })}
-          </>
+          </React.Fragment>
         );
       })}
     </ContentLoader>

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -10,6 +10,7 @@
     "editDataVirtualizationTip": "Edit the data virtualization",
     "emptyStateInfoMessage": "There are no virtualizations available. Click the button below to create one.",
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
+    "errorUpdatingDescription": "Error saving the description for virtualization \"{{name}}\"",
     "errorValidatingViewName": "Error validating the view name",
     "errorValidatingVirtualizationName": "Error validating the virtualization name",
     "importVirtualizationTip": "Import a data virtualization",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -10,6 +10,7 @@
     "editDataVirtualizationTip": "Edit the data virtualization",
     "emptyStateInfoMessage": "There are no virtualizations available. Please click on the button below to create one.",
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
+    "errorUpdatingDescription": "Errore durante il salvataggio della descrizione per la virtualizzazione \"{{name}}\"",
     "errorValidatingViewName": "Error validating the view name",
     "errorValidatingVirtualizationName": "Error validating the virtualization name",
     "importVirtualizationTip": "Import a data virtualization",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationRelationshipPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationRelationshipPage.tsx
@@ -1,11 +1,15 @@
-import { useVirtualization, useVirtualizationHelpers } from '@syndesis/api';
+import { useVirtualizationHelpers } from '@syndesis/api';
 import { RestDataService } from '@syndesis/models';
-import { Breadcrumb, PageSection, VirtualizationDetailsHeader } from '@syndesis/ui';
+import {
+  Breadcrumb,
+  PageSection,
+  VirtualizationDetailsHeader,
+} from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { AppContext } from '../../../app';
+import { AppContext, UIContext } from '../../../app';
 import resolvers from '../../resolvers';
 import { VirtualizationNavBar } from '../shared';
 import {
@@ -30,29 +34,44 @@ export interface IVirtualizationRelationshipPageRouteState {
 }
 
 export const VirtualizationRelationshipPage: React.FunctionComponent = () => {
-
   const { t } = useTranslation(['data', 'shared']);
-  const { params } = useRouteData<
+  const { params, state } = useRouteData<
     IVirtualizationRelationshipPageRouteParams,
     IVirtualizationRelationshipPageRouteState
   >();
+  const [description, setDescription] = React.useState(
+    state.virtualization.tko__description
+  );
   const appContext = React.useContext(AppContext);
+  const { pushNotification } = React.useContext(UIContext);
   const { updateVirtualizationDescription } = useVirtualizationHelpers();
-  const { resource: virtualization } = useVirtualization(params.virtualizationId);
 
   const publishingDetails = getPublishingDetails(
     appContext.config.consoleUrl,
-    virtualization
+    state.virtualization
   );
 
   const doSetDescription = async (newDescription: string) => {
-    await updateVirtualizationDescription(
-      appContext.user.username || 'developer',
-      params.virtualizationId,
-      newDescription
-    );
-    virtualization.tko__description = newDescription;
-    return true;
+    const previous = description;
+    setDescription(newDescription); // this sets InlineTextEdit component to new value
+    try {
+      await updateVirtualizationDescription(
+        appContext.user.username || 'developer',
+        params.virtualizationId,
+        newDescription
+      );
+      state.virtualization.tko__description = newDescription;
+      return true;
+    } catch {
+      pushNotification(
+        t('virtualization.errorUpdatingDescription', {
+          name: state.virtualization.keng__id,
+        }),
+        'error'
+      );
+      setDescription(previous); // save failed so set InlineTextEdit back to old value
+      return false;
+    }
   };
 
   return (
@@ -65,9 +84,7 @@ export const VirtualizationRelationshipPage: React.FunctionComponent = () => {
           {t('shared:Home')}
         </Link>
         <Link
-          data-testid={
-            'virtualization-relationship-page-virtualizations-link'
-          }
+          data-testid={'virtualization-relationship-page-virtualizations-link'}
           to={resolvers.data.root()}
         >
           {t('shared:DataVirtualizations')}
@@ -81,33 +98,27 @@ export const VirtualizationRelationshipPage: React.FunctionComponent = () => {
         i18nDescriptionPlaceholder={t('virtualization.descriptionPlaceholder')}
         i18nDraft={t('shared:Draft')}
         i18nError={t('shared:Error')}
-        i18nPublished={t(
-          'virtualization.publishedDataVirtualization'
-        )}
-        i18nPublishInProgress={t(
-          'virtualization.publishInProgress'
-        )}
-        i18nUnpublishInProgress={t(
-          'virtualization.unpublishInProgress'
-        )}
+        i18nPublished={t('virtualization.publishedDataVirtualization')}
+        i18nPublishInProgress={t('virtualization.publishInProgress')}
+        i18nUnpublishInProgress={t('virtualization.unpublishInProgress')}
         i18nPublishLogUrlText={t('shared:viewLogs')}
-        odataUrl={getOdataUrl(virtualization)}
+        odataUrl={getOdataUrl(state.virtualization)}
         publishedState={publishingDetails.state}
         publishingCurrentStep={publishingDetails.stepNumber}
         publishingLogUrl={publishingDetails.logUrl}
         publishingTotalSteps={publishingDetails.stepTotal}
         publishingStepText={publishingDetails.stepText}
-        virtualizationDescription={virtualization.tko__description}
-        virtualizationName={virtualization.keng__id}
+        virtualizationDescription={description}
+        virtualizationName={state.virtualization.keng__id}
         isWorking={false}
         onChangeDescription={doSetDescription}
       />
       <PageSection variant={'light'} noPadding={true}>
-        <VirtualizationNavBar virtualization={virtualization} />
+        <VirtualizationNavBar virtualization={state.virtualization} />
       </PageSection>
       <PageSection>
         <h2>Relationships are not yet implemented</h2>
       </PageSection>
     </>
   );
-}
+};

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -1,4 +1,7 @@
-import { useViewDefinitionDescriptors, useVirtualizationHelpers } from '@syndesis/api';
+import {
+  useViewDefinitionDescriptors,
+  useVirtualizationHelpers,
+} from '@syndesis/api';
 import { ViewDefinitionDescriptor } from '@syndesis/models';
 import { RestDataService } from '@syndesis/models';
 import {
@@ -7,7 +10,6 @@ import {
   VirtualizationDetailsHeader,
 } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
-import { useContext } from 'react';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../../i18n';
@@ -56,8 +58,9 @@ function getFilteredAndSortedViewDefns(
   let filteredAndSorted = viewDefinitionDescriptors;
   activeFilters.forEach((filter: IActiveFilter) => {
     const valueToLower = filter.value.toLowerCase();
-    filteredAndSorted = filteredAndSorted.filter((view: ViewDefinitionDescriptor) =>
-      view.name.toLowerCase().includes(valueToLower)
+    filteredAndSorted = filteredAndSorted.filter(
+      (view: ViewDefinitionDescriptor) =>
+        view.name.toLowerCase().includes(valueToLower)
     );
   });
 
@@ -92,12 +95,15 @@ const sortTypes: ISortType[] = [sortByName];
 
 export const VirtualizationViewsPage: React.FunctionComponent = () => {
   const appContext = React.useContext(AppContext);
-  const { pushNotification } = useContext(UIContext);
+  const { pushNotification } = React.useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
   const { params, state, history } = useRouteData<
     IVirtualizationViewsPageRouteParams,
     IVirtualizationViewsPageRouteState
   >();
+  const [description, setDescription] = React.useState(
+    state.virtualization.tko__description
+  );
   const {
     deleteViewDefinition,
     updateVirtualizationDescription,
@@ -140,48 +146,48 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   };
 
   const doSetDescription = async (newDescription: string) => {
-    await updateVirtualizationDescription(
-      appContext.user.username || 'developer',
-      params.virtualizationId,
-      newDescription
-    );
-    state.virtualization.tko__description = newDescription;
-    return true;
+    const previous = description;
+    setDescription(newDescription); // this sets InlineTextEdit component to new value
+    try {
+      await updateVirtualizationDescription(
+        appContext.user.username || 'developer',
+        params.virtualizationId,
+        newDescription
+      );
+      state.virtualization.tko__description = newDescription;
+      return true;
+    } catch {
+      pushNotification(
+        t('virtualization.errorUpdatingDescription', {
+          name: state.virtualization.keng__id,
+        }),
+        'error'
+      );
+      setDescription(previous); // save failed so set InlineTextEdit back to old value
+      return false;
+    }
   };
 
-  const handleDeleteView = async (
-    viewId: string,
-    viewName: string
-  ) => {
+  const handleDeleteView = async (viewId: string, viewName: string) => {
     // Delete the view
     try {
-      await deleteViewDefinition(
-        viewId
-      );
+      await deleteViewDefinition(viewId);
 
       pushNotification(
-        t(
-          'virtualization.deleteViewSuccess',
-          {
-            name: viewName,
-          }
-        ),
+        t('virtualization.deleteViewSuccess', {
+          name: viewName,
+        }),
         'success'
       );
 
       await read();
     } catch (error) {
-      const details = error.message
-        ? error.message
-        : '';
+      const details = error.message ? error.message : '';
       pushNotification(
-        t(
-          'virtualization.deleteViewFailed',
-          {
-            details,
-            name: viewName,
-          }
-        ),
+        t('virtualization.deleteViewFailed', {
+          details,
+          name: viewName,
+        }),
         'error'
       );
     }
@@ -259,9 +265,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                 publishingLogUrl={publishingDetails.logUrl}
                 publishingTotalSteps={publishingDetails.stepTotal}
                 publishingStepText={publishingDetails.stepText}
-                virtualizationDescription={
-                  state.virtualization.tko__description
-                }
+                virtualizationDescription={description}
                 virtualizationName={state.virtualization.keng__id}
                 isWorking={false}
                 onChangeDescription={doSetDescription}
@@ -283,7 +287,9 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                     }}
                   />
                 }
-                errorChildren={<ApiError error={viewDefinitionDescriptorsError as Error} />}
+                errorChildren={
+                  <ApiError error={viewDefinitionDescriptorsError as Error} />
+                }
               >
                 {() => (
                   <ViewList
@@ -326,40 +332,48 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                     hasListData={viewDefinitionDescriptors.length > 0}
                   >
                     {filteredAndSorted
-                      .filter((viewDefinitionDescriptor: ViewDefinitionDescriptor) =>
-                        filterUndefinedId(viewDefinitionDescriptor)
+                      .filter(
+                        (viewDefinitionDescriptor: ViewDefinitionDescriptor) =>
+                          filterUndefinedId(viewDefinitionDescriptor)
                       )
-                      .map((viewDefinitionDescriptor: ViewDefinitionDescriptor, index: number) => (
-                        <ViewListItem
-                          key={index}
-                          viewId={viewDefinitionDescriptor.id}
-                          viewName={viewDefinitionDescriptor.name}
-                          viewDescription={viewDefinitionDescriptor.description}
-                          viewEditPageLink={resolvers.data.virtualizations.views.edit.sql(
-                            {
-                              virtualization: state.virtualization,
-                              // tslint:disable-next-line: object-literal-sort-keys
-                              viewDefinitionId: viewDefinitionDescriptor.id,
-                              viewDefinition: undefined,
-                              previewExpanded:true,
+                      .map(
+                        (
+                          viewDefinitionDescriptor: ViewDefinitionDescriptor,
+                          index: number
+                        ) => (
+                          <ViewListItem
+                            key={index}
+                            viewId={viewDefinitionDescriptor.id}
+                            viewName={viewDefinitionDescriptor.name}
+                            viewDescription={
+                              viewDefinitionDescriptor.description
                             }
-                          )}
-                          i18nCancelText={t('shared:Cancel')}
-                          i18nDelete={t('shared:Delete')}
-                          i18nDeleteModalMessage={t(
-                            'virtualization.deleteViewModalMessage',
-                            {
-                              name: viewDefinitionDescriptor.name,
-                            }
-                          )}
-                          i18nDeleteModalTitle={t(
-                            'virtualization.deleteModalTitle'
-                          )}
-                          i18nEdit={t('shared:Edit')}
-                          i18nEditTip={t('view.editViewTip')}
-                          onDelete={handleDeleteView}
-                        />
-                      ))}
+                            viewEditPageLink={resolvers.data.virtualizations.views.edit.sql(
+                              {
+                                virtualization: state.virtualization,
+                                // tslint:disable-next-line: object-literal-sort-keys
+                                viewDefinitionId: viewDefinitionDescriptor.id,
+                                viewDefinition: undefined,
+                                previewExpanded: true,
+                              }
+                            )}
+                            i18nCancelText={t('shared:Cancel')}
+                            i18nDelete={t('shared:Delete')}
+                            i18nDeleteModalMessage={t(
+                              'virtualization.deleteViewModalMessage',
+                              {
+                                name: viewDefinitionDescriptor.name,
+                              }
+                            )}
+                            i18nDeleteModalTitle={t(
+                              'virtualization.deleteModalTitle'
+                            )}
+                            i18nEdit={t('shared:Edit')}
+                            i18nEditTip={t('view.editViewTip')}
+                            onDelete={handleDeleteView}
+                          />
+                        )
+                      )}
                   </ViewList>
                 )}
               </WithLoader>


### PR DESCRIPTION
- removed `useVirtualization` API call from tab pages since the virtualization is available from the route state
- added a push notification if there was an error saving the description
- inline edit component now displays the new description while saving is in progress
- required changes be made in the 4 virtualization tab pages
- added `key` attributes to map results in `SqlClienContentSkeleton`