### PR TITLE
chore: Improve operator debug output by showing the update diff on the resources.

### DIFF
--- a/install/operator/go.mod
+++ b/install/operator/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.0.0-20190815222052-4ca881a92eb7
 	github.com/pkg/errors v0.8.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/shurcooL/httpfs v0.0.0-20190527155220-6a4d4a70508b
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/spf13/cobra v0.0.5

--- a/install/operator/go.sum
+++ b/install/operator/go.sum
@@ -73,12 +73,15 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/docker/distribution v2.6.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20180612054059-a9fbbdc8dd87/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
+github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f h1:8GDPb0tCY8LQ+OJ3dbHb5sA6YZWXFORQYZx5sdsTlMs=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f h1:AUj1VoZUfhPhOPHULCQQDnGhRelpFWHMLhQVWDsS0v4=
 github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.8.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/install/operator/pkg/util/create_or_update.go
+++ b/install/operator/pkg/util/create_or_update.go
@@ -20,9 +20,14 @@ func CreateOrUpdate(ctx context.Context, cl client.Client, o runtime.Object, ski
 		return desired, controllerutil.OperationResultNone, err
 	}
 
+	originalYaml := ""
+	updatedYaml := ""
+
 	createdCopy := desired.DeepCopy()
 	modType, err := controllerutil.CreateOrUpdate(ctx, cl, createdCopy, func(o runtime.Object) error {
+
 		existing := o.(*unstructured.Unstructured)
+		originalYaml = Dump(existing)
 
 		mergePath := desired.GetAPIVersion() + "/" + desired.GetKind()
 		if len(skipFields) == 0 {
@@ -35,11 +40,18 @@ func CreateOrUpdate(ctx context.Context, cl client.Client, o runtime.Object, ski
 		}
 
 		mergeMap(mergePath, existing.Object, desired.Object, skip)
+		updatedYaml = Dump(existing)
+
 		//if d.GetKind() == "DeploymentConfig" && d.GetName() == "syndesis-meta" {
 		//	Debug("existing:", existing, "(index .Object.spec.template.spec.containers 0).resources.limits.memory")
 		//}
 		return nil
 	})
+
+	if modType == controllerutil.OperationResultUpdated {
+		fmt.Println("resource", desired.GetKind(), "update:", desired.GetName())
+		fmt.Println(UnifiedDiff(originalYaml, updatedYaml))
+	}
 	return createdCopy, modType, err
 }
 

--- a/install/operator/pkg/util/debug.go
+++ b/install/operator/pkg/util/debug.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"github.com/pmezard/go-difflib/difflib"
 	"sigs.k8s.io/yaml"
 	"text/template"
 )
@@ -16,6 +17,19 @@ func Debug(msg string, o interface{}, fields ...string) {
 	if s != "" {
 		fmt.Println(msg, s)
 	}
+}
+
+func UnifiedDiff(a string, b string) (string, error) {
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(a),
+		B:        difflib.SplitLines(b),
+		FromFile: "a",
+		FromDate: "00-00-00 00:00:00",
+		ToFile:   "b",
+		ToDate:   "00-00-00 00:00:00",
+		Context:  3,
+	}
+	return difflib.GetUnifiedDiffString(diff)
 }
 
 //


### PR DESCRIPTION
Sometimes the operator can get into an update loop updating the same resource over and over, that’s not good.  Knowing what is being updated on the resources can help in fixing these types of issues.