### PR TITLE
feat: various conditional flow improvements based on user feedback

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.css
@@ -2,8 +2,16 @@
   white-space: nowrap ;
 }
 
+.form-array-section__title {
+  white-space: nowrap;
+}
+
 .form-array-control__array-controls .fa {
   font-size: 20px;
+}
+
+.form-array-control__array-add .btn {
+  font-size: inherit;
 }
 
 .form-array-layout {

--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
@@ -55,7 +55,7 @@ export const FormArrayComponent: React.FunctionComponent<
                 </h5>
               </div>
             )}
-            <div className="form-array-section__fields form-array-layout">
+            <div className="form-array-section__fields form-array-layout" {...formGroupAttributes}>
               {propertiesArray.map(property => {
                 const propertyFieldName = `${fieldName}.${property.name}`;
 

--- a/app/ui-react/packages/auto-form/src/widgets/FormHiddenComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormHiddenComponent.tsx
@@ -5,7 +5,7 @@ import { toValidHtmlId } from './helpers';
 export const FormHiddenComponent: React.FunctionComponent<
   IFormControlProps
 > = props => (
-  <div {...props.property.formGroupAttributes}>
+  <div {...props.property.formGroupAttributes} style={{ display: 'none' }}>
     <input
       {...props.property.fieldAttributes}
       {...props.field}

--- a/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.css
@@ -1,6 +1,8 @@
 .auto-form-legend {
+  white-space: nowrap;
   margin-top: 1em;
 }
-.auto-form-legend h4 {
+.auto-form-legend h5 {
   margin-bottom: 0;
+  font-weight: 600;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.tsx
@@ -6,6 +6,6 @@ export const FormLegendComponent: React.FunctionComponent<
   IFormControlProps
 > = props => (
   <TextContent className={'pf-c-form__group auto-form-legend'}>
-    <Text component={TextVariants.h4}>{props.property.displayName}</Text>
+    <Text component={TextVariants.h5}>{props.property.displayName}</Text>
   </TextContent>
 );

--- a/app/ui-react/packages/auto-form/stories/FormWrapper.tsx
+++ b/app/ui-react/packages/auto-form/stories/FormWrapper.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 export interface IFormWrapperProps {
   isHorizontal?: boolean;
+  className?: string;
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
   fields: JSX.Element;
 }
@@ -16,6 +17,7 @@ export class FormWrapper extends React.Component<IFormWrapperProps> {
             ? this.props.isHorizontal
             : true
         }
+        className={this.props.className || ''}
         onSubmit={this.props.onSubmit}
       >
         {this.props.fields}

--- a/app/ui-react/packages/auto-form/stories/SyndesisUIs.stories.tsx
+++ b/app/ui-react/packages/auto-form/stories/SyndesisUIs.stories.tsx
@@ -280,6 +280,7 @@ stories.add('Editor Basic Filter', () => {
 stories.add('Conditional Flow', () => {
   const definition = {
     defaultFlowId: {
+      order: 6,
       type: 'hidden',
     },
     flowConditions: {
@@ -288,7 +289,7 @@ stories.add('Conditional Flow', () => {
           defaultValue: '',
           description:
             "Provide a condition that you want to evaluate (for example, ${in.header.type} == 'note' or ${in.body.title} contains 'Important').",
-          displayName: 'Condition',
+          displayName: '',
           placeholder: 'Simple language expression',
           required: true,
           type: 'text',
@@ -305,33 +306,45 @@ stories.add('Conditional Flow', () => {
       },
       arrayDefinitionOptions: {
         arrayControlAttributes: {
-          className: 'col-md-2 form-group',
+          className: 'conditional-flow__controls',
         },
         arrayRowTitleAttributes: {
-          className: 'col-md-2',
+          className: 'conditional-flow__title',
         },
         controlLabelAttributes: {
           style: { display: 'none' },
         },
         formGroupAttributes: {
-          className: 'col-md-8',
+          className: 'conditional-flow__form-group',
         },
         i18nAddElementText: 'Add another condition',
         minElements: 1,
         rowTitle: 'When',
         showSortControls: true,
       },
+      order: 1,
       required: true,
       type: 'array',
     },
+    forAllIncomingData: {
+      displayName: 'For all incoming data',
+      order: 0,
+      type: 'legend',
+    },
+    otherwise: {
+      displayName: 'If incoming data does not match all of the above conditions',
+      order: 2,
+      type: 'legend'
+    },
     routingScheme: {
       defaultValue: 'direct',
+      order: 5,
       type: 'hidden',
     },
     useDefaultFlow: {
       defaultValue: 'false',
-      description: 'Execute this flow when no other condition matches.',
-      displayName: 'Use a default flow',
+      displayName: 'Execute default flow',
+      order: 3,
       type: 'boolean',
     },
   } as IFormDefinition;
@@ -368,6 +381,33 @@ stories.add('Conditional Flow', () => {
 
   return (
     <StoryWrapper definition={definition}>
+      <style dangerouslySetInnerHTML={{__html: `
+        .conditional-flow__form section {
+          display: flex;
+          flex-wrap: nowrap;
+          flex-direction: row;
+          margin-left: 7em;
+        }
+        .conditional-flow__form-group {
+          padding: 0 15px 0 15px;
+        }
+        .conditional-flow__controls {
+          padding-top: 4px;
+        }
+        .conditional-flow__form .conditional-flow__form-group .pf-c-form__group {
+          display: inherit !important;
+        }
+        .conditional-flow__title {
+          padding-top: 10px;
+        }
+        .conditional-flow__form .form-array-control__array-add {
+          display: block;
+          padding-left: 6.5em;
+        }
+        .conditional-flow__form .form-array-control__array-add .btn {
+        
+        }
+      `}}/>
       <AutoForm
         definition={object('Definition', definition)}
         initialValue={object('Initial Value', initialValue)}
@@ -383,7 +423,7 @@ stories.add('Conditional Flow', () => {
         }}
       >
         {({ fields, handleSubmit }) => (
-          <FormWrapper onSubmit={handleSubmit} fields={fields} />
+          <FormWrapper className={'conditional-flow__form'} onSubmit={handleSubmit} fields={fields} />
         )}
       </AutoForm>
     </StoryWrapper>

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceConfigurationView.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceConfigurationView.tsx
@@ -1,5 +1,5 @@
 import * as H from '@syndesis/history';
-import { Icon, ListView, ListViewItem } from 'patternfly-react';
+import { ListView, ListViewItem } from 'patternfly-react';
 import * as React from 'react';
 import { toValidHtmlId } from '../../../helpers';
 import { ButtonLink } from '../../../Layout';
@@ -48,10 +48,10 @@ export class ChoiceConfigurationView extends React.Component<
             additionalInfo={[]}
           />
         ))}
-        <ListViewItem
-          key={'otherwise'}
-          actions={
-            this.props.useDefaultFlow && (
+        {this.props.useDefaultFlow && (
+          <ListViewItem
+            key={'otherwise'}
+            actions={
               <ButtonLink
                 data-testid="choice-view-mode-view-default-flow-button"
                 href={this.props.defaultFlowHref}
@@ -59,18 +59,11 @@ export class ChoiceConfigurationView extends React.Component<
               >
                 {this.props.i18nOpenFlow}
               </ButtonLink>
-            )
-          }
-          description={
-            <>
-              {this.props.useDefaultFlow && <Icon name="check" />}
-              {!this.props.useDefaultFlow && <Icon name="ban" />}
-              &nbsp;
-              {this.props.i18nUseDefaultFlow}
-            </>
-          }
-          heading={<strong>{this.props.i18nOtherwise}</strong>}
-        />
+            }
+            description={this.props.i18nUseDefaultFlow}
+            heading={<strong>{this.props.i18nOtherwise}</strong>}
+          />
+        )}
       </ListView>
     );
   }

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.css
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.css
@@ -1,0 +1,35 @@
+.conditional-flow__form {
+  margin-bottom: 2em;
+}
+.conditional-flow__form .auto-form-legend h5 {
+  font-weight: 600 !important;
+}
+.conditional-flow__form section {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  margin-left: 7em;
+}
+.conditional-flow__form-group {
+  padding: 0 15px 0 15px;
+}
+.conditional-flow__controls {
+  padding-top: 4px;
+}
+.conditional-flow__form .conditional-flow__form-group .pf-c-form__group {
+  /* undo the grid layout specifically for this form */
+  display: inherit !important;
+}
+.conditional-flow__title {
+  padding-top: 10px;
+}
+.conditional-flow__title h5 strong {
+  font-weight: 600;
+}
+.conditional-flow__form .form-array-control__array-add {
+  display: block;
+  padding-left: 6.5em;
+}
+.conditional-flow__form .form-array-control__array-add .btn {
+
+}

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
@@ -1,0 +1,45 @@
+import { Form } from '@patternfly/react-core';
+import * as React from 'react';
+import { ButtonLink, Container, PageSection } from '../../../Layout';
+
+import './ChoicePageCard.css';
+
+export interface IChoicePageCardProps {
+  header?: JSX.Element;
+  i18nDone: string;
+  isValid: boolean;
+  submitForm: (e?: any) => void;
+}
+
+export class ChoicePageCard extends React.Component<IChoicePageCardProps> {
+  public render() {
+    return (
+      <PageSection>
+        <Container>
+          <div className="row row-cards-pf">
+            <div className="card-pf">
+              {this.props.header && (
+                <div className="card-pf-header">{this.props.header}</div>
+              )}
+              <div className="card-pf-body">
+                <Container>
+                  <Form className={'conditional-flow__form'} isHorizontal={true}>{this.props.children}</Form>
+                </Container>
+              </div>
+              <div className="card-pf-footer">
+                <ButtonLink
+                  data-testid={'editor-page-card-done-button'}
+                  onClick={this.props.submitForm}
+                  disabled={!this.props.isValid}
+                  as={'primary'}
+                >
+                  {this.props.i18nDone}
+                </ButtonLink>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </PageSection>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/index.ts
@@ -1,2 +1,3 @@
 export * from './ChoiceCardHeader';
 export * from './ChoiceConfigurationView';
+export * from './ChoicePageCard';

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
@@ -12,7 +12,7 @@ import * as H from '@syndesis/history';
 import { Integration, StringMap } from '@syndesis/models';
 import {
   ChoiceCardHeader,
-  EditorPageCard,
+  ChoicePageCard,
   IntegrationEditorLayout,
   PageLoader,
   PageSection,
@@ -241,7 +241,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                                 stepId={step.id!}
                               >
                                 {({ fields, isValid, submitForm }) => (
-                                  <EditorPageCard
+                                  <ChoicePageCard
                                     header={
                                       <ChoiceCardHeader
                                         i18nConditions={'Conditions'}
@@ -252,7 +252,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                                     submitForm={submitForm}
                                   >
                                       {fields}
-                                  </EditorPageCard>
+                                  </ChoicePageCard>
                                 )}
                               </WithChoiceConfigurationForm>
                             )}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/WithChoiceConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/WithChoiceConfigurationForm.tsx
@@ -26,14 +26,16 @@ export const WithChoiceConfigurationForm: React.FunctionComponent<
 
   const definition = {
     defaultFlowId: {
+      order: 6,
       type: 'hidden',
     },
+
     flowConditions: {
       arrayDefinition: {
         condition: {
           defaultValue: '',
           description: t('integrations:editor:choiceForm:conditionDescription'),
-          displayName: t('integrations:editor:choiceForm:conditionName'),
+          displayName: '',
           placeholder: t('integrations:editor:choiceForm:conditionPlaceholder'),
           required: true,
           type: 'text',
@@ -50,35 +52,45 @@ export const WithChoiceConfigurationForm: React.FunctionComponent<
       },
       arrayDefinitionOptions: {
         arrayControlAttributes: {
-          className: 'col-md-2 form-group',
+          className: 'conditional-flow__controls',
         },
         arrayRowTitleAttributes: {
-          className: 'col-md-2',
+          className: 'conditional-flow__title',
         },
         controlLabelAttributes: {
           style: { display: 'none' },
         },
         formGroupAttributes: {
-          className: 'col-md-8',
+          className: 'conditional-flow__form-group',
         },
         i18nAddElementText: t('integrations:editor:choiceForm:addCondition'),
         minElements: 1,
         rowTitle: t('integrations:editor:choiceForm:addConditionTitle'),
         showSortControls: true,
       },
+      order: 1,
       required: true,
       type: 'array',
     },
+    forAllIncomingData: {
+      displayName: t('integrations:editor:choiceForm:forAllIncomingData'),
+      order: 0,
+      type: 'legend',
+    },
+    otherwise: {
+      displayName: t('integrations:editor:choiceForm:otherwise'),
+      order: 2,
+      type: 'legend'
+    },
     routingScheme: {
       defaultValue: 'direct',
+      order: 5,
       type: 'hidden',
     },
     useDefaultFlow: {
       defaultValue: 'false',
-      description: t(
-        'integrations:editor:choiceForm:useDefaultFlowDescription'
-      ),
       displayName: t('integrations:editor:choiceForm:useDefaultFlowTitle'),
+      order: 3,
       type: 'boolean',
     },
   } as IFormDefinition;

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -96,8 +96,9 @@
       "conditionPlaceholder": "Simple language expression",
       "addCondition": "Add another condition",
       "addConditionTitle": "When",
-      "useDefaultFlowDescription": "Execute this flow when no other condition matches.",
-      "useDefaultFlowTitle": "Use a default flow",
+      "forAllIncomingData": "For all incoming data",
+      "otherwise": "If incoming data does not match all of the above conditions",
+      "useDefaultFlowTitle": "Execute default flow",
       "fieldRequired": "{{field}} is required"
     },
     "ruleForm": {


### PR DESCRIPTION
related to #6093 

Form now looks like:
![image(1)](https://user-images.githubusercontent.com/351660/63967143-c6132b80-ca6a-11e9-8a32-52965e92b7e5.png)

very loosely based on [this design](https://marvelapp.com/7ai4d53/screen/60537627)

When you don't check the "use default flow box":
![image](https://user-images.githubusercontent.com/351660/63967108-b1cf2e80-ca6a-11e9-9e74-d56342a2e2f0.png)


And when you do:
![image](https://user-images.githubusercontent.com/351660/63966965-6ae13900-ca6a-11e9-94a7-93289774049b.png)

Also updates the storybook to use the same layout/css etc.

@mcoker kinda fought with the horizontal form grid layout there a bit, dunno if you might want to have a look.