### PR TITLE
fix: ensure api provider return page can still work with the old form definition

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -94,6 +94,10 @@ function applyErrorKeysToForm(action: Action, errorKeys: ErrorKey[]) {
   } as any;
   const errorResponseCodes = definition!.properties!
     .errorResponseCodes as IConfigurationProperty;
+  // TODO compatibility, remove when this property is defined
+  if (!errorResponseCodes) {
+    return definition.properties;
+  }
   const extProperties =
     typeof errorResponseCodes.extendedProperties === 'string'
       ? JSON.parse(errorResponseCodes.extendedProperties)


### PR DESCRIPTION
related to PR #6415, meant to include this change in there and apparently neglected to actually push it to that branch.