### PR TITLE
fix(build): remove template generation

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -262,10 +262,6 @@ generate_versioned_files() {
     local tag="$2"
     local previous_tag="${3:-latest}"
 
-    echo "==== Creating templates for $tag"
-    cd $dir/generator
-    sh run.sh --syndesis-tag="$tag" --upgrade-tag="$tag"
-
     echo "==== Updating operator deployment config"
     cd $dir/operator/deploy
 


### PR DESCRIPTION
We no longer need to generate the templates during the release, the templates have been removed in favor of the operator.