### PR TITLE
[ENTESB-11495] [AWS-DDB] Adding schema for input and output data

### DIFF
--- a/app/connector/aws-ddb/pom.xml
+++ b/app/connector/aws-ddb/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>common-model</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.syndesis.integration</groupId>
       <artifactId>integration-component-proxy</artifactId>
     </dependency>
@@ -59,6 +63,14 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -123,7 +135,6 @@
       <artifactId>connector-support-test</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
@@ -15,20 +15,16 @@
  */
 package io.syndesis.connector.aws.ddb.customizer;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.aws.ddb.DdbConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Generic class to customize DDB operations. Common utilities.
@@ -37,9 +33,6 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
 
     //Store options to customize the connector
     private Map<String, Object> options;
-
-    private static final Logger LOG = LoggerFactory.getLogger(DDBConnectorCustomizer.class);
-    public static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
@@ -68,6 +61,49 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
         } else {
             out.setBody(in.getHeader(DdbConstants.ITEMS));
         }
+
+        if(out.getBody() instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Set<Map.Entry<String, AttributeValue>> elements = ((Map<String, AttributeValue>) out.getBody()).entrySet();
+            Map<String, Object> output = new HashMap<String, Object>();
+
+            for(Map.Entry<String, AttributeValue> element : elements) {
+                AttributeValue value = element.getValue();
+                if(value.getB() != null) {
+                    output.put(element.getKey(), value.getB());
+                } else if (value.getS() != null){
+                    output.put(element.getKey(), value.getS());
+                } else if (value.getBOOL() != null){
+                    output.put(element.getKey(), value.getBOOL());
+                } else if (value.getBS() != null){
+                    output.put(element.getKey(), value.getBS());
+                } else if (value.getL() != null){
+                    output.put(element.getKey(), value.getL());
+                } else if (value.getM() != null){
+                    output.put(element.getKey(), value.getM());
+                } else if (value.getN() != null){
+                    output.put(element.getKey(), value.getN());
+                } else if (value.getNS() != null){
+                    output.put(element.getKey(), value.getNS());
+                } else if (value.getSS() != null){
+                    output.put(element.getKey(), value.getSS());
+                } else if (value.getNULL() != null){
+                    output.put(element.getKey(), null);
+                }
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            try
+            {
+                //Convert Map to JSON
+                String json = mapper.writeValueAsString(output);
+
+                out.setBody(json);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
     }
 
 
@@ -92,45 +128,5 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
     abstract void customize(Exchange exchange, Map<String,
     Object> options);
 
-
-    /**
-     * Extract a map from a JSON in a header as AttributeValue. Useful for the headers.
-     *
-     * @param parameterName
-     * @param options
-     * @return
-     */
-    protected Map<String, AttributeValue> getAttributeValueMap(
-    final String parameterName, Map<String, Object> options) {
-        final Map<String, AttributeValue> attributeMap = new HashMap<String, AttributeValue>();
-
-
-        String element = ConnectorOptions.extractOption(options, parameterName, "");
-
-        if (!element.isEmpty()) {
-            try {
-
-                @SuppressWarnings("unchecked")
-                Map<String, Object> attributes = MAPPER.readValue(element, Map.class);
-
-                if (attributes.isEmpty() && LOG.isWarnEnabled()) {
-                    LOG.warn("The parameter {} is an empty map.", parameterName);
-                }
-
-                for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
-                    attributeMap.put(attribute.getKey(),
-                    new AttributeValue(attribute.getValue().toString()));
-                    LOG.trace("Parameter adding '" + attribute.getKey() + "'->'" + attribute.getValue() + "'");
-
-                }
-            } catch (IOException e) {
-                LOG.warn("Error trying to parse the json: {}", element, e);
-            }
-        } else {
-            LOG.warn("The parameter {} is empty.", parameterName);
-        }
-
-        return attributeMap;
-    }
 
 }

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizerQuery.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizerQuery.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.aws.ddb.customizer;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.base.Splitter;
+import io.syndesis.connector.aws.ddb.util.Util;
 import io.syndesis.connector.support.util.ConnectorOptions;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.aws.ddb.DdbConstants;
@@ -31,7 +32,7 @@ public class DDBConnectorCustomizerQuery extends DDBConnectorCustomizer {
     @Override
     protected void customize(Exchange exchange, Map<String, Object> options) {
         Map<String, AttributeValue> element =
-        getAttributeValueMap("element", options);
+        Util.getAttributeValueMap("element", options);
         exchange.getIn().setHeader(DdbConstants.KEY, element);
         exchange.getIn().setHeader(DdbConstants.OPERATION, DdbOperations.GetItem);
 

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBConnectorMetaDataExtension.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBConnectorMetaDataExtension.java
@@ -13,20 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.connector.aws.ddb.customizer;
-
-import io.syndesis.connector.aws.ddb.util.Util;
-import org.apache.camel.Exchange;
-import org.apache.camel.component.aws.ddb.DdbConstants;
-import org.apache.camel.component.aws.ddb.DdbOperations;
+package io.syndesis.connector.aws.ddb.metadata;
 
 import java.util.Map;
+import java.util.Optional;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.metadata.AbstractMetaDataExtension;
+import org.apache.camel.component.extension.metadata.DefaultMetaData;
 
-public class DDBConnectorCustomizerPutItem extends DDBConnectorCustomizer {
+public class AWSDDBConnectorMetaDataExtension extends AbstractMetaDataExtension {
+
+    public AWSDDBConnectorMetaDataExtension(CamelContext camelContext) {
+        super(camelContext);
+    }
 
     @Override
-    protected void customize(Exchange exchange, Map<String, Object> options) {
-        exchange.getIn().setHeader(DdbConstants.ITEM, Util.getAttributeValueMap("element", options));
-        exchange.getIn().setHeader(DdbConstants.OPERATION, DdbOperations.PutItem);
+    public Optional<MetaData> meta(Map<String, Object> parameters) {
+        final MetaData metaData = new DefaultMetaData(null, null, null);
+
+        return Optional.of(metaData);
     }
 }

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataRetrieval.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataRetrieval.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.aws.ddb.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.google.common.base.Splitter;
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.common.model.DataShapeMetaData;
+import io.syndesis.common.util.Json;
+import io.syndesis.connector.aws.ddb.util.Util;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
+import io.syndesis.connector.support.verifier.api.PropertyPair;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+import org.apache.camel.component.extension.MetaDataExtension.MetaData;
+
+/**
+ * Extract all automatic info (column names) to enrich the properties.
+ */
+public final class AWSDDBMetadataRetrieval extends ComponentMetadataRetrieval {
+
+    @Override
+    protected MetaDataExtension resolveMetaDataExtension(CamelContext context,
+                                                         Class<? extends MetaDataExtension> metaDataExtensionClass,
+                                                         String componentId,
+                                                         String actionId) {
+        return new AWSDDBConnectorMetaDataExtension(context);
+    }
+
+
+    @Override
+    protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId,
+                                     Map<String, Object> properties, MetaData metadata) {
+
+        return adaptForDDB(properties);
+    }
+
+    /**
+     * Extract columns of query and result to create a data shape.
+     *
+     * @param properties
+     * @return
+     */
+    private SyndesisMetadata adaptForDDB(final Map<String, Object> properties) {
+
+        final Map<String, List<PropertyPair>> enrichedProperties = new HashMap<>();
+
+
+        Map<String, AttributeValue> element = Util.getAttributeValueMap("element", properties);
+
+        List<String> attributes = new ArrayList<String>();
+        String optionAttributes = ConnectorOptions.extractOption(properties, "attributes", "");
+        if (!optionAttributes.isEmpty()) {
+            Splitter splitter = Splitter.on(',');
+            splitter = splitter.trimResults();
+            splitter = splitter.omitEmptyStrings();
+            attributes = splitter.splitToList(optionAttributes);
+        }
+
+
+        //fallback to use the list of attributes on the filter
+        //this is used always on put-item
+        if (attributes.isEmpty()) {
+            attributes.addAll(element.keySet());
+        }
+
+
+        // build the input and output schemas
+        final JsonSchemaFactory factory = new JsonSchemaFactory();
+        final ObjectSchema builderIn = new ObjectSchema();
+        builderIn.setTitle("Parameters");
+
+        Set<Map.Entry<String, AttributeValue>> elements = element.entrySet();
+        elements.removeIf(e -> !e.getValue().getS().startsWith(":"));
+
+        for (Map.Entry<String, AttributeValue> inParam : elements) {
+            builderIn.putOptionalProperty(inParam.getKey(), factory.stringSchema());
+        }
+
+        final ObjectSchema builderOut = new ObjectSchema();
+        builderOut.setTitle("Result");
+        for (String outParam : attributes) {
+            builderOut.putOptionalProperty(outParam, factory.stringSchema());
+        }
+
+        try {
+            DataShape.Builder inDataShapeBuilder = new DataShape.Builder().type(builderIn.getTitle());
+            if (builderIn.getProperties().isEmpty()) {
+                inDataShapeBuilder.kind(DataShapeKinds.NONE);
+            } else {
+                inDataShapeBuilder.kind(DataShapeKinds.JSON_SCHEMA)
+                .name("Parameters")
+                .description(String.format("Query parameters."))
+                .specification(Json.writer().writeValueAsString(builderIn));
+
+                inDataShapeBuilder.putMetadata(DataShapeMetaData.VARIANT, DataShapeMetaData.VARIANT_ELEMENT);
+
+            }
+            DataShape.Builder outDataShapeBuilder = new DataShape.Builder().type(builderOut.getTitle());
+            if (builderOut.getProperties().isEmpty()) {
+                outDataShapeBuilder.kind(DataShapeKinds.NONE);
+            } else {
+                outDataShapeBuilder.kind(DataShapeKinds.JSON_SCHEMA)
+                .name("Result")
+                .description(String.format("Attributes on the result."))
+                .putMetadata(DataShapeMetaData.VARIANT, DataShapeMetaData.VARIANT_COLLECTION)
+                .specification(Json.writer().writeValueAsString(builderOut));
+            }
+
+            return new SyndesisMetadata(enrichedProperties,
+            inDataShapeBuilder.build(), outDataShapeBuilder.build());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.connector.aws.ddb.util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import org.apache.camel.CamelContext;
+import org.apache.camel.TypeConverter;
+import org.apache.camel.util.EndpointHelper;
+import org.apache.camel.util.IntrospectionSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for common procedures.
+ */
+public class Util {
+    public static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
+    /**
+     * Extract a map from a JSON in a header as AttributeValue. Useful for the headers.
+     *
+     * @param parameterName
+     * @param options
+     * @return
+     */
+    public static Map<String, AttributeValue> getAttributeValueMap(
+    final String parameterName, Map<String, Object> options) {
+        final Map<String, AttributeValue> attributeMap = new HashMap<String, AttributeValue>();
+
+
+        String element = ConnectorOptions.extractOption(options, parameterName, "");
+
+        if (!element.isEmpty()) {
+            try {
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> attributes = MAPPER.readValue(element, Map.class);
+
+                if (attributes.isEmpty() && LOG.isWarnEnabled()) {
+                    LOG.warn("The parameter {} is an empty map.", parameterName);
+                }
+
+                for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
+                    attributeMap.put(attribute.getKey(),
+                    new AttributeValue(attribute.getValue().toString()));
+                    LOG.trace("Parameter adding '" + attribute.getKey() + "'->'" + attribute.getValue() + "'");
+
+                }
+            } catch (IOException e) {
+                LOG.warn("Error trying to parse the json: {}", element, e);
+            }
+        } else {
+            LOG.warn("The parameter {} is empty.", parameterName);
+        }
+
+        return attributeMap;
+    }
+
+
+
+    public static <T> T setProperties(T instance, Map<String, Object> properties,
+                                  CamelContext camelContext) {
+        if (camelContext == null) {
+            throw new IllegalStateException("Camel context is null");
+        }
+
+        try {
+            if (!properties.isEmpty()) {
+                final TypeConverter converter = camelContext.getTypeConverter();
+
+                IntrospectionSupport.setProperties(converter, instance, properties);
+
+                for (Map.Entry<String, Object> entry : properties.entrySet()) {
+                    if (entry.getValue() instanceof String) {
+                        String value = (String) entry.getValue();
+                        if (EndpointHelper.isReferenceParameter(value)) {
+                            IntrospectionSupport.setProperty(camelContext, converter, instance, entry.getKey(), null, value, true);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(
+            "Get information about tables failed.", e);
+        }
+
+        return instance;
+    }
+}

--- a/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/aws-ddb.json
+++ b/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/aws-ddb.json
@@ -9,10 +9,10 @@
           "io.syndesis.connector.aws.ddb.customizer.DDBConnectorCustomizerQuery"
         ],
         "inputDataShape": {
-          "kind": "any"
+          "kind": "json-schema"
         },
         "outputDataShape": {
-          "kind": "any"
+          "kind": "json-schema"
         },
         "propertyDefinitionSteps": [
           {
@@ -51,6 +51,7 @@
       "name": "Query",
       "pattern": "To",
       "tags": [
+        "dynamic"
       ]
     },
     {
@@ -62,10 +63,10 @@
           "io.syndesis.connector.aws.ddb.customizer.DDBConnectorCustomizerPutItem"
         ],
         "outputDataShape": {
-          "kind": "any"
+          "kind": "json-schema"
         },
         "inputDataShape": {
-          "kind": "any"
+          "kind": "json-schema"
         },
         "propertyDefinitionSteps": [
           {
@@ -92,6 +93,7 @@
       "name": "Put Item",
       "pattern": "To",
       "tags": [
+        "dynamic"
       ]
     }
   ],

--- a/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/meta/aws-ddb
+++ b/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/meta/aws-ddb
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class=io.syndesis.connector.aws.ddb.metadata.AWSDDBMetadataRetrieval

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
@@ -43,7 +43,6 @@ public class AWSDDBConfiguration {
     protected static final Long randomId = System.currentTimeMillis();
 
     //TODO change this to your table constraints
-    protected static final String ELEMENT_VALUE = "{\"clave\" : \"" + randomId + "\"}";
-    protected static final String ELEMENT_OUTPUT = "{clave={S: " + randomId + ",}}";
+    protected static final String ELEMENT_VALUE = "{\"clave\":\"" + randomId + "\"}";
     //TODO change this to your table constraints
 }

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
@@ -135,7 +135,7 @@ public abstract class AWSDDBGenericOperation extends ConnectorTestSupport {
             String result = template.requestBody("direct:start",
                     AWSDDBConfiguration.ELEMENT_VALUE, String.class);
 
-            Assertions.assertThat(result).isEqualTo(AWSDDBConfiguration.ELEMENT_OUTPUT);
+            Assertions.assertThat(result).isEqualTo(AWSDDBConfiguration.ELEMENT_VALUE);
 
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Extend the DynamoDB connector to have metadata included. Now you can map properties to query and put items on DDB.

#6298