### PR TITLE
fix(ci): don't trigger image transfer for master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ quay_transfer: &quay_transfer
   run:
     name: Trigger image transfer to quay.io
     command: |
-      curl -vs "https://ci.fabric8.io/generic-webhook-trigger/invoke?token=syndesis-circleci-to-quay&build_number=$CIRCLE_BUILD_NUM"
+      [ -n "${CIRCLE_PR_NUMBER}" ] && curl -vs "https://ci.fabric8.io/generic-webhook-trigger/invoke?token=syndesis-circleci-to-quay&build_number=$CIRCLE_BUILD_NUM"
 
 jobs:
   ui:


### PR DESCRIPTION
We don't need to trigger the image transfer for builds off of master
branch as they're not saving images as artifacts.

Fixes #6578