### PR TITLE
fix(TEIIDTOOLS-771) - View Editor - prompt user for pending changes if navigating away

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -73,6 +73,8 @@
       "reorderColumnUp": "Reorder column up",
       "sqlTab": "SQL",
       "title": "View Editor",
+      "unsavedChangesTitle": "Cancel editing?",
+      "unsavedChangesMessage": "You have unsaved changes to the view definition which will be lost. Do you still want to stop editing?",
       "viewOutputTab": "View Output"
     },
     "viewNameDisplay": "View Name",
@@ -107,6 +109,7 @@
     "saveViewFailed": "Save view {{name}} failed. Details: {{details}}",
     "validationResultsTitle": "DDL Validation",
     "validateViewRequired": "Please re-validate view {{name}} and re-try",
+    "viewValidationFailed": "View \"{{name}}\" failed validation so no results are available. Details: {{details}}",
     "activeConnectionsEmptyStateTitle": "No Active Connections",
     "activeConnectionsEmptyStateInfo": "There are no active connections available. Try again."
   }

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -73,6 +73,8 @@
       "reorderColumnUp": "Riordina colonna in alto",
       "sqlTab": "SQL",
       "title": "View Editor",
+      "unsavedChangesTitle": "Annullare la modifica?",
+      "unsavedChangesMessage": "Sono state apportate modifiche non salvate alla definizione della vista che andranno perse. Vuoi ancora interrompere la modifica?",
       "viewOutputTab": "Visualizza Produzione"
     },
     "viewNameDisplay": "View Name",
@@ -107,6 +109,7 @@
     "saveViewFailed": "Save view {{name}} failed. Details: {{details}}",
     "validationResultsTitle": "DDL Validation",
     "validateViewRequired": "Please re-validate view {{name}} and re-try",
+    "viewValidationFailed": "Visualizza la convalida \"{{name}}\" non riuscita, quindi non sono disponibili risultati. Dettagli: {{details}}",
     "activeConnectionsEmptyStateTitle": "No Active Connections",
     "activeConnectionsEmptyStateInfo": "There are no active connections available. Please retry."
   }

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -1,5 +1,8 @@
-import { useViewDefinition, useVirtualization } from '@syndesis/api';
-import { useVirtualizationHelpers } from '@syndesis/api';
+import {
+  useViewDefinition,
+  useVirtualization,
+  useVirtualizationHelpers,
+} from '@syndesis/api';
 import {
   QueryResults,
   RestDataService,
@@ -7,15 +10,8 @@ import {
   ViewSourceInfo,
 } from '@syndesis/models';
 import { TableColumns } from '@syndesis/models';
-import {
-  Breadcrumb,
-  DdlEditor,
-  IViewEditValidationResult,
-} from '@syndesis/ui';
-import { 
-  ExpandablePreview, 
-  PageLoader, 
-} from '@syndesis/ui';
+import { Breadcrumb, DdlEditor, IViewEditValidationResult } from '@syndesis/ui';
+import { ExpandablePreview, PageLoader } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
 import { useContext } from 'react';
 import * as React from 'react';
@@ -23,8 +19,14 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { UIContext } from '../../../../app';
 import { ApiError } from '../../../../shared';
+import { WithLeaveConfirmation } from '../../../../shared/WithLeaveConfirmation';
 import resolvers from '../../../resolvers';
-import { generateTableColumns, getPreviewSql, getQueryColumns, getQueryRows } from '../../shared/VirtualizationUtils';
+import {
+  generateTableColumns,
+  getPreviewSql,
+  getQueryColumns,
+  getQueryRows,
+} from '../../shared/VirtualizationUtils';
 
 /**
  * @param virtualizationId - the ID of the virtualization that the view belongs to
@@ -49,24 +51,50 @@ export interface IViewEditorSqlRouteState {
 }
 
 export const ViewEditorSqlPage: React.FunctionComponent = () => {
-
   const [isSaving, setIsSaving] = React.useState(false);
   const [isLoadingPreview, setIsLoadingPreview] = React.useState(false);
   const [isMetadataLoaded, setMetadataLoaded] = React.useState(false);
-  const [sourceTableColumns, setSourceTableColumns] = React.useState<TableColumns[]>([]);
+  const [sourceTableColumns, setSourceTableColumns] = React.useState<
+    TableColumns[]
+  >([]);
   const [viewValid, setViewValid] = React.useState(true);
-  const [validationMessageVisible, setValidationMessageVisible] = React.useState(false);
-  const [validationResults, setValidationResults] = React.useState<IViewEditValidationResult[]>([]);
+  const [
+    validationMessageVisible,
+    setValidationMessageVisible,
+  ] = React.useState(false);
+  const [validationResults, setValidationResults] = React.useState<
+    IViewEditValidationResult[]
+  >([]);
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data', 'shared']);
-  const { params, state, history } = useRouteData<IViewEditorSqlRouteParams, IViewEditorSqlRouteState>();
-  const { getSourceInfoForView, queryVirtualization, saveViewDefinition, validateViewDefinition } = useVirtualizationHelpers();
-  const [previewExpanded, setPreviewExpanded] = React.useState(state.previewExpanded);
+  const { params, state, history } = useRouteData<
+    IViewEditorSqlRouteParams,
+    IViewEditorSqlRouteState
+  >();
+  const {
+    getSourceInfoForView,
+    queryVirtualization,
+    saveViewDefinition,
+    validateViewDefinition,
+  } = useVirtualizationHelpers();
+  const [previewExpanded, setPreviewExpanded] = React.useState(
+    state.previewExpanded
+  );
   const [queryResults, setQueryResults] = React.useState(state.queryResults);
-  const { resource: virtualization } = useVirtualization(params.virtualizationId);
-  const { resource: viewDefn, loading, error } = useViewDefinition(params.viewDefinitionId, state.viewDefinition);
-  const [noResultsTitle, setNoResultsTitle] = React.useState(t('data:virtualization.preview.resultsTableValidEmptyTitle'));
-  const [noResultsMessage, setNoResultsMessage] = React.useState(t('data:virtualization.preview.resultsTableValidEmptyInfo'));
+  const { resource: virtualization } = useVirtualization(
+    params.virtualizationId
+  );
+  const { resource: viewDefn, loading, error } = useViewDefinition(
+    params.viewDefinitionId,
+    state.viewDefinition
+  );
+  const [noResultsTitle, setNoResultsTitle] = React.useState(
+    t('data:virtualization.preview.resultsTableValidEmptyTitle')
+  );
+  const [noResultsMessage, setNoResultsMessage] = React.useState(
+    t('data:virtualization.preview.resultsTableValidEmptyInfo')
+  );
+  const ddlHasChanges = React.useRef(false);
 
   const queryResultsEmpty: QueryResults = {
     columns: [],
@@ -74,7 +102,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
   };
 
   const handleMetadataLoaded = async (): Promise<void> => {
-    if( sourceTableColumns != null && sourceTableColumns.length > 0 ) {
+    if (sourceTableColumns != null && sourceTableColumns.length > 0) {
       setMetadataLoaded(true);
     }
   };
@@ -85,9 +113,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
    */
   const handleValidateView = async (view: ViewDefinition) => {
     // Validate the View
-    const validationResponse = await validateViewDefinition(
-      view
-    );
+    const validationResponse = await validateViewDefinition(view);
     let validationResult = null;
     if (validationResponse.status === 'SUCCESS') {
       validationResult = {
@@ -104,31 +130,44 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     setQueryResultEmptyContent(isValid);
     setDdlValidationInfo(validationResult, isValid);
     updateQueryResults(isValid);
-  }
+  };
 
   // Preview result empty content changes if view is invalid
   const setQueryResultEmptyContent = (isValid: boolean) => {
-    if(isValid) {
-      setNoResultsTitle(t('data:virtualization.preview.resultsTableValidEmptyTitle'));
-      setNoResultsMessage(t('data:virtualization.preview.resultsTableValidEmptyInfo'));
+    if (isValid) {
+      setNoResultsTitle(
+        t('data:virtualization.preview.resultsTableValidEmptyTitle')
+      );
+      setNoResultsMessage(
+        t('data:virtualization.preview.resultsTableValidEmptyInfo')
+      );
     } else {
-      setNoResultsTitle(t('data:virtualization.preview.resultsTableInvalidEmptyTitle'));
-      setNoResultsMessage(t('data:virtualization.preview.resultsTableInvalidEmptyInfo'));
+      setNoResultsTitle(
+        t('data:virtualization.preview.resultsTableInvalidEmptyTitle')
+      );
+      setNoResultsMessage(
+        t('data:virtualization.preview.resultsTableInvalidEmptyInfo')
+      );
     }
-  }
+  };
 
   // Update info for the DDL editor
-  const setDdlValidationInfo = (validationResult: IViewEditValidationResult, isValid: boolean) => {
+  const setDdlValidationInfo = (
+    validationResult: IViewEditValidationResult,
+    isValid: boolean
+  ) => {
     setValidationResults([validationResult]);
     setValidationMessageVisible(!isValid);
     setViewValid(isValid);
-  }
+  };
 
   /**
    * Saves View with the new DDL value.  The View is also validated, and preview results updated
    */
-  const handleSaveView = async (ddlValue: string) => {
+  const handleSaveView = async (ddlValue: string): Promise<boolean> => {
     setIsSaving(true);
+    let saveSuccess = false;
+
     // View Definition
     const view: ViewDefinition = {
       dataVirtualizationName: viewDefn.dataVirtualizationName,
@@ -144,28 +183,38 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     try {
       // Save the View
       await saveViewDefinition(view);
+      saveSuccess = true;
+
       // Validate the View
       await handleValidateView(view);
 
       setIsSaving(false);
+      return true;
     } catch (error) {
-      const details = error.message
-        ? error.message
-        : '';
-        setIsSaving(false);
+      const details = error.message ? error.message : '';
+      setIsSaving(false);
+      if (saveSuccess) {
         pushNotification(
-        t('virtualization.saveViewFailed', {
-          details,
-          name: viewDefn.name,
-        }),
-        'error'
-      );
+          t('virtualization.viewValidationFailed', {
+            details,
+            name: viewDefn.name,
+          }),
+          'error'
+        );
+      } else {
+        pushNotification(
+          t('virtualization.saveViewFailed', {
+            details,
+            name: viewDefn.name,
+          }),
+          'error'
+        );
+      }
+      return saveSuccess;
     }
   };
 
-  const handlePreviewExpandedChanged = (
-    expanded: boolean
-  ) => {
+  const handlePreviewExpandedChanged = (expanded: boolean) => {
     setPreviewExpanded(expanded);
   };
 
@@ -181,20 +230,31 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
     );
   };
 
+  /**
+   * Callback for when the dirty state of the DDL editor changes.
+   * @param dirty `true` if DDL editor has changes
+   */
+  const handleDirtyStateChanged = (dirty: boolean) => {
+    ddlHasChanges.current = dirty;
+  };
+
   const handleRefreshResults = async () => {
     updateQueryResults(viewValid, true);
-  }
-  
+  };
+
   /**
    * Update the preview query results
    * @param isValid 'true' if the view definition is valid
    * @param refreshClick 'true' if update is initiated by the preview refresh button
    */
-  const updateQueryResults = async (isValid: boolean, refreshClick: boolean = false) => {
+  const updateQueryResults = async (
+    isValid: boolean,
+    refreshClick: boolean = false
+  ) => {
     setIsLoadingPreview(true);
     let queryResult = queryResultsEmpty;
     try {
-      // Valid view - run the preview query 
+      // Valid view - run the preview query
       if (isValid) {
         queryResult = await queryVirtualization(
           params.virtualizationId,
@@ -232,24 +292,36 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
 
   // load source table/column information
   React.useEffect(() => {
-    if (!isMetadataLoaded && virtualization !== null && (virtualization as RestDataService).keng__id !== null
-      && (virtualization as RestDataService).keng__id.length > 0) {
+    if (
+      !isMetadataLoaded &&
+      virtualization !== null &&
+      (virtualization as RestDataService).keng__id !== null &&
+      (virtualization as RestDataService).keng__id.length > 0
+    ) {
       // load source table/column info by retrieving the view source info from
       // the server and converting to TableColumn objects
       const loadSourceTableInfo = async () => {
         try {
-          const results: ViewSourceInfo = await getSourceInfoForView(virtualization);
-          setSourceTableColumns(generateTableColumns(results as ViewSourceInfo));
+          const results: ViewSourceInfo = await getSourceInfoForView(
+            virtualization
+          );
+          setSourceTableColumns(
+            generateTableColumns(results as ViewSourceInfo)
+          );
         } catch (error) {
           pushNotification(error.message, 'error');
         }
-      }
+      };
       loadSourceTableInfo();
       handleMetadataLoaded();
     }
     // eslint-disable-next-line
   }, [virtualization as RestDataService]);
-  
+
+  const shouldDisplayDialog = React.useCallback(() => {
+    return ddlHasChanges.current;
+  }, [ddlHasChanges]);
+
   return (
     <WithLoader
       loading={loading}
@@ -258,61 +330,66 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
       errorChildren={<ApiError error={error as Error} />}
     >
       {() => (
-        <>
-          <Breadcrumb>
-            <Link to={resolvers.dashboard.root()}>
-              {t('shared:Home')}
-            </Link>
-            <Link to={resolvers.data.root()}>
-              {t('shared:DataVirtualizations')}
-            </Link>
-            <Link
-              to={resolvers.data.virtualizations.views.root(
-                {
-                  virtualization,
-                }
-              )}
-            >
-              {virtualization.keng__id}
-            </Link>
-            <span>{viewDefn.name}</span>
-          </Breadcrumb>
-          <DdlEditor
-            viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
-            i18nDoneLabel={t('shared:Done')}
-            i18nSaveLabel={t('shared:Save')}
-            i18nTitle={t('data:virtualization.viewEditor.title')}
-            i18nValidationResultsTitle={t('data:virtualization.validationResultsTitle')}
-            showValidationMessage={validationMessageVisible}
-            isSaving={isSaving}
-            sourceTableInfos={sourceTableColumns}
-            onCloseValidationMessage={handleHideValidationMessage}
-            onFinish={handleEditFinished}
-            onSave={handleSaveView}
-            validationResults={
-              validationResults
-            }
-          />
-          <ExpandablePreview
-            i18nEmptyResultsTitle={noResultsTitle}
-            i18nEmptyResultsMsg={noResultsMessage}
-            i18nHidePreview={t('data:virtualization.preview.hidePreview')}
-            i18nLoadingQueryResults={t('data:virtualization.preview.loadingQueryResults')}
-            i18nShowPreview={t('data:virtualization.preview.showPreview')}
-            i18nTitle={t('data:virtualization.preview.title')}
-            initialExpanded={previewExpanded}
-            isLoadingPreview={isLoadingPreview}
-            onPreviewExpandedChanged={handlePreviewExpandedChanged}
-            onRefreshResults={handleRefreshResults}
-            queryResultRows={getQueryRows(
-              queryResults
-            )}
-            queryResultCols={getQueryColumns(
-              queryResults
-            )}
-          />
-        </>
+        <WithLeaveConfirmation
+          i18nTitle={t('virtualization.viewEditor.unsavedChangesTitle')}
+          i18nConfirmationMessage={t(
+            'virtualization.viewEditor.unsavedChangesMessage'
+          )}
+          shouldDisplayDialog={shouldDisplayDialog}
+        >
+          {() => (
+            <>
+              <Breadcrumb>
+                <Link to={resolvers.dashboard.root()}>{t('shared:Home')}</Link>
+                <Link to={resolvers.data.root()}>
+                  {t('shared:DataVirtualizations')}
+                </Link>
+                <Link
+                  to={resolvers.data.virtualizations.views.root({
+                    virtualization,
+                  })}
+                >
+                  {virtualization.keng__id}
+                </Link>
+                <span>{viewDefn.name}</span>
+              </Breadcrumb>
+              <DdlEditor
+                viewDdl={viewDefn.ddl ? viewDefn.ddl : ''}
+                i18nDoneLabel={t('shared:Done')}
+                i18nSaveLabel={t('shared:Save')}
+                i18nTitle={t('data:virtualization.viewEditor.title')}
+                i18nValidationResultsTitle={t(
+                  'data:virtualization.validationResultsTitle'
+                )}
+                showValidationMessage={validationMessageVisible}
+                isSaving={isSaving}
+                sourceTableInfos={sourceTableColumns}
+                onCloseValidationMessage={handleHideValidationMessage}
+                onFinish={handleEditFinished}
+                onSave={handleSaveView}
+                setDirty={handleDirtyStateChanged}
+                validationResults={validationResults}
+              />
+              <ExpandablePreview
+                i18nEmptyResultsTitle={noResultsTitle}
+                i18nEmptyResultsMsg={noResultsMessage}
+                i18nHidePreview={t('data:virtualization.preview.hidePreview')}
+                i18nLoadingQueryResults={t(
+                  'data:virtualization.preview.loadingQueryResults'
+                )}
+                i18nShowPreview={t('data:virtualization.preview.showPreview')}
+                i18nTitle={t('data:virtualization.preview.title')}
+                initialExpanded={previewExpanded}
+                isLoadingPreview={isLoadingPreview}
+                onPreviewExpandedChanged={handlePreviewExpandedChanged}
+                onRefreshResults={handleRefreshResults}
+                queryResultRows={getQueryRows(queryResults)}
+                queryResultCols={getQueryColumns(queryResults)}
+              />
+            </>
+          )}
+        </WithLeaveConfirmation>
       )}
     </WithLoader>
   );
-}
+};


### PR DESCRIPTION
- See [TEIIDTOOLS-771](https://issues.jboss.org/projects/TEIIDTOOLS/issues/TEIIDTOOLS-771)
- The `Save` button in DDL Editor is now only enabled when the DDL has changed from the last successful save.
- The `Done` button in DDL Editor now disables during a save.
- A confirmation dialog is displayed when DDL changes exist in the editor and the user wants to navigate to a different page.