### PR TITLE
ENTESB-11643 Rework of virtualization create form

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationCreateForm.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationCreateForm.tsx
@@ -1,0 +1,86 @@
+import { ActionGroup, 
+         Alert, 
+         Button, 
+         Card, 
+         CardBody, 
+         Form } from '@patternfly/react-core';
+import * as React from 'react';
+
+export interface IVirtualizationCreateValidationResult {
+  message: string;
+  type: 'danger' | 'success';
+}
+
+export interface IVirtualizationCreateFormProps {
+  /**
+   * The localized text for the cancel button.
+   */
+  i18nCancelLabel: string;
+
+  /**
+   * The localized text for the create button.
+   */
+  i18nCreateLabel: string;
+
+  /**
+   * `true` if work in progress and this form should disable user input.
+   */
+  isWorking: boolean;
+
+  /**
+   * Form level validationResults
+   */
+  validationResults: IVirtualizationCreateValidationResult[];
+
+  /**
+   * The callback fired when submitting the form.
+   * @param e
+   */
+  handleSubmit: (e?: any) => void;
+
+  /**
+   * The callback for cancel.
+   */
+  onCancel: () => void;
+}
+
+export const VirtualizationCreateForm: React.FunctionComponent<
+  IVirtualizationCreateFormProps
+> = props => {
+  return (
+    <Card>
+      <CardBody>
+        <Form
+          isHorizontal={true}
+          data-testid={'virtualization-create-form'}
+          onSubmit={props.handleSubmit}
+        >
+          {props.validationResults.map((e, idx) => (
+            <Alert key={idx} title={''} variant={e.type}>
+              {e.message}
+            </Alert>
+          ))}
+          {props.children}
+          <ActionGroup>
+            <Button
+              data-testid={'virtualization-create-form-save-button'}
+              variant="primary"
+              isDisabled={props.isWorking}
+              onClick={props.handleSubmit}
+            >
+              {props.i18nCreateLabel}
+            </Button>
+            <Button
+              data-testid={'virtualization-create-form-cancel-button'}
+              variant="secondary"
+              isDisabled={props.isWorking}
+              onClick={props.onCancel}
+            >
+              {props.i18nCancelLabel}
+            </Button>
+          </ActionGroup>
+        </Form>
+      </CardBody>
+    </Card>
+  );
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
@@ -4,6 +4,7 @@ export * from './PublishStatusWithProgress';
 export * from './SqlClientContent';
 export * from './SqlClientContentSkeleton';
 export * from './SqlClientForm';
+export * from './VirtualizationCreateForm';
 export * from './VirtualizationDetailsHeader';
 export * from './VirtualizationList';
 export * from './VirtualizationListItem';

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationCreateForm.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationCreateForm.stories.tsx
@@ -1,0 +1,52 @@
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import {
+  IVirtualizationCreateValidationResult,
+  VirtualizationCreateForm,
+} from '../../../src';
+
+const stories = storiesOf('Data/Virtualizations/VirtualizationCreateForm', module);
+const cancelLabel = 'Cancel';
+const createLabel = 'Create';
+
+const cancelText = 'cancel';
+const createText = 'creating';
+const errorMessage = 'An error message';
+const successMessage = 'A success message';
+
+const validationResults: IVirtualizationCreateValidationResult[] = [
+  { message: successMessage, type: 'success' },
+  { message: errorMessage, type: 'danger' },
+];
+
+const storyNotes =
+  '- Verify the cancel button is enabled and has the text of "' +
+  cancelLabel +
+  '"\n' +
+  '- Verify clicking the cancel button prints "' +
+  cancelText +
+  '" in the action log' +
+  '"\n' +
+  '- Verify the create button is enabled and has the text of "' +
+  createLabel +
+  '"\n' +
+  '- Verify clicking the save button prints "' +
+  createText +
+  '" in the action log';
+
+stories.add(
+  'render',
+  () => (
+    <VirtualizationCreateForm
+      handleSubmit={action(createText)}
+      i18nCancelLabel={cancelLabel}
+      i18nCreateLabel={createLabel}
+      isWorking={boolean('isWorking', false)}
+      validationResults={validationResults}
+      onCancel={action(cancelText)}
+    />
+  ),
+  { notes: storyNotes }
+);

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -14,7 +14,6 @@
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
     "errorUpdatingDescription": "Error saving the description for virtualization \"{{name}}\"",
     "errorValidatingViewName": "Error validating the view name",
-    "errorValidatingVirtualizationName": "Error validating the virtualization name",
     "importVirtualizationTip": "Import a data virtualization",
     "publishedDataVirtualization": "Published",
     "publishInProgress": "publish in progress...",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -14,7 +14,6 @@
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
     "errorUpdatingDescription": "Errore durante il salvataggio della descrizione per la virtualizzazione \"{{name}}\"",
     "errorValidatingViewName": "Error validating the view name",
-    "errorValidatingVirtualizationName": "Error validating the virtualization name",
     "importVirtualizationTip": "Import a data virtualization",
     "publishedDataVirtualization": "Published",
     "publishInProgress": "publish in progress...",


### PR DESCRIPTION
Rework the virtualization create page based on feedback from UX
- The VirtualizationCreateForm component was created in packages/ui - now utilizes pf4 components
- The button positions follow pf4 guidelines (cancel button to the right of create button)
- created story for the component
- VirtualizationCreateForm was incorporated into the VirtualizationCreatePage.  Added handler for cancel button - redirects to virtualizations summary page.  Reworked error handling so that the error is more appropriately shown above the form - instead of a toast notification.

