### PR TITLE
TEIIDTOOLS-761 Reorganize the ViewEditor

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -350,17 +350,17 @@ export const useVirtualizationHelpers = () => {
    */
   const getSourceInfoForView = async (
     virtualization: RestDataService
-    ): Promise<ViewSourceInfo> => {
-      const response = await callFetch({
-        headers: {},
-        method: 'GET',
-        url: `${apiContext.dvApiUri}metadata/runtimeMetadata/${virtualization.keng__id}`,
-      });
-      if (!response.ok) {
-        throw new Error(response.statusText);
-      }
-      return (await response.json()) as ViewSourceInfo;
+  ): Promise<ViewSourceInfo> => {
+    const response = await callFetch({
+      headers: {},
+      method: 'GET',
+      url: `${apiContext.dvApiUri}metadata/runtimeMetadata/${virtualization.keng__id}`,
+    });
+    if (!response.ok) {
+      throw new Error(response.statusText);
     }
+    return (await response.json()) as ViewSourceInfo;
+  }
   
   return {
     createVirtualization,

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -82,6 +82,9 @@ export interface ViewDefinition {
   isUserDefined: boolean;
   sourcePaths: string[];
   ddl?: string;
+  createdAt?: number;
+  modifiedAt?: number;
+  version?: number;
 }
 
 export interface ColumnData {

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
@@ -1,4 +1,12 @@
-import { Alert, AlertActionCloseButton, Button, Card, CardBody, CardFooter } from '@patternfly/react-core';
+import { 
+  Alert, 
+  AlertActionCloseButton, 
+  Button, 
+  Card, 
+  CardBody, 
+  CardFooter, 
+  Title 
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { Loader, PageSection } from '../../../Layout';
 import { ITextEditor, TextEditor } from '../../../Shared';
@@ -18,34 +26,34 @@ export interface IDdlEditorProps {
   viewDdl: string;
 
   /**
+   * The localized text for the done button.
+   */
+  i18nDoneLabel: string;
+
+  /**
    * The localized text for the save button.
    */
   i18nSaveLabel: string;
 
   /**
-   * The localized text for the validate button.
+   * The localized text for the title
    */
-  i18nValidateLabel: string;
+  i18nTitle: string;
 
   /**
-   * The localized text for the validate results alert title
+   * The localized text for the validate results message title
    */
   i18nValidationResultsTitle: string;
 
   /**
-   * `true` if all form fields have valid values.
+   * `true` if the validation message is to be shown
    */
-  isValid: boolean;
+  showValidationMessage: boolean;
 
   /**
    * `true` if save is in progress.
    */
   isSaving: boolean;
-
-  /**
-   * `true` if validation is in progress.
-   */
-  isValidating: boolean;
 
   /**
    * View validationResults
@@ -58,16 +66,20 @@ export interface IDdlEditorProps {
   sourceTableInfos: ITableInfo[];
 
   /**
+   * The callback for closing the validation message
+   */
+  onCloseValidationMessage: () => void;
+
+  /**
+   * The callback for when the done button is clicked
+   */
+  onFinish: () => void;
+
+  /**
    * The callback for when the save button is clicked
    * @param ddl the text area ddl
    */
   onSave: (ddl: string) => void;
-
-  /**
-   * The callback for when the validate button is clicked.
-   * @param ddl the ddl
-   */
-  onValidate: (ddl: string) => void;
 }
 
 export const DdlEditor: React.FunctionComponent<
@@ -76,26 +88,22 @@ IDdlEditorProps
 
   const [ddlValue, setDdlValue] = React.useState(props.viewDdl);
   const [initialDdlValue] = React.useState(props.viewDdl);
-  const [needsValidation, setNeedsValidation] = React.useState(false);
-  const [validationAlertVisible, setValidationAlertVisible] = React.useState(false);
 
-  const handleDdlValidation = () => {
-    props.onValidate(ddlValue);
-    setNeedsValidation(false);
-    setValidationAlertVisible(true);
-  };
+  const handleCloseValidationMessage = () => {
+    props.onCloseValidationMessage();
+  }
 
   const handleDdlChange = (editor: ITextEditor, data: any, value: string) => {
     setDdlValue(value);
-    setNeedsValidation(true);
+    handleCloseValidationMessage();
   }
+
+  const handleFinish = () => {
+    props.onFinish();
+  };
 
   const handleSave = () => {
     props.onSave(ddlValue);
-  };
-
-  const hideValidationAlert = () => {
-    setValidationAlertVisible(false);
   };
 
   /**
@@ -132,14 +140,17 @@ IDdlEditorProps
   };
 
   return (
-    <PageSection>
+    <PageSection variant={'light'}>
+      <Title headingLevel="h5" size="lg">
+        {props.i18nTitle}
+      </Title>
       <Card>
         <CardBody>
-          {validationAlertVisible ? props.validationResults.map((e, idx) => (
+          {props.showValidationMessage ? props.validationResults.map((e, idx) => (
             <Alert key={idx}
               variant={e.type}
               title={props.i18nValidationResultsTitle}
-              action={<AlertActionCloseButton onClose={hideValidationAlert} />}
+              action={<AlertActionCloseButton onClose={handleCloseValidationMessage} />}
             >{e.message}
             </Alert>
           )) : null}
@@ -150,26 +161,20 @@ IDdlEditorProps
           />
         </CardBody>
         <CardFooter>
-          <Button
+        <Button
+            data-testid={'ddl-editor-done-button'}
             variant="secondary"
             className="ddl-editor__button"
-            isDisabled={props.isValidating || !needsValidation}
-            onClick={handleDdlValidation}
+            isDisabled={false}
+            onClick={handleFinish}
           >
-            {props.isValidating ? (
-              <Loader size={'sm'} inline={true} />
-            ) : null}
-            {props.i18nValidateLabel}
+            {props.i18nDoneLabel}
           </Button>
           <Button
+            data-testid={'ddl-editor-save-button'}
             variant="primary"
             className="ddl-editor__button"
-            isDisabled={
-              props.isSaving ||
-              props.isValidating ||
-              !props.isValid ||
-              needsValidation
-            }
+            isDisabled={props.isSaving}
             onClick={handleSave}
           >
             {props.isSaving ? <Loader size={'xs'} inline={true} /> : null}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.css
@@ -5,7 +5,3 @@
   --pf-c-button--m-secondary--focus--Color: #fff;
   --pf-c-button--m-secondary--focus--BackgroundColor: #06c;
 }
-
-.expandable-preview__content {
-  margin-top: 15px;
-}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -1,33 +1,40 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
-import { Button, Expandable } from '@patternfly/react-core';
+import { 
+  Button, 
+  Expandable, 
+  PageSection, 
+  Split, 
+  SplitItem, 
+  Title 
+} from '@patternfly/react-core';
 import { SyncIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { TextEditor } from '../../../Shared';
 import './ExpandablePreview.css';
 import { IColumn, PreviewResults } from './PreviewResults';
 
 /**
+ * @param i18nEmptyResultsTitle - text for empty results title
+ * @param i18nEmptyResultsMsg - text for empty results message
  * @param i18nHidePreview - text for hide preview toggle control
  * @param i18nShowPreview - text for show preview toggle control
+ * @param i18nTitle - title for the component
  * @param initialExpanded - 'true' if preview is to be expanded initially
  * @param onPreviewExpandedChanged - handle changes in expansion
+ * @param onRefreshResults - handle results refresh
+ * @param queryResultCols - the result columns
+ * @param queryResultRows - the result rows
  */
 export interface IExpandablePreviewProps {
   i18nEmptyResultsTitle: string;
   i18nEmptyResultsMsg: string;
   i18nHidePreview: string;
   i18nShowPreview: string;
-  // i18nSelectSqlText: string;
-  // i18nSelectPreviewText: string;
+  i18nTitle: string;
   initialExpanded?: boolean;
-  // initialPreviewButtonSelection?: PreviewButtonSelection;
   onPreviewExpandedChanged: (
     previewExpanded: boolean
   ) => void;
-  // onPreviewButtonSelectionChanged: (
-  //   previewButtonSelection: PreviewButtonSelection
-  // ) => void;
   onRefreshResults: () => void;
   /**
    * Array of column info for the query results.  (The column id and display label)
@@ -48,15 +55,6 @@ export interface IExpandablePreviewProps {
    * ]
    */
   queryResultRows: Array<{}>;
-  viewDdl?: string;
-}
-
-/**
- * The 'button' selection - SQL or Preview
- */
-export enum PreviewButtonSelection {
-  SQL = 'SQL',
-  PREVIEW = 'PREVIEW',
 }
 
 /**
@@ -69,95 +67,47 @@ export const ExpandablePreview: React.FunctionComponent<
   i18nEmptyResultsMsg,
   i18nHidePreview,
   i18nShowPreview,
-  // i18nSelectSqlText,
-  // i18nSelectPreviewText,
+  i18nTitle,
   initialExpanded = true,
-  // initialPreviewButtonSelection = PreviewButtonSelection.PREVIEW,
   onPreviewExpandedChanged,
-  // onPreviewButtonSelectionChanged,
   onRefreshResults,
   queryResultCols,
   queryResultRows,
-  viewDdl
 }: IExpandablePreviewProps) => {
 
   const [expanded, setExpanded] = React.useState(initialExpanded);
-  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(initialPreviewButtonSelection); 
-  // const [refreshDisabled, setRefreshDisabled] = React.useState(initialPreviewButtonSelection === PreviewButtonSelection.SQL); 
-  const previewButtonSelection = PreviewButtonSelection.PREVIEW;
-  const refreshDisabled = false;
-
   const toggleExpanded = () => {
     setExpanded(!expanded);
     onPreviewExpandedChanged(!expanded);
   };
 
-  // const handleShowSql = () => {
-  //   if(previewButtonSelection === PreviewButtonSelection.PREVIEW) {
-  //     setPreviewButtonSelection(PreviewButtonSelection.SQL);
-  //     setRefreshDisabled(true);
-  //     onPreviewButtonSelectionChanged(PreviewButtonSelection.SQL);
-  //   }
-  // };
-
-  // const handleShowPreview = () => {
-  //   if(previewButtonSelection === PreviewButtonSelection.SQL) {
-  //     setPreviewButtonSelection(PreviewButtonSelection.PREVIEW);
-  //     setRefreshDisabled(false);
-  //     onPreviewButtonSelectionChanged(PreviewButtonSelection.PREVIEW);
-  //   }
-  // };
-
-  const editorOptions = {
-    autofocus: true,
-    extraKeys: { 'Ctrl-Space': 'autocomplete' },
-    gutters: ['CodeMirror-lint-markers'],
-    lineNumbers: true,
-    lineWrapping: true,
-    matchBrackets: true,
-    mode: 'text/x-mysql',
-    readOnly: true,
-    showCursorWhenSelecting: true,
-    styleActiveLine: true,
-    tabSize: 2,
-  };
-
   return (
-    <Expandable toggleText={expanded ? i18nHidePreview : i18nShowPreview} onToggle={toggleExpanded} isExpanded={expanded}>
-      {/* <Button 
-        variant="secondary" 
-        className="expandable-preview__button" 
-        onClick={handleShowSql} 
-        isActive={previewButtonSelection === PreviewButtonSelection.SQL}>
-        {i18nSelectSqlText}
-      </Button>
-      <Button 
-        variant="secondary" 
-        className="expandable-preview__button" 
-        onClick={handleShowPreview} 
-        isActive={previewButtonSelection === PreviewButtonSelection.PREVIEW}>
-        {i18nSelectPreviewText}
-      </Button> */}
-      <Button 
-        variant="plain" 
-        aria-label="Action" 
-        onClick={onRefreshResults} 
-        isDisabled={refreshDisabled}>
-        <SyncIcon />
-      </Button>
-      <div className="expandable-preview__content" />
-      {previewButtonSelection === PreviewButtonSelection.PREVIEW ?
+    <PageSection variant='light'>
+      <Expandable toggleText={expanded ? i18nHidePreview : i18nShowPreview} onToggle={toggleExpanded} isExpanded={expanded}>
+        <Split>
+          <SplitItem isFilled={false}>
+            <Title headingLevel="h5" size="lg">
+              {i18nTitle}
+            </Title>
+          </SplitItem>
+          <SplitItem isFilled={false}>
+            <Button
+              variant="plain"
+              aria-label="Action"
+              onClick={onRefreshResults}
+              isDisabled={false}>
+              <SyncIcon />
+            </Button>
+          </SplitItem>
+          <SplitItem isFilled={true} />
+        </Split>
         <PreviewResults
           queryResultRows={queryResultRows}
           queryResultCols={queryResultCols}
           i18nEmptyResultsTitle={i18nEmptyResultsTitle}
           i18nEmptyResultsMsg={i18nEmptyResultsMsg}
         />
-        : <TextEditor
-          value={viewDdl}
-          options={editorOptions}
-        />
-      }
-    </Expandable>
+      </Expandable>
+    </PageSection>
     );
   };

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -18,16 +18,16 @@ export interface IExpandablePreviewProps {
   i18nEmptyResultsMsg: string;
   i18nHidePreview: string;
   i18nShowPreview: string;
-  i18nSelectSqlText: string;
-  i18nSelectPreviewText: string;
+  // i18nSelectSqlText: string;
+  // i18nSelectPreviewText: string;
   initialExpanded?: boolean;
-  initialPreviewButtonSelection?: PreviewButtonSelection;
+  // initialPreviewButtonSelection?: PreviewButtonSelection;
   onPreviewExpandedChanged: (
     previewExpanded: boolean
   ) => void;
-  onPreviewButtonSelectionChanged: (
-    previewButtonSelection: PreviewButtonSelection
-  ) => void;
+  // onPreviewButtonSelectionChanged: (
+  //   previewButtonSelection: PreviewButtonSelection
+  // ) => void;
   onRefreshResults: () => void;
   /**
    * Array of column info for the query results.  (The column id and display label)
@@ -69,12 +69,12 @@ export const ExpandablePreview: React.FunctionComponent<
   i18nEmptyResultsMsg,
   i18nHidePreview,
   i18nShowPreview,
-  i18nSelectSqlText,
-  i18nSelectPreviewText,
+  // i18nSelectSqlText,
+  // i18nSelectPreviewText,
   initialExpanded = true,
-  initialPreviewButtonSelection = PreviewButtonSelection.PREVIEW,
+  // initialPreviewButtonSelection = PreviewButtonSelection.PREVIEW,
   onPreviewExpandedChanged,
-  onPreviewButtonSelectionChanged,
+  // onPreviewButtonSelectionChanged,
   onRefreshResults,
   queryResultCols,
   queryResultRows,
@@ -82,29 +82,31 @@ export const ExpandablePreview: React.FunctionComponent<
 }: IExpandablePreviewProps) => {
 
   const [expanded, setExpanded] = React.useState(initialExpanded);
-  const [previewButtonSelection, setPreviewButtonSelection] = React.useState(initialPreviewButtonSelection); 
-  const [refreshDisabled, setRefreshDisabled] = React.useState(initialPreviewButtonSelection === PreviewButtonSelection.SQL); 
+  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(initialPreviewButtonSelection); 
+  // const [refreshDisabled, setRefreshDisabled] = React.useState(initialPreviewButtonSelection === PreviewButtonSelection.SQL); 
+  const previewButtonSelection = PreviewButtonSelection.PREVIEW;
+  const refreshDisabled = false;
 
   const toggleExpanded = () => {
     setExpanded(!expanded);
     onPreviewExpandedChanged(!expanded);
   };
 
-  const handleShowSql = () => {
-    if(previewButtonSelection === PreviewButtonSelection.PREVIEW) {
-      setPreviewButtonSelection(PreviewButtonSelection.SQL);
-      setRefreshDisabled(true);
-      onPreviewButtonSelectionChanged(PreviewButtonSelection.SQL);
-    }
-  };
+  // const handleShowSql = () => {
+  //   if(previewButtonSelection === PreviewButtonSelection.PREVIEW) {
+  //     setPreviewButtonSelection(PreviewButtonSelection.SQL);
+  //     setRefreshDisabled(true);
+  //     onPreviewButtonSelectionChanged(PreviewButtonSelection.SQL);
+  //   }
+  // };
 
-  const handleShowPreview = () => {
-    if(previewButtonSelection === PreviewButtonSelection.SQL) {
-      setPreviewButtonSelection(PreviewButtonSelection.PREVIEW);
-      setRefreshDisabled(false);
-      onPreviewButtonSelectionChanged(PreviewButtonSelection.PREVIEW);
-    }
-  };
+  // const handleShowPreview = () => {
+  //   if(previewButtonSelection === PreviewButtonSelection.SQL) {
+  //     setPreviewButtonSelection(PreviewButtonSelection.PREVIEW);
+  //     setRefreshDisabled(false);
+  //     onPreviewButtonSelectionChanged(PreviewButtonSelection.PREVIEW);
+  //   }
+  // };
 
   const editorOptions = {
     autofocus: true,
@@ -122,7 +124,7 @@ export const ExpandablePreview: React.FunctionComponent<
 
   return (
     <Expandable toggleText={expanded ? i18nHidePreview : i18nShowPreview} onToggle={toggleExpanded} isExpanded={expanded}>
-      <Button 
+      {/* <Button 
         variant="secondary" 
         className="expandable-preview__button" 
         onClick={handleShowSql} 
@@ -135,7 +137,7 @@ export const ExpandablePreview: React.FunctionComponent<
         onClick={handleShowPreview} 
         isActive={previewButtonSelection === PreviewButtonSelection.PREVIEW}>
         {i18nSelectPreviewText}
-      </Button>
+      </Button> */}
       <Button 
         variant="plain" 
         aria-label="Action" 

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor.stories.tsx
@@ -20,15 +20,16 @@ stories.add('render', () => {
   return (
     <DdlEditor
       viewDdl={viewDdl}
+      i18nDoneLabel={'Done'}
       i18nSaveLabel={'Save'}
-      i18nValidateLabel={'Validate'}
+      i18nTitle={'View Editor'}
       i18nValidationResultsTitle={'DDL Validation'}
-      isValid={true}
+      showValidationMessage={true}
       isSaving={false}
-      isValidating={false}
       sourceTableInfos={sourceTables}
       validationResults={[]}
-      onValidate={action('validate')}
+      onCloseValidationMessage={action('ddlChange')}
+      onFinish={action('done')}
       onSave={action('save')}
     />
   );

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
@@ -36,11 +36,11 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      i18nSelectSqlText={'SQL'}
-      i18nSelectPreviewText={'Preview'}
+      // i18nSelectSqlText={'SQL'}
+      // i18nSelectPreviewText={'Preview'}
       initialExpanded={false}
       onPreviewExpandedChanged={action('expanded changed')}
-      onPreviewButtonSelectionChanged={action('selection changed')}
+      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={resultCols}
       queryResultRows={resultRows}
@@ -56,12 +56,12 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      i18nSelectSqlText={'SQL'}
-      i18nSelectPreviewText={'Preview'}
+      // i18nSelectSqlText={'SQL'}
+      // i18nSelectPreviewText={'Preview'}
       initialExpanded={true}
-      initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
+      // initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
       onPreviewExpandedChanged={action('expanded changed')}
-      onPreviewButtonSelectionChanged={action('selection changed')}
+      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={resultCols}
       queryResultRows={resultRows}
@@ -77,33 +77,12 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      i18nSelectSqlText={'SQL'}
-      i18nSelectPreviewText={'Preview'}
+      // i18nSelectSqlText={'SQL'}
+      // i18nSelectPreviewText={'Preview'}
       initialExpanded={true}
-      initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
+      // initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
       onPreviewExpandedChanged={action('expanded changed')}
-      onPreviewButtonSelectionChanged={action('selection changed')}
-      onRefreshResults={action('refresh results')}
-      queryResultCols={[]}
-      queryResultRows={[]}
-      viewDdl={viewDdl}
-    />
-  );
-})
-
-.add('expanded, SQL', () => {
-  return (
-    <ExpandablePreview
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-      i18nHidePreview={'Hide Preview'}
-      i18nShowPreview={'Show Preview'}
-      i18nSelectSqlText={'SQL'}
-      i18nSelectPreviewText={'Preview'}
-      initialExpanded={true}
-      initialPreviewButtonSelection={PreviewButtonSelection.SQL}
-      onPreviewExpandedChanged={action('expanded changed')}
-      onPreviewButtonSelectionChanged={action('selection changed')}
+      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={[]}
       queryResultRows={[]}
@@ -111,3 +90,24 @@ stories.add('collapsed', () => {
     />
   );
 });
+
+// .add('expanded, SQL', () => {
+//   return (
+//     <ExpandablePreview
+//       i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+//       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+//       i18nHidePreview={'Hide Preview'}
+//       i18nShowPreview={'Show Preview'}
+//       i18nSelectSqlText={'SQL'}
+//       i18nSelectPreviewText={'Preview'}
+//       initialExpanded={true}
+//       initialPreviewButtonSelection={PreviewButtonSelection.SQL}
+//       onPreviewExpandedChanged={action('expanded changed')}
+//       onPreviewButtonSelectionChanged={action('selection changed')}
+//       onRefreshResults={action('refresh results')}
+//       queryResultCols={[]}
+//       queryResultRows={[]}
+//       viewDdl={viewDdl}
+//     />
+//   );
+// });

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { ExpandablePreview, PreviewButtonSelection } from '../../../src';
+import { ExpandablePreview } from '../../../src';
 
 const stories = storiesOf('Data/ViewEditor/ExpandablePreview', module);
 
@@ -26,9 +26,6 @@ const resultRows = [
   { FirstName: 'Julia', LastName: 'Zhang', Country: 'China' },
 ];
 
-const viewDdl =
-  'CREATE VIEW PgCustomer_account (\n\tRowId long,\n\taccount_id integer,\n\tssn string,\n\tstatus string,\n\ttype string,\n\tdateopened timestamp,\n\tdateclosed timestamp,\n\tPRIMARY KEY(RowId)\n)\nAS\nSELECT ROW_NUMBER() OVER (ORDER BY account_id), account_id, ssn, status, type, dateopened, dateclosed FROM pgcustomerschemamodel.account;';
-
 stories.add('collapsed', () => {
   return (
     <ExpandablePreview
@@ -36,15 +33,12 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      // i18nSelectSqlText={'SQL'}
-      // i18nSelectPreviewText={'Preview'}
+      i18nTitle={'Preview Results'}
       initialExpanded={false}
       onPreviewExpandedChanged={action('expanded changed')}
-      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={resultCols}
       queryResultRows={resultRows}
-      viewDdl={viewDdl}
     />
   );
 })
@@ -56,16 +50,12 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      // i18nSelectSqlText={'SQL'}
-      // i18nSelectPreviewText={'Preview'}
+      i18nTitle={'Preview Results'}
       initialExpanded={true}
-      // initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
       onPreviewExpandedChanged={action('expanded changed')}
-      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={resultCols}
       queryResultRows={resultRows}
-      viewDdl={viewDdl}
     />
   );
 })
@@ -77,37 +67,12 @@ stories.add('collapsed', () => {
       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
       i18nHidePreview={'Hide Preview'}
       i18nShowPreview={'Show Preview'}
-      // i18nSelectSqlText={'SQL'}
-      // i18nSelectPreviewText={'Preview'}
+      i18nTitle={'Preview Results'}
       initialExpanded={true}
-      // initialPreviewButtonSelection={PreviewButtonSelection.PREVIEW}
       onPreviewExpandedChanged={action('expanded changed')}
-      // onPreviewButtonSelectionChanged={action('selection changed')}
       onRefreshResults={action('refresh results')}
       queryResultCols={[]}
       queryResultRows={[]}
-      viewDdl={viewDdl}
     />
   );
 });
-
-// .add('expanded, SQL', () => {
-//   return (
-//     <ExpandablePreview
-//       i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-//       i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-//       i18nHidePreview={'Hide Preview'}
-//       i18nShowPreview={'Show Preview'}
-//       i18nSelectSqlText={'SQL'}
-//       i18nSelectPreviewText={'Preview'}
-//       initialExpanded={true}
-//       initialPreviewButtonSelection={PreviewButtonSelection.SQL}
-//       onPreviewExpandedChanged={action('expanded changed')}
-//       onPreviewButtonSelectionChanged={action('selection changed')}
-//       onRefreshResults={action('refresh results')}
-//       queryResultCols={[]}
-//       queryResultRows={[]}
-//       viewDdl={viewDdl}
-//     />
-//   );
-// });

--- a/app/ui-react/syndesis/src/modules/data/index.tsx
+++ b/app/ui-react/syndesis/src/modules/data/index.tsx
@@ -8,10 +8,7 @@ import {
   VirtualizationSqlClientPage,
   VirtualizationViewsPage,
 } from './pages';
-import {
-  ViewEditorOutputPage,
-  ViewEditorSqlPage
-} from './pages/viewEditor';
+import { ViewEditorSqlPage } from './pages/viewEditor';
 import routes from './routes';
 import { ViewCreateApp } from './ViewCreateApp';
 import { ViewsImportApp } from './ViewsImportApp';
@@ -38,11 +35,6 @@ export class DataModule extends React.Component {
             path={routes.virtualizations.virtualization.views.edit.sql}
             exact={true}
             component={ViewEditorSqlPage}
-          />
-          <Route
-            path={routes.virtualizations.virtualization.views.edit.viewOutput}
-            exact={true}
-            component={ViewEditorOutputPage}
           />
           <Route
             path={routes.virtualizations.create}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -45,8 +45,11 @@
       "showPreview": "Show Preview",
       "selectSql": "SQL",
       "selectPreview": "Preview",
-      "resultsTableEmptyStateTitle": "NO DATA AVAILABLE",
-      "resultsTableEmptyStateInfo": "Click 'refresh' button to refresh the preview results"
+      "resultsTableInvalidEmptyTitle": "CURRENT VIEW INVALID",
+      "resultsTableInvalidEmptyInfo": "The current view is invalid - no results to show",
+      "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
+      "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
+      "title": "Preview Results"
     },
     "unpublishModalMessage": "This Virtualization has been published. Unpublish Virtualization \"{{name}}\" first.",
     "unpublishModalTitle": "Unpublish Virtualization",
@@ -68,6 +71,7 @@
       "reorderColumnDown": "Reorder column down",
       "reorderColumnUp": "Reorder column up",
       "sqlTab": "SQL",
+      "title": "View Editor",
       "viewOutputTab": "View Output"
     },
     "viewNameDisplay": "View Name",
@@ -82,6 +86,7 @@
     "queryResultsTableEmptyStateTitle": "NO DATA AVAILABLE",
     "queryResultsTitle": "Query Results",
     "queryResultsRowCountMsg": "Number of Rows: ",
+    "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",
     "publishVirtualizationSuccess": "Virtualization {{name}} was submitted for publishing.",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -45,8 +45,11 @@
       "showPreview": "Show Preview",
       "selectSql": "SQL",
       "selectPreview": "Preview",
-      "resultsTableEmptyStateTitle": "NO DATA AVAILABLE",
-      "resultsTableEmptyStateInfo": "Click 'refresh' button to refresh the preview results"
+      "resultsTableInvalidEmptyTitle": "CURRENT VIEW INVALID",
+      "resultsTableInvalidEmptyInfo": "The current view is invalid - no results to show",
+      "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
+      "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
+      "title": "Preview Results"
     },
     "unpublishModalMessage": "This Virtualization has been published.  Please unpublish Virtualization \"{{name}}\" first.",
     "unpublishModalTitle": "Unpublish Virtualization",
@@ -68,6 +71,7 @@
       "reorderColumnDown": "Riordina colonna verso il basso",
       "reorderColumnUp": "Riordina colonna in alto",
       "sqlTab": "SQL",
+      "title": "View Editor",
       "viewOutputTab": "Visualizza Produzione"
     },
     "viewNameDisplay": "View Name",
@@ -82,6 +86,7 @@
     "queryResultsTableEmptyStateTitle": "NO DATA AVAILABLE",
     "queryResultsTitle": "Query Results",
     "queryResultsRowCountMsg": "Number of Rows: ",
+    "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",
     "publishVirtualizationSuccess": "Virtualization {{name}} was submitted for publishing.",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -6,7 +6,6 @@ import { QueryResults, ViewDefinitionDescriptor } from '@syndesis/models';
 import { RestDataService } from '@syndesis/models';
 import {
   PageSection,
-  PreviewButtonSelection,
   ViewHeaderBreadcrumb,
   VirtualizationDetailsHeader,
 } from '@syndesis/ui';
@@ -361,7 +360,6 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                                 viewDefinitionId: viewDefinitionDescriptor.id,
                                 viewDefinition: undefined,
                                 previewExpanded:true,
-                                previewButtonSelection:PreviewButtonSelection.PREVIEW,
                                 queryResults:queryResultsEmpty
                               }
                             )}

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorOutputPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorOutputPage.tsx
@@ -9,7 +9,6 @@ import {
   ExpandablePreview,
   PageLoader,
   PageSection,
-  PreviewButtonSelection,
   ViewOutputToolbar,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
@@ -35,14 +34,12 @@ export interface IViewEditorOutputRouteParams {
  * @param previewExpanded - expanded state of the preview area
  * @param viewDefinition - the ViewDefinition
  * @param previewExpanded - the state of preview component expansion
- * @param previewButtonSelection - the button selection state in the preview component
  * @param queryResults - the current query results in the preview component
  */
 export interface IViewEditorOutputRouteState {
   virtualization: RestDataService;
   previewExpanded: boolean;
   viewDefinition: ViewDefinition;
-  previewButtonSelection: PreviewButtonSelection;
   queryResults: QueryResults;
 }
 
@@ -61,8 +58,6 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
   const [previewExpanded, setPreviewExpanded] = React.useState(
     state.previewExpanded
   );
-  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
-  // const [viewDdl, setViewDdl] = React.useState(state.viewDefinition.ddl);
   const [queryResults, setQueryResults] = React.useState(state.queryResults);
   const { queryVirtualization } = useVirtualizationHelpers();
   const { resource: virtualization } = useVirtualization(params.virtualizationId);
@@ -106,12 +101,6 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
     // TODO: implement save
   };
 
-  // const handlePreviewButtonSelectionChanged = (
-  //   selection: PreviewButtonSelection
-  // ) => {
-  //   setPreviewButtonSelection(selection);
-  // };
-  
   // const handleEditFinished = () => {
   //   history.push(
   //     resolvers.data.virtualizations.views.root({
@@ -131,12 +120,6 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
         sqlStatement,
         15,
         0
-      );
-      pushNotification(
-        t('virtualization.queryViewSuccess', {
-          name: state.viewDefinition.name,
-        }),
-        'success'
       );
       setQueryResults(results);
     } catch (error) {
@@ -178,32 +161,6 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
             </Link>
             <span>{viewDefn.name}</span>
           </Breadcrumb>
-          {/* <PageSection variant={'light'} noPadding={true}>
-            <ViewEditorNavBar
-              i18nFinishButton={t('data:virtualization.viewEditor.Done')}
-              i18nViewOutputTab={t('data:virtualization.viewEditor.viewOutputTab')}
-              i18nViewSqlTab={t('data:virtualization.viewEditor.sqlTab')}
-              viewOutputHref={resolvers.data.virtualizations.views.edit.viewOutput({
-                virtualization,
-                // tslint:disable-next-line: object-literal-sort-keys
-                viewDefinitionId: params.viewDefinitionId,
-                previewExpanded,
-                viewDefinition: viewDefn,
-                previewButtonSelection,
-                queryResults,
-              })}
-              viewSqlHref={resolvers.data.virtualizations.views.edit.sql({
-                virtualization,
-                // tslint:disable-next-line: object-literal-sort-keys
-                viewDefinitionId: params.viewDefinitionId,
-                previewExpanded,
-                viewDefinition: viewDefn,
-                previewButtonSelection,
-                queryResults,
-              })}
-              onEditFinished={handleEditFinished}
-            />
-          </PageSection> */}
           <PageSection>
             <ViewOutputToolbar
               a11yFilterColumns={t('virtualization.viewEditor.applyColumnFilter')}
@@ -247,7 +204,7 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
               onSave={handleSave}
             />
           </PageSection>
-          <PageSection variant={'light'} noPadding={true}>
+          <PageSection variant={'light'}>
             <ExpandablePreview
               i18nEmptyResultsTitle={t(
                 'data:virtualization.preview.resultsTableEmptyStateTitle'
@@ -257,14 +214,10 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
               )}
               i18nHidePreview={t('data:virtualization.preview.hidePreview')}
               i18nShowPreview={t('data:virtualization.preview.showPreview')}
-              // i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
-              // i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
+              i18nTitle={t('data:virtualization.preview.title')}
               initialExpanded={previewExpanded}
-              // initialPreviewButtonSelection={previewButtonSelection}
               onPreviewExpandedChanged={handlePreviewExpandedChanged}
-              // onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
               onRefreshResults={handleRefreshResults}
-              viewDdl={state.viewDefinition.ddl}
               queryResultRows={getQueryRows(
                 queryResults
               )}

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorOutputPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorOutputPage.tsx
@@ -10,7 +10,6 @@ import {
   PageLoader,
   PageSection,
   PreviewButtonSelection,
-  ViewEditorNavBar,
   ViewOutputToolbar,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
@@ -50,7 +49,7 @@ export interface IViewEditorOutputRouteState {
 export const ViewEditorOutputPage: React.FunctionComponent = () => {
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
-  const { params, state, history } = useRouteData<IViewEditorOutputRouteParams, IViewEditorOutputRouteState>();
+  const { params, state } = useRouteData<IViewEditorOutputRouteParams, IViewEditorOutputRouteState>();
 
   const [activeFilter, setActiveFilter] = React.useState();
   const [columnsToDelete] = React.useState();
@@ -62,7 +61,7 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
   const [previewExpanded, setPreviewExpanded] = React.useState(
     state.previewExpanded
   );
-  const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
+  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
   // const [viewDdl, setViewDdl] = React.useState(state.viewDefinition.ddl);
   const [queryResults, setQueryResults] = React.useState(state.queryResults);
   const { queryVirtualization } = useVirtualizationHelpers();
@@ -107,19 +106,19 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
     // TODO: implement save
   };
 
-  const handlePreviewButtonSelectionChanged = (
-    selection: PreviewButtonSelection
-  ) => {
-    setPreviewButtonSelection(selection);
-  };
+  // const handlePreviewButtonSelectionChanged = (
+  //   selection: PreviewButtonSelection
+  // ) => {
+  //   setPreviewButtonSelection(selection);
+  // };
   
-  const handleEditFinished = () => {
-    history.push(
-      resolvers.data.virtualizations.views.root({
-        virtualization: state.virtualization,
-      })
-    );
-  }
+  // const handleEditFinished = () => {
+  //   history.push(
+  //     resolvers.data.virtualizations.views.root({
+  //       virtualization: state.virtualization,
+  //     })
+  //   );
+  // }
   
   const handleRefreshResults = async () => {
     try {
@@ -179,7 +178,7 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
             </Link>
             <span>{viewDefn.name}</span>
           </Breadcrumb>
-          <PageSection variant={'light'} noPadding={true}>
+          {/* <PageSection variant={'light'} noPadding={true}>
             <ViewEditorNavBar
               i18nFinishButton={t('data:virtualization.viewEditor.Done')}
               i18nViewOutputTab={t('data:virtualization.viewEditor.viewOutputTab')}
@@ -204,7 +203,7 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
               })}
               onEditFinished={handleEditFinished}
             />
-          </PageSection>
+          </PageSection> */}
           <PageSection>
             <ViewOutputToolbar
               a11yFilterColumns={t('virtualization.viewEditor.applyColumnFilter')}
@@ -258,12 +257,12 @@ export const ViewEditorOutputPage: React.FunctionComponent = () => {
               )}
               i18nHidePreview={t('data:virtualization.preview.hidePreview')}
               i18nShowPreview={t('data:virtualization.preview.showPreview')}
-              i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
-              i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
+              // i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
+              // i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
               initialExpanded={previewExpanded}
-              initialPreviewButtonSelection={previewButtonSelection}
+              // initialPreviewButtonSelection={previewButtonSelection}
               onPreviewExpandedChanged={handlePreviewExpandedChanged}
-              onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
+              // onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
               onRefreshResults={handleRefreshResults}
               viewDdl={state.viewDefinition.ddl}
               queryResultRows={getQueryRows(

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -15,8 +15,6 @@ import {
 import { 
   ExpandablePreview, 
   PageLoader, 
-  PageSection, 
-  PreviewButtonSelection,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
 import { useContext } from 'react';
@@ -41,14 +39,12 @@ export interface IViewEditorSqlRouteParams {
  * @param virtualization - the Virtualization
  * @param viewDefinition - the ViewDefinition
  * @param previewExpanded - the state of preview component expansion
- * @param previewButtonSelection - the button selection state in the preview component
  * @param queryResults - the current query results in the preview component
  */
 export interface IViewEditorSqlRouteState {
   virtualization: RestDataService;
   viewDefinition: ViewDefinition;
   previewExpanded: boolean;
-  previewButtonSelection: PreviewButtonSelection;
   queryResults: QueryResults;
 }
 
@@ -56,40 +52,80 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
 
   const [isSaving, setIsSaving] = React.useState(false);
   const [isMetadataLoaded, setMetadataLoaded] = React.useState(false);
-  const [isValidating, setIsValidating] = React.useState(false);
-  const [sourceTableColumns, setSourceTableColumns ] = React.useState<TableColumns[]>([]);
+  const [sourceTableColumns, setSourceTableColumns] = React.useState<TableColumns[]>([]);
   const [viewValid, setViewValid] = React.useState(true);
+  const [validationMessageVisible, setValidationMessageVisible] = React.useState(false);
   const [validationResults, setValidationResults] = React.useState<IViewEditValidationResult[]>([]);
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
-  const { params, state } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
+  const { params, state, history } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
   const { getSourceInfoForView, queryVirtualization, saveViewDefinition, validateViewDefinition } = useVirtualizationHelpers();
   const [previewExpanded, setPreviewExpanded] = React.useState(state.previewExpanded);
   const [queryResults, setQueryResults] = React.useState(state.queryResults);
-  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
   const { resource: virtualization } = useVirtualization(params.virtualizationId);
   const { resource: viewDefn, loading, error } = useViewDefinition(params.viewDefinitionId, state.viewDefinition);
+  const [noResultsTitle, setNoResultsTitle] = React.useState(t('data:virtualization.preview.resultsTableValidEmptyTitle'));
+  const [noResultsMessage, setNoResultsMessage] = React.useState(t('data:virtualization.preview.resultsTableValidEmptyInfo'));
+
+  const queryResultsEmpty: QueryResults = {
+    columns: [],
+    rows: [],
+  };
 
   const handleMetadataLoaded = async (): Promise<void> => {
     if( sourceTableColumns != null && sourceTableColumns.length > 0 ) {
       setMetadataLoaded(true);
     }
-
   };
 
-  const handleValidationStarted = async (): Promise<void> => {
-    setIsValidating(true);
-  };
+  /**
+   * Validate the view and update preview results
+   * @param view the view definiton
+   */
+  const handleValidateView = async (view: ViewDefinition) => {
+    // Validate the View
+    const validationResponse = await validateViewDefinition(
+      view
+    );
+    let validationResult = null;
+    if (validationResponse.status === 'SUCCESS') {
+      validationResult = {
+        message: 'Validation successful',
+        type: 'success',
+      } as IViewEditValidationResult;
+    } else {
+      validationResult = {
+        message: validationResponse.message,
+        type: 'danger',
+      } as IViewEditValidationResult;
+    }
+    const isValid = validationResult.type === 'success';
+    setQueryResultEmptyContent(isValid);
+    setDdlValidationInfo(validationResult, isValid);
+    updateQueryResults(isValid);
+  }
 
-  const handleValidationComplete = async (
-    validation: IViewEditValidationResult
-  ): Promise<void> => {
-    setIsValidating(false);
-    setValidationResults([validation]);
-    setViewValid(validation.type === 'success');
-  };
+  // Preview result empty content changes if view is invalid
+  const setQueryResultEmptyContent = (isValid: boolean) => {
+    if(isValid) {
+      setNoResultsTitle(t('data:virtualization.preview.resultsTableValidEmptyTitle'));
+      setNoResultsMessage(t('data:virtualization.preview.resultsTableValidEmptyInfo'));
+    } else {
+      setNoResultsTitle(t('data:virtualization.preview.resultsTableInvalidEmptyTitle'));
+      setNoResultsMessage(t('data:virtualization.preview.resultsTableInvalidEmptyInfo'));
+    }
+  }
 
-  // Save the View with new DDL and description
+  // Update info for the DDL editor
+  const setDdlValidationInfo = (validationResult: IViewEditValidationResult, isValid: boolean) => {
+    setValidationResults([validationResult]);
+    setValidationMessageVisible(!isValid);
+    setViewValid(isValid);
+  }
+
+  /**
+   * Saves View with the new DDL value.  The View is also validated, and preview results updated
+   */
   const handleSaveView = async (ddlValue: string) => {
     setIsSaving(true);
     // View Definition
@@ -105,15 +141,12 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     };
 
     try {
+      // Save the View
       await saveViewDefinition(view);
+      // Validate the View
+      await handleValidateView(view);
+
       setIsSaving(false);
-      pushNotification(
-        t(
-          'virtualization.saveViewSuccess',
-          { name: viewDefn.name,
-        }),
-        'success'
-      );
     } catch (error) {
       const details = error.message
         ? error.message
@@ -129,109 +162,89 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     }
   };
 
-  // Validate the View using the new DDL
-  const handleValidateView = async (ddlValue: string) => {
-    handleValidationStarted();
-
-    // View Definition
-    const view: ViewDefinition = {
-      dataVirtualizationName: viewDefn.dataVirtualizationName,
-      ddl: ddlValue,
-      id: viewDefn.id,
-      isComplete: viewDefn.isComplete,
-      isUserDefined: true,
-      keng__description: viewDefn.keng__description,
-      name: viewDefn.name,
-      sourcePaths: viewDefn.sourcePaths,
-    };
-
-    const validationResponse = await validateViewDefinition(
-      view
-    );
-    if (validationResponse.status === 'SUCCESS') {
-      const validationResult = {
-        message: 'Validation successful',
-        type: 'success',
-      } as IViewEditValidationResult;
-      handleValidationComplete(validationResult);
-    } else {
-      const validationResult = {
-        message: validationResponse.message,
-        type: 'danger',
-      } as IViewEditValidationResult;
-
-      handleValidationComplete(validationResult);
-    }
-  };
-
   const handlePreviewExpandedChanged = (
     expanded: boolean
   ) => {
     setPreviewExpanded(expanded);
   };
 
-  // const handlePreviewButtonSelectionChanged = (
-  //   selection: PreviewButtonSelection
-  // ) => {
-  //   setPreviewButtonSelection(selection);
-  // };
+  const handleHideValidationMessage = () => {
+    setValidationMessageVisible(false);
+  };
 
-  // const handleEditFinished = () => {
-  //   history.push(
-  //     resolvers.data.virtualizations.views.root({
-  //       virtualization: state.virtualization,
-  //     })
-  //   );
-  // };
+  const handleEditFinished = () => {
+    history.push(
+      resolvers.data.virtualizations.views.root({
+        virtualization: state.virtualization,
+      })
+    );
+  };
 
   const handleRefreshResults = async () => {
+    updateQueryResults(viewValid, true);
+  }
+  
+  /**
+   * Update the preview query results
+   * @param isValid 'true' if the view definition is valid
+   * @param refreshClick 'true' if update is initiated by the preview refresh button
+   */
+  const updateQueryResults = async (isValid: boolean, refreshClick: boolean = false) => {
+    let queryResult = queryResultsEmpty;
     try {
-      const sqlStatement = getPreviewSql(viewDefn);
-
-      const results: QueryResults = await queryVirtualization(
-        params.virtualizationId,
-        sqlStatement,
-        15,
-        0
-      );
-      pushNotification(
-        t('virtualization.queryViewSuccess', {
-          name: viewDefn.name,
-        }),
-        'success'
-      );
-      setQueryResults(results);
+      // Valid view - run the preview query 
+      if (isValid) {
+        queryResult = await queryVirtualization(
+          params.virtualizationId,
+          getPreviewSql(viewDefn),
+          15,
+          0
+        );
+      }
+      setQueryResults(queryResult);
+      // Show toast for refresh click
+      if (refreshClick) {
+        pushNotification(
+          t('virtualization.queryResultsRefreshed', {
+            name: viewDefn.name,
+          }),
+          'success'
+        );
+      }
     } catch (error) {
-      const details = error.message ? error.message : '';
-      pushNotification(
-        t('virtualization.queryViewFailed', {
-          details,
-          name: viewDefn.name,
-        }),
-        'error'
-      );
+      setQueryResults(queryResult);
+      if (refreshClick) {
+        const details = error.message ? error.message : '';
+        pushNotification(
+          t('virtualization.queryViewFailed', {
+            details,
+            name: viewDefn.name,
+          }),
+          'error'
+        );
+      }
     }
   };
 
-    // load source table/column information
-    React.useEffect(() =>  {
-      if( ! isMetadataLoaded && virtualization !== null && (virtualization as RestDataService).keng__id !== null
-        && (virtualization as RestDataService).keng__id.length > 0) {
-        // load source table/column info by retrieving the view source info from
-        // the server and converting to TableColumn objects
-        const loadSourceTableInfo = async () => {
-          try {
-            const results : ViewSourceInfo =  await getSourceInfoForView(virtualization);
-            setSourceTableColumns(generateTableColumns(results as ViewSourceInfo));
-          } catch (error) {
-            pushNotification(error.message, 'error');
-          }
+  // load source table/column information
+  React.useEffect(() => {
+    if (!isMetadataLoaded && virtualization !== null && (virtualization as RestDataService).keng__id !== null
+      && (virtualization as RestDataService).keng__id.length > 0) {
+      // load source table/column info by retrieving the view source info from
+      // the server and converting to TableColumn objects
+      const loadSourceTableInfo = async () => {
+        try {
+          const results: ViewSourceInfo = await getSourceInfoForView(virtualization);
+          setSourceTableColumns(generateTableColumns(results as ViewSourceInfo));
+        } catch (error) {
+          pushNotification(error.message, 'error');
         }
-        loadSourceTableInfo();
-        handleMetadataLoaded();
       }
-      // eslint-disable-next-line
-    }, [virtualization as RestDataService]);
+      loadSourceTableInfo();
+      handleMetadataLoaded();
+    }
+    // eslint-disable-next-line
+  }, [virtualization as RestDataService]);
   
   return (
     <WithLoader
@@ -260,73 +273,38 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
             </Link>
             <span>{viewDefn.name}</span>
           </Breadcrumb>
-          {/* <PageSection variant={'light'} noPadding={true}>
-            <ViewEditorNavBar
-              i18nFinishButton={t('data:virtualization.viewEditor.Done')}
-              i18nViewOutputTab={t('data:virtualization.viewEditor.viewOutputTab')}
-              i18nViewSqlTab={t('data:virtualization.viewEditor.sqlTab')}
-              viewOutputHref={resolvers.data.virtualizations.views.edit.viewOutput({
-                virtualization,
-                // tslint:disable-next-line: object-literal-sort-keys
-                viewDefinitionId: params.viewDefinitionId,
-                previewExpanded,
-                viewDefinition: viewDefn,
-                previewButtonSelection,
-                queryResults,
-              })}
-              viewSqlHref={resolvers.data.virtualizations.views.edit.sql({
-                virtualization,
-                // tslint:disable-next-line: object-literal-sort-keys
-                viewDefinitionId: params.viewDefinitionId,
-                previewExpanded,
-                viewDefinition: viewDefn,
-                previewButtonSelection,
-                queryResults,
-              })}
-              onEditFinished={handleEditFinished}            
-            />
-          </PageSection> */}
           <DdlEditor
             viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
+            i18nDoneLabel={t('shared:Done')}
             i18nSaveLabel={t('shared:Save')}
-            i18nValidateLabel={t('shared:Validate')}
+            i18nTitle={t('data:virtualization.viewEditor.title')}
             i18nValidationResultsTitle={t('data:virtualization.validationResultsTitle')}
-            isValid={viewValid}
+            showValidationMessage={validationMessageVisible}
             isSaving={isSaving}
-            isValidating={isValidating}
             sourceTableInfos={sourceTableColumns}
-            onValidate={handleValidateView}
+            onCloseValidationMessage={handleHideValidationMessage}
+            onFinish={handleEditFinished}
             onSave={handleSaveView}
             validationResults={
               validationResults
             }
           />
-          <PageSection variant={'light'} noPadding={true}>
-            <ExpandablePreview
-              i18nEmptyResultsTitle={t(
-                'data:virtualization.preview.resultsTableEmptyStateTitle'
-              )}
-              i18nEmptyResultsMsg={t(
-                'data:virtualization.preview.resultsTableEmptyStateInfo'
-              )}
-              i18nHidePreview={t('data:virtualization.preview.hidePreview')}
-              i18nShowPreview={t('data:virtualization.preview.showPreview')}
-              // i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
-              // i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
-              initialExpanded={previewExpanded}
-              // initialPreviewButtonSelection={previewButtonSelection}
-              onPreviewExpandedChanged={handlePreviewExpandedChanged}
-              // onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
-              onRefreshResults={handleRefreshResults}
-              viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
-              queryResultRows={getQueryRows(
-                queryResults
-              )}
-              queryResultCols={getQueryColumns(
-                queryResults
-              )}
-            />
-          </PageSection>
+          <ExpandablePreview
+            i18nEmptyResultsTitle={noResultsTitle}
+            i18nEmptyResultsMsg={noResultsMessage}
+            i18nHidePreview={t('data:virtualization.preview.hidePreview')}
+            i18nShowPreview={t('data:virtualization.preview.showPreview')}
+            i18nTitle={t('data:virtualization.preview.title')}
+            initialExpanded={previewExpanded}
+            onPreviewExpandedChanged={handlePreviewExpandedChanged}
+            onRefreshResults={handleRefreshResults}
+            queryResultRows={getQueryRows(
+              queryResults
+            )}
+            queryResultCols={getQueryColumns(
+              queryResults
+            )}
+          />
         </>
       )}
     </WithLoader>

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -16,8 +16,7 @@ import {
   ExpandablePreview, 
   PageLoader, 
   PageSection, 
-  PreviewButtonSelection, 
-  ViewEditorNavBar 
+  PreviewButtonSelection,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
 import { useContext } from 'react';
@@ -63,11 +62,11 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
   const [validationResults, setValidationResults] = React.useState<IViewEditValidationResult[]>([]);
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
-  const { params, state, history } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
+  const { params, state } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
   const { getSourceInfoForView, queryVirtualization, saveViewDefinition, validateViewDefinition } = useVirtualizationHelpers();
   const [previewExpanded, setPreviewExpanded] = React.useState(state.previewExpanded);
   const [queryResults, setQueryResults] = React.useState(state.queryResults);
-  const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
+  // const [previewButtonSelection, setPreviewButtonSelection] = React.useState(state.previewButtonSelection);
   const { resource: virtualization } = useVirtualization(params.virtualizationId);
   const { resource: viewDefn, loading, error } = useViewDefinition(params.viewDefinitionId, state.viewDefinition);
 
@@ -171,19 +170,19 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     setPreviewExpanded(expanded);
   };
 
-  const handlePreviewButtonSelectionChanged = (
-    selection: PreviewButtonSelection
-  ) => {
-    setPreviewButtonSelection(selection);
-  };
+  // const handlePreviewButtonSelectionChanged = (
+  //   selection: PreviewButtonSelection
+  // ) => {
+  //   setPreviewButtonSelection(selection);
+  // };
 
-  const handleEditFinished = () => {
-    history.push(
-      resolvers.data.virtualizations.views.root({
-        virtualization: state.virtualization,
-      })
-    );
-  };
+  // const handleEditFinished = () => {
+  //   history.push(
+  //     resolvers.data.virtualizations.views.root({
+  //       virtualization: state.virtualization,
+  //     })
+  //   );
+  // };
 
   const handleRefreshResults = async () => {
     try {
@@ -261,7 +260,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
             </Link>
             <span>{viewDefn.name}</span>
           </Breadcrumb>
-          <PageSection variant={'light'} noPadding={true}>
+          {/* <PageSection variant={'light'} noPadding={true}>
             <ViewEditorNavBar
               i18nFinishButton={t('data:virtualization.viewEditor.Done')}
               i18nViewOutputTab={t('data:virtualization.viewEditor.viewOutputTab')}
@@ -286,7 +285,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
               })}
               onEditFinished={handleEditFinished}            
             />
-          </PageSection>
+          </PageSection> */}
           <DdlEditor
             viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
             i18nSaveLabel={t('shared:Save')}
@@ -312,12 +311,12 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
               )}
               i18nHidePreview={t('data:virtualization.preview.hidePreview')}
               i18nShowPreview={t('data:virtualization.preview.showPreview')}
-              i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
-              i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
+              // i18nSelectSqlText={t('data:virtualization.preview.selectSql')}
+              // i18nSelectPreviewText={t('data:virtualization.preview.selectPreview')}
               initialExpanded={previewExpanded}
-              initialPreviewButtonSelection={previewButtonSelection}
+              // initialPreviewButtonSelection={previewButtonSelection}
               onPreviewExpandedChanged={handlePreviewExpandedChanged}
-              onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
+              // onPreviewButtonSelectionChanged={handlePreviewButtonSelectionChanged}
               onRefreshResults={handleRefreshResults}
               viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
               queryResultRows={getQueryRows(

--- a/app/ui-react/syndesis/src/modules/data/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/data/resolvers.ts
@@ -5,7 +5,6 @@ import {
   SchemaNodeInfo,
   ViewDefinition,
 } from '@syndesis/models';
-import { PreviewButtonSelection } from '@syndesis/ui';
 import { makeResolver, makeResolverNoParams } from '@syndesis/utils';
 import routes from './routes';
 
@@ -61,11 +60,10 @@ export default {
           viewDefinitionId: string;
           previewExpanded: boolean;
           viewDefinition?: ViewDefinition;
-          previewButtonSelection: PreviewButtonSelection;
           queryResults: QueryResults;
         }>(
           routes.virtualizations.virtualization.views.edit.sql,
-          ({ virtualization, viewDefinitionId, viewDefinition, previewExpanded, previewButtonSelection, queryResults }) => ({
+          ({ virtualization, viewDefinitionId, viewDefinition, previewExpanded, queryResults }) => ({
             params: {
               virtualizationId: virtualization.keng__id,
               viewDefinitionId,
@@ -74,30 +72,6 @@ export default {
               virtualization,
               previewExpanded,
               viewDefinition,
-              previewButtonSelection,
-              queryResults
-            },
-          })
-        ),
-        viewOutput: makeResolver<{
-          virtualization: RestDataService;
-          viewDefinitionId: string;
-          previewExpanded: boolean;
-          viewDefinition?: ViewDefinition;
-          previewButtonSelection: PreviewButtonSelection;
-          queryResults: QueryResults;
-        }>(
-          routes.virtualizations.virtualization.views.edit.viewOutput,
-          ({ virtualization, viewDefinitionId, viewDefinition, previewExpanded, previewButtonSelection, queryResults }) => ({
-            params: {
-              virtualizationId: virtualization.keng__id,
-              viewDefinitionId,
-            },
-            state: {
-              virtualization,
-              previewExpanded,
-              viewDefinition,
-              previewButtonSelection,
               queryResults
             },
           })

--- a/app/ui-react/syndesis/src/modules/data/routes.ts
+++ b/app/ui-react/syndesis/src/modules/data/routes.ts
@@ -24,7 +24,6 @@ export default include('/data', {
           properties: 'properties',
           root: '',
           sql: 'sql',
-          viewOutput: 'viewOutput',
         }),
         importSource: include('importSource', {
           root: '',


### PR DESCRIPTION
Reorganization of the ViewEditor per feedback from F2F.
- Removed the ViewEditorNavBar (tabs) from ViewEditorSqlPage.  The current view editor will be a single page with DDL text editor.
- Removed ViewEditorNavBar from the ViewEditorOutputPage.  The page remains, but removed the route and resolver so the output page cannot be accessed - it will most likely be reinstated in some form.
- Removed capability to toggle between SQL and queryResults from the ExpandablePreview component.  It is no longer needed with a single page editor
- Rework DdlEditor - there are no longer separate Validate/Save buttons.  The user can save the view in any state (not required to be valid).  Validation is still done as part of the save process, and an error message is shown if the DDL is invalid.  The query preview results are also refreshed on save.
- other minor story updates and layout fixes. 