### PR TITLE
fix(ENTESB-11672) - SQL Client results are not horizontally scrollable

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContent.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContent.css
@@ -1,5 +1,0 @@
-.generic-table_content {
-  overflow: auto;
-  padding: 0;
-  width: 100%;
-}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContent.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlClientContent.tsx
@@ -1,11 +1,10 @@
-import { Split, SplitItem, Text, TextContent } from '@patternfly/react-core';
+import { Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import { EmptyState, Table } from 'patternfly-react';
 import * as React from 'react';
 import { PageSection } from '../../../src/Layout';
 import { GenericTable } from '../../Shared/GenericTable';
 import { EmptyViewsState } from '../Virtualizations/Views/EmptyViewsState';
-import './SqlClientContent.css';
 
 export interface ISqlClientContentProps {
   /**
@@ -73,23 +72,19 @@ export const SqlClientContent: React.FunctionComponent<
       {props.viewNames.length > 0 ? (
         <Split gutter="md">
           <SplitItem isFilled={false}>{props.formContent}</SplitItem>
-          <SplitItem isFilled={true}>
+          <SplitItem isFilled={true} style={{ overflowX: 'auto' }}>
             {props.queryResultCols.length > 0 ? (
-              <>
-                <TextContent>
-                  <Text>{props.i18nResultsTitle}</Text>
-                </TextContent>
-                <TextContent>
-                  <Text>
-                    <small>
-                      <i>
-                        {props.i18nResultsRowCountMsg}
-                        {props.queryResultRows.length}
-                      </i>
-                    </small>
-                  </Text>
-                </TextContent>
-                <div className="generic-table_content">
+              <Stack>
+                <StackItem isFilled={false}>{props.i18nResultsTitle}</StackItem>
+                <StackItem isFilled={false}>
+                  <small>
+                    <i>
+                      {props.i18nResultsRowCountMsg}
+                      {props.queryResultRows.length}
+                    </i>
+                  </small>
+                </StackItem>
+                <StackItem isFilled={true}>
                   <GenericTable
                     columns={props.queryResultCols.map(col => ({
                       cell: {
@@ -109,8 +104,8 @@ export const SqlClientContent: React.FunctionComponent<
                     }
                     {...props}
                   />
-                </div>
-              </>
+                </StackItem>
+              </Stack>
             ) : (
               <EmptyState>
                 <EmptyState.Title>


### PR DESCRIPTION
- See [ENTESB-11672](https://issues.jboss.org/browse/ENTESB-11672)
- the results panel can now be scrolled horizontally if all the columns aren't visible on the screen
- deleted `SqlClientContent.css` as it is no longer used
- added `Stack` layout for results panel