### PR TITLE
fix [5673]: Add back to primary flow button

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.css
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.css
@@ -74,4 +74,11 @@
   }
 }
 
+.integration-editor-condition[data-verb=WHEN] {
+  color: #3C96D4;
+}
+.integration-editor-condition[data-verb=OTHERWISE] {
+  color: #61AF5A;
+}
+
 

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.tsx
@@ -49,6 +49,10 @@ export interface IIntegrationEditorLayoutProps {
   saveHref?: H.LocationDescriptor;
   cancelHref?: H.LocationDescriptor;
   publishHref?: H.LocationDescriptor;
+  primaryFlowHref?: H.LocationDescriptor;
+  isApiProvider?: boolean;
+  isAlternateFlow?: boolean;
+  isDefaultFlow?: boolean;
   isSaveDisabled?: boolean;
   isSaveLoading?: boolean;
   isPublishDisabled?: boolean;
@@ -81,69 +85,107 @@ export const IntegrationEditorLayout: React.FunctionComponent<
   saveHref,
   cancelHref,
   publishHref,
+  primaryFlowHref,
+  isApiProvider,
+  isAlternateFlow,
+  isDefaultFlow,
   isSaveLoading,
   isSaveDisabled,
   isPublishLoading,
   isPublishDisabled,
   extraActions,
 }: IIntegrationEditorLayoutProps) => {
+  const condition = isDefaultFlow ? 'OTHERWISE' : 'WHEN';
+
   return (
     <div className={'integration-editor-layout'}>
       <div className={'integration-editor-layout__header'}>
         <PageSection variant={'light'}>
           {toolbar}
           <Level gutter={'sm'}>
-            <LevelItem>
-              <TextContent>
-                <Title size={'2xl'} headingLevel={TitleLevel.h1}>
-                  {title}
-                </Title>
-                <Text>{description}</Text>
-              </TextContent>
-            </LevelItem>
-            <LevelItem>
-              {(cancelHref || onCancel) && (
-                <>
-                  <ButtonLink
-                    id={'integration-editor-cancel-button'}
-                    onClick={onCancel}
-                    href={cancelHref}
-                  >
-                    Cancel
-                  </ButtonLink>
-                  &nbsp;&nbsp;&nbsp;
-                </>
-              )}
-              {(saveHref || onSave) && (
-                <>
-                  <ButtonLink
-                    id={'integration-editor-save-button'}
-                    onClick={onSave}
-                    href={saveHref}
-                    disabled={isSaveLoading || isSaveDisabled}
-                    as={publishHref || onPublish ? 'default' : 'primary'}
-                  >
-                    {isSaveLoading ? (
-                      <Loader size={'xs'} inline={true} />
-                    ) : null}
-                    Save
-                  </ButtonLink>
-                  &nbsp;
-                </>
-              )}
-              {(publishHref || onPublish) && (
+            {isAlternateFlow ? (
+            <>
+              <LevelItem>
+                <TextContent>
+                  <Title size={'2xl'} headingLevel={TitleLevel.h1}>
+                    <strong
+                      className="integration-editor-condition"
+                      data-verb={condition}
+                    >
+                      {condition}
+                    </strong>
+                    &nbsp;{title}
+                  </Title>
+                  <Text>{description}</Text>
+                </TextContent>
+              </LevelItem>
+              <LevelItem>
                 <ButtonLink
-                  id={'integration-editor-publish-button'}
-                  onClick={onPublish}
-                  href={publishHref}
-                  as={'primary'}
-                  disabled={isPublishLoading || isPublishDisabled}
+                  id={'integration-editor-back-button'}
+                  href={primaryFlowHref}
                 >
-                  Publish
+                  {isApiProvider ?
+                    'Go to Operation Flow' :
+                    'Go to Primary Flow'
+                  }
                 </ButtonLink>
-              )}
-              {extraActions}
-            </LevelItem>
+              </LevelItem>
+            </>
+            ) : (
+            <>
+              <LevelItem>
+                <TextContent>
+                  <Title size={'2xl'} headingLevel={TitleLevel.h1}>
+                    {title}
+                  </Title>
+                  <Text>{description}</Text>
+                </TextContent>
+              </LevelItem>
+              <LevelItem>
+                {(cancelHref || onCancel) && (
+                  <>
+                    <ButtonLink
+                      id={'integration-editor-cancel-button'}
+                      onClick={onCancel}
+                      href={cancelHref}
+                    >
+                      Cancel
+                    </ButtonLink>
+                    &nbsp;&nbsp;&nbsp;
+                  </>
+                )}
+                {(saveHref || onSave) && (
+                  <>
+                    <ButtonLink
+                      id={'integration-editor-save-button'}
+                      onClick={onSave}
+                      href={saveHref}
+                      disabled={isSaveLoading || isSaveDisabled}
+                      as={publishHref || onPublish ? 'default' : 'primary'}
+                    >
+                      {isSaveLoading ? (
+                        <Loader size={'xs'} inline={true} />
+                      ) : null}
+                      Save
+                    </ButtonLink>
+                    &nbsp;
+                  </>
+                )}
+                {(publishHref || onPublish) && (
+                  <ButtonLink
+                    id={'integration-editor-publish-button'}
+                    onClick={onPublish}
+                    href={publishHref}
+                    as={'primary'}
+                    disabled={isPublishLoading || isPublishDisabled}
+                  >
+                    Publish
+                  </ButtonLink>
+                )}
+                {extraActions}
+              </LevelItem>
+            </>
+            )}
           </Level>
         </PageSection>
       </div>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -1,7 +1,12 @@
 import {
   getFirstPosition,
+  getFlow,
   getLastPosition,
+  getMetadataValue,
   getSteps,
+  isDefaultFlow,
+  isIntegrationApiProvider,
+  isPrimaryFlow,
   useIntegrationHelpers,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
@@ -130,6 +135,16 @@ export const AddStepPage: React.FunctionComponent<
     openDeleteDialog();
   };
 
+  const isApiProvider = isIntegrationApiProvider(state.integration);
+  const currentFlow = getFlow(state.integration, params.flowId);
+  const isPrimary = isPrimaryFlow(currentFlow!);
+  const primaryFlow = isPrimary
+    ? currentFlow
+    : getFlow(
+      state.integration,
+      getMetadataValue<string>('primaryFlowId', currentFlow!.metadata)!
+    );
+
   return (
     <Translation ns={['integrations', 'shared']}>
       {t => (
@@ -189,7 +204,10 @@ export const AddStepPage: React.FunctionComponent<
           )}
           <PageTitle title={t('integrations:editor:saveOrAddStep')} />
           <IntegrationEditorLayout
-            title={t('integrations:editor:addToIntegration')}
+            title={isPrimary
+              ? t('integrations:editor:addToIntegration')
+              : currentFlow!.description || ''
+            }
             description={t('integrations:editor:addStepDescription')}
             toolbar={getBreadcrumb(
               t('integrations:editor:addToIntegration'),
@@ -232,6 +250,10 @@ export const AddStepPage: React.FunctionComponent<
             cancelHref={cancelHref(params, state)}
             saveHref={saveHref(params, state)}
             publishHref={saveHref(params, state)}
+            isApiProvider={isApiProvider}
+            isAlternateFlow={!isPrimary}
+            isDefaultFlow={isDefaultFlow(currentFlow!)}
+            primaryFlowHref={getFlowHref(primaryFlow!.id!, params, state)}
           />
         </React.Fragment>
       )}


### PR DESCRIPTION
Fixes #5673 

Hide `Cancel`, `Save` and `Publish` buttons when working on a conditional flows alternate flow and display `Back to Primary Flow` button instead. Also display current condition expression as page heading. Also works within API provider integrations.

![Bildschirmfoto 2019-09-06 um 11 17 52](https://user-images.githubusercontent.com/195264/64417170-e2315100-d098-11e9-94e0-e64397decfba.png)
