### PR TITLE
Get default value for syndesis components from conf file

### DIFF
--- a/install/operator/pkg/syndesis/action/checkupdates.go
+++ b/install/operator/pkg/syndesis/action/checkupdates.go
@@ -32,7 +32,7 @@ func (a checkUpdatesAction) CanExecute(syndesis *v1alpha1.Syndesis) bool {
 
 func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis) error {
 	if a.operatorVersion == "" {
-		operatorVersion, err := template.GetSyndesisVersionFromOperator(ctx, a.client, syndesis)
+		operatorVersion, err := template.GetSyndesisVersionFromOperatorTemplate(a.scheme)
 		if err != nil {
 			return err
 		}

--- a/install/operator/pkg/syndesis/action/initialize.go
+++ b/install/operator/pkg/syndesis/action/initialize.go
@@ -47,7 +47,7 @@ func (a *initializeAction) Execute(ctx context.Context, syndesis *v1alpha1.Synde
 		target.Status.Description = "Cannot install two Syndesis resources in the same namespace"
 		a.log.Error(nil, "Cannot initialize Syndesis resource because its a duplicate", "name", syndesis.Name)
 	} else {
-		syndesisVersion, err := template.GetSyndesisVersionFromOperator(ctx, a.client, syndesis)
+		syndesisVersion, err := template.GetSyndesisVersionFromOperatorTemplate(a.scheme)
 		if err != nil {
 			return err
 		}

--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -109,11 +109,6 @@ func (a *installAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis
 		return err
 	}
 
-	renderContext.Tags.Syndesis, err = syndesistemplate.GetSyndesisVersionFromOperator(ctx, a.client, syndesis)
-	if err != nil {
-		return err
-	}
-
 	err = syndesistemplate.SetupRenderContext(renderContext, syndesis, params, config)
 	if err != nil {
 		return err
@@ -295,13 +290,14 @@ func checkTags(context *generator.Context) error {
 		{"s2i", context.Syndesis.Spec.Components.S2I.Tag},
 	}
 	for _, image := range images {
-
-		if image.tag != "latest" && c.Match(version.Normalize(image.tag)) == false {
-			return fmt.Errorf("tag for %s[%s] component is not valid, should have a value between [%s] and [%s]",
-				image.name,
-				image.tag,
-				context.TagMinor,
-				context.TagMajor)
+		if image.tag != "latest" {
+			if c.Match(version.Normalize(image.tag)) == false {
+				return fmt.Errorf("tag for %s[%s] component is not valid, should have a value between [%s] and [%s]",
+					image.name,
+					image.tag,
+					context.TagMinor,
+					context.TagMajor)
+			}
 		}
 	}
 

--- a/install/operator/pkg/syndesis/action/upgrade.go
+++ b/install/operator/pkg/syndesis/action/upgrade.go
@@ -45,7 +45,7 @@ func (a *upgradeAction) CanExecute(syndesis *v1alpha1.Syndesis) bool {
 
 func (a *upgradeAction) Execute(ctx context.Context, syndesis *v1alpha1.Syndesis) error {
 	if a.operatorVersion == "" {
-		operatorVersion, err := template.GetSyndesisVersionFromOperator(ctx, a.client, syndesis)
+		operatorVersion, err := template.GetSyndesisVersionFromOperatorTemplate(a.scheme)
 		if err != nil {
 			return err
 		}

--- a/install/operator/pkg/syndesis/template/install.go
+++ b/install/operator/pkg/syndesis/template/install.go
@@ -1,21 +1,16 @@
 package template
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-
 	"math/rand"
 	"time"
 
-	v1 "github.com/openshift/api/image/v1"
 	"github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1alpha1"
 	"github.com/syndesisio/syndesis/install/operator/pkg/generator"
 	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
 	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -83,20 +78,6 @@ func GetSyndesisVersionFromOperatorTemplate(scheme *runtime.Scheme) (string, err
 		return "", err
 	}
 	return ctx.Tags.Syndesis, nil
-}
-
-func GetSyndesisVersionFromOperator(ctx context.Context, c client.Client, syndesis *v1alpha1.Syndesis) (string, error) {
-	is := &v1.ImageStream{}
-	err := c.Get(ctx, types.NamespacedName{Namespace: syndesis.Namespace, Name: "syndesis-operator"}, is)
-	if err != nil {
-		return "", err
-	}
-
-	if len(is.Spec.Tags) == 1 {
-		return is.Spec.Tags[0].Name, nil
-	} else {
-		return "", fmt.Errorf("more than one tag found, unable to find the version")
-	}
 }
 
 func SetupRenderContext(renderContext *generator.Context, syndesis *v1alpha1.Syndesis, params ResourceParams, env map[string]string) error {

--- a/install/operator/tests/e2e/install_with_defaults_test.go
+++ b/install/operator/tests/e2e/install_with_defaults_test.go
@@ -18,13 +18,25 @@ package e2e
 
 import (
 	goctx "context"
+	"testing"
+	"time"
+
+	"github.com/syndesisio/syndesis/install/operator/pkg/generator"
+
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
+
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/template"
+
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	"github.com/syndesisio/syndesis/install/operator/pkg/apis"
 	"github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -34,9 +46,10 @@ var (
 	installingPhaseTimeout = time.Second * 500
 	cleanupRetryInterval   = time.Second * 1
 	cleanupTimeout         = time.Second * 5
+	configLocation         = "build/conf/config.yaml"
 )
 
-func TestSyndesis(t *testing.T) {
+func TestSyndesis1(t *testing.T) {
 	syndesis := &v1alpha1.SyndesisList{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Syndesis",
@@ -50,8 +63,7 @@ func TestSyndesis(t *testing.T) {
 
 	// run subtests
 	t.Run("e2e", func(t *testing.T) {
-		t.Run("install-default", installWithDefaultsTest)
-		t.Run("install-full", installTest)
+		t.Run("install-empty-cr", installWithDefaultsTest)
 	})
 }
 
@@ -63,6 +75,10 @@ func installWithDefaultsTest(t *testing.T) {
 	defer ctx.Cleanup()
 
 	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cr := "syndesis-test"
 
 	co := framework.CleanupOptions{
@@ -93,7 +109,11 @@ func installWithDefaultsTest(t *testing.T) {
 
 	syndesis := CreateEmpyCR(cr, namespace)
 
-	t.Logf("creating empty syndesis cr")
+	configuration.TemplateConfig = configLocation
+	renderContext, err := template.GetTemplateContext()
+	if err != nil {
+		t.Fatalf("unable to render config content: %v", err)
+	}
 
 	if err := f.Client.Create(goctx.TODO(), syndesis, &co); err != nil {
 		t.Fatal(err)
@@ -111,61 +131,44 @@ func installWithDefaultsTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	installWithDefaultsImageStreamsTest(t, f, renderContext, namespace)
+
 }
 
-// Install syndesis with a fully CR, verify some of the generated values
-func installTest(t *testing.T) {
-	t.Parallel()
-	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup()
+func installWithDefaultsImageStreamsTest(t *testing.T, f *framework.Framework, config *generator.Context, namespace string) {
+	t.Log("checking ImageStreams for syndesis components")
 
-	namespace, err := ctx.GetNamespace()
-	cr := "syndesis-test"
-
-	co := framework.CleanupOptions{
-		TestContext:   ctx,
-		Timeout:       cleanupTimeout,
-		RetryInterval: cleanupRetryInterval,
+	is := &imagev1.ImageStream{}
+	if err := framework.AddToFrameworkScheme(imagev1.AddToScheme, is); err != nil {
+		t.Fatalf("could not add scheme to framework scheme: %v", err)
 	}
 
-	// Initialize cluster resources from yaml, including operator deployment
-	// and needed roles / rbac
-	if err := ctx.InitializeClusterResources(&co); err != nil {
-		t.Fatalf("failed to initialize cluster resources: %v", err)
-	}
-	t.Log("initialized cluster resources from yaml")
-
-	n, err := ctx.GetNamespace()
-	if err != nil {
-		t.Fatal(err)
+	var flagtests = []struct {
+		name      string
+		imageName string
+	}{
+		{"Server", "syndesis-server"},
+		{"Meta", "syndesis-meta"},
+		{"S2I", "syndesis-s2i"},
+		{"UI", "syndesis-ui"},
 	}
 
-	// get global framework variables
-	f := framework.Global
+	for _, tt := range flagtests {
+		t.Logf("checking imagestream for %s", tt.name)
+		if err := f.Client.Get(context.TODO(), client.ObjectKey{Name: tt.imageName, Namespace: namespace}, is); err != nil {
+			t.Fatalf("an imagestream named [%s] should be created, but got an error [%v]", tt.imageName, err)
+		}
 
-	// wait for syndesis-operator to be ready
-	if err := e2eutil.WaitForOperatorDeployment(t, f.KubeClient, n, "syndesis-operator", 1, retryInterval, operatorTimeout); err != nil {
-		t.Fatal(err)
-	}
+		if l := len(is.Spec.Tags); l != 1 {
+			t.Fatalf("the imagestream should have only one tag, but got %d", l)
+		} else {
+			t.Logf("the imagestream has only one tag")
 
-	syndesis := CreateCR(cr, namespace)
-
-	t.Logf("creating syndesis cr")
-
-	if err := f.Client.Create(goctx.TODO(), syndesis, &co); err != nil {
-		t.Fatal(err)
-	}
-
-	// wait for syndesis operator to reach 1 replicas
-	t.Logf("waiting syndesis to be initialized")
-	err = WaitForSyndesisPhase(t, f, namespace, cr, v1alpha1.SyndesisPhaseInstalling, retryInterval, startingPhaseTimeout)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("waiting syndesis to be installed")
-	err = WaitForSyndesisPhase(t, f, namespace, cr, v1alpha1.SyndesisPhaseInstalled, retryInterval, installingPhaseTimeout)
-	if err != nil {
-		t.Fatal(err)
+			if is.Spec.Tags[0].Name != config.Tags.Syndesis {
+				t.Fatalf("the imagestream tag should be named [%s], but got %s", config.Tags.Syndesis, is.Spec.Tags[0].Name)
+			}
+			t.Logf("the imagestream tag is named [%s]", config.Tags.Syndesis)
+		}
 	}
 }

--- a/install/operator/tests/e2e/install_with_defaults_test.go
+++ b/install/operator/tests/e2e/install_with_defaults_test.go
@@ -49,7 +49,7 @@ var (
 	configLocation         = "build/conf/config.yaml"
 )
 
-func TestSyndesis1(t *testing.T) {
+func TestSyndesis(t *testing.T) {
 	syndesis := &v1alpha1.SyndesisList{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Syndesis",


### PR DESCRIPTION
This PR partially reverts https://github.com/syndesisio/syndesis/pull/6491

- It is still possible to define the operator image tag by using `--tag tagValue`, but this will only set the tag for the operator, as well as the tag name.
- The default value for images comes from file. What this value should be, is yet to be defined.
- e2e test are working again