### PR TITLE
fix(ENTESB-11273): Fix required column names configuration for Google Sheets

### DIFF
--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -279,7 +279,7 @@
                 "label": "producer",
                 "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
-                "required": false,
+                "required": true,
                 "secret": false,
                 "type": "string"
               }
@@ -420,7 +420,7 @@
                 "label": "producer",
                 "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
-                "required": false,
+                "required": true,
                 "secret": false,
                 "type": "string"
               }
@@ -533,7 +533,7 @@
                 "label": "producer",
                 "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
-                "required": false,
+                "required": true,
                 "secret": false,
                 "type": "string"
               }
@@ -700,7 +700,7 @@
                 "label": "producer",
                 "labelHint": "Comma delimited list of names that describe the columns.",
                 "order": "4",
-                "required": false,
+                "required": true,
                 "secret": false,
                 "type": "string"
               }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -206,9 +206,15 @@ public class ConnectionActionHandler {
                     else if ("string".equalsIgnoreCase(property.getType())
                        || "text".equalsIgnoreCase(property.getType()) ) {
                         enriched.replaceConfigurationProperty(suggestions.getKey(),
-                                builder -> builder.addAllDataList(suggestions.getValue()
-                                                    .stream()
-                                                    .map(ConfigurationProperty.PropertyValue.Builder::value)::iterator));
+                                builder -> {
+                                    if (suggestions.getValue().size() == 1) {
+                                        builder.defaultValue(suggestions.getValue().get(0).value());
+                                    }
+
+                                    builder.addAllDataList(suggestions.getValue()
+                                            .stream()
+                                            .map(ConfigurationProperty.PropertyValue.Builder::value)::iterator);
+                                });
                     } else if (suggestions.getValue().size() == 1) {
                         //for types 'hidden', 'boolean', 'int', etc.
                         enriched.replaceConfigurationProperty(suggestions.getKey(), builder -> builder.defaultValue(suggestions.getValue().get(0).value()));

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.hystrix.HystrixExecutable;
 import com.netflix.hystrix.HystrixInvokableInfo;
 import io.syndesis.common.model.DataShape;
@@ -34,14 +33,11 @@ import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.DynamicActionMetadata;
-import io.syndesis.common.util.Json;
 import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.endpoint.v1.dto.MetaData;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
-
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -178,14 +174,13 @@ public class ConnectionActionHandlerTest {
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
             .replaceConfigurationProperty("sObjectName",
-                c -> c.addDataList("Contact"))
+                c -> c.addDataList("Contact").defaultValue("Contact"))
             .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("ID", "Contact ID")))
-            .replaceConfigurationProperty("sObjectIdName", 
+            .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Email", "Email")))
             .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("TwitterScreenName__c", "Twitter Screen Name")))
-
             .inputDataShape(salesforceContactShape)//
             .build();
 


### PR DESCRIPTION
When no column names are provided the dynamic json schema generation is not working. Therefore require column names setting. Also gives a default value to data list form object when only one single enum value is provided.

Fixes ENTESB-11273