### PR TITLE
Fix #6507: fix jaeger configuration

### DIFF
--- a/app/common/jaeger-spring-boot-starter/src/main/java/io/syndesis/common/jaeger/JaegerConfiguration.java
+++ b/app/common/jaeger-spring-boot-starter/src/main/java/io/syndesis/common/jaeger/JaegerConfiguration.java
@@ -16,6 +16,7 @@
 package io.syndesis.common.jaeger;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @Configuration
 @ConditionalOnProperty("jaeger.service.name")
 @ConditionalOnClass(WebMvcConfigurerAdapter.class)
+@AutoConfigureOrder(-2147483639)
 public class JaegerConfiguration {
 
     @Value("${jaeger.service.name}")

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
@@ -34,6 +34,6 @@ spring.autoconfigure.exclude[2] = org.springframework.boot.autoconfigure.data.mo
 {{#configuration.isActivityTracing}}
 # Jaeger/Opentracing
 jaeger.service.name = {{integration.id}}
-syndesis.integration.runtime.logging=false
-syndesis.integration.runtime.tracing=true
+syndesis.integration.runtime.logging.enabled=false
+syndesis.integration.runtime.tracing.enabled=true
 {{/configuration.isActivityTracing}}

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application-tracing.properties
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application-tracing.properties
@@ -33,5 +33,5 @@ spring.autoconfigure.exclude[2] = org.springframework.boot.autoconfigure.data.mo
 
 # Jaeger/Opentracing
 jaeger.service.name = test-integration
-syndesis.integration.runtime.logging=false
-syndesis.integration.runtime.tracing=true
+syndesis.integration.runtime.logging.enabled=false
+syndesis.integration.runtime.tracing.enabled=true


### PR DESCRIPTION
Fix #6507

Randomly the tracer was being instantiated too late. I've used a high priority order instead of referencing a specific configuration class because the Jaeger starter has changed a lot recently. Priority is sufficient to instantiate the tracer before spring-web.

There was also a typo in the generator project.