### PR TITLE
fix: [6068] Configuration required warnings for conditional flows steps

### DIFF
--- a/app/connector/flow/src/main/resources/META-INF/syndesis/connector/flow.json
+++ b/app/connector/flow/src/main/resources/META-INF/syndesis/connector/flow.json
@@ -7,9 +7,11 @@
         "componentScheme": "direct",
         "connectorCustomizers": [],
         "inputDataShape": {
+          "name": "No shape",
           "kind": "none"
         },
         "outputDataShape": {
+          "name": "Any shape",
           "kind": "any"
         },
         "propertyDefinitionSteps": [

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
@@ -42,7 +42,7 @@ class ChoiceMetadataHandler implements StepMetadataHandler {
         return new DynamicActionMetadata.Builder()
                         .inputShape(outputShape)
                         .outputShape(step.outputDataShape()
-                                         .orElse(StepMetadataHelper.NO_SHAPE))
+                                         .orElse(StepMetadataHelper.ANY_SHAPE))
                         .build();
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandler.java
@@ -146,7 +146,7 @@ public class StepActionHandler extends BaseHandler {
         if (shouldEnrichDataShape(output)) {
             enriched.outputDataShape(adaptDataShape(output));
         } else {
-            enriched.outputDataShape(StepMetadataHelper.NO_SHAPE);
+            enriched.outputDataShape(StepMetadataHelper.ANY_SHAPE);
         }
 
         return enriched.build();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
@@ -31,8 +31,8 @@ import io.syndesis.common.model.integration.Step;
  */
 final class StepMetadataHelper {
 
-    static final DataShape ANY_SHAPE = new DataShape.Builder().kind(DataShapeKinds.ANY).build();
-    static final DataShape NO_SHAPE = new DataShape.Builder().kind(DataShapeKinds.NONE).build();
+    static final DataShape ANY_SHAPE = new DataShape.Builder().kind(DataShapeKinds.ANY).name("Any shape").build();
+    static final DataShape NO_SHAPE = new DataShape.Builder().kind(DataShapeKinds.NONE).name("No shape").build();
 
     /**
      * Prevent instantiation of utility class.

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
@@ -76,7 +76,7 @@ public class ChoiceMetadataHandlerTest {
         DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
 
         Assert.assertNotNull(metadata.outputShape());
-        Assert.assertEquals(DataShapeKinds.NONE, metadata.outputShape().getKind());
+        Assert.assertEquals(DataShapeKinds.ANY, metadata.outputShape().getKind());
 
         Assert.assertNotNull(metadata.inputShape());
         Assert.assertEquals(DataShapeKinds.JSON_INSTANCE, metadata.inputShape().getKind());
@@ -111,7 +111,7 @@ public class ChoiceMetadataHandlerTest {
         DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.singletonList(previousStep), Collections.singletonList(subsequentStep));
 
         Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.inputShape());
-        Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.outputShape());
+        Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.outputShape());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class ChoiceMetadataHandlerTest {
         DynamicActionMetadata metadata = metadataHandler.createMetadata(choiceStep, Collections.emptyList(), Collections.emptyList());
 
         Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.inputShape());
-        Assert.assertEquals(StepMetadataHelper.NO_SHAPE, metadata.outputShape());
+        Assert.assertEquals(StepMetadataHelper.ANY_SHAPE, metadata.outputShape());
     }
 
     @Test

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
@@ -213,7 +213,7 @@ public class StepActionHandlerTest {
 
         final StepDescriptor descriptor = meta.getValue();
         assertThat(descriptor.getInputDataShape()).contains(StepMetadataHelper.NO_SHAPE);
-        assertThat(descriptor.getOutputDataShape()).contains(StepMetadataHelper.NO_SHAPE);
+        assertThat(descriptor.getOutputDataShape()).contains(StepMetadataHelper.ANY_SHAPE);
     }
 
     @Test

--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -1437,7 +1437,7 @@ export function createConditionalFlowStart(
     name: 'Flow start',
     properties: {},
   } as StepKind;
-  return adaptOutputShape(thisStep, step);
+  return step;
 }
 
 /**
@@ -1466,26 +1466,6 @@ function getConnectorAction(id: string, connection: Connection): Action {
   return connection!.connector!.actions!.find(
     action => action.id === id
   ) as Action;
-}
-
-/**
- * Helper function to ensure a conditional flow step assumes the correct
- * output shape that reflects the required input shape it's being inserted
- * in front of.
- * @param thisStep
- * @param step
- */
-function adaptOutputShape(thisStep: StepKind, step: StepKind) {
-  if (
-    thisStep &&
-    thisStep.action &&
-    thisStep.action.descriptor &&
-    thisStep.action.descriptor.inputDataShape
-  ) {
-    step.action!.descriptor!.outputDataShape =
-      thisStep.action.descriptor.inputDataShape;
-  }
-  return step;
 }
 
 /**


### PR DESCRIPTION
When an integration uses conditional flows step the warning "Configuration Required" always showed up after save. This was because data shapes in connection descriptors were automatically adjusted for each subflow.

For some reason (I still do not understand the javascript magic) the data shape was adjusted not only in `flow->step->action->descriptor->datashape` but also in `flow->step->action->connection->descriptor->datashape`. The latter connection descriptor data shape should never be changed by a data shape auto adapt. This difference of the connection configuration caused the "Configuration Required" warning to always show up.

The data shape adjustment on the connector descriptor took place in https://github.com/syndesisio/syndesis/blob/master/app/ui-react/packages/api/src/helpers/integrationFunctions.ts#L1478

I tried to fix and then found out that the data shape adjustment at this point is not necessary as the shapes get set later on during step reconcile mechanism. So removing the initial data shape adjustment completely fixed the issue.