### PR TITLE
ENTESB-11251 Resolve connection refresh issue in import datasource wizard

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
@@ -1,10 +1,20 @@
 import { VirtualizationSourceStatus } from '@syndesis/models';
 import { useApiResource } from './useApiResource';
+import { usePolling } from './usePolling';
 
-export const useVirtualizationConnectionStatuses = () => {
-  return useApiResource<VirtualizationSourceStatus[]>({
+export const useVirtualizationConnectionStatuses = (disableUpdates: boolean = false) => {
+  const { read, ...rest } = useApiResource<VirtualizationSourceStatus[]>({
     defaultValue: [],
     url: 'metadata/syndesisSourceStatuses',
     useDvApiUrl: true,
   });
+
+  if (!disableUpdates) {
+    usePolling({ callback: read, delay: 10000 });
+  }
+
+  return {
+    ...rest,
+    read,
+  };
 };

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -50,14 +50,11 @@ export interface SchemaNodeInfo {
 }
 
 export interface VirtualizationSourceStatus {
-  sourceName: string;
-  hasTeiidSource: boolean;
-  vdbState: 'ACTIVE' | 'MISSING' | 'LOADING' | 'FAILED';
-  schemaState: 'ACTIVE' | 'MISSING' | 'LOADING' | 'FAILED';
   errors: string[];
-  vdbName?: string;
-  schemaVdbName?: string;
-  schemaModelName?: string;
+  id: string;
+  loading: boolean;
+  schemaState: 'ACTIVE' | 'MISSING' | 'FAILED';
+  sourceName: string;
 }
 
 export interface ViewDefinitionDescriptor {

--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
@@ -4,16 +4,17 @@ import {
   Card,
   CardBody,
   CardHeader,
-  Label,
   Text,
   Title,
 } from '@patternfly/react-core';
+import { Label, Spinner } from 'patternfly-react';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 import './DvConnectionCard.css';
 
 export enum ConnectionStatus {
   ACTIVE = 'ACTIVE',
+  FAILED = 'FAILED',
   INACTIVE = 'INACTIVE',
 }
 
@@ -22,6 +23,7 @@ export interface IDvConnectionCardProps {
   description: string;
   dvStatus: string;
   icon: React.ReactNode;
+  loading: boolean;
   selected: boolean;
   onSelectionChanged: (connName: string, isSelected: boolean) => void;
 }
@@ -32,8 +34,8 @@ export const DvConnectionCard: React.FunctionComponent<
   const [isSelected, setIsSelected] = React.useState(props.selected);
 
   const doToggleSelected = (connName: string) => (event: any) => {
-    // User can only select active connections
-    if (props.dvStatus === ConnectionStatus.ACTIVE) {
+    // User can only select active connections that are not loading
+    if (props.dvStatus === ConnectionStatus.ACTIVE && props.loading === false) {
       setIsSelected(!isSelected);
       props.onSelectionChanged(connName, !isSelected);
     }
@@ -48,6 +50,10 @@ export const DvConnectionCard: React.FunctionComponent<
       onClick={doToggleSelected(props.name)}
     >
       <CardHeader>
+        {props.loading ? (
+          <Spinner loading={true} inline={true} />
+        ) : ( <></> )
+        }
         <Label
           className="dv-connection-card__status"
           type={

--- a/app/ui-react/packages/ui/stories/Data/DvConnection/DvConnectionCard.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/DvConnection/DvConnectionCard.stories.tsx
@@ -1,0 +1,69 @@
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import {
+  ConnectionStatus,
+  DvConnectionCard,
+} from '../../../src';
+
+const stories = storiesOf(
+  'Data/DvConnection/DvConnectionCard',
+  module
+);
+
+stories.add('ACTIVE, not loading, not selected', () => {
+  return (
+    <DvConnectionCard
+      name={'Connection1'}
+      description={'Connection1 description'}
+      dvStatus={ConnectionStatus.ACTIVE}
+      icon={<div />}
+      loading={false}
+      selected={false}
+      onSelectionChanged={action('selection changed')}
+    />
+  );
+})
+
+stories.add('ACTIVE, loading, not selected', () => {
+  return (
+    <DvConnectionCard
+      name={'Connection1'}
+      description={'Connection1 description'}
+      dvStatus={ConnectionStatus.ACTIVE}
+      icon={<div />}
+      loading={true}
+      selected={false}
+      onSelectionChanged={action('selection changed')}
+    />
+  );
+})
+
+.add('INACTIVE, loading, not selected', () => {
+  return (
+    <DvConnectionCard
+      name={'Connection1'}
+      description={'Connection1 description'}
+      dvStatus={ConnectionStatus.INACTIVE}
+      icon={<div />}
+      loading={true}
+      selected={false}
+      onSelectionChanged={action('selection changed')}
+    />
+  );
+})
+
+.add('FAILED, not loading, not selected', () => {
+  return (
+    <DvConnectionCard
+      name={'Connection1'}
+      description={'Connection1 description'}
+      dvStatus={ConnectionStatus.FAILED}
+      icon={<div />}
+      loading={false}
+      selected={false}
+      onSelectionChanged={action('selection changed')}
+    />
+  );
+});

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
@@ -6,7 +6,7 @@ import {
 } from '@syndesis/ui';
 import * as React from 'react';
 import { EntityIcon } from '../../../shared';
-import { getDvConnectionStatus } from './VirtualizationUtils';
+import { getDvConnectionStatus, isDvConnectionLoading } from './VirtualizationUtils';
 
 export interface IDvConnectionsProps {
   connections: Connection[];
@@ -40,6 +40,7 @@ export const DvConnections: React.FunctionComponent<
             description={c.description || ''}
             dvStatus={getDvConnectionStatus(c)}
             icon={<EntityIcon entity={c} alt={c.name} width={46} />}
+            loading={isDvConnectionLoading(c)}
             selected={selectedConnection === c.name}
             onSelectionChanged={handleConnSourceSelectionChanged}
           />

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
@@ -62,8 +62,7 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
     let filteredAndSortedConnections = generateDvConnections(
       connections,
       dvSourceStatuses,
-      selectedConn,
-      true
+      selectedConn
     );
     activeFilters.forEach((filter: IActiveFilter) => {
       const valueToLower = filter.value.toLowerCase();


### PR DESCRIPTION
Resolve issue with connection refresh in the import datasource wizard
- adapt VirtualizationSourceStatus model to backend changes.  The schemaStates were clarified and new loading attribute was added.
- VirtualizationUtils functions were corrected for the updated model and functions simplified
- useVirtualizationConnectionStatuses now includes a polling option, so that pages can update periodically.
- added loading spinner to the DvConnectionCard to show when connection load is in progress
- added story for the DvConnectionCard