### PR TITLE
fix: documentation build in the daily release

### DIFF
--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -1,0 +1,14 @@
+:experimental:
+include::shared/attributes.adoc[]
+
+= Syndesis User Documentation
+
+include::tutorials/master.adoc[offsetlevel=+1]
+
+include::integrating_applications/master.adoc[offsetlevel=+1]
+
+include::connecting/master.adoc[offsetlevel=+1]
+
+include::developing_extensions/master.adoc[offsetlevel=+1]
+
+include::managing_environments/master.adoc[offsetlevel=+1]

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -32,6 +32,10 @@
 
     <packaging>pom</packaging>
 
+    <properties>
+      <basepom.check.skip-all>true</basepom.check.skip-all>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -45,7 +49,7 @@
                         </goals>
                         <configuration>
                             <sourceDirectory>${project.basedir}</sourceDirectory>
-                            <sourceDocumentName>master.adoc</sourceDocumentName>
+                            <sourceDocumentName>index.adoc</sourceDocumentName>
                             <imagesDir>images</imagesDir>
                             <backend>html</backend>
                             <doctype>book</doctype>


### PR DESCRIPTION
This adds a `index.adoc` to pull in all documents from modules within the `doc` directory. Currently the daily build is failing because of missing `master.adoc`.

@fbolton, @TovaCohen I don't think this makes a difference in the product doc build, but just to make sure...