### PR TITLE
fix: syndesis release command

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -95,14 +95,11 @@ release::run() {
     # Set pom.xml version to the given release_version
     update_pom_versions "$topdir" "$release_version" "$maven_opts"
 
-    # Make a clean install
-    mvn_clean_install "$topdir" "$maven_opts"
-
-    # Create templates for the full syndesis version
+    # Updates install/operator/deploy/syndesis-operator.yml
     generate_versioned_files "$topdir" "$release_version"
 
     # Build and stage artefacts to Sonatype
-    build_and_stage_artefacts "$topdir" "$maven_opts -pl !ui-react"
+    build_and_stage_artefacts "$topdir" "$maven_opts"
 
     # Build all Docker Images
     docker_login
@@ -157,9 +154,6 @@ create_moving_tag_release() {
     if [ ! $(hasflag --snapshot-release) ]; then
         generate_versioned_files "$topdir" "$moving_tag" "$release_version"
 
-        # Recreate operator image with the versioned templates and push. Note that because
-        # the templates has already processed, they contain now the $release_version instead of latest
-        create_operator_image "$topdir/install/operator" "true" "$moving_tag"
         docker push "syndesis/syndesis-operator:$moving_tag"
 
         echo "==== Git commit for templates and syndesis-operator.yml, $moving_tag"
@@ -248,16 +242,6 @@ get_next_version() {
     echo "$prefix"."$((suffix+1))"
 }
 
-mvn_clean_install() {
-    local topdir="$1"
-    local maven_opts="$2"
-
-    echo "==== Running 'mvn clean install'"
-    cd $topdir/app
-    ./mvnw ${maven_opts} clean install -Pflash
-    ./mvnw ${maven_opts} -f "$topdir/doc/pom.xml" clean install
-}
-
 generate_versioned_files() {
     local dir="$1/install"
     local tag="$2"
@@ -291,7 +275,7 @@ build_and_stage_artefacts() {
 
     if [ $(hasflag --snapshot-release) ]; then
         echo "==== Building locally (--no-maven-release)"
-        ./mvnw ${maven_opts} install -Pflash
+        ./mvnw ${maven_opts} install
     else
         echo "==== Building and staging Maven artefacts to Sonatype"
         ./mvnw ${maven_opts} -Prelease deploy -DstagingDescription="Staging Syndesis for $(readopt --release-version)"
@@ -444,7 +428,7 @@ drop_staging_repo() {
 # Helper
 
 extract_maven_opts() {
-    local maven_opts="-Dmaven.repo.local=$1 --batch-mode"
+    local maven_opts="-Dmaven.repo.local=$1 --batch-mode -q -V -e"
 
     local settings_xml=$(readopt --settings-xml --settings)
     if [ -n "${settings_xml}" ]; then


### PR DESCRIPTION
Tries to fix the issue with the operator release build:

```
tools/bin/commands/release: line 162: create_operator_image: command not found
```

This also removes two Maven builds and replaces it with a single Maven
build.