### PR TITLE
user doc: Add restriction that you cannot map from/to a nested collection

### DIFF
--- a/doc/integrating-applications/topics/p_using-data-mapper-to-process-collections.adoc
+++ b/doc/integrating-applications/topics/p_using-data-mapper-to-process-collections.adoc
@@ -34,6 +34,7 @@ When a collection contains more
 than one kind of primitive type or when it contains at least one complex 
 type then the data mapper displays the collection’s child fields. 
 You can map from/to each field.
+However, you cannot map from or to a nested collection. 
 
 When {prodname} executes the flow, it iterates over the source 
 collection elements to populate the target collection elements.


### PR DESCRIPTION
This restriction came up in a Fuse Online Evaluation email. It was not documented.
So now it is. Gary approved the wording and the update. 