### PR TITLE
fix(build): Make operator docker build work on fresh clone

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -139,6 +139,7 @@ EODockerfile
         for GOARCH in amd64 ; do
           for GOOS in linux darwin windows ; do
             echo extracting executable to ./dist/${GOOS}-${GOARCH}/operator
+            mkdir -p ./dist/${GOOS}-${GOARCH}
             docker run "${BUILDER_IMAGE_NAME}" cat /dist/${GOOS}-${GOARCH}/operator > ./dist/${GOOS}-${GOARCH}/operator
           done
         done


### PR DESCRIPTION
The docker-based build would fail when run on fresh clones of sydesis repo because the `dist` directory [did not exist](https://ci.fabric8.io/view/release%20builds/job/asmigala-syndesis-release-daily-dry-run/3/console).