### PR TITLE
chore: polish connection page skeleton loaders

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
@@ -7,16 +7,15 @@ export const ConnectionSkeleton = (props: any) => (
     <CardBody>
       <ContentLoader
         height={250}
-        width={200}
+        width={360}
         speed={2}
         primaryColor="#f3f3f3"
         secondaryColor="#ecebeb"
         {...props}
       >
-        <circle cx="100" cy="50" r="40" />
-        <rect x="5" y="125" rx="5" ry="5" width="190" height="30" />
-        <rect x="25" y="180" rx="5" ry="5" width="150" height="15" />
-        <rect x="40" y="205" rx="5" ry="5" width="120" height="15" />
+        <circle cx="180" cy="65" r="48" />
+        <rect x="30" y="150" rx="5" ry="5" width="300" height="20" />
+        <rect x="15" y="180" rx="5" ry="5" width="330" height="18" />
       </ContentLoader>
     </CardBody>
   </Card>

--- a/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
@@ -61,13 +61,13 @@ export class Connections extends React.Component<IConnectionsProps> {
                         error={this.props.error}
                         loading={this.props.loading}
                         loaderChildren={
-                          <>
+                          <ConnectionsGrid>
                             {new Array(5).fill(0).map((_, index) => (
                               <ConnectionsGridCell key={index}>
                                 <ConnectionSkeleton />
                               </ConnectionsGridCell>
                             ))}
-                          </>
+                          </ConnectionsGrid>
                         }
                         errorChildren={
                           <ApiError error={this.props.errorMessage!} />

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
@@ -83,11 +83,13 @@ export class ConnectorsPage extends React.Component {
                       loading={!hasData}
                       loaderChildren={
                         <PageSection>
-                          {new Array(5).fill(0).map((_, index) => (
-                            <ConnectionsGridCell key={index}>
-                              <ConnectionSkeleton />
-                            </ConnectionsGridCell>
-                          ))}
+                          <ConnectionsGrid>
+                            {new Array(5).fill(0).map((_, index) => (
+                              <ConnectionsGridCell key={index}>
+                                <ConnectionSkeleton />
+                              </ConnectionsGridCell>
+                            ))}
+                          </ConnectionsGrid>
                         </PageSection>
                       }
                       errorChildren={<ApiError error={errorMessage!} />}
@@ -130,11 +132,15 @@ export class ConnectorsPage extends React.Component {
                                               description={
                                                 connector.description || ''
                                               }
-                                              i18nCannotDelete={t('cannotDelete')}
+                                              i18nCannotDelete={t(
+                                                'cannotDelete'
+                                              )}
                                               i18nConfigRequired={t(
                                                 'configurationRequired'
                                               )}
-                                              i18nTechPreview={t('shared:techPreview')}
+                                              i18nTechPreview={t(
+                                                'shared:techPreview'
+                                              )}
                                               icon={
                                                 <EntityIcon
                                                   entity={connector}


### PR DESCRIPTION
Adds the grid back and tweaks the skeletons to look more like the actual cards:

![image](https://user-images.githubusercontent.com/351660/65164223-780a9b80-da0a-11e9-873f-071d81e3b0cf.png)
