### PR TITLE
[ENTESB-11669] Remove Syndesis registry from Prometheus image prefix

### DIFF
--- a/install/operator/pkg/generator/assets/infrastructure/02-syndesis-image-streams.yml.tmpl
+++ b/install/operator/pkg/generator/assets/infrastructure/02-syndesis-image-streams.yml.tmpl
@@ -106,7 +106,7 @@
     tags:
     - from:
         kind: DockerImage
-        name: '{{.Syndesis.Spec.Registry}}/{{.Images.PrometheusImagePrefix}}/{{ .Images.Support.Prometheus }}:{{ .Syndesis.Spec.Components.Prometheus.Tag }}'
+        name: '{{.Images.PrometheusImagePrefix}}/{{ .Images.Support.Prometheus }}:{{ .Syndesis.Spec.Components.Prometheus.Tag }}'
       {{if .Syndesis.Spec.Components.Scheduled}}
       importPolicy:
         scheduled: true


### PR DESCRIPTION
This would be a problem with productized builds:

* QE needs to pull the productized images from either brew or quay
* the prometheus image is not built as part of the the productization, an already released image is used

This solves the problem:
* in upstream builds, nothing changes, since `docker.io` is the default when the registry is not specified
* for productized builds, `PrometheusImagePrefix` in `config.yaml` will be changed to `registry.redhat.io/openshift3` and the released image will be used

cc @orpiske 