### PR TITLE
fix(build): prevent staging of test modules

### DIFF
--- a/app/test/pom.xml
+++ b/app/test/pom.xml
@@ -42,6 +42,17 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <configuration>
+            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencyManagement>


### PR DESCRIPTION
Currently the 1.8.0 release fails because of:

```
[ERROR] Repository "iosyndesis-1268" failures
[ERROR]   Rule "sources-staging" failures
[ERROR]     * Missing: no main jar artifact found in folder '/io/syndesis/test/integration-test/1.8.0'
[ERROR]     * Missing: no main jar artifact found in folder '/io/syndesis/test/system-test/1.8.0'
[ERROR]   Rule "javadoc-staging" failures
[ERROR]     * Missing: no main jar artifact found in folder '/io/syndesis/test/integration-test/1.8.0'
[ERROR]     * Missing: no main jar artifact found in folder '/io/syndesis/test/system-test/1.8.0'
```

This disables staging to OSS Maven repository of any artifacts from the
test modules.