### PR TITLE
fix(TEIIDTOOLS-769) - View Editor sizing issues

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
@@ -2,3 +2,19 @@
   margin-bottom: 8px;
   margin-right: 4px;
 }
+
+.ddl-editor .text-editor {
+  flex: 1 1 auto;
+  height: 100%;
+  margin-top: 0;
+  position: relative;
+}
+
+.ddl-editor .CodeMirror {
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
@@ -119,6 +119,7 @@ export const DdlEditor: React.FunctionComponent<IDdlEditorProps> = props => {
     if (saved) {
       setSavedValue(ddlValue);
       setHasChanges(false);
+      props.setDirty(false);
     }
   };
 
@@ -156,11 +157,11 @@ export const DdlEditor: React.FunctionComponent<IDdlEditorProps> = props => {
   };
 
   return (
-    <PageSection variant={'light'}>
+    <PageSection isFilled={true} variant={'light'} className={'ddl-editor'}>
       <Title headingLevel="h5" size="lg">
         {props.i18nTitle}
       </Title>
-      <Card>
+      <Card style={{ height: '100%' }}>
         <CardBody>
           {props.showValidationMessage
             ? props.validationResults.map((e, idx) => (

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -1,12 +1,12 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
-import { 
-  Button, 
-  Expandable, 
-  PageSection, 
-  Split, 
-  SplitItem, 
-  Title 
+import {
+  Button,
+  Expandable,
+  PageSection,
+  Split,
+  SplitItem,
+  Title,
 } from '@patternfly/react-core';
 import { SyncIcon } from '@patternfly/react-icons';
 import * as React from 'react';
@@ -34,10 +34,8 @@ export interface IExpandablePreviewProps {
   i18nShowPreview: string;
   i18nTitle: string;
   initialExpanded?: boolean;
-  isLoadingPreview: boolean
-  onPreviewExpandedChanged: (
-    previewExpanded: boolean
-  ) => void;
+  isLoadingPreview: boolean;
+  onPreviewExpandedChanged: (previewExpanded: boolean) => void;
   onRefreshResults: () => void;
   /**
    * Array of column info for the query results.  (The column id and display label)
@@ -79,7 +77,6 @@ export const ExpandablePreview: React.FunctionComponent<
   queryResultCols,
   queryResultRows,
 }: IExpandablePreviewProps) => {
-
   const [expanded, setExpanded] = React.useState(initialExpanded);
   const toggleExpanded = () => {
     setExpanded(!expanded);
@@ -87,8 +84,12 @@ export const ExpandablePreview: React.FunctionComponent<
   };
 
   return (
-    <PageSection variant='light'>
-      <Expandable toggleText={expanded ? i18nHidePreview : i18nShowPreview} onToggle={toggleExpanded} isExpanded={expanded}>
+    <PageSection isFilled={expanded} variant="light">
+      <Expandable
+        toggleText={expanded ? i18nHidePreview : i18nShowPreview}
+        onToggle={toggleExpanded}
+        isExpanded={expanded}
+      >
         <Split>
           <SplitItem isFilled={false}>
             <Title headingLevel="h5" size="lg">
@@ -100,7 +101,8 @@ export const ExpandablePreview: React.FunctionComponent<
               variant="plain"
               aria-label="Action"
               onClick={onRefreshResults}
-              isDisabled={false}>
+              isDisabled={false}
+            >
               <SyncIcon />
             </Button>
           </SplitItem>
@@ -112,8 +114,9 @@ export const ExpandablePreview: React.FunctionComponent<
           i18nEmptyResultsTitle={i18nEmptyResultsTitle}
           i18nEmptyResultsMsg={i18nEmptyResultsMsg}
           i18nLoadingQueryResults={i18nLoadingQueryResults}
-          isLoadingPreview={isLoadingPreview}/>
+          isLoadingPreview={isLoadingPreview}
+        />
       </Expandable>
     </PageSection>
-    );
-  };
+  );
+};

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor-styling.css
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor-styling.css
@@ -1,0 +1,3 @@
+.ddl-editor .text-editor {
+  height: 300px; /* gives the editor some default height */
+}

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/DdlEditor.stories.tsx
@@ -1,7 +1,9 @@
 import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { DdlEditor } from '../../../src';
+import './DdlEditor-styling.css';
 
 const stories = storiesOf('Data/ViewEditor/DdlEditor', module);
 
@@ -9,11 +11,11 @@ const viewDdl =
   'CREATE VIEW PgCustomer_account (\n\tRowId long,\n\taccount_id integer,\n\tssn string,\n\tstatus string,\n\ttype string,\n\tdateopened timestamp,\n\tdateclosed timestamp,\n\tPRIMARY KEY(RowId)\n)\nAS\nSELECT ROW_NUMBER() OVER (ORDER BY account_id), account_id, ssn, status, type, dateopened, dateclosed FROM pgcustomerschemamodel.account;';
 
 const sourceTables = [
-  { 'columnNames': ['name', 'population', 'size'], // column names
-    'name': 'countries' },                         // table name
-  { 'columnNames': ['name','score', 'birthDate'],  
-    'name': 'users' 
-  }
+  {
+    columnNames: ['name', 'population', 'size'], // column names
+    name: 'countries',
+  }, // table name
+  { columnNames: ['name', 'score', 'birthDate'], name: 'users' },
 ];
 
 stories.add('render', () => {
@@ -25,12 +27,13 @@ stories.add('render', () => {
       i18nTitle={'View Editor'}
       i18nValidationResultsTitle={'DDL Validation'}
       showValidationMessage={true}
-      isSaving={false}
+      isSaving={boolean('isSaving', false)}
       sourceTableInfos={sourceTables}
       validationResults={[]}
-      onCloseValidationMessage={action('ddlChange')}
+      onCloseValidationMessage={action('onCloseValidationMessage')}
       onFinish={action('done')}
       onSave={action('save')}
+      setDirty={action('dirty')}
     />
   );
 });


### PR DESCRIPTION
- See [TEIIDTOOLS-769](https://issues.jboss.org/browse/TEIIDTOOLS-769)
- added styling such that the DDL editor expands to take up available space when the preview area is collapsed
- fixed a bug that DDL editor dirty flag wasn't getting set to `false` after a successful save
- changes to DdlEditor story to get editor to show and to add in missing `setDirty` property