### PR TITLE
fix(atlasmap-assembly): remove routing related console warning

### DIFF
--- a/app/ui-react/packages/atlasmap-assembly/src/app/app.module.ts
+++ b/app/ui-react/packages/atlasmap-assembly/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
 import { DataMapperModule } from '@atlasmap/atlasmap-data-mapper';
 import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
@@ -8,12 +7,7 @@ import { DataMapperHostComponent } from './data-mapper-host.component';
 
 @NgModule({
   declarations: [AppComponent, DataMapperHostComponent],
-  imports: [
-    BrowserModule,
-    FormsModule,
-    RouterModule.forRoot([]),
-    DataMapperModule.withInterceptor(),
-  ],
+  imports: [BrowserModule, FormsModule, DataMapperModule.withInterceptor()],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/app/ui-react/syndesis/scripts/minishift-restore.sh
+++ b/app/ui-react/syndesis/scripts/minishift-restore.sh
@@ -83,3 +83,6 @@ oc replace --force -f - <<EOF
   ]
 }
 EOF
+
+# also scale back up the operator
+oc scale --replicas=1 dc syndesis-operator

--- a/app/ui-react/syndesis/scripts/minishift-setup.sh
+++ b/app/ui-react/syndesis/scripts/minishift-setup.sh
@@ -22,6 +22,8 @@ sed -i.bu "s#https://192\.168\.64\.2:8443#${OS_HOST}#" public/config.json
 sed -i.bu "s/Syndesis/Syndesis - DEVELOPMENT/" public/config.json
 rm public/config.json.bu
 
+# scale down the operator to stop it replacing our local changes
+oc scale --replicas=0 dc syndesis-operator
 oc replace --force -f - <<EOF
 {
   "kind": "List",


### PR DESCRIPTION
Since Atlasmap doesn't use the routing, we can avoid enabling it. This
gets rid of the warning we were having about the router not being happy
about being initialized in an iframe without an src attribute.

Also, fixes the minishift setup/restore script to work with the
operator. Since the operator reverts back any local change to operator's
managed resources, we have to scale it down to 0 when running the setup
script. The restore script brings the operator back to 1 replica.

Related to ENTESB-11628