### PR TITLE
fix(ENTESB-11388): Use server side calculation for integration uptime

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
@@ -19,14 +19,13 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Optional;
 
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationDeploymentMetrics.Builder.class)
 @SuppressWarnings("immutables")
-public interface IntegrationDeploymentMetrics extends Serializable{
+public interface IntegrationDeploymentMetrics extends Serializable {
 
     String getVersion();
     /**
@@ -46,6 +45,10 @@ public interface IntegrationDeploymentMetrics extends Serializable{
      * @return the TimeStamp of when the last message for processed
      */
     Optional<Date> getLastProcessed();
+    /**
+     * @return the duration this deployment is up and running.
+     */
+    Long getUptimeDuration();
 
     class Builder extends ImmutableIntegrationDeploymentMetrics.Builder {
         // allow access to ImmutableIntegrationDeploymentMetrics.Builder

--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
@@ -21,11 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.immutables.value.Value;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithId;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationMetricsSummary.Builder.class)
@@ -54,6 +53,10 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
      * @return the TimeStamp of when the last message for processed
      */
     Optional<Date> getLastProcessed();
+    /**
+     * @return the duration this application is up and running.
+     */
+    Long getUptimeDuration();
 
     Optional<List<IntegrationDeploymentMetrics>> getIntegrationDeploymentMetrics();
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/metrics/SQLMetricsProviderImpl.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/metrics/SQLMetricsProviderImpl.java
@@ -100,6 +100,7 @@ public class SQLMetricsProviderImpl implements MetricsProvider {
                 .messages(totalMessages)
                 .errors(totalErrors)
                 .lastProcessed(totalLastProcessed)
+                .uptimeDuration(totalStart.map(date -> System.currentTimeMillis() - date.getTime()).orElse(0L))
                 .start(totalStart)
                 .build();
     }

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.common.model.metrics.IntegrationDeploymentMetrics;
 import io.syndesis.common.model.metrics.IntegrationMetricsSummary;
+import io.syndesis.server.dao.manager.DataManager;
 import lombok.Data;
 
 public class IntegrationMetricsHandler {
@@ -97,6 +97,7 @@ public class IntegrationMetricsHandler {
                     .errors(mh.getErrors())
                     .start(mh.getStartDate())
                     .lastProcessed(mh.getLastProcessed())
+                    .uptimeDuration(mh.getStartDate().map(date -> System.currentTimeMillis() - date.getTime()).orElse(0L))
                     .build();
             dmList.add(dm);
         }
@@ -106,6 +107,7 @@ public class IntegrationMetricsHandler {
                 .errors(tm.getErrors())
                 .start(tm.getStartDate())
                 .lastProcessed(tm.getLastProcessed())
+                .uptimeDuration(tm.getStartDate().map(date -> System.currentTimeMillis() - date.getTime()).orElse(0L))
                 .integrationDeploymentMetrics(dmList)
                 .build();
     }

--- a/app/ui-react/packages/api/src/WithIntegrationMetrics.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrationMetrics.tsx
@@ -23,6 +23,7 @@ export class WithIntegrationMetrics extends React.Component<
           messages: 0, // int64
           metricsProvider: 'null',
           start: `${Date.now()}`, // date-time
+          uptimeDuration: 0, // int64
         }}
       >
         {({ read, response }) => {

--- a/app/ui-react/packages/api/src/WithIntegrationsMetrics.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrationsMetrics.tsx
@@ -25,6 +25,7 @@ export class WithIntegrationsMetrics extends React.Component<
           metricsProvider: 'null',
           start: `${Date.now()}`, // date-time
           topIntegrations: {},
+          uptimeDuration: 0, // int64
         }}
       >
         {({ read, response }) => {

--- a/app/ui-react/packages/models/swagger.internal.json
+++ b/app/ui-react/packages/models/swagger.internal.json
@@ -3427,6 +3427,10 @@
         "lastProcessed": {
           "type": "string",
           "format": "date-time"
+        },
+        "uptimeDuration": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -3491,6 +3495,10 @@
         "lastProcessed": {
           "type": "string",
           "format": "date-time"
+        },
+        "uptimeDuration": {
+          "type": "integer",
+          "format": "int64"
         },
         "topIntegrations": {
           "type": "object",

--- a/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
@@ -4,7 +4,7 @@ import './UptimeMetric.css';
 
 export interface IUptimeMetricProps {
   start: number;
-  durationDifference: string;
+  uptimeDuration: string;
   i18nTitle: string;
 }
 
@@ -19,7 +19,7 @@ export class UptimeMetric extends React.PureComponent<IUptimeMetricProps> {
           <div className="metrics-uptime__uptime">since {startAsHuman}</div>
         </Title>
         <CardBody>
-          <span>{this.props.durationDifference}</span>
+          <span>{this.props.uptimeDuration}</span>
         </CardBody>
       </Card>
     );

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -27,7 +27,7 @@ export interface IIntegrationDetailMetricsProps {
   lastProcessed?: string;
   messages?: number;
   start?: number;
-  durationDifference?: string;
+  uptimeDuration?: string;
 }
 
 export class IntegrationDetailMetrics extends React.Component<
@@ -106,7 +106,7 @@ export class IntegrationDetailMetrics extends React.Component<
                 <Title size="lg" className="integration-detail-metrics__uptime-header">
                   <div>{this.props.i18nUptime}</div>
                   {this.props.start !== undefined &&
-                    this.props.durationDifference !== undefined && (
+                    this.props.uptimeDuration !== undefined && (
                       <div className="integration-detail-metrics__uptime-uptime">
                         {startAsHuman}
                       </div>
@@ -116,8 +116,8 @@ export class IntegrationDetailMetrics extends React.Component<
               <CardBody>
                 <AggregateStatusNotifications>
                   <AggregateStatusNotification className="integration-detail-metrics__duration-difference">
-                    {this.props.durationDifference !== undefined
-                      ? this.props.durationDifference
+                    {this.props.uptimeDuration !== undefined
+                      ? this.props.uptimeDuration
                       : this.props.i18nNoDataAvailable}
                   </AggregateStatusNotification>
                 </AggregateStatusNotifications>

--- a/app/ui-react/packages/ui/stories/Integration/IntegrationDetail.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Integration/IntegrationDetail.stories.tsx
@@ -233,7 +233,7 @@ storiesOf('Integration/Detail', module)
             lastProcessed={'2 May 2019 08:19:42 GMT'}
             messages={26126}
             start={2323342333}
-            durationDifference={'3:15:59'}
+            uptimeDuration={'3:15:59'}
           />
         </Container>
       </>

--- a/app/ui-react/packages/ui/stories/Integration/Metrics/IntegrationDetailsMetrics.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Integration/Metrics/IntegrationDetailsMetrics.stories.tsx
@@ -10,7 +10,7 @@ const stories = storiesOf(
   module
 );
 
-const durationDifference = '3:15:59';
+const uptimeDuration = '3:15:59';
 const errors = 2;
 const i18nLastProcessed = 'Last Processed';
 const i18nNoDataAvailable = 'No data available';
@@ -33,7 +33,7 @@ const propsOnlyRequired = {
 
 const propsAll = {
   ...propsOnlyRequired,
-  durationDifference,
+  uptimeDuration,
   errors,
   lastProcessed,
   messages,

--- a/app/ui-react/packages/utils/src/dateHelpers.ts
+++ b/app/ui-react/packages/utils/src/dateHelpers.ts
@@ -1,24 +1,36 @@
 import moment from 'moment';
 
-export function toDurationDifferenceString(
+export function toUptimeDurationString(
   timestamp: number,
   defaultValue = 'n/a'
 ): string {
   if (!timestamp) {
     return defaultValue;
   }
-  const startDate = moment(timestamp);
-  const uptimeDuration = moment.duration(moment().diff(startDate));
+
+  const uptimeDuration = moment.duration(timestamp);
   const duration = {
     days: uptimeDuration.days(),
     hours: uptimeDuration.hours(),
     minutes: uptimeDuration.minutes(),
+    seconds: uptimeDuration.seconds()
   };
   const durationString = Object.keys(duration).reduce(
     (timeSpan: string, key: string) => {
-      return duration[key] > 0
-        ? timeSpan + `${duration[key]} ${key} `
-        : timeSpan;
+      if (duration[key] > 0) {
+        if (key === 'seconds') {
+          if (timeSpan.length === 0) {
+            // show seconds only when overall duration is below one minute
+            return `${duration[key]} ${key}`;
+          } else {
+            return timeSpan;
+          }
+        }
+
+        return timeSpan + `${duration[key]} ${key} `;
+      }
+
+      return timeSpan;
     },
     ''
   );

--- a/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
+++ b/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
@@ -15,8 +15,11 @@ import {
   TopIntegrationsCard,
   UptimeMetric,
 } from '@syndesis/ui';
-import { toShortDateAndTimeString } from '@syndesis/utils';
-import { toDurationDifferenceString, WithLoader } from '@syndesis/utils';
+import {
+  toShortDateAndTimeString,
+  toUptimeDurationString,
+  WithLoader
+} from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { ApiError } from '../../../shared';
@@ -183,9 +186,7 @@ export default () => (
                         <div data-testid={'dashboard-page-metrics-uptime'}>
                           <UptimeMetric
                             start={parseInt(metricsData.start!, 10)}
-                            durationDifference={toDurationDifferenceString(
-                              parseInt(metricsData.start!, 10)
-                            )}
+                            uptimeDuration={toUptimeDurationString(metricsData.uptimeDuration!, t('metrics.NoDataAvailable'))}
                             i18nTitle={t('titleUptimeMetric')}
                           />
                         </div>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
@@ -4,7 +4,7 @@ import {
 } from '@syndesis/api';
 import { IntegrationDetailMetrics, PageLoader } from '@syndesis/ui';
 import {
-  toDurationDifferenceString,
+  toUptimeDurationString,
   WithLoader,
   WithRouteData,
 } from '@syndesis/utils';
@@ -119,17 +119,10 @@ export class MetricsPage extends React.Component {
                                                     10
                                                   )
                                             }
-                                            durationDifference={
-                                              metricsData.lastProcessed !==
-                                                undefined &&
-                                              metricsData.start !== undefined &&
-                                              metricsData.lastProcessed !==
-                                                metricsData.start
-                                                ? toDurationDifferenceString(
-                                                    parseInt(
-                                                      metricsData.start!,
-                                                      10
-                                                    ),
+                                            uptimeDuration={
+                                              metricsData.uptimeDuration! > 0
+                                                ? toUptimeDurationString(
+                                                    metricsData.uptimeDuration!,
                                                     t('metrics.NoDataAvailable')
                                                   )
                                                 : undefined


### PR DESCRIPTION
… duration on deployment metrics

This fixes the situation where we have a integration deployment up and running but not yet have had any messages being processed (e.g. webhook integrations)

Fixes ENTESB-11388