### PR TITLE
chore(cards): upgrade more cards to pf4

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
@@ -1,5 +1,5 @@
-import { Form } from '@patternfly/react-core';
-import { Alert, Button, Card } from 'patternfly-react';
+import { Card, CardBody, CardFooter, CardHeader, Form, Title } from '@patternfly/react-core';
+import { Alert, Button } from 'patternfly-react';
 import * as React from 'react';
 import { Container, Loader, PageSection } from '../Layout';
 import './ConnectionDetailsForm.css';
@@ -90,10 +90,10 @@ export class ConnectionDetailsForm extends React.Component<
         <Container>
           <div className="row row-cards-pf">
             <Card>
-              <Card.Heading>
-                <Card.Title>{this.props.i18nTitle}</Card.Title>
-              </Card.Heading>
-              <Card.Body>
+              <CardHeader>
+                <Title size="2xl">{this.props.i18nTitle}</Title>
+              </CardHeader>
+              <CardBody>
                 <Form
                   isHorizontal={true}
                   data-testid={'connection-details-form'}
@@ -129,9 +129,9 @@ export class ConnectionDetailsForm extends React.Component<
                     )}
                   </div>
                 </Form>
-              </Card.Body>
+              </CardBody>
               {this.props.isEditing ? (
-                <Card.Footer>
+                <CardFooter>
                   <Button
                     data-testid={'connection-details-form-cancel-button'}
                     bsStyle="default"
@@ -150,7 +150,7 @@ export class ConnectionDetailsForm extends React.Component<
                   >
                     {this.props.i18nSaveLabel}
                   </Button>
-                </Card.Footer>
+                </CardFooter>
               ) : null}
             </Card>
           </div>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
@@ -1,6 +1,6 @@
+import { Card, CardBody, CardFooter, CardHeader, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import {
-  Card,
   ControlLabel,
   FormControl,
   FormGroup,
@@ -110,10 +110,10 @@ export class ApiClientConnectorCreateSecurity extends React.Component<
   public render() {
     return (
       <Card style={{ maxWidth: '600px', margin: ' auto' }}>
-        <Card.Heading>
-          <Card.Title>{this.props.i18nTitle}</Card.Title>
-        </Card.Heading>
-        <Card.Body>
+        <CardHeader>
+          <Title size="2xl">{this.props.i18nTitle}</Title>
+        </CardHeader>
+        <CardBody>
           <FormGroup controlId={'authenticationType'} disabled={false}>
             {this.props.authenticationTypes!.map(
               (authType: IAuthenticationTypes, idx) => {
@@ -156,8 +156,8 @@ export class ApiClientConnectorCreateSecurity extends React.Component<
               </>
             )}
           </FormGroup>
-        </Card.Body>
-        <Card.Footer>
+        </CardBody>
+        <CardFooter>
           <div>
             <ButtonLink href={this.props.backHref}>
               {this.props.i18nBtnBack}
@@ -177,7 +177,7 @@ export class ApiClientConnectorCreateSecurity extends React.Component<
               {this.props.i18nBtnNext}
             </ButtonLink>
           </div>
-        </Card.Footer>
+        </CardFooter>
       </Card>
     );
   }

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
@@ -1,4 +1,6 @@
 import {
+  Card,
+  CardBody,
   Level,
   LevelItem,
   PageSection,
@@ -10,8 +12,6 @@ import {
 import * as H from '@syndesis/history';
 import {
   Button,
-  Card,
-  CardBody,
   OverlayTrigger,
   Tooltip,
 } from 'patternfly-react';

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportCard.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportCard.tsx
@@ -1,4 +1,5 @@
-import { Alert, Card } from 'patternfly-react';
+import { Card, CardBody } from '@patternfly/react-core';
+import { Alert } from 'patternfly-react';
 import * as React from 'react';
 import { DndFileChooser } from '../../Shared/DndFileChooser';
 
@@ -65,7 +66,7 @@ export const ExtensionImportCard: React.FunctionComponent<
 > = props => {
   return (
     <Card>
-      <Card.Body>
+      <CardBody>
         {props.i18nAlertMessage ? (
           <Alert type={'error'}>
             <span>{props.i18nAlertMessage}</span>
@@ -83,7 +84,7 @@ export const ExtensionImportCard: React.FunctionComponent<
           onUploadAccepted={props.onDndUploadAccepted}
           onUploadRejected={props.onDndUploadRejected}
         />
-      </Card.Body>
+      </CardBody>
     </Card>
   );
 };

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.css
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.css
@@ -1,6 +1,5 @@
-.integration-detail-metrics .card-pf.card-pf-aggregate-status {
-  padding-top: 10px;
-  padding-bottom: 10px;
+.integration-detail-metrics .pf-c-card {
+  min-height: 155px;
 }
 
 .integration-detail-metrics__duration-difference {
@@ -20,4 +19,6 @@
 .integration-detail-metrics__uptime-uptime {
   font-size: 11px;
   color: #8b8d8f;
+  text-align: right;
 }
+

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -1,16 +1,19 @@
-import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Grid,
+  GridItem,
+  Title
+} from '@patternfly/react-core';
 import {
   AggregateStatusCount,
   AggregateStatusNotification,
   AggregateStatusNotifications,
-  CardGrid,
-  Col,
   Icon,
-  Row,
 } from 'patternfly-react';
 import * as React from 'react';
 import { PageSection } from '../../Layout';
-
 import './IntegrationDetailMetrics.css';
 
 export interface IIntegrationDetailMetricsProps {
@@ -36,101 +39,92 @@ export class IntegrationDetailMetrics extends React.Component<
     const startAsHuman = this.props.i18nSince + startAsDate.toLocaleString();
     return (
       <PageSection className="integration-detail-metrics">
-        <CardGrid fluid={true} matchHeight={true}>
-          <Row style={{ marginBottom: '20px', marginTop: '20px' }}>
-            <Col xs={6} sm={3} md={3}>
-              <Card
-                data-testid={'integration-detail-metrics-total-errors-card'}
-              >
-                <CardHeader>
-                  <Title size="lg">{this.props.i18nTotalErrors}</Title>
-                </CardHeader>
-                <CardBody>
-                  <AggregateStatusNotifications>
-                    <AggregateStatusNotification>
-                      <Icon type="pf" name="error-circle-o" />
-                      {this.props.errors ? this.props.errors : 0}
-                    </AggregateStatusNotification>
-                  </AggregateStatusNotifications>
-                </CardBody>
-              </Card>
-            </Col>
-            <Col xs={6} sm={3} md={3}>
-              <Card
-                data-testid={'integration-detail-metrics-last-processed-card'}
-              >
-                <CardHeader>
-                  <Title size="lg">{this.props.i18nLastProcessed}</Title>
-                </CardHeader>
-                <CardBody>
-                  <AggregateStatusNotifications>
-                    <AggregateStatusNotification className="integration-detail-metrics__last-processed">
-                      {this.props.lastProcessed
-                        ? this.props.lastProcessed
-                        : this.props.i18nNoDataAvailable}
-                    </AggregateStatusNotification>
-                  </AggregateStatusNotifications>
-                </CardBody>
-              </Card>
-            </Col>
-            <Col xs={6} sm={3} md={3}>
-              <Card
-                data-testid={'integration-detail-metrics-total-messages-card'}
-              ><CardHeader>
-                  <Title size="lg">
 
-                    <AggregateStatusCount>
-                      {this.props.messages ? this.props.messages : 0}&nbsp;
+        <Grid md={6} xl={3} gutter={'sm'}>
+          <GridItem>
+            <Card data-testid={'integration-detail-metrics-total-errors-card'}>
+              <CardHeader>
+                <Title size="lg">{this.props.i18nTotalErrors}</Title>
+              </CardHeader>
+              <CardBody>
+                <AggregateStatusNotifications>
+                  <AggregateStatusNotification>
+                    <Icon type="pf" name="error-circle-o" />
+                    {this.props.errors ? this.props.errors : 0}
+                  </AggregateStatusNotification>
+                </AggregateStatusNotifications>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem>
+            <Card data-testid={'integration-detail-metrics-last-processed-card'}>
+              <CardHeader>
+                <Title size="lg">{this.props.i18nLastProcessed}</Title>
+              </CardHeader>
+              <CardBody>
+                <AggregateStatusNotifications>
+                  <AggregateStatusNotification className="integration-detail-metrics__last-processed">
+                    {this.props.lastProcessed
+                      ? this.props.lastProcessed
+                      : this.props.i18nNoDataAvailable}
+                  </AggregateStatusNotification>
+                </AggregateStatusNotifications>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem>
+            <Card data-testid={'integration-detail-metrics-total-messages-card'}>
+              <CardHeader>
+                <Title size="lg">
+                  <AggregateStatusCount>
+                    {this.props.messages ? this.props.messages : 0}&nbsp;
                   </AggregateStatusCount>
-                    {this.props.i18nTotalMessages}
-                  </Title>
-                </CardHeader>
-                <CardBody>
-                  <AggregateStatusNotifications>
-                    <AggregateStatusNotification>
-                      <Icon type="pf" name="ok" />
-                      {this.props.errors !== undefined &&
-                        this.props.messages !== undefined
-                        ? okMessagesCount
-                        : 0}
-                      &nbsp;
+                  {this.props.i18nTotalMessages}
+                </Title>
+              </CardHeader>
+              <CardBody>
+                <AggregateStatusNotifications>
+                  <AggregateStatusNotification>
+                    <Icon type="pf" name="ok" />
+                    {this.props.errors !== undefined &&
+                      this.props.messages !== undefined
+                      ? okMessagesCount
+                      : 0}
+                    &nbsp;
                     </AggregateStatusNotification>
-                    <AggregateStatusNotification>
-                      <Icon type="pf" name="error-circle-o" />
-                      {this.props.errors ? this.props.errors : 0}
-                    </AggregateStatusNotification>
-                  </AggregateStatusNotifications>
-                </CardBody>
-              </Card>
-            </Col>
-            <Col xs={6} sm={3} md={3}>
-              <Card
-                data-testid={'integration-detail-metrics-uptime-card'}
-              >
-                <CardHeader>
-                  <Title size="lg" className="integration-detail-metrics__uptime-header">
-                    <div>{this.props.i18nUptime}</div>
-                    {this.props.start !== undefined &&
-                      this.props.durationDifference !== undefined && (
-                        <div className="integration-detail-metrics__uptime-uptime">
-                          {startAsHuman}
-                        </div>
-                      )}
-                  </Title>
-                </CardHeader>
-                <CardBody>
-                  <AggregateStatusNotifications>
-                    <AggregateStatusNotification className="integration-detail-metrics__duration-difference">
-                      {this.props.durationDifference !== undefined
-                        ? this.props.durationDifference
-                        : this.props.i18nNoDataAvailable}
-                    </AggregateStatusNotification>
-                  </AggregateStatusNotifications>
-                </CardBody>
-              </Card>
-            </Col>
-          </Row>
-        </CardGrid>
+                  <AggregateStatusNotification>
+                    <Icon type="pf" name="error-circle-o" />
+                    {this.props.errors ? this.props.errors : 0}
+                  </AggregateStatusNotification>
+                </AggregateStatusNotifications>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem>
+            <Card data-testid={'integration-detail-metrics-uptime-card'}>
+              <CardHeader>
+                <Title size="lg" className="integration-detail-metrics__uptime-header">
+                  <div>{this.props.i18nUptime}</div>
+                  {this.props.start !== undefined &&
+                    this.props.durationDifference !== undefined && (
+                      <div className="integration-detail-metrics__uptime-uptime">
+                        {startAsHuman}
+                      </div>
+                    )}
+                </Title>
+              </CardHeader>
+              <CardBody>
+                <AggregateStatusNotifications>
+                  <AggregateStatusNotification className="integration-detail-metrics__duration-difference">
+                    {this.props.durationDifference !== undefined
+                      ? this.props.durationDifference
+                      : this.props.i18nNoDataAvailable}
+                  </AggregateStatusNotification>
+                </AggregateStatusNotifications>
+              </CardBody>
+            </Card>
+          </GridItem>
+        </Grid>
       </PageSection>
     );
   }

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -1,11 +1,9 @@
+import { Card, CardBody, Title } from '@patternfly/react-core';
 import {
   AggregateStatusCount,
   AggregateStatusNotification,
   AggregateStatusNotifications,
-  Card,
-  CardBody,
   CardGrid,
-  CardTitle,
   Col,
   Icon,
   Row,
@@ -43,11 +41,8 @@ export class IntegrationDetailMetrics extends React.Component<
             <Col xs={6} sm={3} md={3}>
               <Card
                 data-testid={'integration-detail-metrics-total-errors-card'}
-                accented={true}
-                aggregated={true}
-                matchHeight={true}
               >
-                <CardTitle>{this.props.i18nTotalErrors}</CardTitle>
+                <Title size="2xl">{this.props.i18nTotalErrors}</Title>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification>
@@ -61,11 +56,8 @@ export class IntegrationDetailMetrics extends React.Component<
             <Col xs={6} sm={3} md={3}>
               <Card
                 data-testid={'integration-detail-metrics-last-processed-card'}
-                accented={true}
-                aggregated={true}
-                matchHeight={true}
               >
-                <CardTitle>{this.props.i18nLastProcessed}</CardTitle>
+                <Title size="2xl">{this.props.i18nLastProcessed}</Title>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification className="integration-detail-metrics__last-processed">
@@ -80,16 +72,13 @@ export class IntegrationDetailMetrics extends React.Component<
             <Col xs={6} sm={3} md={3}>
               <Card
                 data-testid={'integration-detail-metrics-total-messages-card'}
-                accented={true}
-                aggregated={true}
-                matchHeight={true}
               >
-                <CardTitle>
+                <Title size="2xl">
                   <AggregateStatusCount>
                     {this.props.messages ? this.props.messages : 0}&nbsp;
                   </AggregateStatusCount>
                   {this.props.i18nTotalMessages}
-                </CardTitle>
+                </Title>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification>
@@ -111,11 +100,8 @@ export class IntegrationDetailMetrics extends React.Component<
             <Col xs={6} sm={3} md={3}>
               <Card
                 data-testid={'integration-detail-metrics-uptime-card'}
-                accented={true}
-                aggregated={true}
-                matchHeight={true}
               >
-                <Card.Title className="integration-detail-metrics__uptime-header">
+                <Title size="2xl" className="integration-detail-metrics__uptime-header">
                   <div>{this.props.i18nUptime}</div>
                   {this.props.start !== undefined &&
                     this.props.durationDifference !== undefined && (
@@ -123,8 +109,8 @@ export class IntegrationDetailMetrics extends React.Component<
                         {startAsHuman}
                       </div>
                     )}
-                </Card.Title>
-                <Card.Body>
+                </Title>
+                <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification className="integration-detail-metrics__duration-difference">
                       {this.props.durationDifference !== undefined
@@ -132,7 +118,7 @@ export class IntegrationDetailMetrics extends React.Component<
                         : this.props.i18nNoDataAvailable}
                     </AggregateStatusNotification>
                   </AggregateStatusNotifications>
-                </Card.Body>
+                </CardBody>
               </Card>
             </Col>
           </Row>

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import {
   AggregateStatusCount,
   AggregateStatusNotification,
@@ -29,7 +29,7 @@ export interface IIntegrationDetailMetricsProps {
 
 export class IntegrationDetailMetrics extends React.Component<
   IIntegrationDetailMetricsProps
-> {
+  > {
   public render() {
     const okMessagesCount = this.props.messages! - this.props.errors!;
     const startAsDate = new Date(this.props.start!);
@@ -42,7 +42,9 @@ export class IntegrationDetailMetrics extends React.Component<
               <Card
                 data-testid={'integration-detail-metrics-total-errors-card'}
               >
-                <Title size="2xl">{this.props.i18nTotalErrors}</Title>
+                <CardHeader>
+                  <Title size="lg">{this.props.i18nTotalErrors}</Title>
+                </CardHeader>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification>
@@ -57,7 +59,9 @@ export class IntegrationDetailMetrics extends React.Component<
               <Card
                 data-testid={'integration-detail-metrics-last-processed-card'}
               >
-                <Title size="2xl">{this.props.i18nLastProcessed}</Title>
+                <CardHeader>
+                  <Title size="lg">{this.props.i18nLastProcessed}</Title>
+                </CardHeader>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification className="integration-detail-metrics__last-processed">
@@ -72,19 +76,21 @@ export class IntegrationDetailMetrics extends React.Component<
             <Col xs={6} sm={3} md={3}>
               <Card
                 data-testid={'integration-detail-metrics-total-messages-card'}
-              >
-                <Title size="2xl">
-                  <AggregateStatusCount>
-                    {this.props.messages ? this.props.messages : 0}&nbsp;
+              ><CardHeader>
+                  <Title size="lg">
+
+                    <AggregateStatusCount>
+                      {this.props.messages ? this.props.messages : 0}&nbsp;
                   </AggregateStatusCount>
-                  {this.props.i18nTotalMessages}
-                </Title>
+                    {this.props.i18nTotalMessages}
+                  </Title>
+                </CardHeader>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification>
                       <Icon type="pf" name="ok" />
                       {this.props.errors !== undefined &&
-                      this.props.messages !== undefined
+                        this.props.messages !== undefined
                         ? okMessagesCount
                         : 0}
                       &nbsp;
@@ -101,15 +107,17 @@ export class IntegrationDetailMetrics extends React.Component<
               <Card
                 data-testid={'integration-detail-metrics-uptime-card'}
               >
-                <Title size="2xl" className="integration-detail-metrics__uptime-header">
-                  <div>{this.props.i18nUptime}</div>
-                  {this.props.start !== undefined &&
-                    this.props.durationDifference !== undefined && (
-                      <div className="integration-detail-metrics__uptime-uptime">
-                        {startAsHuman}
-                      </div>
-                    )}
-                </Title>
+                <CardHeader>
+                  <Title size="lg" className="integration-detail-metrics__uptime-header">
+                    <div>{this.props.i18nUptime}</div>
+                    {this.props.start !== undefined &&
+                      this.props.durationDifference !== undefined && (
+                        <div className="integration-detail-metrics__uptime-uptime">
+                          {startAsHuman}
+                        </div>
+                      )}
+                  </Title>
+                </CardHeader>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification className="integration-detail-metrics__duration-difference">

--- a/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
@@ -1,6 +1,6 @@
 // tslint:disable:no-console
+import { Card, CardBody } from '@patternfly/react-core';
 import {
-  Card,
   Col,
   FormControl,
   FormGroup,
@@ -184,7 +184,7 @@ export class OpenApiSelectMethod extends React.Component<
   public render() {
     return (
       <Card className={'open-api-review-actions'}>
-        <Card.Body>
+        <CardBody>
           <Grid fluid={true} className={'open-api-select-method'}>
             <Row>
               <Col>
@@ -271,7 +271,7 @@ export class OpenApiSelectMethod extends React.Component<
               </ButtonLink>
             </Row>
           </Grid>
-        </Card.Body>
+        </CardBody>
       </Card>
     );
   }


### PR DESCRIPTION
This PR upgrades another batch of PF3 cards as part of the work in https://github.com/syndesisio/syndesis/issues/6240

Upgrades Card view in the following components

- StoryWrapper
- ConnectionDetailsForm
- OpenApiSelectMethod
- IntegrationDetailMetrics
- ExtensionImportCard
- ExtensionDetail
- ApiClientConnectorCreateSecurity

There are still a couple of places that are still using PF3 CardGrid for layout (below), can replace those with PF4 layouts in a follow-up PR as it's not technically required until milestone 5 of the integration product suite PF4 adoption strategy.. and I'm out of time for today :) 

- DvConnectionsGridCell
- DvConnectionsGrid


