### PR TITLE
fix(ENTESB-11758): Fix form field rendering on metadata lookup

### DIFF
--- a/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
+++ b/app/connector/google-sheets/src/main/resources/META-INF/syndesis/connector/sheets.json
@@ -281,7 +281,7 @@
                 "order": "4",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }
@@ -422,7 +422,7 @@
                 "order": "4",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }
@@ -535,7 +535,7 @@
                 "order": "4",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }
@@ -702,7 +702,7 @@
                 "order": "4",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -193,18 +193,10 @@ public class ConnectionActionHandler {
 
         // Setting enum or dataList as needed by UI widget
         for (final Entry<String, List<DynamicActionMetadata.ActionPropertySuggestion>> suggestions : actionPropertySuggestions.entrySet()) {
-            if (! suggestions.getValue().isEmpty()) {
-
+            if (!suggestions.getValue().isEmpty()) {
                 ConfigurationProperty property= enriched.findProperty(suggestions.getKey());
                 if (property != null) {
-                    if ("select".equalsIgnoreCase(property.getType())) {
-                        enriched.replaceConfigurationProperty(suggestions.getKey(),
-                                builder -> builder.addAllEnum(suggestions.getValue()
-                                                    .stream()
-                                                    .map(ConfigurationProperty.PropertyValue.Builder::from)::iterator));
-                    }
-                    else if ("string".equalsIgnoreCase(property.getType())
-                       || "text".equalsIgnoreCase(property.getType()) ) {
+                    if ("dataList".equalsIgnoreCase(property.getType())) {
                         enriched.replaceConfigurationProperty(suggestions.getKey(),
                                 builder -> {
                                     if (suggestions.getValue().size() == 1) {
@@ -215,9 +207,17 @@ public class ConnectionActionHandler {
                                             .stream()
                                             .map(ConfigurationProperty.PropertyValue.Builder::value)::iterator);
                                 });
-                    } else if (suggestions.getValue().size() == 1) {
-                        //for types 'hidden', 'boolean', 'int', etc.
-                        enriched.replaceConfigurationProperty(suggestions.getKey(), builder -> builder.defaultValue(suggestions.getValue().get(0).value()));
+                    } else {
+                        enriched.replaceConfigurationProperty(suggestions.getKey(),
+                                builder -> {
+                                    if (suggestions.getValue().size() == 1) {
+                                        builder.defaultValue(suggestions.getValue().get(0).value());
+                                    }
+
+                                    builder.addAllEnum(suggestions.getValue()
+                                            .stream()
+                                            .map(ConfigurationProperty.PropertyValue.Builder::from)::iterator);
+                                });
                     }
                 }
             }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -174,7 +174,7 @@ public class ConnectionActionHandlerTest {
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
             .replaceConfigurationProperty("sObjectName",
-                c -> c.addDataList("Contact").defaultValue("Contact"))
+                c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact")).defaultValue("Contact"))
             .replaceConfigurationProperty("sObjectIdName",
                 c -> c.addEnum(ConfigurationProperty.PropertyValue.Builder.of("ID", "Contact ID")))
             .replaceConfigurationProperty("sObjectIdName",
@@ -233,7 +233,9 @@ public class ConnectionActionHandlerTest {
         final ConnectorDescriptor enrichedDefinitioin = new ConnectorDescriptor.Builder()
             .createFrom(createOrUpdateSalesforceObjectDescriptor)
             .replaceConfigurationProperty("sObjectName",
-                c -> c.addDataList("Account", "Contact"))
+                c -> c.addAllEnum(Arrays.asList(
+                        ConfigurationProperty.PropertyValue.Builder.of("Account", "Account"),
+                        ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact"))))
             .inputDataShape(ConnectionActionHandler.ANY_SHAPE)//
             .build();
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/action/DynamicActionSalesforceITCase.java
@@ -97,6 +97,7 @@ public class DynamicActionSalesforceITCase extends BaseITCase {
     private final ConfigurationProperty contactSalesforceObjectName = new ConfigurationProperty.Builder()
         .createFrom(_DEFAULT_SALESFORCE_OBJECT_NAME)
         .addEnum(ConfigurationProperty.PropertyValue.Builder.of("Contact", "Contact"))
+        .defaultValue("Contact")
         .build();
 
     private final ConfigurationProperty suggestedSalesforceIdNames = new ConfigurationProperty.Builder()


### PR DESCRIPTION
Restores old behavior (before data list feature) where we use select dropdown by default. Only use dataList for those fields marked accordingly in the connector json (just used by Google Sheets at the moment).

When only one single value is suggested pick this as default value so it is preselected in dropdowns and dataList components.

Fixes ENTESB-11758