### PR TITLE
feat: extract standardized errors from the flow and supply it to the error mapping form

### DIFF
--- a/app/ui-react/packages/api/src/constants.ts
+++ b/app/ui-react/packages/api/src/constants.ts
@@ -98,6 +98,9 @@ export const EXCERPT_METADATA_KEY = 'excerpt';
 export const STEP_ID_METADATA_KEY = 'stepId';
 export const PRIMARY_FLOW_ID_METADATA_KEY = 'primaryFlowId';
 
+// Special action IDs
+export const API_PROVIDER_END_ACTION_ID = 'io.syndesis:api-provider-end';
+
 // Special sekret connection metadata keys
 export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';
 export const HIDE_FROM_CONNECTION_PAGES = 'hide-from-connection-pages';

--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -13,7 +13,11 @@ import produce from 'immer';
 import * as React from 'react';
 import { ApiContext } from './ApiContext';
 import { callFetch } from './callFetch';
-import { PUBLISHED, UNPUBLISHED } from './constants';
+import {
+  API_PROVIDER_END_ACTION_ID,
+  PUBLISHED,
+  UNPUBLISHED,
+} from './constants';
 import {
   createStep,
   getStep,
@@ -337,11 +341,16 @@ export const useIntegrationHelpers = () => {
   ): Promise<Integration> => {
     return produce(integration, async () => {
       const originalStep = getStep(integration, flowId, position);
-      const actionDescriptor = await getActionDescriptor(
-        connection.id!,
-        action.id!,
-        configuredProperties
-      );
+      // the API provider end action needs to maintain the descriptor
+      // as stored on the step
+      const actionDescriptor =
+        action.id !== API_PROVIDER_END_ACTION_ID
+          ? await getActionDescriptor(
+              connection.id!,
+              action.id!,
+              configuredProperties
+            )
+          : originalStep!.action!.descriptor!;
       const step: Step = setDescriptorOnStep(
         {
           action,

--- a/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.tsx
@@ -25,6 +25,7 @@ export const FormMapsetComponent: React.FunctionComponent<
 > = props => {
   const { getField } = useFormBuilder();
   const { value, onChange, onBlur, ...field } = props.field;
+  const mapsetValue = typeof value === 'string' ? JSON.parse(value) : value;
   const id = toValidHtmlId(field.name);
   const mapsetOptions = props.property.mapsetOptions || ({} as IMapsetOptions);
   const mapsetValueDefinition = {
@@ -106,7 +107,7 @@ export const FormMapsetComponent: React.FunctionComponent<
                                 ...mapsetValueDefinition,
                                 name: `${field.name}.${mapsetKey.name}`,
                               },
-                              value: value[mapsetKey.name],
+                              value: mapsetValue[mapsetKey.name],
                             })}
                           </div>
                         </DataListCell>,

--- a/app/ui-react/packages/models/src/extra.d.ts
+++ b/app/ui-react/packages/models/src/extra.d.ts
@@ -11,6 +11,7 @@ import {
   IntegrationOverview,
   Step,
 } from './models';
+import { ActionDescriptor } from './models-internal';
 
 /**
  * Extra interfaces and overrides for the swagger generated models
@@ -137,4 +138,13 @@ export interface StringMap<T> {
 export interface IndexedStep {
   step: Step;
   index: number;
+}
+
+export interface ErrorKey {
+  displayName: string;
+  name: string;
+}
+
+export interface ExtendedActionDescriptor extends ActionDescriptor {
+  standardizedErrors?: ErrorKey[];
 }

--- a/app/ui-react/packages/utils/src/autoformHelpers.ts
+++ b/app/ui-react/packages/utils/src/autoformHelpers.ts
@@ -47,7 +47,9 @@ export function toFormDefinitionProperty(property: IConfigurationProperty) {
   } = property as any; // needed, ConfigurationProperty is a lie
   return {
     ...formDefinitionProperty,
-    ...(extendedProperties || {}),
+    ...((typeof extendedProperties === 'string'
+      ? JSON.parse(extendedProperties)
+      : extendedProperties) || {}),
     controlHint: controlHint || controlTooltip,
     fieldAttributes: {
       cols,
@@ -198,4 +200,19 @@ export function validateRequiredProperties<T>(
       return { ...acc, ...result };
     }, {});
   return { ...validationResults, ...arrayValidationResults };
+}
+
+/**
+ * Stringifies non-complex types in a property map
+ * @param values
+ */
+export function coerceFormValues(values: any) {
+  const updated = {};
+  Object.keys(values).forEach(key => {
+    updated[key] =
+      typeof values[key] === 'object'
+        ? JSON.stringify(values[key])
+        : values[key];
+  });
+  return updated;
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -5,10 +5,15 @@ import {
   getActionSteps,
 } from '@syndesis/api';
 import { AutoForm, IFormValue } from '@syndesis/auto-form';
-import { Action, ActionDescriptor } from '@syndesis/models';
+import {
+  Action,
+  ActionDescriptor,
+  IConfigurationProperties,
+} from '@syndesis/models';
 import { IntegrationEditorForm } from '@syndesis/ui';
 import {
   allFieldsRequired,
+  coerceFormValues,
   getRequiredStatusText,
   toFormDefinition,
   validateRequiredProperties,
@@ -26,6 +31,7 @@ export interface IConfigurationFormProps
     Pick<IWithConfigurationFormProps, 'chooseActionHref'> {
   action: Action;
   descriptor: ActionDescriptor;
+  definitionOverride?: IConfigurationProperties;
   children: any;
 }
 
@@ -35,6 +41,7 @@ export const ConfigurationForm: React.FunctionComponent<
   action,
   configurationPage,
   descriptor,
+  definitionOverride,
   initialValue,
   oldAction,
   chooseActionHref,
@@ -46,7 +53,7 @@ export const ConfigurationForm: React.FunctionComponent<
   try {
     const steps = getActionSteps(descriptor);
     const step = getActionStep(steps, configurationPage);
-    const definition = getActionStepDefinition(step);
+    const definition = definitionOverride || getActionStepDefinition(step);
     const moreConfigurationSteps = configurationPage < steps.length - 1;
     const onSave = async (
       values: { [key: string]: string },
@@ -63,7 +70,7 @@ export const ConfigurationForm: React.FunctionComponent<
         await onUpdatedIntegration({
           action,
           moreConfigurationSteps,
-          values,
+          values: coerceFormValues(values),
         });
       } catch (e) {
         setError(e.message);

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -1,4 +1,5 @@
 import {
+  getFlow,
   getStep,
   getSteps,
   isEndStep,
@@ -22,7 +23,7 @@ import {
   IDescribeDataShapeRouteState,
   IPageWithEditorBreadcrumb,
 } from '../interfaces';
-import { toUIStep, toUIStepCollection } from '../utils';
+import { collectErrorKeys, toUIStep, toUIStepCollection } from '../utils';
 import {
   IOnUpdatedIntegrationProps,
   WithConfigurationForm,
@@ -82,6 +83,13 @@ export class ConfigureActionPage extends React.Component<
               const oldStepConfig = getStep(
                 state.updatedIntegration || state.integration,
                 params.flowId,
+                positionAsNumber
+              );
+              const errorKeys = collectErrorKeys(
+                getFlow(
+                  state.updatedIntegration || state.integration,
+                  params.flowId
+                )!,
                 positionAsNumber
               );
               /**
@@ -240,13 +248,14 @@ export class ConfigureActionPage extends React.Component<
                         key={`${positionAsNumber}:${pageAsNumber}`}
                         connection={state.connection}
                         actionId={params.actionId}
+                        configurationPage={pageAsNumber}
+                        errorKeys={errorKeys}
+                        initialValue={configuredProperties}
                         oldAction={
                           useOldStepConfig && oldStepConfig!.action
                             ? oldStepConfig!.action!
                             : undefined
                         }
-                        configurationPage={pageAsNumber}
-                        initialValue={configuredProperties}
                         onUpdatedIntegration={onUpdatedIntegration}
                         chooseActionHref={this.props.backHref(params, state)}
                       />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -1,20 +1,24 @@
 import {
+  API_PROVIDER_END_ACTION_ID,
   getActionById,
   getConnectionConnector,
   getConnectorActions,
   WithActionDescriptor,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import { Action, IConnectionOverview } from '@syndesis/models';
+import {
+  Action,
+  ErrorKey,
+  IConfigurationProperties,
+  IConfigurationProperty,
+  IConnectionOverview,
+} from '@syndesis/models';
 import { PageSectionLoader } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { ApiError } from '../../../../../shared';
 import { ConfigurationForm } from './ConfigurationForm';
 import { NothingToConfigure } from './NothingToConfigure';
-
-// Special action IDs
-export const API_PROVIDER_END_ACTION_ID = 'io.syndesis:api-provider-end';
 
 export interface IOnUpdatedIntegrationProps {
   /**
@@ -46,7 +50,14 @@ export interface IWithConfigurationFormProps {
    */
   actionId: string;
 
+  /**
+   * the action configuration that had been previously configured on the step
+   */
   oldAction?: Action;
+  /**
+   * a list of possible error keys for steps that need to worry about error handling
+   */
+  errorKeys?: ErrorKey[];
   /**
    * for actions whose configuration must be performed in multiple steps,
    * indicates the current step.
@@ -72,6 +83,29 @@ export interface IWithConfigurationFormProps {
 }
 
 /**
+ * A really specific helper function to apply collected error keys to
+ * an error mapping form
+ * @param action
+ * @param errorKeys
+ */
+function applyErrorKeysToForm(action: Action, errorKeys: ErrorKey[]) {
+  const definition = {
+    ...action.descriptor!.propertyDefinitionSteps![0],
+  } as any;
+  const errorResponseCodes = definition!.properties!
+    .errorResponseCodes as IConfigurationProperty;
+  const extProperties =
+    typeof errorResponseCodes.extendedProperties === 'string'
+      ? JSON.parse(errorResponseCodes.extendedProperties)
+      : { ...errorResponseCodes.extendedProperties };
+  errorResponseCodes.extendedProperties = JSON.stringify({
+    ...extProperties,
+    mapsetKeys: errorKeys,
+  });
+  return definition.properties as IConfigurationProperties;
+}
+
+/**
  * A component to generate a configuration form for a given action and values.
  *
  * @see [action]{@link IWithConfigurationFormProps#action}
@@ -81,14 +115,23 @@ export interface IWithConfigurationFormProps {
 export const WithConfigurationForm: React.FunctionComponent<
   IWithConfigurationFormProps
 > = props => {
-  const action = getActionById(
-    getConnectorActions(getConnectionConnector(props.connection)),
-    props.actionId
-  );
-  // For the API provider end action, the descriptor stored in the integration is the source of truth
+  // Use the action configuration that was set on the step, otherwise find it in the connection definition
+  const action =
+    props.oldAction ||
+    getActionById(
+      getConnectorActions(getConnectionConnector(props.connection)),
+      props.actionId
+    );
+  // The API provider end action gets some special treatment
   if (props.actionId === API_PROVIDER_END_ACTION_ID) {
+    const definitionOverride = applyErrorKeysToForm(action, props.errorKeys!);
     return (
-      <ConfigurationForm action={action} descriptor={action.descriptor!} {...props}>
+      <ConfigurationForm
+        action={action}
+        descriptor={action.descriptor!}
+        definitionOverride={definitionOverride}
+        {...props}
+      >
         <NothingToConfigure
           action={action}
           descriptor={action.descriptor!}

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -116,6 +116,12 @@
       "fieldRequired": "{{field}} is required"
     }
   },
+  "errorKeys": {
+    "SqlEntityNotFoundError": "SQL Entity Not Found",
+    "SqlDataAccessError": "SQL Data Access Error",
+    "SqlConnectorError": "SQL Connector Error",
+    "ServerError": "Server Error"
+  },
   "apiProvider": {
     "editSpecification": {
       "title": "Provide API Definition",


### PR DESCRIPTION
for #4259

Rough old screenshot, also still compatible with the old api provider end action definition kinda a little bit:

![image](https://user-images.githubusercontent.com/351660/63379948-69758980-c363-11e9-92c8-9ac996ca20f1.png)
