### PR TITLE
Upgrade UI dependencies

### DIFF
--- a/app/ui-react/packages/auto-form/package.json
+++ b/app/ui-react/packages/auto-form/package.json
@@ -77,7 +77,7 @@
     }
   },
   "dependencies": {
-    "@patternfly/react-core": "^3.86.3",
+    "@patternfly/react-core": "^3.95.4",
     "@patternfly/react-icons": "^3.10.1",
     "@patternfly/react-styles": "^3.3.3",
     "formik": "^1.5.4"

--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -76,6 +76,7 @@
     "@patternfly/react-core": "^3.95.4",
     "@patternfly/react-icons": "^3.9.2",
     "@patternfly/react-styles": "^3.2.0",
+    "@patternfly/react-table": "^2.19.16",
     "@patternfly/react-tokens": "^2.5.3",
     "@syndesis/history": "*",
     "classnames": "^2.2.6",

--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "^2.23.2",
-    "@patternfly/react-core": "^3.32.9",
+    "@patternfly/react-core": "^3.95.4",
     "@patternfly/react-icons": "^3.9.2",
     "@patternfly/react-styles": "^3.2.0",
     "@patternfly/react-tokens": "^2.5.3",

--- a/app/ui-react/packages/ui/src/Shared/PfDropdownItem.tsx
+++ b/app/ui-react/packages/ui/src/Shared/PfDropdownItem.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 export interface IPfDropdownItem {
   children: React.ReactNode;
   disabled?: boolean;
-  onClick?(event?: React.MouseEvent): void;
+  onClick?(event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent): void;
 }
 class PfDropdownItem extends React.Component<IPfDropdownItem> {
   public render() {

--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -5,13 +5,13 @@
   "workspaces": {
     "nohoist": [
       "**/babel-loader",
-      "**/babel-jest"
+      "**/babel-jest",
+      "**/babel-jest/**"
     ]
   },
   "dependencies": {
     "@allpro/react-router-pause": "^1.1.3",
     "@craco/craco": "^5.0.2",
-    "@patternfly/react-core": "^3.32.9",
     "@syndesis/api": "*",
     "@syndesis/apicurio-adapter": "*",
     "@syndesis/atlasmap-adapter": "*",

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationExposeVia.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationExposeVia.tsx
@@ -1,4 +1,3 @@
-import { TextContent } from '@patternfly/react-core';
 import { IntegrationOverview } from "@syndesis/models";
 import { ButtonLink, PageSection } from '@syndesis/ui';
 import { MessageDialog } from 'patternfly-react';
@@ -46,75 +45,75 @@ export const IntegrationExposeVia: React.FunctionComponent<
   if (exposureMeans.indexOf('_3SCALE') !== -1) {
     return (
       <>
-      { integration.exposure && integration.exposure !== '_3SCALE' ? (
-        <PageSection>
-          <TextContent>
-            <MessageDialog
-              show={showDialog}
-              title={t('integrations:exposeVia:3scale')} primaryContent={
-              <p className="lead">{t('integrations:exposeVia:3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
-              }
-              primaryActionButtonContent={t('shared:Yes')}
-              primaryAction={doEnable3scale}
-              secondaryActionButtonContent={t('shared:No')}
-              secondaryAction={doHideDialog}
-              onHide={doHideDialog}
-              onCancel={doHideDialog}
-            />
-            <div className="pf-l-split pf-m-gutter">
-              <div><ButtonLink children={t('integrations:exposeVia:3scale')} onClick={doShowDialog} disabled={pending} /></div>
-              <div>{t('integrations:exposeVia:3scaleDescription')}</div>
-            </div>
-          </TextContent>
-        </PageSection>
-      ) : (
-        <>
+        {integration.exposure && integration.exposure !== '_3SCALE' ? (
           <PageSection>
-            <TextContent>
-              <div className="pf-l-split pf-m-gutter">
-                <div><ButtonLink children={t('integrations:exposeVia:manageIn3scale')} onClick={doManageIn3scale} disabled={pending || unpublished} /></div>
-                {(pending || unpublished) ? (
-                  <div>{t('integrations:exposeVia:manageIn3scalePendingDescription')}</div>
-                ) : (
-                  <div>{t('integrations:exposeVia:manageIn3scaleDescription')}</div>
-                )
-                }
-              </div>
-            </TextContent>
-          </PageSection>
-          <PageSection>
-            <TextContent>
+            <div className="pf-c-content">
               <MessageDialog
                 show={showDialog}
-                title={t('integrations:exposeVia:not3scale')} primaryContent={
-                <p className="lead">{t('integrations:exposeVia:not3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
-              }
+                title={t('integrations:exposeVia:3scale')} primaryContent={
+                  <p className="lead">{t('integrations:exposeVia:3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
+                }
                 primaryActionButtonContent={t('shared:Yes')}
-                primaryAction={doDisable3scale}
+                primaryAction={doEnable3scale}
                 secondaryActionButtonContent={t('shared:No')}
                 secondaryAction={doHideDialog}
                 onHide={doHideDialog}
                 onCancel={doHideDialog}
               />
               <div className="pf-l-split pf-m-gutter">
-                <div><ButtonLink children={t('integrations:exposeVia:not3scale')} onClick={doShowDialog} disabled={pending}/></div>
-                <div>{t('integrations:exposeVia:not3scaleDescription')}</div>
+                <div><ButtonLink children={t('integrations:exposeVia:3scale')} onClick={doShowDialog} disabled={pending} /></div>
+                <div>{t('integrations:exposeVia:3scaleDescription')}</div>
               </div>
-            </TextContent>
+            </div>
           </PageSection>
-        </>
-      )}
+        ) : (
+            <>
+              <PageSection>
+                <div className="pf-c-content">
+                  <div className="pf-l-split pf-m-gutter">
+                    <div><ButtonLink children={t('integrations:exposeVia:manageIn3scale')} onClick={doManageIn3scale} disabled={pending || unpublished} /></div>
+                    {(pending || unpublished) ? (
+                      <div>{t('integrations:exposeVia:manageIn3scalePendingDescription')}</div>
+                    ) : (
+                        <div>{t('integrations:exposeVia:manageIn3scaleDescription')}</div>
+                      )
+                    }
+                  </div>
+                </div>
+              </PageSection>
+              <PageSection>
+                <div className="pf-c-content">
+                  <MessageDialog
+                    show={showDialog}
+                    title={t('integrations:exposeVia:not3scale')} primaryContent={
+                      <p className="lead">{t('integrations:exposeVia:not3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
+                    }
+                    primaryActionButtonContent={t('shared:Yes')}
+                    primaryAction={doDisable3scale}
+                    secondaryActionButtonContent={t('shared:No')}
+                    secondaryAction={doHideDialog}
+                    onHide={doHideDialog}
+                    onCancel={doHideDialog}
+                  />
+                  <div className="pf-l-split pf-m-gutter">
+                    <div><ButtonLink children={t('integrations:exposeVia:not3scale')} onClick={doShowDialog} disabled={pending} /></div>
+                    <div>{t('integrations:exposeVia:not3scaleDescription')}</div>
+                  </div>
+                </div>
+              </PageSection>
+            </>
+          )}
       </>
     );
   } else {
     return (integration.exposure && integration.exposure === '_3SCALE') ? (
       <PageSection>
-        <TextContent>
+        <div className="pf-c-content">
           <MessageDialog
             show={showDialog}
             title={t('integrations:exposeVia:not3scale')} primaryContent={
-            <p className="lead">{t('integrations:exposeVia:not3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
-          }
+              <p className="lead">{t('integrations:exposeVia:not3scaleConfirm')}{unpublished ? (null) : (<> {t('integrations:exposeVia:republish')}</>)}?</p>
+            }
             primaryActionButtonContent={t('shared:Yes')}
             primaryAction={doDisable3scale}
             secondaryActionButtonContent={t('shared:No')}
@@ -123,10 +122,10 @@ export const IntegrationExposeVia: React.FunctionComponent<
             onCancel={doHideDialog}
           />
           <div className="pf-l-split pf-m-gutter">
-            <div><ButtonLink children={t('integrations:exposeVia:not3scale')} onClick={doShowDialog} disabled={pending}/></div>
+            <div><ButtonLink children={t('integrations:exposeVia:not3scale')} onClick={doShowDialog} disabled={pending} /></div>
             <div>{t('integrations:exposeVia:no3scaleConfigured')}</div>
           </div>
-        </TextContent>
+        </div>
       </PageSection>
     ) : null;
   }

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2614,7 +2614,7 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@patternfly/patternfly@1.0.250", "@patternfly/patternfly@2.6.6", "@patternfly/patternfly@^2.23.2":
+"@patternfly/patternfly@1.0.250", "@patternfly/patternfly@2.29.0", "@patternfly/patternfly@2.6.6", "@patternfly/patternfly@^2.23.2":
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.6.6.tgz#d4ba153f0b1470fbc91ea308c8c7260c9bcb0d28"
   integrity sha512-lKbsTE/VlU1BiVzeo0BhfDe/qeqIqheejBz0qAm3CYuHyfUXd4+Uu+/9lfEB2EMb+wXpK4Np74OHtYCC82fP0Q==
@@ -2623,6 +2623,19 @@
   version "3.95.5"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.95.5.tgz#9af2c7401494b401898bd14523958654835b41e4"
   integrity sha512-J00HzEbeTC2AlQ8J/MFElYND68qOvIy/3sLhbCtgXHSnRYf3fZB5iabn5Tdd0CR9ydX+dWImSCXhPUgN8xDg2Q==
+  dependencies:
+    "@patternfly/react-icons" "^3.12.3"
+    "@patternfly/react-styles" "^3.5.18"
+    "@patternfly/react-tokens" "^2.6.22"
+    emotion "^9.2.9"
+    exenv "^1.2.2"
+    focus-trap-react "^4.0.1"
+    tippy.js "3.4.1"
+
+"@patternfly/react-core@^3.95.6":
+  version "3.95.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.95.6.tgz#ac250689251f5da19649fad20b9f509011f50c74"
+  integrity sha512-XYHasjjAInnSz0JLfFf005cgoy8VyAIJR07zjWKvQukQr5jfuZQHKalP+Bi4DI7xBzvtVhzDgwLTQ/3ATGXcpw==
   dependencies:
     "@patternfly/react-icons" "^3.12.3"
     "@patternfly/react-styles" "^3.5.18"
@@ -2708,6 +2721,20 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
     typescript "3.4.5"
+
+"@patternfly/react-table@^2.19.16":
+  version "2.19.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-2.19.16.tgz#44b3ff9d0ac524ac0a833885ec3ca3c3790f62f6"
+  integrity sha512-NpNG3SqbhybYVpnCIBMuEEsDx+JLjH/QV+k5gLnL9GP98O0yMrqdDPKkDQZwRWDSnnQ2OLWFwS4Yf44UWlVb4g==
+  dependencies:
+    "@patternfly/patternfly" "2.29.0"
+    "@patternfly/react-core" "^3.95.6"
+    "@patternfly/react-icons" "^3.12.3"
+    "@patternfly/react-styles" "^3.5.18"
+    "@patternfly/react-tokens" "^2.6.22"
+    classnames "^2.2.5"
+    exenv "^1.2.2"
+    lodash "^4.2.1"
 
 "@patternfly/react-tokens@^2.5.3":
   version "2.5.3"

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2619,31 +2619,18 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.6.6.tgz#d4ba153f0b1470fbc91ea308c8c7260c9bcb0d28"
   integrity sha512-lKbsTE/VlU1BiVzeo0BhfDe/qeqIqheejBz0qAm3CYuHyfUXd4+Uu+/9lfEB2EMb+wXpK4Np74OHtYCC82fP0Q==
 
-"@patternfly/react-core@^3.32.9":
-  version "3.32.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.32.9.tgz#40321ccc568853bda57088c490ec684992aabd7e"
-  integrity sha512-c+KET5+GNLloe5fi5P+taGgyMSsEsKmFuznxlNUW4CoDGkvA+EGuKoFhu39yQhQd+Zq0OWxWjOlFygTZwkWQUA==
+"@patternfly/react-core@^3.95.4":
+  version "3.95.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.95.5.tgz#9af2c7401494b401898bd14523958654835b41e4"
+  integrity sha512-J00HzEbeTC2AlQ8J/MFElYND68qOvIy/3sLhbCtgXHSnRYf3fZB5iabn5Tdd0CR9ydX+dWImSCXhPUgN8xDg2Q==
   dependencies:
-    "@patternfly/react-icons" "^3.9.3"
-    "@patternfly/react-styles" "^3.2.3"
-    "@patternfly/react-tokens" "^2.5.3"
-    "@tippy.js/react" "^1.1.1"
+    "@patternfly/react-icons" "^3.12.3"
+    "@patternfly/react-styles" "^3.5.18"
+    "@patternfly/react-tokens" "^2.6.22"
     emotion "^9.2.9"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
-
-"@patternfly/react-core@^3.86.3":
-  version "3.86.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.86.3.tgz#83dc4d394a5480903ee076670e0a7ad7aff41ccc"
-  integrity sha512-AXogLl6PnlpXNEAYLi/OGDbHDdRxIJFOHzubGWrhLJgyn3IYsSNphl40YqqB+HgEAS804Vcev7AQ9CXsiLqnpQ==
-  dependencies:
-    "@patternfly/react-icons" "^3.10.17"
-    "@patternfly/react-styles" "^3.5.11"
-    "@patternfly/react-tokens" "^2.6.16"
-    emotion "^9.2.9"
-    exenv "^1.2.2"
-    focus-trap-react "^4.0.1"
-    tippy.js "^3.2.0"
+    tippy.js "3.4.1"
 
 "@patternfly/react-icons@^3.10.1":
   version "3.10.1"
@@ -2652,14 +2639,14 @@
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
-"@patternfly/react-icons@^3.10.17":
-  version "3.10.17"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.17.tgz#4e3e104ea86bc47fe3c528e13d1fa6c7c8ec216a"
-  integrity sha512-UVmmH6gQSMcJg0EB2b0dMvC+SQEGhdSxhRkEyn7OVN1tJFYBZrcCRBeJxxFIQwY7PExIZ1ZinleRmVPD/ZI+jQ==
+"@patternfly/react-icons@^3.12.3":
+  version "3.12.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.12.3.tgz#57ed0cde36cf5908874ad9664b731405b3e5813a"
+  integrity sha512-Ymzb8/xUDx8LW8ri5p0XFmu7mWILzSqflSyHvFD9edcEvGhG0iFncStaxSQdVbTPwruI6iycT3AY93JUNcsBqg==
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
-"@patternfly/react-icons@^3.9.2", "@patternfly/react-icons@^3.9.3":
+"@patternfly/react-icons@^3.9.2":
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.9.3.tgz#a06a589ef90472568a40a01491473e741e6a91a5"
   integrity sha512-tLKuA5Qt4Kq+Bex2eDVazJrrixzbKQdxwkbPwzjzRdJ6oGb2CpZNjCVWIxKxibDsc0vGZ6aUaHguY6AFVcydQQ==
@@ -2670,24 +2657,6 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.2.0.tgz#c3008b472767109ff5127b14da9cad6506c6bf4f"
   integrity sha512-8M7bo4kPvypHlbzuynV53xjk5176EktfEgZ283sfHmvUlU3Yvq2+m8hS9ERHE9gd91Ip4HiyucAVVACd2gtHNQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
-    camel-case "^3.0.0"
-    css "^2.2.3"
-    cssom "^0.3.4"
-    cssstyle "^0.3.1"
-    emotion "^9.2.9"
-    emotion-server "^9.2.9"
-    fbjs-scripts "^0.8.3"
-    fs-extra "^6.0.1"
-    jsdom "^11.11.0"
-    relative "^3.0.2"
-    resolve-from "^4.0.0"
-
-"@patternfly/react-styles@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.2.3.tgz#1774be2e74758ba3aaa8324859d802c2861760d7"
-  integrity sha512-2CSR+gkLLDKzgW1dLf2xL8wubdexcDwHuUJ+Q2ee9XD6kKD+qJBV86LAGTAQH4wTYTv6gPuSLTSnde3DR3vJag==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -2721,10 +2690,10 @@
     resolve-from "^4.0.0"
     typescript "3.4.5"
 
-"@patternfly/react-styles@^3.5.11":
-  version "3.5.11"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.5.11.tgz#79f79c209111f8c5074e7a79440c23f58b10c254"
-  integrity sha512-EaTuCC0oRUNQI7wCm/YlQene+KLwCtS3FHpwDGQpUNF5+W6rR2vgB0SOpDtdwY0v5quLfL7j1B6oRTBjDUIclg==
+"@patternfly/react-styles@^3.5.18":
+  version "3.5.18"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.5.18.tgz#d158bd690ec03d38c68c5ee4bc4071a0f4fdb738"
+  integrity sha512-6q+EK4Hv74vtji0/mL0RV8R13oWLrRkR7RzudqD550Azjaa8PT0L1HHKHeiP03gZ1V4nr2q7aiY4Ron71Ztb7A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -2745,10 +2714,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.3.tgz#b1804626762583534745cede7599acf5a715fab8"
   integrity sha512-vH3fHKkx7VxyKkAiLx+VvOzZAuFIHhX01lW3HP66koFeUnKbCRynPuBy/Ep4nGZINZAgf5l9LNDmLS1ymntrLg==
 
-"@patternfly/react-tokens@^2.6.16":
-  version "2.6.16"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.16.tgz#c177a3960761d509b09a45b9a02a58a52d5f0ed1"
-  integrity sha512-dhr4ne4thSmSKBr4anV07KSzUXEs6KpCMDxxNiwrgFdZwNHtyNcaPc+F9pQZ5A0n4qYmMLpCrprb7m5o/83riQ==
+"@patternfly/react-tokens@^2.6.22":
+  version "2.6.22"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.22.tgz#7ea18bd90859a4fbabf97fd68b2ca0a4be2064c2"
+  integrity sha512-FC/GKW5yY9mmewaeNKZZum2q+k5tCKYMWJUKLr3WtdFycCOQ+CjltgksfV0NbSGrjDdsfp0vx4BfcB31X7U1gg==
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -3324,14 +3293,6 @@
 "@swimlane/ngx-datatable@^13.0.0":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@swimlane/ngx-datatable/-/ngx-datatable-13.1.0.tgz#a79edc7eaed762a2f7868209a2ff597bbfc7137b"
-
-"@tippy.js/react@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@tippy.js/react/-/react-1.1.1.tgz#91476726529e31d4c9f9074d995d0fa31f3b6e2d"
-  integrity sha512-TkL1VufxgUvTMouDoBGv2vTdtUxtLUaRpspI4Rv0DsoKe2Ex1E5bl/qISk434mhuAhEnXuemrcgTaPWrfDvmGw==
-  dependencies:
-    prop-types "^15.6.2"
-    tippy.js "^3.2.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"
@@ -19839,7 +19800,7 @@ tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
-tippy.js@^3.2.0:
+tippy.js@3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
   integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==


### PR DESCRIPTION
This PR

- upgrades the main @patternfly/react-core dependency in `ui` and `auto-form`
- removes @patternfly/react-core as a dependency on `syndesis` (replacing its usage with raw pf4 markup)
- introduces @patternfly/react-table as a dependency
- ensures the test suite can run with these dependencies in place
- registers new glob pattern for jest nohoist config

After making the upgrades, the test suite failed to run with errors similar to those noted in https://github.com/syndesisio/syndesis/issues/6485 - adding the new glob pattern seems to have fixed it. @elvisisking can you give it a spin when you have time and let me know if it fixes it for you?
