### PR TITLE
fix: hide the configure buttons for the flow start/end connections

### DIFF
--- a/app/ui-react/packages/api/src/constants.ts
+++ b/app/ui-react/packages/api/src/constants.ts
@@ -100,6 +100,8 @@ export const PRIMARY_FLOW_ID_METADATA_KEY = 'primaryFlowId';
 
 // Special action IDs
 export const API_PROVIDER_END_ACTION_ID = 'io.syndesis:api-provider-end';
+export const FLOW_START_ACTION_ID = 'io.syndesis:flow-start';
+export const FLOW_END_ACTION_ID = 'io.syndesis:flow-end';
 
 // Special sekret connection metadata keys
 export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -160,17 +160,21 @@ export class IntegrationEditorStepAdder extends React.Component<
                               <i className="fa fa-trash" />
                             </ButtonLink>
                           )}
-                          <ButtonLink
-                            data-testid={
-                              'integration-editor-step-adder-configure-button'
-                            }
-                            href={this.props.configureStepHref(
-                              idx,
-                              this.props.steps[idx]
-                            )}
-                          >
-                            {t('shared:Configure')}
-                          </ButtonLink>
+                          {s.notConfigurable ? (
+                            <>&nbsp;</>
+                          ) : (
+                            <ButtonLink
+                              data-testid={
+                                'integration-editor-step-adder-configure-button'
+                              }
+                              href={this.props.configureStepHref(
+                                idx,
+                                this.props.steps[idx]
+                              )}
+                            >
+                              {t('shared:Configure')}
+                            </ButtonLink>
+                          )}
                         </>
                       }
                     />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.ts
@@ -46,6 +46,7 @@ export interface IUIIntegrationStep extends IUIStep {
   shouldAddDataMapper: boolean;
   isUnclosedSplit: boolean;
   restrictedDelete: boolean;
+  notConfigurable: boolean;
 }
 
 /*********************************/

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -10,6 +10,8 @@ import {
   ENDPOINT,
   EXTENSION,
   FLOW,
+  FLOW_END_ACTION_ID,
+  FLOW_START_ACTION_ID,
   getNextAggregateStep,
   getPreviousSteps,
   getPreviousStepWithDataShape,
@@ -164,7 +166,6 @@ export function toUIIntegrationStepCollection(
     let previousStepShouldDefineDataShapePosition: number | undefined;
     let shouldAddDataMapper = false;
     let restrictedDelete = false;
-
     if (
       step.connection &&
       (step.connection!.connectorId! === FLOW ||
@@ -172,6 +173,10 @@ export function toUIIntegrationStepCollection(
     ) {
       restrictedDelete = true;
     }
+    const notConfigurable =
+      (step.action || false) &&
+      (step.action!.id === FLOW_START_ACTION_ID ||
+        step.action!.id === FLOW_END_ACTION_ID);
     const isUnclosedSplit =
       step.stepKind === SPLIT &&
       getNextAggregateStep(steps, position) === undefined;
@@ -213,6 +218,7 @@ export function toUIIntegrationStepCollection(
     return {
       ...step,
       isUnclosedSplit,
+      notConfigurable,
       previousStepShouldDefineDataShape,
       previousStepShouldDefineDataShapePosition,
       restrictedDelete,


### PR DESCRIPTION
for #6093

Was on my list for the last PR and totally forgot to do it.  This PR makes this happen for these two connections in the editor:

![image](https://user-images.githubusercontent.com/351660/64189549-7c4b8c00-ce42-11e9-8c39-2d9907e27336.png)

and

![image](https://user-images.githubusercontent.com/351660/64189571-89687b00-ce42-11e9-85b3-6e4a4b35634f.png)

@christophd FYI