### PR TITLE
[ENTESB-11593] Forcing the channel to be selected from a list, no free text

### DIFF
--- a/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
+++ b/app/connector/slack/src/main/resources/META-INF/syndesis/connector/slack.json
@@ -70,7 +70,7 @@
                 "labelHint": "The name of the Slack channel to send the message to.",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "select"
               }
             }
           }
@@ -111,7 +111,7 @@
                 "order": "1",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "select"
               },
               "delay": {
                 "defaultValue": 500,


### PR DESCRIPTION
Tested that it works fine and that it can migrate old values of the connector cleanly.