### PR TITLE
user doc: Change path for images in all books

### DIFF
--- a/doc/connecting/master.adoc
+++ b/doc/connecting/master.adoc
@@ -4,7 +4,6 @@ include::attributes-links.adoc[]
 
 :prodname: Syndesis
 :prodversion: 7.5
-:imagesdir: images
 :prodnameinurl: fuse-ignite
 :productpkg: red_hat_fuse
 :version: 7.5

--- a/doc/customizing/master.adoc
+++ b/doc/customizing/master.adoc
@@ -3,7 +3,6 @@ include::attributes.adoc[]
 
 :prodname: Syndesis
 :prodversion: 7.5
-:imagesdir: images
 :prodnameinurl: fuse-ignite
 :productpkg: red_hat_fuse
 :version: 7.5

--- a/doc/integrating-applications/master.adoc
+++ b/doc/integrating-applications/master.adoc
@@ -3,7 +3,6 @@ include::attributes.adoc[]
 
 :prodname: Syndesis
 :prodversion: 7.5
-:imagesdir: images
 :prodnameinurl: fuse-ignite
 :productpkg: red_hat_fuse
 :version: 7.5

--- a/doc/modules/connecting/p_add-google-calendar-connection-to-get-one-event.adoc
+++ b/doc/modules/connecting/p_add-google-calendar-connection-to-get-one-event.adoc
@@ -46,7 +46,7 @@ following:
 .. Append `?gsessionid=OK&eventdeb=1` to the URL and redisplay the calendar.
 .. In the calendar, click the event that you want to get. 
 .. In the event popup, click 
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Options] and select 
+image:images/tutorials/ThreeVerticalDotsKebab.png[Options] and select 
 *Troubleshooting info*. 
 .. In the popup that Google Calendar displays, copy the string that
 follows *`eid=`*. For example, an event ID looks something like this: 

--- a/doc/modules/connecting/p_add-servicenow-connection-finish.adoc
+++ b/doc/modules/connecting/p_add-servicenow-connection-finish.adoc
@@ -40,7 +40,7 @@ you want to add records to.
 Typically, a data mapper step is needed before this connection.
 In the integration visualization, 
 {prodname} displays 
-image:../../images/tutorials/WarningIcon.png[Data Type Mismatch] on the
+image:images/tutorials/WarningIcon.png[Data Type Mismatch] on the
 connection. In most integrations, you need to map a source field 
 to the target field used as the correlation field in the 
 ServiceNow table. 

--- a/doc/modules/connecting/p_register-with-dropbox.adoc
+++ b/doc/modules/connecting/p_register-with-dropbox.adoc
@@ -25,7 +25,7 @@ to download or upload files.
 .. In the left panel, click *Settings*.
 .. On the *Settings* page, near the top, to the right of the callback URL, 
 click 
-image:../../images/tutorials/CopyCallback.png[Copy Callback URL] to 
+image:images/tutorials/CopyCallback.png[Copy Callback URL] to 
 copy the callback URL for your {prodname} environment to the clipboard. 
 You will need this URL toward the end of this procedure. 
 . In another browser tab, go  to `https://www.dropbox.com` 

--- a/doc/modules/connecting/p_register-with-google.adoc
+++ b/doc/modules/connecting/p_register-with-google.adoc
@@ -58,7 +58,7 @@ use to register {prodname} as a Google client application.
 .. In the left navigation panel, click *Settings*.
 .. On the *Settings* page, near the top, to the right of the callback URL,
 click
-image:../../images/tutorials/CopyCallback.png[Copy Callback URL] to
+image:images/tutorials/CopyCallback.png[Copy Callback URL] to
 copy the callback URL for your {prodname} environment to the clipboard.
 You will need this URL later in this procedure.
 . In another browser tab, go to `https://console.developers.google.com`
@@ -76,7 +76,7 @@ If this Google account does not already
 have a project, you must create one. 
 .. Enable Google APIs:
 ... In the upper left corner, click 
-image:../../images/connecting/Hamburger.png[Navigation menu icon] and select
+image:images/connecting/Hamburger.png[Navigation menu icon] and select
 *APIs and Services* > *Library*.
 ... If necessary, scroll down to see the *G Suite* row of cards. 
 ... Click the *Google Calendar API* card, which displays a page that indicates
@@ -84,7 +84,7 @@ that the Google Calendar API is enabled.
 ... Scroll down and click the *Gmail API* card, which displays a page that indicates
 that the Gmail API is enabled.
 ... In the upper left corner, click 
-image:../../images/connecting/Hamburger.png[Navigation menu icon] and select
+image:images/connecting/Hamburger.png[Navigation menu icon] and select
 *APIs and Services* > *Library*.
 ... If necessary, scroll down to see the *G Suite* row of cards. 
 ... Click the *Google Sheets API* card, which displays a page that indicates
@@ -113,7 +113,7 @@ this procedure.
 ... Click *Create* to display the client ID and client secret for your
 {prodname} environment.
 .. To the right of the client ID field, click
-image:../../images/connecting/copy_icon.png[the Copy icon] to copy the client ID
+image:images/connecting/copy_icon.png[the Copy icon] to copy the client ID
 to your clipboard.
 
 . Return to the {prodname} *Settings* page and do the following: 
@@ -123,7 +123,7 @@ paste the Google client ID that you just copied.
 
 . Return to the Google developers site and to the right of the
 client secret field, click
-image:../../images/connecting/copy_icon.png[the Copy icon] to copy the client secret to
+image:images/connecting/copy_icon.png[the Copy icon] to copy the client secret to
 your clipboard.
 
 . Return to the {prodname} *Settings* page and do the following in

--- a/doc/modules/connecting/p_registering-with-jira.adoc
+++ b/doc/modules/connecting/p_registering-with-jira.adoc
@@ -155,7 +155,7 @@ endif::[]
 . Configure your Jira server to recognize your {prodname} environment 
 as a consumer application. 
 You must be logged in to the Jira server as an administrative user. 
-.. Select *Settings* (image:../../images/tutorials/EditorSettings.png[cog]) > *Products* > *Application links*. 
+.. Select *Settings* (image:images/tutorials/EditorSettings.png[cog]) > *Products* > *Application links*. 
 .. In the *Create new link* input field, enter any URL, for example, 
 enter: `https://example.com`.
 +

--- a/doc/modules/connecting/p_registering-with-rest-api.adoc
+++ b/doc/modules/connecting/p_registering-with-rest-api.adoc
@@ -23,7 +23,7 @@ REST API that you want to connect to.
 
 . In {prodname}:
 .. On the *Settings* page, near the top, to the right of the callback URL, click
-image:../../images/tutorials/CopyCallback.png[Copy Callback URL] to 
+image:images/tutorials/CopyCallback.png[Copy Callback URL] to 
 copy the callback URL for your {prodname} environment to the clipboard. 
 You will need this URL later in this procedure. 
 .. Look for the name of the API you want to connect to and click it

--- a/doc/modules/customizing/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
+++ b/doc/modules/customizing/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
@@ -63,7 +63,7 @@ the user enters values in the two required fields and clicks
 *Next*, {prodname} creates an IRC connection that is configured 
 with the values that the {prodname} user enters. 
 
-image:../../images/integrating-applications/IRC-create-connection-fields.png[Hostname, Password, Port]
+image:images/integrating-applications/IRC-create-connection-fields.png[Hostname, Password, Port]
 
 .About `properties` objects in extension definition JSON files
 

--- a/doc/modules/customizing/r_how-to-specify-data-shapes.adoc
+++ b/doc/modules/customizing/r_how-to-specify-data-shapes.adoc
@@ -190,7 +190,7 @@ as the label for the data fields. In the following image,
 *Twitter Mention* is an example of where you would see the value of
 the `name` property.
 
-image:../../images/integrating-applications/TwitterMention.png[Name example]
+image:images/integrating-applications/TwitterMention.png[Name example]
 
 This name also appears in data type indicators in the {prodname} 
 flow visualization. 

--- a/doc/modules/integrating-applications/c_about-adding-steps.adoc
+++ b/doc/modules/integrating-applications/c_about-adding-steps.adoc
@@ -18,7 +18,7 @@ check the flow visualization.
 For each connection that requires data mapping before
 it can operate on the input data,
 {prodname} displays
-image:../../images/integrating-applications/DataTypeMismatchWarning.png[title="a warning"]. Click this
+image:images/integrating-applications/DataTypeMismatchWarning.png[title="a warning"]. Click this
 icon to see *Data Type Mismatch: Add a data
 mapper step before this connection to resolve the difference.*
 

--- a/doc/modules/integrating-applications/c_about-integration-lifecycle-handling.adoc
+++ b/doc/modules/integrating-applications/c_about-integration-lifecycle-handling.adoc
@@ -87,6 +87,6 @@ The error suspended start-up or execution.  If this happens, try
 starting an earlier integration version that ran correctly. 
 Alternatively, contact technical support for help. 
 To do that, in any {prodname} page, in the upper right, click the 
-image:../../images/tutorials/InfoIcon.png[title="Help"] icon and select *Support*. 
+image:images/tutorials/InfoIcon.png[title="Help"] icon and select *Support*. 
 
 |===

--- a/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
@@ -54,7 +54,7 @@ execution of the integration.
 The *general* workflow for creating an API provider integration is shown 
 in the following diagram: 
 
-image::../../images/integrating-applications/ApiProviderCreateIntegrationWorkflow.png[General workflow for creating an API provider integration]
+image:images/integrating-applications/ApiProviderCreateIntegrationWorkflow.png[General workflow for creating an API provider integration]
 
 .Publishing an API provider integration
 After you publish an API provider integration, in the integration's

--- a/doc/modules/integrating-applications/c_workflow-overview.adoc
+++ b/doc/modules/integrating-applications/c_workflow-overview.adoc
@@ -19,7 +19,7 @@ Applications that you must register with include:
 With registration in place for those applications, the workflow for
 creating a simple integration looks like this:
 
-image:../../images/integrating-applications/general-workflow.png[general workflow]
+image:images/integrating-applications/general-workflow.png[general workflow]
 
 .Additional resource
 link:{LinkFuseOnlineIntegrationGuide}#workflow-api-providers_api-provider[Workflow for creating API provider integrations].

--- a/doc/modules/integrating-applications/p_add-advanced-filter-step.adoc
+++ b/doc/modules/integrating-applications/p_add-advanced-filter-step.adoc
@@ -20,7 +20,7 @@ you have been provided with a filter expression.
 
 . In the flow visualization, where you want to add an advanced filter step to
 the flow, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 
 . Click *Advanced Filter*.
 

--- a/doc/modules/integrating-applications/p_add-aggregate-step.adoc
+++ b/doc/modules/integrating-applications/p_add-aggregate-step.adoc
@@ -25,7 +25,7 @@ connect once rather than multiple times.
 
 . In the flow visualization, where you want to 
 add an aggregate step to the flow, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 
 . Click *Aggregate*. This step does not require any configuration. 
 . Click *Next*. 

--- a/doc/modules/integrating-applications/p_add-basic-filter-step.adoc
+++ b/doc/modules/integrating-applications/p_add-basic-filter-step.adoc
@@ -18,7 +18,7 @@ continue execution by operating only on tweets that contain "Red Hat".
 .Procedure
 
 . In the flow visualization, where you want to add a filter step, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 
 . Click *Basic Filter*. 
 

--- a/doc/modules/integrating-applications/p_add-custom-step.adoc
+++ b/doc/modules/integrating-applications/p_add-custom-step.adoc
@@ -25,7 +25,7 @@ link:{LinkFuseOnlineIntegrationGuide}#making-extensions-available_custom[Making 
 .Procedure
 
 . In the flow visualization, where you want to add a custom step, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 
 . Click the custom step that you want to add.
 +

--- a/doc/modules/integrating-applications/p_add-data-mapping-step.adoc
+++ b/doc/modules/integrating-applications/p_add-data-mapping-step.adoc
@@ -20,7 +20,7 @@ You are creating or editing a flow.
 .Procedure
 
 . In the flow visualization, where you want to add a data mapper step,
-click the image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+click the image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 . Click *Data Mapper* to display source
 and target fields in the data mapper canvas. 
 

--- a/doc/modules/integrating-applications/p_add-split-step.adoc
+++ b/doc/modules/integrating-applications/p_add-split-step.adoc
@@ -31,7 +31,7 @@ indicates that the data is a *(Collection)*.
 
 . In the flow visualization, where you want to 
 add a split step, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 
 . Click *Split*. This step does not require any configuration. 
 . Click *Next*. 

--- a/doc/modules/integrating-applications/p_add-template-step.adoc
+++ b/doc/modules/integrating-applications/p_add-template-step.adoc
@@ -34,7 +34,7 @@ integration then it must already have its start and finish connections.
 .Procedure
 
 . In the flow visualization, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign]
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign]
 where you want to add a template step.
 . Click *Template*. The
 *Upload Template* page opens.
@@ -50,7 +50,7 @@ want to modify to create a template, into the template editor.
 . In the template editor, ensure that the template
 is valid for use with {prodname}. Examples of valid templates are 
 after this procedure. {prodname} displays
-image:../../images/integrating-applications/RedCircleXError.png[a red error indicator] to the left of
+image:images/integrating-applications/RedCircleXError.png[a red error indicator] to the left of
 a line that contains a syntax error. Hovering over a syntax error 
 indicator displays hints about how to resolve the error.
 
@@ -64,7 +64,7 @@ you must add
 a data mapping step before a template step.
 . To add a data mapper step before the template step:
 .. In the flow visualization, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign] that is
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign] that is
 immediately before the template step that you just added.
 .. Click *Data Mapper*.
 .. In the data mapper, map a source field to each template placeholder field.
@@ -83,7 +83,7 @@ Output from a template step is always a JSON object. Consequently, you must
 add a data mapper step after a template step.
 . To add a data mapper step after the template step:
 .. In the flow visualization, click the
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign] that is
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[Plus Sign] that is
 immediately after the template step that you just added.
 .. Click *Data Mapper*.
 .. In the data mapper, map the template's *message* field, which

--- a/doc/modules/integrating-applications/p_adding-conditional-execution-flows.adoc
+++ b/doc/modules/integrating-applications/p_adding-conditional-execution-flows.adoc
@@ -85,7 +85,7 @@ conditions that you want to evaluate.
 .Procedure
 
 . In the integration visualization, where you want to add a *Conditional Flows* step,
-click image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
+click image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign'].
 . Click *Conditional Flows*.
 . In the *Configure Conditional Flows* page, define one or more conditions: 
 .. In the initial *When* field, enter a Camel Simple Expression. For example, 
@@ -146,7 +146,7 @@ The conditional flow visualization shows the *Flow Start* and
 *Flow End* steps that all conditional flows have. 
 
 .. In the flow visualization, click the 
-image:../../images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign']
+image:images/integrating-applications/PlusSignToAddStepOrConnection.png[title='plus sign']
 where you want to add a step to this conditional flow. 
 
 .. Click the step that you want to add. You can add any connection or 

--- a/doc/modules/integrating-applications/p_applying-conditions-to-mappings.adoc
+++ b/doc/modules/integrating-applications/p_applying-conditions-to-mappings.adoc
@@ -50,7 +50,7 @@ to a mapping.
 .Procedure
 
 . If data types are not already visible, display them by clicking 
-image:../../images/tutorials/EditorSettings.png[Editor settings] and then 
+image:images/tutorials/EditorSettings.png[Editor settings] and then 
 *Show Types*. 
 +
 While this is not a requirement for specifying a condition, it is
@@ -60,16 +60,16 @@ helpful to see the data types.
 ensure that the currently selected mapping is the mapping that you 
 want to apply a condition to. For example, consider this mapping: 
 +
-image:../../images/integrating-applications/first-conditional-mapping.png[lastName and firstName map to customerName]
+image:images/integrating-applications/first-conditional-mapping.png[lastName and firstName map to customerName]
 
 . In the upper right, click
-image:../../images/integrating-applications/add-condition-to-mapping.png[Add expression] to 
+image:images/integrating-applications/add-condition-to-mapping.png[Add expression] to 
 display the conditional expression input field. 
 +
 In the expression field, the data mapper automatically displays 
 the names of the source fields in the current mapping. For example: 
 +
-image:../../images/integrating-applications/first-conditional-mapping-expression.png[lastName + firstName]
+image:images/integrating-applications/first-conditional-mapping-expression.png[lastName + firstName]
 +
 In the expression input field, the order of the source fields is the 
 order in which you selected them when you created the mapping. 
@@ -99,7 +99,7 @@ that field to the mapping. For example, consider this conditional
 expression: 
 
 +
-image:../../images/integrating-applications/second-conditional-mapping-expression.png[if(ISEMPTY(lastName), firstName, orderId + phone)]
+image:images/integrating-applications/second-conditional-mapping-expression.png[if(ISEMPTY(lastName), firstName, orderId + phone)]
 
 +
 During execution, if the data mapper determines that the `lastName`
@@ -118,7 +118,7 @@ For this example, after you complete entering the expression,
 the data mapping is: 
 
 +
-image:../../images/integrating-applications/second-conditional-mapping.png[lastName, firstName, orderId, phone are mapped to customerName]
+image:images/integrating-applications/second-conditional-mapping.png[lastName, firstName, orderId, phone are mapped to customerName]
 
 +
 In the conditional expression, if you remove a field name that is in 
@@ -127,7 +127,7 @@ field from the mapping. In other words, every field name in the mapping
 must be in the conditional expression. 
 
 . If mapping preview fields are not already visible, display them 
-by clicking image:../../images/tutorials/EditorSettings.png[Editor settings] and then 
+by clicking image:images/tutorials/EditorSettings.png[Editor settings] and then 
 *Show Mapping Preview*. 
 
 . Enter sample data in the source preview input field(s) 

--- a/doc/modules/integrating-applications/p_combine-multiple-source-fields-into-one-target-field.adoc
+++ b/doc/modules/integrating-applications/p_combine-multiple-source-fields-into-one-target-field.adoc
@@ -57,7 +57,7 @@ icon on each extra padding field to delete it.
 
 . Optionally, preview the data mapping result: 
 .. In the upper right of the data mapper, click 
-image:../../images/tutorials/EditorSettings.png[Editor settings] and select 
+image:images/tutorials/EditorSettings.png[Editor settings] and select 
 *Show Mapping Preview* to display a text input field on each source
 field for the currently selected mapping and a read-only result field 
 on the target field of the currently selected mapping. 
@@ -70,7 +70,7 @@ detects any errors, it displays informative messages at the top of the
 *Mapping Details* panel. 
 
 .. Hide the preview fields by clicking 
-image:../../images/tutorials/EditorSettings.png[Editor settings] again and selecting
+image:images/tutorials/EditorSettings.png[Editor settings] again and selecting
 *Show Mapping Preview*. 
 +
 If you redisplay the preview fields, any data
@@ -78,13 +78,13 @@ that you entered in them is still there and it
 remains there until you exit the data mapper. 
 
 . To confirm that the mapping is correctly defined, in the upper right, click
-image:../../images/tutorials/grid.png[Grid] to display the mappings defined in
+image:images/tutorials/grid.png[Grid] to display the mappings defined in
 this step. A mapping that combines the values of more than one source field
 into one target field looks like this:
-image:../../images/integrating-applications/CombineMapping.png[Combine Fields Mapping]. 
+image:images/integrating-applications/CombineMapping.png[Combine Fields Mapping]. 
 +
 You can also preview mapping results in this view. Click 
-image:../../images/tutorials/EditorSettings.png[Editor settings], select 
+image:images/tutorials/EditorSettings.png[Editor settings], select 
 *Show Mapping Preview*, and enter text as described in the previous step.
 Preview fields appear for only the selected mapping. Click another
 mapping in the table to view preview fields for it. 

--- a/doc/modules/integrating-applications/p_create-integration-operation-flows.adoc
+++ b/doc/modules/integrating-applications/p_create-integration-operation-flows.adoc
@@ -64,7 +64,7 @@ data between connections, repeat this subset of instructions.
 
 . Map data to fields in the next connection: 
 .. In the flow visualization, check for data type mismatch 
-image:../../images/integrating-applications/DataTypeMismatchWarning.png[data mismatch] icons, which
+image:images/integrating-applications/DataTypeMismatchWarning.png[data mismatch] icons, which
 indicate that the connection cannot process the incoming data. You need
 to add a data mapper step here. 
 .. For each data mismatch icon in the flow visualization:

--- a/doc/modules/integrating-applications/p_deleting-integrations.adoc
+++ b/doc/modules/integrating-applications/p_deleting-integrations.adoc
@@ -14,6 +14,6 @@ the imported integration.
 . In the left {prodname} panel, click *Integrations*.
 . In the list of integrations, at the right of the entry for the integration
 that you want to delete, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select
 *Delete*.
 . In the popup, click *OK* to confirm that you want to delete the integration.

--- a/doc/modules/integrating-applications/p_exporting-integrations.adoc
+++ b/doc/modules/integrating-applications/p_exporting-integrations.adoc
@@ -19,7 +19,7 @@ an integration is not required for having a backup copy.
 . In the list of integrations, identify the entry for the integration 
 that you want to export.
 . At the right of the entry, click 
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
+image:images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
 select *Export*. 
 
 .Next step

--- a/doc/modules/integrating-applications/p_identify-where-data-mapping-is-needed.adoc
+++ b/doc/modules/integrating-applications/p_identify-where-data-mapping-is-needed.adoc
@@ -14,7 +14,7 @@ requires data mapping.
 .Procedure
 
 . In the flow visualization, look for any
-image:../../images/tutorials/WarningIcon.png[Warning] icons.
+image:images/tutorials/WarningIcon.png[Warning] icons.
 
 . Click the icon to see the *Data Type Mismatch* notification. 
 

--- a/doc/modules/integrating-applications/p_importing-integrations.adoc
+++ b/doc/modules/integrating-applications/p_importing-integrations.adoc
@@ -58,7 +58,7 @@ imported integrations have a
 green triangle in the upper left corner of their entries. 
 . In the list of integrations, at the right of the entry for the
 integration that you imported, click 
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
+image:images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
 select *Edit*. 
 . In the upper right, click *Save* or, if you want to start
 running the imported integration, click *Publish*. Regardless of whether

--- a/doc/modules/integrating-applications/p_map-one-source-field-to-one-target-field.adoc
+++ b/doc/modules/integrating-applications/p_map-one-source-field-to-one-target-field.adoc
@@ -16,7 +16,7 @@ provides.
 +
 When there are many source fields, you can search for the
 field of interest by clicking the
-image:../../images/tutorials/magnifying-glass.png[Magnifying Glass] and entering
+image:images/tutorials/magnifying-glass.png[Magnifying Glass] and entering
 the name of the data field in the search field.
 . In the *Target* panel, click the data field that you want to map to.
 +
@@ -27,7 +27,7 @@ selected.
 you add a transformation to the mapping or when the mapping requires
 a type conversion. 
 .. In the upper right of the data mapper, click 
-image:../../images/tutorials/EditorSettings.png[Editor settings] and select 
+image:images/tutorials/EditorSettings.png[Editor settings] and select 
 *Show Mapping Preview* to display a text input field on the source
 field and a read-only result field on the target field. 
 .. In the source field's data input field, enter text. 
@@ -37,22 +37,22 @@ the mapping result in the read-only field on the target field.
 in the *Mapping Details* panel. 
 
 .. Hide the preview fields by clicking 
-image:../../images/tutorials/EditorSettings.png[Editor settings] again and selecting
+image:images/tutorials/EditorSettings.png[Editor settings] again and selecting
 *Show Mapping Preview*. 
 
 . Optionally, to confirm that the mapping is defined, in the upper right, click
-image:../../images/tutorials/grid.png[Grid] to display the defined mappings.
+image:images/tutorials/grid.png[Grid] to display the defined mappings.
 
 +
 You can also preview data mapping results in this view. 
 If preview fields are not visible, 
-click image:../../images/tutorials/EditorSettings.png[Editor settings] and select 
+click image:images/tutorials/EditorSettings.png[Editor settings] and select 
 *Show Mapping Preview*. Enter data as described in the previous step.
 In the table of defined mappings, preview fields 
 appear for only the selected mapping. To see preview fields for another 
 mapping, select it. 
 +
-Click image:../../images/tutorials/grid.png[Grid] again to display the data field
+Click image:images/tutorials/grid.png[Grid] again to display the data field
 panels.
 . In the upper right, click *Done* to add the data mapper step to the integration. 
 

--- a/doc/modules/integrating-applications/p_procedure-for-creating-an-integration.adoc
+++ b/doc/modules/integrating-applications/p_procedure-for-creating-an-integration.adoc
@@ -79,7 +79,7 @@ data between connections. See
 link:{LinkFuseOnlineIntegrationGuide}#about-adding-steps_create[About adding steps between connections].
 
 . In the integration visualization, look for any
-image:../../images/tutorials/WarningIcon.png[Warning] icons. These 
+image:images/tutorials/WarningIcon.png[Warning] icons. These 
 warnings indicate that a data mapper step is needed before 
 this connection. Add the required data mapper steps. 
 

--- a/doc/modules/integrating-applications/p_restarting-older-integration-versions.adoc
+++ b/doc/modules/integrating-applications/p_restarting-older-integration-versions.adoc
@@ -21,7 +21,7 @@ the integrations in this environment.
 an older version. {prodname} displays a list of the versions of the
 integration. 
 . In the entry for the version that is running, at the far right, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select
 *Stop*.
 . Click *OK* to confirm that you want to stop running this version.
 . Wait for *Stopped* to appear to the right of the integration name near
@@ -30,14 +30,14 @@ the top of the page.
 before you publish the older version, you can update it: 
 .. In the entry for the integration version that you want to update, 
 at the far right, click  
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select *Replace Draft*.
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab] and select *Replace Draft*.
 .. Update the integration as needed. 
 .. When updates are complete, in the upper right, click *Publish*, 
 and then click *Publish* to confirm. This takes the place of the next two steps. 
 . To publish the older version as is, in the entry for the integration 
 version that you want to start
 running again, at the far right, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab]
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab]
 and select *Start*.
 . Click *Start* to confirm that you want to start this version of the
 integration.

--- a/doc/modules/integrating-applications/p_separate-one-source-field-into-multiple-target-fields.adoc
+++ b/doc/modules/integrating-applications/p_separate-one-source-field-into-multiple-target-fields.adoc
@@ -49,7 +49,7 @@ padding fields as needed to indicate unwanted data.
 
 . Optionally, preview the data mapping result: 
 .. In the upper right of the data mapper, click 
-image:../../images/tutorials/EditorSettings.png[Editor settings] and select 
+image:images/tutorials/EditorSettings.png[Editor settings] and select 
 *Show Mapping Preview* to display a text input field on the source
 field and read-only result fields on each target field. 
 .. In the source field's data input field, enter text. Be sure to enter
@@ -63,20 +63,20 @@ detects any errors, it displays informative messages at the top of the
 *Mapping Details* panel. 
 
 .. Hide the preview fields by clicking 
-image:../../images/tutorials/EditorSettings.png[Editor settings] again and selecting
+image:images/tutorials/EditorSettings.png[Editor settings] again and selecting
 *Show Mapping Preview*. 
 +
 If you redisplay the preview fields, any data that you entered in them is 
 still there and it remains there until you exit the data mapper. 
 
 . To confirm that the mapping is correctly defined, click
-image:../../images/tutorials/grid.png[Grid] to display the mappings defined in
+image:images/tutorials/grid.png[Grid] to display the mappings defined in
 this step. A mapping that separates the value of a source field into
 multiple target fields looks like this:
-image:../../images/integrating-applications/SeparateMapping.png[Separate Fields Mapping]. 
+image:images/integrating-applications/SeparateMapping.png[Separate Fields Mapping]. 
 +
 You can also preview mapping results in this view. Click 
-image:../../images/tutorials/EditorSettings.png[Editor settings], select 
+image:images/tutorials/EditorSettings.png[Editor settings], select 
 *Show Mapping Preview*, and enter text as described in the previous step.
 Preview fields appear for only the selected mapping. Click another
 mapping in the table to view preview fields for it. 

--- a/doc/modules/integrating-applications/p_starting-integrations.adoc
+++ b/doc/modules/integrating-applications/p_starting-integrations.adoc
@@ -17,7 +17,7 @@ The integration that you want to start is in the *Stopped* state.
 . In the left navigation panel, click *Integrations*. 
 . In the list of integrations, on the right of the entry for the
 integration that you want to start, click  
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab].
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab].
 . Select *Start*. 
 
 .Result

--- a/doc/modules/integrating-applications/p_stopping-integrations.adoc
+++ b/doc/modules/integrating-applications/p_stopping-integrations.adoc
@@ -17,7 +17,7 @@ The integration that you want to stop is in the *Running* state.
 . In the list of integrations, identify the entry for the integration that you
 want to stop running. The entry shows that this integration is *Running*.
 . On the far right of this integration's entry, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab]
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab]
 and select *Stop*.
 
 .Result

--- a/doc/modules/integrating-applications/p_updating-integrations.adoc
+++ b/doc/modules/integrating-applications/p_updating-integrations.adoc
@@ -32,7 +32,7 @@ sign that is where you want to add the step.
 Then click the card that represents the step that you want to add.
 
 * To delete a step, in the flow visualization, click
-image:../../images/integrating-applications/TrashIcon.png[title='Delete']
+image:images/integrating-applications/TrashIcon.png[title='Delete']
 on the step that you want to delete.
 
 * To change the configuration of a step, in the flow visualization,

--- a/doc/modules/integrating-applications/p_using-data-mapper-to-process-collections.adoc
+++ b/doc/modules/integrating-applications/p_using-data-mapper-to-process-collections.adoc
@@ -13,7 +13,7 @@ process the collection.
 When a step outputs a collection, the flow visualization 
 displays *Collection* in the details about the step. For example: 
 
-image:../../images/integrating-applications/data-type-collection.png[Data Type: SQL Result (Collection)]
+image:images/integrating-applications/data-type-collection.png[Data Type: SQL Result (Collection)]
 
 Add a data mapper step after the step that provides the collection and 
 before the step that needs the mappings. Exactly where in the flow this 
@@ -21,10 +21,10 @@ data mapper step needs to be depends on the other steps in the flow.
 The following image shows mappings from source collection fields 
 to target collection fields: 
 
-image:../../images/integrating-applications/map-collections.png[mapping collection]
+image:images/integrating-applications/map-collections.png[mapping collection]
 
 In the source and target panels, the data mapper displays 
-image:../../images/integrating-applications/collection-icon.png[this icon] to indicate
+image:images/integrating-applications/collection-icon.png[this icon] to indicate
 a collection. When a source collection or a target 
 collection contain only primitive types, the data mapper does not 
 display collection fields because there is no need to. You can map 

--- a/doc/modules/integrating-applications/p_view-mappings-in-a-step.adoc
+++ b/doc/modules/integrating-applications/p_view-mappings-in-a-step.adoc
@@ -15,7 +15,7 @@ correct mappings are in place.
 
 .Procedure
 . In the upper right, click
-image:../../images/tutorials/grid.png[title="Grid"].
+image:images/tutorials/grid.png[title="Grid"].
 
 . To dismiss the list of mappings and redisplay the source and
-target fields, click image:../../images/tutorials/grid.png[title="Grid"] again.
+target fields, click image:images/tutorials/grid.png[title="Grid"] again.

--- a/doc/modules/integrating-applications/p_viewing-integration-history.adoc
+++ b/doc/modules/integrating-applications/p_viewing-integration-history.adoc
@@ -17,11 +17,11 @@ click *View*.
 .Result 
 In the page that appears, the *History* section lists the versions
 of the integration. The
-image:../../images/tutorials/GreenCircleCheckmark.png[Current Version] icon
+image:images/tutorials/GreenCircleCheckmark.png[Current Version] icon
 identifies the current version, which is the most recently,
 successfully running version.
 For each version, you can also see the date on which it was last started.
 
 To edit, start, or stop a particular version, click the
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Kebab] to the right of the
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab] to the right of the
 version's entry. Select the operation that you want to perform.

--- a/doc/modules/integrating-applications/r_find-data-field-you-want-to-map.adoc
+++ b/doc/modules/integrating-applications/r_find-data-field-you-want-to-map.adoc
@@ -23,7 +23,7 @@ want to map, you can do any of the following:
 +
 The *Sources* panel and the *Target* panel each have
 a search field at the top. If the search field is not visible, click
-image:../../images/tutorials/magnifying-glass.png[Magnifying Glass] at the top
+image:images/tutorials/magnifying-glass.png[Magnifying Glass] at the top
 right of the *Sources* or *Target* panel.
 
 * Enter the names of the fields that you want to map. 

--- a/doc/modules/integrating-applications/r_how-to-specify-request.adoc
+++ b/doc/modules/integrating-applications/r_how-to-specify-request.adoc
@@ -12,13 +12,13 @@ The following examples show how to specify HTTP requests for the
 Consider an integration that starts with a Webhook connection and then
 creates a row in the *Todo* table of the {prodname}-provided database:
 
-image:../../images/integrating-applications/WebhookToDB.png[Webhook-Data Mapper-DB integration]
+image:images/integrating-applications/WebhookToDB.png[Webhook-Data Mapper-DB integration]
 
 During creation of this integration, when you add the Webhook start
 connection, you specify its output data type with a JSON instance that
 has this content: `{"todo":"text"}`:
 
-image:../../images/integrating-applications/SpecifyDataShape.png[Specify Data Shape Image]
+image:images/integrating-applications/SpecifyDataShape.png[Specify Data Shape Image]
 
 When you add the *PostgresDB* connection as the finish connection, you 
 select the *Invoke SQL* action and specify this SQL statement:
@@ -27,12 +27,12 @@ select the *Invoke SQL* action and specify this SQL statement:
 
 After you add the database connection, you add a mapping step: 
 
-image:../../images/integrating-applications/TODOtoTASK.png[Map Todo to Task]
+image:images/integrating-applications/TODOtoTASK.png[Map Todo to Task]
 
 You save and publish the integration. When it is running, you can
 copy the external URL that {prodname} provides: 
 
-image:../../images/integrating-applications/ExternalURL.png[External URL]
+image:images/integrating-applications/ExternalURL.png[External URL]
 
 To understand the parts of the external URL, consider this sample URL: 
  
@@ -100,7 +100,7 @@ Click *Update* and you should see `from webhook` as a new task.
 For this example, consider the same integration as in the previous 
 example: 
 
-image:../../images/integrating-applications/WebhookToDB.png[Webhook-Data Mapper-DB integration]
+image:images/integrating-applications/WebhookToDB.png[Webhook-Data Mapper-DB integration]
 
 But in this example, you define the Webhook connection output
 data type by specifying a JSON schema with this content:
@@ -178,7 +178,7 @@ instance that looks like this:
 
 It is this internal JSON instance that enables the following mapping: 
 
-image:../../images/integrating-applications/TODOtoAddLead.png[Map to Add Lead]
+image:images/integrating-applications/TODOtoAddLead.png[Map to Add Lead]
 
 .Webhook examples with GET
 

--- a/doc/modules/integrating-applications/r_mapping-between-collections-and-non-collections.adoc
+++ b/doc/modules/integrating-applications/r_mapping-between-collections-and-non-collections.adoc
@@ -6,14 +6,14 @@
 
 In the data mapper *Source* and *Target* panels: 
 
-* image:../../images/integrating-applications/collection-icon.png[Collection icon]
+* image:images/integrating-applications/collection-icon.png[Collection icon]
 indicates a collection. If the collection contains one primitive type, 
 you can map directly from or to that collection. If the collection 
 contains two or more different types, the data mapper 
 displays the collection’s child fields and you can map to or from the 
 collection’s fields.  
 
-* image:../../images/integrating-applications/folder.png[Folder icon] indicates an 
+* image:images/integrating-applications/folder.png[Folder icon] indicates an 
 expandable container that is a complex type. A complex type contains 
 multiple fields of different types. A field in a complex type can be a 
 type that is a collection, such as an array. You cannot map a complex 
@@ -21,7 +21,7 @@ type container itself. You can map only the fields that are in the complex type.
 
 To toggle the display of data types, such as `*(COMPLEX)*`, 
 `*STRING*`, `*INTEGER*`, in the upper right of the data mapper, click 
-image:../../images/tutorials/EditorSettings.png[settings] and click 
+image:images/tutorials/EditorSettings.png[settings] and click 
 *Show Types*. 
 
 The following table shows the default behavior when mapping 

--- a/doc/modules/integrating-applications/r_publishing-integrations.adoc
+++ b/doc/modules/integrating-applications/r_publishing-integrations.adoc
@@ -23,7 +23,7 @@ in the upper right, click *Publish*.
 . In the left {prodname} panel, click *Integrations*.
 . In the list of integrations, 
 to the right of the draft entry, click 
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
+image:images/tutorials/ThreeVerticalDotsKebab.png[Three Vertical Dots] and
 select *Publish*.
 
 .About the publication progress

--- a/doc/modules/integrating-applications/r_requirements-for-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/r_requirements-for-api-provider-integrations.adoc
@@ -28,7 +28,7 @@ Each flow can use any connection or step that
 is available in {prodname}. The REST API along with its flows 
 is one {prodname} API provider integration, which is deployed in one OpenShift pod.
 
-image:../../images/integrating-applications/api-provider.png[API provider integration with 3 flows]
+image:images/integrating-applications/api-provider.png[API provider integration with 3 flows]
 
 .Editing the OpenAPI document while creating an API provider integration
 

--- a/doc/modules/integrating-applications/r_viewing-and-editing-connection-information.adoc
+++ b/doc/modules/integrating-applications/r_viewing-and-editing-connection-information.adoc
@@ -21,12 +21,12 @@ to see its summary page. In the integration's flow diagram:
 connection icon to view that connection's details.
 
 ** For an API provider integration, click view
-image:../../images/integrating-applications/ApiProviderReturnIcon.png[flows icon] to display the integration's 
+image:images/integrating-applications/ApiProviderReturnIcon.png[flows icon] to display the integration's 
 operation list. Click the operation whose flow contains the connection 
 that you want to view details for.
 
 On the *Connection Details* page, for the connection that you want to edit, click
-image:../../images/integrating-applications/PencilForEditing.png[Edit] next to a field to edit that field.
+image:images/integrating-applications/PencilForEditing.png[Edit] next to a field to edit that field.
 Or, for some connections, below the configuration fields, click *Edit* to
 change configuration values. If you change any values, be sure to click
 *Save*.

--- a/doc/modules/integrating-applications/r_workflow-example.adoc
+++ b/doc/modules/integrating-applications/r_workflow-example.adoc
@@ -12,7 +12,7 @@ link:{LinkFuseOnlineTutorials}[sample integration tutorials].
 The following diagram shows the workflow for creating the sample
 Salesforce to Database integration. 
 
-image:../../images/integrating-applications/sample-workflow.png[sample workflow]
+image:images/integrating-applications/sample-workflow.png[sample workflow]
 
 After you publish an integration, the {prodname} dashboard
 displays *Running* next to the integration name when the integration

--- a/doc/modules/tutorials/p_amq2api-add-mapping-step.adoc
+++ b/doc/modules/tutorials/p_amq2api-add-mapping-step.adoc
@@ -28,5 +28,5 @@ the API accesses.
 .Result
 The integration is complete and it is ready to be published. 
 On the left, in the integration visualization panel, you might see a
-image:../..//images/tutorials/WarningIcon.png[warning] Data Type Mismatch 
+image:images/tutorials/WarningIcon.png[warning] Data Type Mismatch 
 warning icon. You can ignore it. 

--- a/doc/modules/tutorials/p_amq2api-name-and-publish.adoc
+++ b/doc/modules/tutorials/p_amq2api-name-and-publish.adoc
@@ -48,7 +48,7 @@ these steps to stop an integration:
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to stop, click
-image:../..//images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Stop*. 
 
@@ -56,6 +56,6 @@ on the far right.
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to start, click
-image:../..//images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Start*. 

--- a/doc/modules/tutorials/p_clean-up.adoc
+++ b/doc/modules/tutorials/p_clean-up.adoc
@@ -17,11 +17,11 @@ delete it so that you can use the resources for another integration.
 . In the main panel, identify the entry for the sample integration that 
 you want to stop.
 . In that entry, to the right, click
-image:../..//images/tutorials/ThreeVerticalDotsKebab.png[Kebab Menu] and then 
+image:images/tutorials/ThreeVerticalDotsKebab.png[Kebab Menu] and then 
 click *Stop*. 
 . Click *Stop* to confirm that you want to stop running the integration.
 
 . In the entry for the integration that you just stopped, to the right, click
-image:../..//images/tutorials//ThreeVerticalDotsKebab.png[Kebab Menu] and then 
+image:images/tutorials//ThreeVerticalDotsKebab.png[Kebab Menu] and then 
 click *Delete*. 
 . Click *Delete* to confirm that you want to delete the integration.

--- a/doc/modules/tutorials/p_register-with-sf.adoc
+++ b/doc/modules/tutorials/p_register-with-sf.adoc
@@ -48,7 +48,7 @@ endif::[]
 .. In the left panel, click *Settings*.
 .. On the *Settings* page, near the top, to the right of the callback URL, 
 click 
-image:../../images/tutorials/CopyCallback.png[Copy Callback URL] to 
+image:images/tutorials/CopyCallback.png[Copy Callback URL] to 
 copy the callback URL for your {prodname} environment to the clipboard. 
 You will need this URL toward the end of this procedure. 
 .. Click the *Salesforce* entry 
@@ -76,7 +76,7 @@ For example:
 .. Select *Configure ID token* and then *Include Standard Claims*.
 .. Scroll down and click *Save*.
 .. Scroll up to see that Salesforce indicates a short wait:
-image:../../images/tutorials/SF-message-to-wait-a-few-minutes.png[title="Short Wait"]
+image:images/tutorials/SF-message-to-wait-a-few-minutes.png[title="Short Wait"]
 .. Click *Continue*.
 .. Copy the consumer key that Salesforce provides.
 . Return to your {prodname} *Settings* page and paste the

--- a/doc/modules/tutorials/p_register-with-twitter.adoc
+++ b/doc/modules/tutorials/p_register-with-twitter.adoc
@@ -33,7 +33,7 @@ endif::[]
 . In {prodname}:
 .. In the left panel, click *Settings*.
 .. On the *Settings* page, near the top, to the right of the callback URL, click 
-image:../../images/tutorials/CopyCallback.png[Copy Callback URL] to 
+image:images/tutorials/CopyCallback.png[Copy Callback URL] to 
 copy the callback URL for your installation of {prodname} to the clipboard. 
 You will need this URL later in this procedure. 
 .. Click the *Twitter* entry 

--- a/doc/modules/tutorials/p_sf2db-name-and-publish.adoc
+++ b/doc/modules/tutorials/p_sf2db-name-and-publish.adoc
@@ -46,7 +46,7 @@ these steps to stop an integration:
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to stop, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Stop*. 
 
@@ -54,6 +54,6 @@ on the far right.
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to start, click
-image:../../images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Publish*. 

--- a/doc/modules/tutorials/p_t2sf-add-mapping-step.adoc
+++ b/doc/modules/tutorials/p_t2sf-add-mapping-step.adoc
@@ -23,7 +23,7 @@ and the *Target* panel on the right displays the Salesforce fields.
 . Map the Twitter `name` field to the Salesforce
 `FirstName` and `LastName` fields:
 .. In the *Sources* panel, click the magnifying
-glass image:../../images/tutorials/magnifying-glass.png[title="Magnifying Glass"]
+glass image:images/tutorials/magnifying-glass.png[title="Magnifying Glass"]
 to display the search field and enter `*name*`.
 .. Under the `user` folder, click the `name` field.
 .. In the *Target* panel, scroll down and click *FirstName*. The
@@ -50,7 +50,7 @@ mapping. Then click the trash can icon in the top right of the data mapper's
 the *screenName* field.
 .. On the right, at the top of the *Target* panel,
 click the magnifying
-glass image:../../images/tutorials/magnifying-glass.png[title="Magnifying Glass"]
+glass image:images/tutorials/magnifying-glass.png[title="Magnifying Glass"]
 to display the search field and enter `*Title*`.
 .. Click the *Title* field. The data mapper displays a line
 from the Twitter *screenName* field to the Salesforce *Title* field.
@@ -64,7 +64,7 @@ from the Twitter *screenName* field to the Salesforce *Title* field.
 .. Click the
 Salesforce *Description* field to create the mapping.
 . In the upper right, click
-the grid icon image:../../images/tutorials/grid.png[title="Grid"] to
+the grid icon image:images/tutorials/grid.png[title="Grid"] to
 display the list of mappings, which should look like this:
-image:../../images/tutorials/t2sf-mappings.png[Data Mappings]
+image:images/tutorials/t2sf-mappings.png[Data Mappings]
 . In the upper right, click *Done*.

--- a/doc/modules/tutorials/p_t2sf-name-and-publish.adoc
+++ b/doc/modules/tutorials/p_t2sf-name-and-publish.adoc
@@ -48,7 +48,7 @@ these steps to stop an integration:
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to stop, click
-image:../..//images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Stop*. 
 
@@ -56,6 +56,6 @@ on the far right.
 
 .. In the left panel, click *Integrations*.
 .. In the entry for the integration that you want to start, click
-image:../..//images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
+image:images/tutorials/ThreeVerticalDotsKebab.png[title="the three vertical dots"]
 on the far right. 
 .. In the popup, click *Start*. 

--- a/doc/tutorials/master.adoc
+++ b/doc/tutorials/master.adoc
@@ -3,7 +3,6 @@ include::attributes.adoc[]
 
 :prodname: Syndesis
 :prodversion: 7.5
-:imagesdir: images
 :prodnameinurl: fuse-ignite
 :productpkg: red_hat_fuse
 :version: 7.5


### PR DESCRIPTION
This is a task that is part of rearranging the doc directory. I ran a script from Fintan that changed the image paths. I removed the imagesdir attribute definition from each master.adoc file. I confirmed that each book builds. 