### PR TITLE
TEIIDTOOLS-762 Adapt UI for view definition

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -190,7 +190,6 @@ function getViewDefinition(
   const viewDefn: ViewDefinition = {
     dataVirtualizationName: dataVirtName,
     ddl: viewDdl ? viewDdl : '',
-    id: '',
     isComplete: true,
     isUserDefined: userDefined,
     keng__description: description ? description : '',


### PR DESCRIPTION
Adapt to minor change in teiid backend - UI should not supply an id for the view definition, if it has not yet been defined.