### PR TITLE
fix(ENTESB-11247) - Detail page of Virtualization doesn't contain state of publishing

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import { Icon } from 'patternfly-react';
 import * as React from 'react';
-import { PageSection } from '../../Layout';
+import { Loader, PageSection } from '../../Layout';
 import { InlineTextEdit } from '../../Shared';
 import { VirtualizationPublishState } from './models';
 import { PublishStatusWithProgress } from './PublishStatusWithProgress';
@@ -22,7 +22,7 @@ export interface IVirtualizationDetailsHeaderProps {
   i18nUnpublishInProgress: string;
   i18nPublishLogUrlText: string;
   odataUrl?: string;
-  publishedState: VirtualizationPublishState;
+  publishedState: VirtualizationPublishState | 'Loading';
   publishingCurrentStep?: number;
   publishingLogUrl?: string;
   publishingTotalSteps?: number;
@@ -51,20 +51,24 @@ export const VirtualizationDetailsHeader: React.FunctionComponent<
             {props.virtualizationName}
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            <PublishStatusWithProgress
-              publishedState={props.publishedState}
-              i18nError={props.i18nError}
-              i18nPublished={props.i18nPublished}
-              i18nUnpublished={props.i18nDraft}
-              i18nPublishInProgress={props.i18nPublishInProgress}
-              i18nUnpublishInProgress={props.i18nUnpublishInProgress}
-              i18nPublishLogUrlText={props.i18nPublishLogUrlText}
-              publishingCurrentStep={props.publishingCurrentStep}
-              publishingLogUrl={props.publishingLogUrl}
-              publishingTotalSteps={props.publishingTotalSteps}
-              publishingStepText={props.publishingStepText}
-            />
-            {props.odataUrl && (
+            {props.publishedState !== 'Loading' ? (
+              <PublishStatusWithProgress
+                publishedState={props.publishedState}
+                i18nError={props.i18nError}
+                i18nPublished={props.i18nPublished}
+                i18nUnpublished={props.i18nDraft}
+                i18nPublishInProgress={props.i18nPublishInProgress}
+                i18nUnpublishInProgress={props.i18nUnpublishInProgress}
+                i18nPublishLogUrlText={props.i18nPublishLogUrlText}
+                publishingCurrentStep={props.publishingCurrentStep}
+                publishingLogUrl={props.publishingLogUrl}
+                publishingTotalSteps={props.publishingTotalSteps}
+                publishingStepText={props.publishingStepText}
+              />
+            ) : (
+              <Loader size={'sm'} inline={true} />
+            )}
+            {props.odataUrl && props.publishedState !== 'Loading' && (
               <span>
                 <a
                   data-testid={'virtualization-details-header-odataUrl'}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -49,7 +49,7 @@
       "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
       "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
       "title": "Preview Results",
-      "loadingQueryResults":"Loading query results..."
+      "loadingQueryResults": "Loading query results..."
     },
     "unpublishModalMessage": "This Virtualization has been published. Unpublish Virtualization \"{{name}}\" first.",
     "unpublishModalTitle": "Unpublish Virtualization",
@@ -91,10 +91,10 @@
     "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",
-    "publishVirtualizationSuccess": "Virtualization {{name}} was submitted for publishing.",
+    "publishVirtualizationSuccess": "Virtualization \"{{name}}\" was submitted for publishing.",
     "publishVirtualizationFailed": "Publishing failed for virtualization {{name}}. Details: {{details}}",
     "publishVirtualizationNoViews": "Cannot publish virtualization {{name}} - No views are defined",
-    "unpublishVirtualizationSuccess": "Virtualizaton {{name}} was submitted for unpublishing.",
+    "unpublishVirtualizationSuccess": "Virtualizaton \"{{name}}\" was submitted for unpublishing.",
     "unpublishVirtualizationFailed": "Unpublish virtualization {{name}} failed. Details: {{details}}",
     "deleteVirtualizationSuccess": "Virtualization {{name}} was deleted.",
     "deleteVirtualizationFailed": "Delete virtualization {{name}} failed. Details: {{details}}",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -49,7 +49,7 @@
       "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
       "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
       "title": "Preview Results",
-      "loadingQueryResults":"Loading query results..."
+      "loadingQueryResults": "Loading query results..."
     },
     "unpublishModalMessage": "This Virtualization has been published.  Please unpublish Virtualization \"{{name}}\" first.",
     "unpublishModalTitle": "Unpublish Virtualization",
@@ -91,10 +91,10 @@
     "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",
-    "publishVirtualizationSuccess": "Virtualization {{name}} was submitted for publishing.",
+    "publishVirtualizationSuccess": "Virtualization \"{{name}}\" was submitted for publishing.",
     "publishVirtualizationFailed": "Publishing failed for virtualization {{name}}. Details: {{details}}",
     "publishVirtualizationNoViews": "Cannot publish virtualization {{name}} - No views are defined",
-    "unpublishVirtualizationSuccess": "Virtualizaton {{name}} was submitted for unpublishing.",
+    "unpublishVirtualizationSuccess": "Virtualizaton \"{{name}}\" was submitted for unpublishing.",
     "unpublishVirtualizationFailed": "Unpublish virtualization {{name}} failed. Details: {{details}}",
     "deleteVirtualizationSuccess": "Virtualization {{name}} was deleted.",
     "deleteVirtualizationFailed": "Delete virtualization {{name}} failed. Details: {{details}}",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -166,8 +166,8 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
     await handlePublishVirtualization(pVirtualizationId, hasViews);
   };
 
-  const doUnpublish = async (serviceVdbName: string) => {
-    await handleUnpublishVirtualization(serviceVdbName);
+  const doUnpublish = async (virtualizationName: string) => {
+    await handleUnpublishVirtualization(virtualizationName);
   };
 
   const doSetDescription = async (newDescription: string) => {

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@syndesis/models';
 import { RestDataService } from '@syndesis/models';
 import {
+  Loader,
   PageSection,
   ViewHeaderBreadcrumb,
   VirtualizationDetailsHeader,
@@ -113,13 +114,9 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   const [description, setDescription] = React.useState(
     virtualization.tko__description
   );
-  const [publishedState, setPublishedState] = React.useState({
-    state: 'CONFIGURING',
-    stepNumber: 0,
-    stepText: 'querying for initial publish state',
-    stepTotal: 4,
-  } as VirtualizationPublishingDetails);
-
+  const [publishedState, setPublishedState] = React.useState(
+    {} as VirtualizationPublishingDetails
+  );
   const {
     deleteViewDefinition,
     updateVirtualizationDescription,
@@ -274,29 +271,35 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
               />
             </PageSection>
             <PageSection variant={'light'} noPadding={true}>
-              <VirtualizationDetailsHeader
-                i18nDescriptionPlaceholder={t(
-                  'virtualization.descriptionPlaceholder'
-                )}
-                i18nDraft={t('shared:Draft')}
-                i18nError={t('shared:Error')}
-                i18nPublished={t('virtualization.publishedDataVirtualization')}
-                i18nPublishInProgress={t('virtualization.publishInProgress')}
-                i18nUnpublishInProgress={t(
-                  'virtualization.unpublishInProgress'
-                )}
-                i18nPublishLogUrlText={t('shared:viewLogs')}
-                odataUrl={getOdataUrl(virtualization)}
-                publishedState={publishedState.state}
-                publishingCurrentStep={publishedState.stepNumber}
-                publishingLogUrl={publishedState.logUrl}
-                publishingTotalSteps={publishedState.stepTotal}
-                publishingStepText={publishedState.stepText}
-                virtualizationDescription={description}
-                virtualizationName={virtualization.keng__id}
-                isWorking={false}
-                onChangeDescription={doSetDescription}
-              />
+              {virtualization ? (
+                <VirtualizationDetailsHeader
+                  i18nDescriptionPlaceholder={t(
+                    'virtualization.descriptionPlaceholder'
+                  )}
+                  i18nDraft={t('shared:Draft')}
+                  i18nError={t('shared:Error')}
+                  i18nPublished={t(
+                    'virtualization.publishedDataVirtualization'
+                  )}
+                  i18nPublishInProgress={t('virtualization.publishInProgress')}
+                  i18nUnpublishInProgress={t(
+                    'virtualization.unpublishInProgress'
+                  )}
+                  i18nPublishLogUrlText={t('shared:viewLogs')}
+                  odataUrl={getOdataUrl(virtualization)}
+                  publishedState={publishedState.state || 'Loading'}
+                  publishingCurrentStep={publishedState.stepNumber}
+                  publishingLogUrl={publishedState.logUrl}
+                  publishingTotalSteps={publishedState.stepTotal}
+                  publishingStepText={publishedState.stepText}
+                  virtualizationDescription={description}
+                  virtualizationName={virtualization.keng__id}
+                  isWorking={false}
+                  onChangeDescription={doSetDescription}
+                />
+              ) : (
+                <Loader size={'sm'} inline={true} />
+              )}
             </PageSection>
             <PageSection variant={'light'} noPadding={true}>
               <VirtualizationNavBar virtualization={virtualization} />


### PR DESCRIPTION
- See [ENTESB-11247](https://issues.jboss.org/browse/ENTESB-11247)
- added `useVirtualization` hook in order to get updates to the virtualization
- no longer need `state` from the `useRouteData` hook
- now refreshing the published state every 5 seconds to see if it has changed