### PR TITLE
fix(ENTESB-11647) - Preview section updates for improved usability

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
@@ -1,6 +1,14 @@
+.ddl-editor {
+  min-height: 300px;
+}
+
 .ddl-editor__button {
   margin-bottom: 8px;
   margin-right: 4px;
+}
+
+.ddl-editor__card {
+  height: 100%;
 }
 
 .ddl-editor .text-editor {

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
@@ -161,7 +161,7 @@ export const DdlEditor: React.FunctionComponent<IDdlEditorProps> = props => {
       <Title headingLevel="h5" size="lg">
         {props.i18nTitle}
       </Title>
-      <Card style={{ height: '100%' }}>
+      <Card className={'ddl-editor__card'}>
         <CardBody>
           {props.showValidationMessage
             ? props.validationResults.map((e, idx) => (

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -6,6 +6,11 @@ import {
   PageSection,
   Split,
   SplitItem,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
+  TextVariants,
   Title,
 } from '@patternfly/react-core';
 import { SyncIcon } from '@patternfly/react-icons';
@@ -31,6 +36,7 @@ export interface IExpandablePreviewProps {
   i18nEmptyResultsMsg: string;
   i18nHidePreview: string;
   i18nLoadingQueryResults: string;
+  i18nRowTotalLabel: string;
   i18nShowPreview: string;
   i18nTitle: string;
   initialExpanded?: boolean;
@@ -68,6 +74,7 @@ export const ExpandablePreview: React.FunctionComponent<
   i18nEmptyResultsMsg,
   i18nHidePreview,
   i18nLoadingQueryResults,
+  i18nRowTotalLabel,
   i18nShowPreview,
   i18nTitle,
   initialExpanded = true,
@@ -106,16 +113,28 @@ export const ExpandablePreview: React.FunctionComponent<
               <SyncIcon />
             </Button>
           </SplitItem>
-          <SplitItem isFilled={true} />
         </Split>
-        <PreviewResults
-          queryResultRows={queryResultRows}
-          queryResultCols={queryResultCols}
-          i18nEmptyResultsTitle={i18nEmptyResultsTitle}
-          i18nEmptyResultsMsg={i18nEmptyResultsMsg}
-          i18nLoadingQueryResults={i18nLoadingQueryResults}
-          isLoadingPreview={isLoadingPreview}
-        />
+        <Stack>
+          {queryResultRows.length > 0 && (
+            <StackItem isFilled={false}>
+              <TextContent>
+                <Text component={TextVariants.small}>
+                  {i18nRowTotalLabel} {queryResultRows.length}
+                </Text>
+              </TextContent>
+            </StackItem>
+          )}
+          <StackItem isFilled={true}>
+            <PreviewResults
+              queryResultRows={queryResultRows}
+              queryResultCols={queryResultCols}
+              i18nEmptyResultsTitle={i18nEmptyResultsTitle}
+              i18nEmptyResultsMsg={i18nEmptyResultsMsg}
+              i18nLoadingQueryResults={i18nLoadingQueryResults}
+              isLoadingPreview={isLoadingPreview}
+            />
+          </StackItem>
+        </Stack>
       </Expandable>
     </PageSection>
   );

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -97,7 +97,7 @@ export const ExpandablePreview: React.FunctionComponent<
         onToggle={toggleExpanded}
         isExpanded={expanded}
       >
-        <Split>
+        <Split style={{ alignItems: 'center' }}>
           <SplitItem isFilled={false}>
             <Title headingLevel="h5" size="lg">
               {i18nTitle}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/PreviewResults.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/PreviewResults.tsx
@@ -1,4 +1,9 @@
-import { EmptyState, EmptyStateBody, Title } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
 import { Spinner, Table } from 'patternfly-react';
 import * as React from 'react';
 import { PageSection } from '../../../../src/Layout';
@@ -46,51 +51,47 @@ const defaultHeaderFormat = (value: any) => <Table.Cell>{value}</Table.Cell>;
 export const PreviewResults: React.FunctionComponent<
   IPreviewResultsProps
 > = props => {
-
   return (
     <PageSection>
       {props.isLoadingPreview ? (
         <>
-        <Spinner loading={true} inline={true} />
-        {props.i18nLoadingQueryResults}
+          <Spinner loading={true} inline={true} />
+          {props.i18nLoadingQueryResults}
         </>
-        ) : (
-          <>
-            { props.queryResultCols.length > 0 ? (
-              <div className="generic-table_content">
-                <GenericTable
-                  columns={props.queryResultCols.map(col => ({
-                    cell: {
-                      formatters: [defaultCellFormat],
-                    },
-                    header: {
-                      formatters: [defaultHeaderFormat],
-                      label: col.label,
-                    },
-                    property: col.id,
-                  }))}
-                  rows={props.queryResultRows}
-                  rowKey={
-                    props.queryResultCols.length > 0
-                      ? props.queryResultCols[0].id
-                      : ''
-                  }
-                  {...props}
-                />
-              </div>
-            ) : (
-                <EmptyState>
-                  <Title headingLevel="h5" size="lg">
-                    {props.i18nEmptyResultsTitle}
-                  </Title>
-                  <EmptyStateBody>
-                    {props.i18nEmptyResultsMsg}
-                  </EmptyStateBody>
-                </EmptyState>
-              )}
-          </>
-        )}
+      ) : (
+        <>
+          {props.queryResultCols.length > 0 ? (
+            <div className="generic-table_content">
+              <GenericTable
+                columns={props.queryResultCols.map(col => ({
+                  cell: {
+                    formatters: [defaultCellFormat],
+                  },
+                  header: {
+                    formatters: [defaultHeaderFormat],
+                    label: col.label,
+                  },
+                  property: col.id,
+                }))}
+                rows={props.queryResultRows}
+                rowKey={
+                  props.queryResultCols.length > 0
+                    ? props.queryResultCols[0].id
+                    : ''
+                }
+                {...props}
+              />
+            </div>
+          ) : (
+            <EmptyState variant={EmptyStateVariant.full}>
+              <Title headingLevel="h5" size="lg">
+                {props.i18nEmptyResultsTitle}
+              </Title>
+              <EmptyStateBody>{props.i18nEmptyResultsMsg}</EmptyStateBody>
+            </EmptyState>
+          )}
+        </>
+      )}
     </PageSection>
   );
-
-}
+};

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/ExpandablePreview.stories.tsx
@@ -26,79 +26,83 @@ const resultRows = [
   { FirstName: 'Julia', LastName: 'Zhang', Country: 'China' },
 ];
 
-stories.add('collapsed', () => {
-  return (
-    <ExpandablePreview
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-      i18nHidePreview={'Hide Preview'}
-      i18nLoadingQueryResults={'Loading query results...'}
-      i18nShowPreview={'Show Preview'}
-      i18nTitle={'Preview Results'}
-      initialExpanded={false}
-      isLoadingPreview={false}
-      onPreviewExpandedChanged={action('expanded changed')}
-      onRefreshResults={action('refresh results')}
-      queryResultCols={resultCols}
-      queryResultRows={resultRows}
-    />
-  );
-})
+stories
+  .add('collapsed', () => {
+    return (
+      <ExpandablePreview
+        i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+        i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+        i18nHidePreview={'Hide Preview'}
+        i18nLoadingQueryResults={'Loading query results...'}
+        i18nRowTotalLabel={'Number of Rows:'}
+        i18nShowPreview={'Show Preview'}
+        i18nTitle={'Preview Results'}
+        initialExpanded={false}
+        isLoadingPreview={false}
+        onPreviewExpandedChanged={action('expanded changed')}
+        onRefreshResults={action('refresh results')}
+        queryResultCols={resultCols}
+        queryResultRows={resultRows}
+      />
+    );
+  })
 
+  .add('expanded, Preview with results loading', () => {
+    return (
+      <ExpandablePreview
+        i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+        i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+        i18nHidePreview={'Hide Preview'}
+        i18nLoadingQueryResults={'Loading query results...'}
+        i18nRowTotalLabel={'Number of Rows:'}
+        i18nShowPreview={'Show Preview'}
+        i18nTitle={'Preview Results'}
+        initialExpanded={true}
+        isLoadingPreview={true}
+        onPreviewExpandedChanged={action('expanded changed')}
+        onRefreshResults={action('refresh results')}
+        queryResultCols={resultCols}
+        queryResultRows={resultRows}
+      />
+    );
+  })
 
-.add('expanded, Preview with results loading', () => {
-  return (
-    <ExpandablePreview
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-      i18nHidePreview={'Hide Preview'}
-      i18nLoadingQueryResults={'Loading query results...'}
-      i18nShowPreview={'Show Preview'}
-      i18nTitle={'Preview Results'}
-      initialExpanded={true}
-      isLoadingPreview={true}
-      onPreviewExpandedChanged={action('expanded changed')}
-      onRefreshResults={action('refresh results')}
-      queryResultCols={resultCols}
-      queryResultRows={resultRows}
-    />
-  );
-})
+  .add('expanded, Preview with results', () => {
+    return (
+      <ExpandablePreview
+        i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+        i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+        i18nHidePreview={'Hide Preview'}
+        i18nLoadingQueryResults={'Loading query results...'}
+        i18nRowTotalLabel={'Number of Rows:'}
+        i18nShowPreview={'Show Preview'}
+        i18nTitle={'Preview Results'}
+        initialExpanded={true}
+        isLoadingPreview={false}
+        onPreviewExpandedChanged={action('expanded changed')}
+        onRefreshResults={action('refresh results')}
+        queryResultCols={resultCols}
+        queryResultRows={resultRows}
+      />
+    );
+  })
 
-.add('expanded, Preview with results', () => {
-  return (
-    <ExpandablePreview
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-      i18nHidePreview={'Hide Preview'}
-      i18nLoadingQueryResults={'Loading query results...'}
-      i18nShowPreview={'Show Preview'}
-      i18nTitle={'Preview Results'}
-      initialExpanded={true}
-      isLoadingPreview={false}
-      onPreviewExpandedChanged={action('expanded changed')}
-      onRefreshResults={action('refresh results')}
-      queryResultCols={resultCols}
-      queryResultRows={resultRows}
-    />
-  );
-})
-
-.add('expanded, Preview no results', () => {
-  return (
-    <ExpandablePreview
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-      i18nHidePreview={'Hide Preview'}
-      i18nLoadingQueryResults={'Loading query results...'}
-      i18nShowPreview={'Show Preview'}
-      i18nTitle={'Preview Results'}
-      initialExpanded={true}
-      isLoadingPreview={false}
-      onPreviewExpandedChanged={action('expanded changed')}
-      onRefreshResults={action('refresh results')}
-      queryResultCols={[]}
-      queryResultRows={[]}
-    />
-  );
-});
+  .add('expanded, Preview no results', () => {
+    return (
+      <ExpandablePreview
+        i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+        i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+        i18nHidePreview={'Hide Preview'}
+        i18nLoadingQueryResults={'Loading query results...'}
+        i18nRowTotalLabel={'Number of Rows:'}
+        i18nShowPreview={'Show Preview'}
+        i18nTitle={'Preview Results'}
+        initialExpanded={true}
+        isLoadingPreview={false}
+        onPreviewExpandedChanged={action('expanded changed')}
+        onRefreshResults={action('refresh results')}
+        queryResultCols={[]}
+        queryResultRows={[]}
+      />
+    );
+  });

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -1,4 +1,5 @@
 {
+  "Refresh": "Refresh",
   "Submit": "Submit",
   "virtualization": {
     "createDataVirtualization": "Create $t(shared:DataVirtualization)",
@@ -47,8 +48,7 @@
       "resultsTableInvalidEmptyTitle": "CURRENT VIEW INVALID",
       "resultsTableInvalidEmptyInfo": "The current view is invalid - no results to show",
       "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
-      "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
-      "title": "Preview Results",
+      "resultsTableValidEmptyInfo": "Click the 'Refresh' button to refresh the preview results. Remember to save the View Editor above to make sure you are getting the results you expect.",
       "loadingQueryResults": "Loading query results..."
     },
     "unpublishModalMessage": "This Virtualization has been published. Unpublish Virtualization \"{{name}}\" first.",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -87,7 +87,7 @@
     "queryResultsTableEmptyStateInfo": "Query has not yet been executed.\nSelect view, enter SQL query and click 'Submit'",
     "queryResultsTableEmptyStateTitle": "NO DATA AVAILABLE",
     "queryResultsTitle": "Query Results",
-    "queryResultsRowCountMsg": "Number of Rows: ",
+    "queryResultsRowCountMsg": "Number of rows: ",
     "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -87,7 +87,7 @@
     "queryResultsTableEmptyStateInfo": "Query has not yet been executed.\nSelect view, enter SQL query and click 'Submit'",
     "queryResultsTableEmptyStateTitle": "NO DATA AVAILABLE",
     "queryResultsTitle": "Query Results",
-    "queryResultsRowCountMsg": "Number of Rows: ",
+    "queryResultsRowCountMsg": "Numero di righe: ",
     "queryResultsRefreshed": "The view preview results were refreshed for {{name}}",
     "queryViewFailed": "An error occurred querying the selected view. Details: {{details}}",
     "createVirtualizationSuccess": "{{name}} virtualization created.",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -1,4 +1,5 @@
 {
+  "Refresh": "Aggiorna",
   "Submit": "Sottoscrivi",
   "virtualization": {
     "createDataVirtualization": "Create $t(shared:DataVirtualization)",
@@ -47,8 +48,7 @@
       "resultsTableInvalidEmptyTitle": "CURRENT VIEW INVALID",
       "resultsTableInvalidEmptyInfo": "The current view is invalid - no results to show",
       "resultsTableValidEmptyTitle": "NO DATA AVAILABLE",
-      "resultsTableValidEmptyInfo": "Click 'refresh' button to refresh the preview results",
-      "title": "Preview Results",
+      "resultsTableValidEmptyInfo": "Fai clic sul pulsante 'Aggiorna' per aggiornare i risultati dell'anteprima. Ricorda di salvare l'Editor vista sopra per assicurarti di ottenere i risultati che ti aspetti.",
       "loadingQueryResults": "Loading query results..."
     },
     "unpublishModalMessage": "This Virtualization has been published.  Please unpublish Virtualization \"{{name}}\" first.",

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -377,8 +377,9 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
                 i18nLoadingQueryResults={t(
                   'data:virtualization.preview.loadingQueryResults'
                 )}
+                i18nRowTotalLabel={t('virtualization.queryResultsRowCountMsg')}
                 i18nShowPreview={t('data:virtualization.preview.showPreview')}
-                i18nTitle={t('data:virtualization.preview.title')}
+                i18nTitle={t('Refresh')}
                 initialExpanded={previewExpanded}
                 isLoadingPreview={isLoadingPreview}
                 onPreviewExpandedChanged={handlePreviewExpandedChanged}


### PR DESCRIPTION
- See [ENTESB-11647](https://issues.jboss.org/browse/ENTESB-11647)
- preview results empty state is now centered and uses full width
- updated preview empty results text as recommended
- changed preview results icon text as recommended
- added label above preview results as recommended to tell user the number of result rows
- added `min-height` to DdlEditor to prevent it from getting too small when query results exist
