### PR TITLE
Cards

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
@@ -72,6 +72,8 @@ a.connection-card__content:focus {
   font-weight: 300;
   margin-top: 15px;
   text-decoration: none;
+  overflow: hidden;
+  max-height: var(--pf-global--spacer--3xl);
 }
 
 .pf-c-card__footer.connection-card__footer--config-required {

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -235,6 +235,7 @@ export class ConnectionCard extends React.PureComponent<
               <div className={'connection-card__body'}>
                 <div className="connection-card__icon">{this.props.icon}</div>
                 <Title
+                  headingLevel="h2"
                   size="lg"
                   className="connection-card__title h2"
                   data-testid={'connection-card-title'}

--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsOauthCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsOauthCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Loader, PageSection } from '../Layout';
 

--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsOauthCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsOauthCard.tsx
@@ -1,4 +1,4 @@
-import { Card } from 'patternfly-react';
+import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Loader, PageSection } from '../Layout';
 
@@ -27,11 +27,11 @@ export const ConnectionDetailsOauthCard: React.FunctionComponent<
 }) => (
   <PageSection>
     <Card>
-      <Card.Heading>
-        <Card.Title>{i18nTitle}</Card.Title>
-      </Card.Heading>
-      <Card.Body>{i18nDescription}</Card.Body>
-      <Card.Footer>
+      <CardHeader>
+        <Title size="lg">{i18nTitle}</Title>
+      </CardHeader>
+      <CardBody>{i18nDescription}</CardBody>
+      <CardFooter>
         <ButtonLink disabled={isValidating} onClick={onValidate}>
           {i18nValidateButton}{' '}
           {isValidating && <Loader inline={true} size={'xs'} />}
@@ -45,7 +45,7 @@ export const ConnectionDetailsOauthCard: React.FunctionComponent<
           {i18nReconnectButton}{' '}
           {isReconnecting && <Loader inline={true} size={'xs'} />}
         </ButtonLink>
-      </Card.Footer>
+      </CardFooter>
     </Card>
   </PageSection>
 );

--- a/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
@@ -1,5 +1,5 @@
+import { Card, CardBody, CardFooter, CardHeader, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';
 

--- a/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSetupOAuthCard.tsx
@@ -1,5 +1,5 @@
 import * as H from '@syndesis/history';
-import { Card } from 'patternfly-react';
+import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';
 
@@ -26,15 +26,15 @@ export const ConnectionSetupOAuthCard: React.FunctionComponent<
       maxWidth: 600,
     }}
   >
-    <Card.Heading>
-      <Card.Title>
+    <CardHeader>
+      <Title size="lg">
         <div>{i18nTitle}</div>
-      </Card.Title>
-    </Card.Heading>
-    <Card.Body>
+      </Title>
+    </CardHeader>
+    <CardBody>
       <p>{i18nDescription}</p>
-    </Card.Body>
-    <Card.Footer>
+    </CardBody>
+    <CardFooter>
       <ButtonLink
         data-testid={'connection-creator-back-button'}
         href={backHref}
@@ -50,6 +50,6 @@ export const ConnectionSetupOAuthCard: React.FunctionComponent<
       >
         {i18nOAuthSettingsButton}
       </ButtonLink>
-    </Card.Footer>
+    </CardFooter>
   </Card>
 );

--- a/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
@@ -1,10 +1,10 @@
-import { Card } from 'patternfly-react';
+import { Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
 import ContentLoader from 'react-content-loader';
 
 export const ConnectionSkeleton = (props: any) => (
-  <Card matchHeight={true}>
-    <Card.Body>
+  <Card>
+    <CardBody>
       <ContentLoader
         height={250}
         width={200}
@@ -18,6 +18,6 @@ export const ConnectionSkeleton = (props: any) => (
         <rect x="25" y="180" rx="5" ry="5" width="150" height="15" />
         <rect x="40" y="205" rx="5" ry="5" width="120" height="15" />
       </ContentLoader>
-    </Card.Body>
+    </CardBody>
   </Card>
 );

--- a/app/ui-react/packages/ui/src/Connection/ConnectorAuthorization.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorAuthorization.tsx
@@ -1,4 +1,4 @@
-import { Card } from 'patternfly-react';
+import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Loader } from '../Layout';
 
@@ -25,19 +25,19 @@ export const ConnectorAuthorization: React.FunctionComponent<
       maxWidth: 600,
     }}
   >
-    <Card.Heading>
-      <Card.Title className="metrics-uptime__header">
+    <CardHeader>
+      <Title size="lg" className="metrics-uptime__header">
         <div>{i18nTitle}</div>
-      </Card.Title>
-    </Card.Heading>
-    <Card.Body>
+      </Title>
+    </CardHeader>
+    <CardBody>
       <p>{i18nDescription}</p>
-    </Card.Body>
-    <Card.Footer>
+    </CardBody>
+    <CardFooter>
       <ButtonLink onClick={onConnect} disabled={isConnecting} as={'primary'}>
         {i18nConnectButton}{' '}
         {isConnecting && <Loader size={'xs'} inline={true} />}
       </ButtonLink>
-    </Card.Footer>
+    </CardFooter>
   </Card>
 );

--- a/app/ui-react/packages/ui/src/Connection/ConnectorAuthorization.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorAuthorization.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Loader } from '../Layout';
 

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailCard.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailCard.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@patternfly/react-core';
-import { Card, CardBody } from 'patternfly-react';
+import { Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
 import './ApiConnectorDetailCard.css';
 

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailsForm.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@patternfly/react-core';
-import { Card } from 'patternfly-react';
+import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import './ApiConnectorDetailsForm.css';
 
@@ -47,13 +47,13 @@ export class ApiConnectorDetailsForm extends React.Component<
     return (
       <Card className="api-connector-details-form__card">
         {this.props.apiConnectorName && (
-          <Card.Heading>
-            <Card.Title className="api-connector-details-form__title">
+          <CardHeader>
+            <Title size="lg" className="api-connector-details-form__title">
               {this.props.apiConnectorName}
-            </Card.Title>
-          </Card.Heading>
+            </Title>
+          </CardHeader>
         )}
-        <Card.Body className="api-connector-details-form__body">
+        <CardBody className="api-connector-details-form__body">
           <Form isHorizontal={true} onSubmit={this.props.handleSubmit}>
             <fieldset disabled={!this.props.isEditing}>
               <div className="form-group api-connector-details-form__iconContainer">
@@ -82,8 +82,8 @@ export class ApiConnectorDetailsForm extends React.Component<
             </fieldset>
             {this.props.fields}
           </Form>
-        </Card.Body>
-        <Card.Footer>{this.props.footer}</Card.Footer>
+        </CardBody>
+        <CardFooter>{this.props.footer}</CardFooter>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorDetailsForm.tsx
@@ -1,5 +1,4 @@
-import { Form } from '@patternfly/react-core';
-import { Card, CardHeader, CardBody, CardFooter, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import './ApiConnectorDetailsForm.css';
 

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorReview.tsx
@@ -1,7 +1,7 @@
 import {
   Card,
-  CardHeader,
   CardBody,
+  CardHeader,
   Text,
   TextContent,
   TextList,

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorReview.tsx
@@ -1,4 +1,7 @@
 import {
+  Card,
+  CardHeader,
+  CardBody,
   Text,
   TextContent,
   TextList,
@@ -8,7 +11,6 @@ import {
   TextVariants,
   Title,
 } from '@patternfly/react-core';
-import { Card } from 'patternfly-react';
 import * as React from 'react';
 import { Container } from '../../Layout/Container';
 import './ApiConnectorReview.css';
@@ -36,10 +38,10 @@ export class ApiConnectorReview extends React.Component<
   public render() {
     return (
       <Card>
-        <Card.Heading>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
-        </Card.Heading>
-        <Card.Body>
+        <CardHeader>
+          <Title size="lg">{this.props.i18nTitle}</Title>
+        </CardHeader>
+        <CardBody>
           {this.props.i18nValidationFallbackMessage ? (
             <h5 className="api-connector-review__validationFallbackMessage">
               {this.props.i18nValidationFallbackMessage}
@@ -140,7 +142,7 @@ export class ApiConnectorReview extends React.Component<
                 : null}
             </TextContent>
           )}
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateUpload.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateUpload.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { DndFileChooser } from '../../../Shared';
 

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateUpload.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateUpload.tsx
@@ -1,4 +1,4 @@
-import { Card } from 'patternfly-react';
+import { Card, CardHeader, CardBody, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { DndFileChooser } from '../../../Shared';
 
@@ -70,10 +70,10 @@ export class ApiClientConnectorCreateUpload extends React.Component<
        * keep this is as a list of options: Upload or Use a URL
        */
       <Card>
-        <Card.Heading>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
-        </Card.Heading>
-        <Card.Body>
+        <CardHeader>
+          <Title size="lg">{this.props.i18nTitle}</Title>
+        </CardHeader>
+        <CardBody>
           <DndFileChooser
             disableDropzone={this.props.dndDisabled}
             fileExtensions={'.json'}
@@ -86,7 +86,7 @@ export class ApiClientConnectorCreateUpload extends React.Component<
             onUploadAccepted={this.props.onDndUploadAccepted}
             onUploadRejected={this.props.onDndUploadRejected}
           />
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
@@ -1,4 +1,6 @@
 import {
+  Card,
+  CardBody,
   Stack,
   TextContent,
   TextList,
@@ -8,7 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Button, Card, CardBody, Grid } from 'patternfly-react';
+import { Button, Grid } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../../Layout';
 import './ExtensionImportReview.css';

--- a/app/ui-react/packages/ui/src/Integration/Import/ImportPageUI.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Import/ImportPageUI.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody } from 'patternfly-react';
+import { Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
 import { PageSection } from '../../Layout';
 import { DndFileChooser, SimplePageHeader } from '../../Shared';

--- a/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
@@ -131,6 +131,7 @@ export class HelpDropdown extends React.Component<
             isTabletView ? (
               <KebabToggle
                 id={dropdownId}
+                aria-label="Global dropdown"
                 data-testid={dropdownId}
                 className={classNames('', this.props.className)}
                 onToggle={this.onToggle}
@@ -138,6 +139,7 @@ export class HelpDropdown extends React.Component<
             ) : (
               <DropdownToggle
                 id={dropdownId}
+                aria-label="Help dropdown"
                 data-testid={dropdownId}
                 className={classNames('', this.props.className)}
                 onToggle={this.onToggle}

--- a/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
@@ -1,4 +1,6 @@
 import {
+  Card,
+  CardBody,
   Text,
   TextContent,
   TextList,
@@ -8,7 +10,7 @@ import {
   TextVariants,
   Title,
 } from '@patternfly/react-core';
-import { Card, Label } from 'patternfly-react';
+import { Label } from 'patternfly-react';
 import * as React from 'react';
 import { Container } from '../Layout';
 
@@ -36,7 +38,7 @@ export class OpenApiReviewActions extends React.Component<
   public render() {
     return (
       <Card className={'open-api-review-actions'}>
-        <Card.Body>
+        <CardBody>
           {this.props.i18nValidationFallbackMessage ? (
             <h5 className={'review-actions__validationFallbackMessage'}>
               {this.props.i18nValidationFallbackMessage}
@@ -147,7 +149,7 @@ export class OpenApiReviewActions extends React.Component<
               </Container>
             </TextContent>
           )}
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -24,6 +24,18 @@
   --pf-global--gutter--md: 1.5rem;
 }
 
+.pf-c-page__main-breadcrumb {
+  --pf-c-page__main-breadcrumb--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-page__main-breadcrumb--PaddingBottom: var(--pf-global--spacer--sm);
+}
+
+@media screen and (min-width: 768px) {
+  .pf-c-page__main-breadcrumb {
+    --pf-c-page__main-breadcrumb--PaddingBottom: 0;
+    --pf-c-page__main-breadcrumb--PaddingTop: var(--pf-global--spacer--md);
+  }
+}
+
 .pf-c-page__header-brand-link .pf-c-brand {
   --pf-c-page__header-brand-link--c-brand--MaxHeight: 40px;
   height: 40px;

--- a/app/ui-react/packages/ui/stories/Shared/AboutModal.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/AboutModal.stories.tsx
@@ -9,7 +9,7 @@ stories.addDecorator(withKnobs);
 const modalToggleLogger = action('logging modal toggle');
 stories.add(
   'AboutModal',
-  withState({ isOpen: true })(({ store }) => {
+  withState({ isOpen: false })(({ store }) => {
     function handleModalToggle() {
       store.set({ isOpen: !store.state.isOpen });
       modalToggleLogger();

--- a/app/ui-react/syndesis/src/app/__mocks__/App.tsx
+++ b/app/ui-react/syndesis/src/app/__mocks__/App.tsx
@@ -16,7 +16,7 @@ export class App extends React.Component<IAppBaseProps> {
               value={{
                 config: config!,
                 getPodLogUrl: () => '',
-                user: { username: 'nobody' },
+                user: { username: 'Unknown user' },
               }}
             >
               <ApiContext.Provider

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
@@ -3,6 +3,7 @@ import { IConnector } from '@syndesis/models';
 import {
   ConnectionCard,
   ConnectionCreatorLayout,
+  ConnectionsGrid,
   ConnectionsGridCell,
   ConnectionSkeleton,
   IActiveFilter,
@@ -103,7 +104,6 @@ export class ConnectorsPage extends React.Component {
                               helpers.currentSortType,
                               helpers.isSortAscending
                             );
-
                             return (
                               <>
                                 <PageSection noPadding={true} variant={'light'}>
@@ -120,50 +120,52 @@ export class ConnectorsPage extends React.Component {
                                   />
                                 </PageSection>
                                 <PageSection>
-                                  {filteredAndSortedConnectors.map(
-                                    (connector, index) => {
-                                      return (
-                                        <ConnectionsGridCell key={index}>
-                                          <ConnectionCard
-                                            name={connector.name}
-                                            description={
-                                              connector.description || ''
-                                            }
-                                            i18nCannotDelete={t('cannotDelete')}
-                                            i18nConfigRequired={t(
-                                              'configurationRequired'
-                                            )}
-                                            i18nTechPreview={t('shared:techPreview')}
-                                            icon={
-                                              <EntityIcon
-                                                entity={connector}
-                                                alt={connector.name}
-                                                width={46}
-                                              />
-                                            }
-                                            isConfigRequired={false}
-                                            isTechPreview={
-                                              connector.isTechPreview
-                                            }
-                                            href={resolvers.create.configureConnector(
-                                              {
-                                                connector,
+                                  <ConnectionsGrid>
+                                    {filteredAndSortedConnectors.map(
+                                      (connector, index) => {
+                                        return (
+                                          <ConnectionsGridCell key={index}>
+                                            <ConnectionCard
+                                              name={connector.name}
+                                              description={
+                                                connector.description || ''
                                               }
-                                            )}
-                                            techPreviewPopoverHtml={
-                                              <span
-                                                dangerouslySetInnerHTML={{
-                                                  __html: t(
-                                                    'shared:techPreviewPopoverHtml'
-                                                  ),
-                                                }}
-                                              />
-                                            }
-                                          />
-                                        </ConnectionsGridCell>
-                                      );
-                                    }
-                                  )}
+                                              i18nCannotDelete={t('cannotDelete')}
+                                              i18nConfigRequired={t(
+                                                'configurationRequired'
+                                              )}
+                                              i18nTechPreview={t('shared:techPreview')}
+                                              icon={
+                                                <EntityIcon
+                                                  entity={connector}
+                                                  alt={connector.name}
+                                                  width={46}
+                                                />
+                                              }
+                                              isConfigRequired={false}
+                                              isTechPreview={
+                                                connector.isTechPreview
+                                              }
+                                              href={resolvers.create.configureConnector(
+                                                {
+                                                  connector,
+                                                }
+                                              )}
+                                              techPreviewPopoverHtml={
+                                                <span
+                                                  dangerouslySetInnerHTML={{
+                                                    __html: t(
+                                                      'shared:techPreviewPopoverHtml'
+                                                    ),
+                                                  }}
+                                                />
+                                              }
+                                            />
+                                          </ConnectionsGridCell>
+                                        );
+                                      }
+                                    )}
+                                  </ConnectionsGrid>
                                 </PageSection>
                               </>
                             );

--- a/app/ui-react/syndesis/src/modules/support/components/SelectiveIntegrationList.tsx
+++ b/app/ui-react/syndesis/src/modules/support/components/SelectiveIntegrationList.tsx
@@ -101,6 +101,7 @@ export const SelectiveIntegrationList: React.FunctionComponent<
                         integrationName={si.name}
                         checkboxComponent={
                           <input
+                            aria-label={`${si.name}`}
                             data-testid={
                               'selective-integration-list-integrations-input'
                             }


### PR DESCRIPTION
This PR puts back the card grid that was lost during work toward https://github.com/syndesisio/syndesis/issues/6240 - should help close https://github.com/syndesisio/syndesis/issues/6319

Applies card upgrades to:

- ConnectionDetailsOauthCard
- ConnectionSetupOAuthCard
- ConnectionSkeleton
- ConnectorAuthorization
- ApiConnectorDetailCard
- ApiConnectorDetailsForm
- ApiConnectorReview
- ApiClientConnectorCreateUpload
- ExtensionImportReview
- ImportPageUI
- OpenApiReviewActions

Also applies more suitable accessible name for help dropdown, user dropdown, "unknown user" text, and support integration list checkbox items.

Finally, I assigned a heading level of "h2" for the card titles, the default value of "h1" lead to a poor accessible experience - there should only be a single most important heading per page.

<img width="1670" alt="Screen Shot 2019-09-03 at 1 09 09 PM" src="https://user-images.githubusercontent.com/5942899/64200698-099ada80-ce5b-11e9-8154-77b2a83c1f0e.png">
