### PR TITLE
feat [6094]: Add basic condition expression builder to conditional flows step

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/choice/FlowOption.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/choice/FlowOption.java
@@ -48,7 +48,7 @@ public interface FlowOption extends RuleBase {
      * simple expression from given path, operator and value.
      */
     default String getConditionExpression() {
-        if (getCondition() != null) {
+        if (getCondition() != null && getCondition().trim().length() > 0) {
             return getCondition();
         }
 

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
@@ -59,6 +59,7 @@ public class ChoiceStepHandler implements IntegrationStepHandler {
 
             for (FlowOption flowOption : flows) {
                 choice.when(getPredicate(flowOption.getConditionExpression(), builder.getContext()))
+                        .description(flowOption.getConditionExpression())
                         .process(new EnrichActivityIdHeader())
                         .to(getEndpointUri(routingScheme, flowOption.getFlow()))
                         .end();

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
@@ -273,8 +273,8 @@ public class ChoiceStepHandlerTest extends IntegrationTestSupport {
                             .stepKind(StepKind.choice)
                             .putConfiguredProperty("routingScheme", "mock")
                             .putConfiguredProperty("flows", "[" +
-                                        "{\"path\": \"text\", \"op\": \"contains\", \"value\": \"Hello\", \"flow\": \"hello-flow\"}," +
-                                        "{\"path\": \"text\", \"op\": \"contains\", \"value\": \"Bye\", \"flow\": \"bye-flow\"}" +
+                                        "{\"condition\": \"\", \"path\": \"text\", \"op\": \"contains\", \"value\": \"Hello\", \"flow\": \"hello-flow\"}," +
+                                        "{\"condition\": \"\", \"path\": \"text\", \"op\": \"contains\", \"value\": \"Bye\", \"flow\": \"bye-flow\"}" +
                                     "]")
                             .build(),
                     new Step.Builder()

--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -1182,6 +1182,36 @@ export function getPreviousIntegrationStepsWithDataShape(
   const steps = getSteps(integration, flowId);
   return getPreviousStepsWithDataShape(steps || [], position);
 }
+
+/**
+ * Finds previous step with data shape according to given position in integration flow and returns
+ * that output data shape.
+ * @param integration
+ * @param flowId
+ * @param position
+ */
+export function getOutputDataShapeFromPreviousStep(
+  integration: Integration,
+  flowId: string,
+  position: number
+): DataShape {
+  let dataShape = {} as DataShape;
+  try {
+    const prevStep = getPreviousIntegrationStepWithDataShape(
+      integration,
+      flowId,
+      position
+    );
+    dataShape =
+      prevStep!.action!.descriptor!.outputDataShape ||
+      ({} as DataShape);
+  } catch (err) {
+    // ignore
+  }
+
+  return dataShape;
+}
+
 /**
  * Return all steps before the given position that have a data shape
  * @param steps

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepExpanderBody.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepExpanderBody.tsx
@@ -2,7 +2,7 @@ import * as H from '@syndesis/history';
 import { ChoiceConfigurationView } from '@syndesis/ui';
 import * as React from 'react';
 import { IUIStep } from '../interfaces';
-import { createChoiceConfiguration } from './utils';
+import { createChoiceConfiguration, getConditionExpression } from './utils';
 
 export interface IChoiceStepExpanderBodyProps {
   step: IUIStep;
@@ -16,9 +16,9 @@ export const ChoiceStepExpanderBody: React.FunctionComponent<
     step.configuredProperties || {}
   );
   // create links
-  const flowItems = configuration.flows.map(({ condition, flow }) => ({
-    condition,
-    href: getFlowHref(flow),
+  const flowItems = configuration.flows.map(flowOption => ({
+    condition: getConditionExpression(flowOption),
+    href: getFlowHref(flowOption.flow),
   }));
   const defaultFlowHref = configuration.defaultFlowEnabled
     ? getFlowHref(configuration.defaultFlow!)

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
@@ -1,7 +1,8 @@
 import {
   createConditionalFlow,
   FlowKind,
-  getFlow, getPreviousIntegrationStepWithDataShape,
+  getFlow,
+  getOutputDataShapeFromPreviousStep,
   getStep,
   getSteps,
   reconcileConditionalFlows,
@@ -10,7 +11,7 @@ import {
   WithIntegrationHelpers,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import {DataShape, Integration, StringMap} from '@syndesis/models';
+import { Integration, StringMap } from '@syndesis/models';
 import {
   ChoiceCardHeader,
   ChoicePageCard,
@@ -60,19 +61,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
               <WithRouteData<IChoiceStepRouteParams, IChoiceStepRouteState>>
                 {(params, state, { history }) => {
                   const positionAsNumber = parseInt(params.position, 10);
-                  let dataShape = {} as DataShape;
-                  try {
-                    const prevStep = getPreviousIntegrationStepWithDataShape(
-                      state.integration,
-                      params.flowId,
-                      positionAsNumber
-                    );
-                    dataShape =
-                      prevStep!.action!.descriptor!.outputDataShape ||
-                      ({} as DataShape);
-                  } catch (err) {
-                    // ignore
-                  }
+                  const dataShape = getOutputDataShapeFromPreviousStep(state.integration, params.flowId, positionAsNumber);
                   const step = state.step;
                   // parse the configured properties
                   const configuration = createChoiceConfiguration(

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
@@ -1,15 +1,16 @@
 import {
   createConditionalFlow,
   FlowKind,
-  getFlow,
+  getFlow, getPreviousIntegrationStepWithDataShape,
   getStep,
   getSteps,
   reconcileConditionalFlows,
   WithConnection,
+  WithFilterOptions,
   WithIntegrationHelpers,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import { Integration, StringMap } from '@syndesis/models';
+import {DataShape, Integration, StringMap} from '@syndesis/models';
 import {
   ChoiceCardHeader,
   ChoicePageCard,
@@ -28,7 +29,7 @@ import {
 } from '../interfaces';
 import { toUIStep, toUIStepCollection } from '../utils';
 import { IChoiceFormConfiguration } from './interfaces';
-import { createChoiceConfiguration } from './utils';
+import { createChoiceConfiguration, getFlowDescription } from './utils';
 import { WithChoiceConfigurationForm } from './WithChoiceConfigurationForm';
 
 const NEW_CONDITIONAL_FLOW_NAME = 'Conditional';
@@ -59,6 +60,19 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
               <WithRouteData<IChoiceStepRouteParams, IChoiceStepRouteState>>
                 {(params, state, { history }) => {
                   const positionAsNumber = parseInt(params.position, 10);
+                  let dataShape = {} as DataShape;
+                  try {
+                    const prevStep = getPreviousIntegrationStepWithDataShape(
+                      state.integration,
+                      params.flowId,
+                      positionAsNumber
+                    );
+                    dataShape =
+                      prevStep!.action!.descriptor!.outputDataShape ||
+                      ({} as DataShape);
+                  } catch (err) {
+                    // ignore
+                  }
                   const step = state.step;
                   // parse the configured properties
                   const configuration = createChoiceConfiguration(
@@ -70,9 +84,12 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                       ? configuration.defaultFlow!
                       : '',
                     flowConditions: configuration.flows.map(
-                      ({ condition, flow }) => ({
+                      ({ condition, flow, op, path, value }) => ({
                         condition,
                         flowId: flow,
+                        op,
+                        path,
+                        value,
                       })
                     ),
                     routingScheme: configuration.routingScheme,
@@ -110,7 +127,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                           typeof flowCondition.flowId === 'undefined'
                             ? createConditionalFlow(
                                 NEW_CONDITIONAL_FLOW_NAME,
-                                flowCondition.condition,
+                                getFlowDescription(flowCondition),
                                 FlowKind.CONDITIONAL,
                                 params.flowId,
                                 data,
@@ -122,7 +139,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                               ) ||
                               createConditionalFlow(
                                 NEW_CONDITIONAL_FLOW_NAME,
-                                flowCondition.condition,
+                                getFlowDescription(flowCondition),
                                 FlowKind.CONDITIONAL,
                                 params.flowId,
                                 data,
@@ -130,11 +147,14 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                                 flowCondition.flowId
                               )!;
                         // update the description
-                        flow.description = flowCondition.condition;
+                        flow.description = getFlowDescription(flowCondition);
                         return {
                           condition: flowCondition.condition,
                           flow,
                           flowId: flow.id,
+                          op: flowCondition.op,
+                          path: flowCondition.path,
+                          value: flowCondition.value,
                         };
                       }
                     );
@@ -158,6 +178,9 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                         flowCollection.map(f => ({
                           condition: f.condition,
                           flow: f.flowId,
+                          op: f.op,
+                          path: f.path,
+                          value: f.value,
                         }))
                       ),
                       routingScheme: values.routingScheme,
@@ -224,39 +247,44 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                           ),
                         })}
                         content={
-                          <WithLoader
-                            error={error}
-                            loading={!hasData}
-                            loaderChildren={<PageLoader />}
-                            errorChildren={
-                              <PageSection>
-                                <ApiError error={errorMessage!} />
-                              </PageSection>
-                            }
-                          >
-                            {() => (
-                              <WithChoiceConfigurationForm
-                                initialValue={initialFormValue}
-                                onUpdatedIntegration={onUpdatedIntegration}
-                                stepId={step.id!}
+                          <WithFilterOptions dataShape={dataShape}>
+                            {({ data: options, error: optionsError, errorMessage: optionsErrorMessage, hasData: hasOptions }) => (
+                              <WithLoader
+                                error={optionsError}
+                                loading={!hasOptions}
+                                loaderChildren={<PageLoader />}
+                                errorChildren={
+                                  <PageSection>
+                                    <ApiError error={optionsErrorMessage!} />
+                                  </PageSection>
+                                }
                               >
-                                {({ fields, isValid, submitForm }) => (
-                                  <ChoicePageCard
-                                    header={
-                                      <ChoiceCardHeader
-                                        i18nConditions={'Conditions'}
-                                      />
-                                    }
-                                    i18nDone={'Done'}
-                                    isValid={isValid}
-                                    submitForm={submitForm}
+                                {() => (
+                                  <WithChoiceConfigurationForm
+                                    initialValue={initialFormValue}
+                                    filterOptions={options}
+                                    onUpdatedIntegration={onUpdatedIntegration}
+                                    stepId={step.id!}
                                   >
-                                      {fields}
-                                  </ChoicePageCard>
+                                    {({ fields, isValid, submitForm }) => (
+                                      <ChoicePageCard
+                                        header={
+                                          <ChoiceCardHeader
+                                            i18nConditions={'Conditions'}
+                                          />
+                                        }
+                                        i18nDone={'Done'}
+                                        isValid={isValid}
+                                        submitForm={submitForm}
+                                      >
+                                          {fields}
+                                      </ChoicePageCard>
+                                    )}
+                                  </WithChoiceConfigurationForm>
                                 )}
-                              </WithChoiceConfigurationForm>
+                              </WithLoader>
                             )}
-                          </WithLoader>
+                          </WithFilterOptions>
                         }
                         cancelHref={this.props.cancelHref(params, state)}
                       />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/WithChoiceConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/WithChoiceConfigurationForm.tsx
@@ -1,5 +1,6 @@
 import { AutoForm, IFormDefinition } from '@syndesis/auto-form';
 import { IAutoFormActions } from '@syndesis/auto-form/src';
+import { FilterOptions } from "@syndesis/models";
 import { validateRequiredProperties } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +14,7 @@ export interface IWithChoiceConfigurationFormChildrenProps {
 }
 
 export interface IWithChoiceConfigurationFormProps {
+  filterOptions: FilterOptions;
   initialValue: IChoiceFormConfiguration;
   stepId: string;
   onUpdatedIntegration(props: IChoiceFormConfiguration): Promise<void>;
@@ -21,7 +23,7 @@ export interface IWithChoiceConfigurationFormProps {
 
 export const WithChoiceConfigurationForm: React.FunctionComponent<
   IWithChoiceConfigurationFormProps
-> = ({ onUpdatedIntegration, stepId, initialValue, children }) => {
+> = ({ onUpdatedIntegration, filterOptions, stepId, initialValue, children }) => {
   const { t } = useTranslation(['integrations', 'shared']);
 
   const definition = {
@@ -29,15 +31,15 @@ export const WithChoiceConfigurationForm: React.FunctionComponent<
       order: 6,
       type: 'hidden',
     },
-
     flowConditions: {
       arrayDefinition: {
         condition: {
           defaultValue: '',
           description: t('integrations:editor:choiceForm:conditionDescription'),
           displayName: '',
+          order: 0,
           placeholder: t('integrations:editor:choiceForm:conditionPlaceholder'),
-          required: true,
+          required: false,
           type: 'text',
         },
         flowId: {
@@ -48,6 +50,32 @@ export const WithChoiceConfigurationForm: React.FunctionComponent<
             },
           },
           type: 'hidden',
+        },
+        op: {
+          defaultValue: 'contains',
+          description: t('integrations:editor:choiceForm:operatorDescription'),
+          displayName: '',
+          enum: filterOptions.ops,
+          order: 2,
+          required: false,
+          type: 'text',
+        },
+        path: {
+          dataList: filterOptions.paths,
+          description: t('integrations:editor:choiceForm:pathDescription'),
+          displayName: t('integrations:editor:choiceForm:pathDisplay'),
+          order: 1,
+          placeholder: t('integrations:editor:choiceForm:pathPlaceholder'),
+          required: false,
+          type: 'text',
+        },
+        value: {
+          description: t('integrations:editor:choiceForm:keywordsDescription'),
+          displayName: '',
+          order: 3,
+          placeholder: t('integrations:editor:choiceForm:keywordsPlaceholder'),
+          required: false,
+          type: 'text',
         },
       },
       arrayDefinitionOptions: {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/interfaces.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/interfaces.ts
@@ -11,7 +11,10 @@ export interface IChoiceConfiguration {
 export interface IFlowOption {
   name?: string;
   flow: string;
-  condition: string;
+  condition?: string;
+  path?: string;
+  op?: string;
+  value?: string;
 }
 
 /**
@@ -26,5 +29,8 @@ export interface IChoiceFormConfiguration {
 
 export interface IFlowFormOption {
   flowId: string;
-  condition: string;
+  condition?: string;
+  path?: string;
+  op?: string;
+  value?: string;
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/utils.ts
@@ -22,32 +22,35 @@ export function createChoiceConfiguration(configuredProperties: {
 }
 
 /**
- * Builds a sane flow form option description from either condition expression or path, op, value properties
+ * Builds a sane flow form option description from either condition expression directly or from path, op, value properties
  * @param option
  */
 export function getFlowDescription(option: IFlowFormOption) {
-  if (option.condition) {
-    return option.condition;
-  }
-
-  if (option.path) {
-    return '${body.' + option.path + '} ' + option.op + " '" + option.value + "'";
-  }
-
-  return "";
+  return buildConditionExpression(option.condition, option.path, option.op, option.value);
 }
 
 /**
- * Builds a sane flow option condition expression from either given condition expression or path, op, value properties
+ * Builds a sane flow option description from either condition expression directly or from path, op, value properties
  * @param option
  */
 export function getConditionExpression(option: IFlowOption) {
-  if (option.condition) {
-    return option.condition;
+  return buildConditionExpression(option.condition, option.path, option.op, option.value);
+}
+
+/**
+ * Builds a sane flow form option description from either condition expression or path, op, value properties
+ * @param condition
+ * @param path
+ * @param op
+ * @param value
+ */
+function buildConditionExpression(condition: string | undefined, path: string | undefined, op: string | undefined, value: string | undefined) {
+  if (condition) {
+    return condition;
   }
 
-  if (option.path) {
-    return '${body.' + option.path + '} ' + option.op + " '" + option.value + "'";
+  if (path) {
+    return `\${body.${path}} ${op} '${value}'`;
   }
 
   return "";

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/utils.ts
@@ -1,4 +1,4 @@
-import { IChoiceConfiguration, IFlowOption } from './interfaces';
+import {IChoiceConfiguration, IFlowFormOption, IFlowOption} from './interfaces';
 
 /**
  * Builds a sane choice configuration object from the step's configured properties
@@ -19,4 +19,36 @@ export function createChoiceConfiguration(configuredProperties: {
     flows,
     routingScheme,
   } as IChoiceConfiguration;
+}
+
+/**
+ * Builds a sane flow form option description from either condition expression or path, op, value properties
+ * @param option
+ */
+export function getFlowDescription(option: IFlowFormOption) {
+  if (option.condition) {
+    return option.condition;
+  }
+
+  if (option.path) {
+    return '${body.' + option.path + '} ' + option.op + " '" + option.value + "'";
+  }
+
+  return "";
+}
+
+/**
+ * Builds a sane flow option condition expression from either given condition expression or path, op, value properties
+ * @param option
+ */
+export function getConditionExpression(option: IFlowOption) {
+  if (option.condition) {
+    return option.condition;
+  }
+
+  if (option.path) {
+    return '${body.' + option.path + '} ' + option.op + " '" + option.value + "'";
+  }
+
+  return "";
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/RuleFilterStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/RuleFilterStepPage.tsx
@@ -1,11 +1,11 @@
 import {
-  getPreviousIntegrationStepWithDataShape,
+  getOutputDataShapeFromPreviousStep,
   getSteps,
   WithFilterOptions,
   WithIntegrationHelpers,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import { DataShape, Integration } from '@syndesis/models';
+import { Integration } from '@syndesis/models';
 import {
   EditorPageCard,
   IntegrationEditorLayout,
@@ -57,19 +57,7 @@ export class RuleFilterStepPage extends React.Component<
             >>
               {(params, state, { history }) => {
                 const positionAsNumber = parseInt(params.position, 10);
-                let dataShape = {} as DataShape;
-                try {
-                  const prevStep = getPreviousIntegrationStepWithDataShape(
-                    state.integration,
-                    params.flowId,
-                    positionAsNumber
-                  );
-                  dataShape =
-                    prevStep!.action!.descriptor!.outputDataShape ||
-                    ({} as DataShape);
-                } catch (err) {
-                  // ignore
-                }
+                const dataShape = getOutputDataShapeFromPreviousStep(state.integration, params.flowId, positionAsNumber);
                 const handleSubmitForm = async ({
                   values,
                 }: IOnUpdatedIntegrationProps) => {

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -91,15 +91,21 @@
       "saveAndPublish": "Save and publish"
     },
     "choiceForm": {
-      "conditionDescription": "Provide a condition that you want to evaluate (for example, ${in.header.type} == 'note' or ${in.body.title} contains 'Important').",
+      "conditionDescription": "Provide a condition that you want to evaluate (for example, ${header.type} == 'note' or ${body.title} contains 'Important').",
       "conditionName": "Condition",
-      "conditionPlaceholder": "Simple language expression",
+      "conditionPlaceholder": "Condition expression",
       "addCondition": "Add another condition",
       "addConditionTitle": "When",
       "forAllIncomingData": "For all incoming data",
-      "otherwise": "If incoming data does not match all of the above conditions",
+      "otherwise": "When none of the above conditions matches to the incoming data",
       "useDefaultFlowTitle": "Execute default flow",
-      "fieldRequired": "{{field}} is required"
+      "fieldRequired": "{{field}} is required",
+      "operatorDescription": "Must meet this condition",
+      "pathDisplay": "Build a condition expression from ...",
+      "pathDescription": "The property you want to evaluate",
+      "pathPlaceholder": "Property name",
+      "keywordsDescription": "For this value",
+      "keywordsPlaceholder": "Keywords"
     },
     "ruleForm": {
       "predicateDescription": "Continue only if incoming data match ",

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -97,7 +97,7 @@
       "addCondition": "Add another condition",
       "addConditionTitle": "When",
       "forAllIncomingData": "For all incoming data",
-      "otherwise": "When none of the above conditions matches to the incoming data",
+      "otherwise": "When none of the above conditions match the incoming data",
       "useDefaultFlowTitle": "Execute default flow",
       "fieldRequired": "{{field}} is required",
       "operatorDescription": "Must meet this condition",


### PR DESCRIPTION
Relates to #6094 

Adds rule based form controls to condition expressions in conditional flows step. At the moment just adds the controls next to the advanced expression input field. The user can either provide an advanced expression or use the rule based form components to build the condition expression.

We will need to add some advanced form validation so that user needs to fill in either advanced or rule based form controls.

Backend has already been prepared to handle both advanced and rule based configuration so conditions are evaluated correctly at runtime.