### PR TITLE
TEIIDTOOLS-726 adapt to change in teiid source path specification

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -32,8 +32,8 @@ export interface RestDataService {
 
 export interface SchemaNode {
   name: string;
+  teiidName: string;
   type: string;
-  path: string;
   connectionName: string;
   queryable: boolean;
   children: SchemaNode[];
@@ -51,8 +51,9 @@ export interface ViewInfo {
 
 export interface SchemaNodeInfo {
   connectionName: string;
-  sourceName: string;
-  sourcePath: string;
+  name: string;
+  nodePath: string[];
+  teiidName: string;
 }
 
 export interface VirtualizationSourceStatus {

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
@@ -9,11 +9,14 @@ import './SchemaNodeListItem.css';
 export interface ISchemaNodeListItemProps {
   name: string;
   connectionName: string;
-  schemaPath: string;
+  teiidName: string;
+  nodePath: string[];
   selected: boolean;
   onSelectionChanged: (
     connectionName: string,
-    nodePath: string,
+    name: string,
+    teiidName: string,
+    nodePath: string[],
     selected: boolean
   ) => void;
 }
@@ -24,26 +27,26 @@ export const SchemaNodeListItem: React.FunctionComponent<
 
   const [itemSelected, setItemSelected] = React.useState(props.selected);
 
-  const doToggleCheckbox = (connectionName: string, nodePath: string) => (
+  const doToggleCheckbox = (connectionName: string, name: string, teiidName: string, nodePath: string[]) => (
     event: any
   ) => {
     setItemSelected(!itemSelected);
 
     props.onSelectionChanged(
       connectionName,
+      name,
+      teiidName,
       nodePath,
       !itemSelected
     );
   };
 
-  const schemaDisplayPath = (schemaPath: string) => {
+  const schemaDisplayPath = (nodePath: string[]) => {
     let result = '';
-    schemaPath
-      .split('/')
-      .map(segment => (result += '/' + segment.split('=')[1]));
+    nodePath.map(segment => (result += '/' + segment));
     return result;
   }
-
+  
   return (
     <ListViewItem
       data-testid={`schema-node-list-item-${toValidHtmlId(
@@ -51,7 +54,7 @@ export const SchemaNodeListItem: React.FunctionComponent<
       )}-list-item`}
       heading={props.name}
       className={'schema-node-list-item'}
-      description={schemaDisplayPath(props.schemaPath)}
+      description={schemaDisplayPath(props.nodePath)}
       checkboxInput={
         <input
           data-testid={'schema-node-list-item-selected-input'}
@@ -60,7 +63,9 @@ export const SchemaNodeListItem: React.FunctionComponent<
           defaultChecked={props.selected}
           onChange={doToggleCheckbox(
             props.connectionName,
-            props.schemaPath
+            props.name,
+            props.teiidName,
+            props.nodePath
           )}
         />
       }

--- a/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
@@ -27,16 +27,18 @@ const conn2NodeItems = [
   <SchemaNodeListItem
     key="conn2Item1"
     name={'Customer'}
+    teiidName={'Customer'}
     connectionName={connectionName2}
-    schemaPath={'schema=public/table=Customer'}
+    nodePath={['public','Customer']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />,
   <SchemaNodeListItem
     key="conn2Item2"
     name={'Account'}
+    teiidName={'Account'}
     connectionName={connectionName2}
-    schemaPath={'schema=public/table=Account'}
+    nodePath={['public','Account']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />,
@@ -45,16 +47,18 @@ const conn3NodeItems = [
   <SchemaNodeListItem
     key="conn3Item1"
     name={'Holdings'}
+    teiidName={'Holdings'}
     connectionName={connectionName3}
-    schemaPath={'schema=public/table=Holdings'}
+    nodePath={['public','Holdings']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />,
   <SchemaNodeListItem
     key="conn3Item2"
     name={'Product'}
+    teiidName={'Product'}
     connectionName={connectionName3}
-    schemaPath={'schema=public/table=Product'}
+    nodePath={['public','Product']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />,

--- a/app/ui-react/packages/ui/stories/Data/Views/SchemaNodeListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/SchemaNodeListItem.stories.tsx
@@ -11,14 +11,16 @@ const stories = storiesOf(
 );
 
 const nodeName = 'Customers';
+const teiidName = 'Customers';
 const selectionChangedActionText = 'Selection changed for ' + nodeName;
 
 stories.add('sample schema node item', () => (
   <SchemaNodeListItem
     key="nodeListItem2"
     name={text('name', nodeName)}
+    teiidName={text('teiidName', teiidName)}
     connectionName={'connection1'}
-    schemaPath={'schema=public/table=customers'}
+    nodePath={['public','customers']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -4,7 +4,6 @@ import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import resolvers from '../../../resolvers';
 import { ConnectionSchemaContent, ViewCreateSteps } from '../../shared';
-import { getNodeName } from '../../shared/VirtualizationUtils';
 
 /**
  * @param virtualizationId - the ID of the virtualization for the wizard
@@ -29,12 +28,13 @@ export const SelectSourcesPage: React.FunctionComponent = () => {
   const [selectedSchemaNodes, setSelectedSchemaNodes] = React.useState<SchemaNodeInfo[]>([]);
   const [hasSelectedNodes, setHasSelectedNodes] = React.useState(false);
 
-  const handleNodeSelected = async (connName: string, nodePath: string) => {
+  const handleNodeSelected = async (connName: string, name: string, teiidName: string, nodePath: string[]) => {
     const srcInfo = {
       connectionName: connName,
-      sourceName: getNodeName(nodePath),
-      sourcePath: nodePath,
-    } as SchemaNodeInfo;
+      name,
+      nodePath,
+      teiidName,
+     } as SchemaNodeInfo;
 
     const currentNodes = selectedSchemaNodes;
     currentNodes.push(srcInfo);
@@ -42,9 +42,9 @@ export const SelectSourcesPage: React.FunctionComponent = () => {
     setHasSelectedNodes(currentNodes.length>0);
   }
 
-  const handleNodeDeselected = async (connectionName: string, nodePath: string) => {
+  const handleNodeDeselected = async (connectionName: string, teiidName: string) => {
     const tempArray = selectedSchemaNodes;
-    const index = getIndex(nodePath, tempArray, 'sourcePath');
+    const index = getIndex(teiidName, tempArray, 'teiidName');
     tempArray.splice(index, 1);
     setSelectedSchemaNodes(tempArray);
     setHasSelectedNodes(tempArray.length>0);

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
@@ -28,8 +28,8 @@ function getSchemaNodeInfos(schemaNodes: SchemaNode[], connName: string) {
 }
 
 export interface IConnectionSchemaContentProps {
-  onNodeSelected: (connectionName: string, nodePath: string) => void;
-  onNodeDeselected: (connectionName: string, nodePath: string) => void;
+  onNodeSelected: (connectionName: string, name: string, teiidName: string, nodePath: string[]) => void;
+  onNodeDeselected: (connectionName: string, teiidName: string) => void;
 }
 
 export const ConnectionSchemaContent: React.FunctionComponent<
@@ -39,13 +39,15 @@ export const ConnectionSchemaContent: React.FunctionComponent<
 
   const handleSourceSelectionChange = async (
     connectionName: string,
-    nodePath: string,
-    selected: boolean
+    name: string,
+    teiidName: string,
+    nodePath: string[],
+    selected: boolean,
   ) => {
     if (selected) {
-      props.onNodeSelected(connectionName, nodePath);
+      props.onNodeSelected(connectionName, name, teiidName, nodePath);
     } else {
-      props.onNodeDeselected(connectionName, nodePath);
+      props.onNodeDeselected(connectionName, teiidName);
     }
   };
 
@@ -91,9 +93,10 @@ export const ConnectionSchemaContent: React.FunctionComponent<
                 children={srcInfos.map((info, index) => (
                   <SchemaNodeListItem
                     key={index}
-                    name={info.sourceName}
+                    name={info.name}
+                    teiidName={info.teiidName}
                     connectionName={info.connectionName}
-                    schemaPath={info.sourcePath}
+                    nodePath={info.nodePath}
                     selected={false}
                     onSelectionChanged={handleSourceSelectionChange}
                   />

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -34,7 +34,7 @@ export function getPreviewVdbName(): string {
  * into an array of ViewInfos
  * @param viewInfos the array of ViewInfos
  * @param schemaNode the SchemaNode from which the ViewInfo is generated
- * @param nodePath path for current SchemaNode
+ * @param nodePath path for current SchemaNode eg ['name0', 'name1', 'name2']
  * @param selectedViewNames names of views which are selected
  * @param existingViewNames names of views which exist (marked as update)
  */
@@ -98,7 +98,7 @@ export function generateViewInfos(
  * into an array of SchemaNodeInfos
  * @param schemaNodeInfos the array of SchemaNodeInfos
  * @param schemaNode the SchemaNode from which the SchemaNodeInfo is generated
- * @param nodePath path for current SchemaNode
+ * @param nodePath path for current SchemaNode eg ['sName', 'tName']
  */
 export function generateSchemaNodeInfos(
   schemaNodeInfos: SchemaNodeInfo[],
@@ -117,13 +117,16 @@ export function generateSchemaNodeInfos(
       // Create SchemaNodeInfo
       const view: SchemaNodeInfo = {
         connectionName: schemaNode.connectionName,
-        sourceName: schemaNode.name,
-        sourcePath: schemaNode.path,
+        name: schemaNode.name,
+        nodePath: sourcePath,
+        teiidName: schemaNode.teiidName
       };
       schemaNodeInfos.push(view);
     }
     // Update path for next level
-    sourcePath.push(schemaNode.name);
+    if(schemaNode.type !== 'root') {
+      sourcePath.push(schemaNode.name);
+    }
     // Process this nodes children
     if (schemaNode.children && schemaNode.children.length > 0) {
       for (const childNode of schemaNode.children) {
@@ -162,8 +165,7 @@ function loadPaths(schemaNodeInfo: SchemaNodeInfo[]): string[] {
   let index = 0;
   schemaNodeInfo.map(
     item =>
-      (srcPaths[index++] =
-        'connection=' + item.connectionName + '/' + item.sourcePath)
+      (srcPaths[index++] = 'schema=' + item.connectionName + '/table=' + item.teiidName)
   );
 
   return srcPaths;
@@ -190,6 +192,7 @@ function getViewDefinition(
   const viewDefn: ViewDefinition = {
     dataVirtualizationName: dataVirtName,
     ddl: viewDdl ? viewDdl : '',
+    id: '',
     isComplete: true,
     isUserDefined: userDefined,
     keng__description: description ? description : '',
@@ -373,34 +376,14 @@ export function getPreviewSql(viewDefinition: ViewDefinition): string {
 }
 
 /**
- * Generates the table name for the preview query, given the source path.
- * Example sourcePath: (connection=pgConn/schema=public/table=account)
- * @param sourcePath the path for the view source
+ * Get the table name for the preview query, given the source path.
+ * Example sourcePath: (schema=pgConn/table=account)
+ * @param sourcePath the path for the source
  */
 function getPreviewTableName(sourcePath: string): string {
-  // Assemble the name, utilizing the schema model suffix
-  return `"${getConnectionName(
-    sourcePath
-  ).toLowerCase()}${SCHEMA_MODEL_SUFFIX}"."${getNodeName(sourcePath)}"`;
-}
-
-/**
- * Get the connection name from the supplied source path.  connection is always the first segment.
- * Example sourcePath: 'connection=pgConn/schema=public/table=account'
- * @param sourcePath the view definition sourcePath
- */
-function getConnectionName(sourcePath: string): string {
-  // Connection name is the value of the first segment
-  return sourcePath.split('/')[0].split('=')[1];
-}
-
-/**
- * Get the node name from the supplied source path.
- * Example sourcePath: 'connection=pgConn/schema=public/table=account'
- * @param sourcePath the view definition sourcePath
- */
-export function getNodeName(sourcePath: string): string {
   const segments = sourcePath.split('/');
-  // Node name is the value of the last segment
-  return segments[segments.length - 1].split('=')[1];
+  const connectionName = segments[0].split('=')[1];
+  const tableName = segments[1].split('=')[1];
+  // Assemble the name, utilizing the schema model suffix
+  return `"${connectionName.toLowerCase()}${SCHEMA_MODEL_SUFFIX}"."${tableName}"`;
 }


### PR DESCRIPTION
Adapt to change in source specification for viewDefinitions
- 'path' was removed from SchemaNode model and 'teiidName' added
- modified the SchemaNodeInfos generated in UI to account for changes
- removed functions no longer needed from VirtualizationUtils (there will be further simplifications after the next teiid PR)
- updated stories
