### PR TITLE
feat: support a `—source-gen skip` option in the operator build script.

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -44,6 +44,8 @@ build_operator()
 {
     local strategy="$1"
     shift
+    local source_gen="$1"
+    shift
 
     local hasgo=$(go_is_available)
     local hasdocker=$(docker_is_available)
@@ -74,19 +76,23 @@ build_operator()
         echo ======================================================
         export GO111MODULE=on
 
-        go mod tidy
-        go mod vendor
+        if [ "$source_gen" == "on" ]; then
+        	echo "generating sources"
+	        go mod vendor
 
-        local hassdk=$(operatorsdk_is_available)
-        if [ "$hassdk" == "OK" ]; then
-            operator-sdk generate k8s
-            operator-sdk generate openapi
+	        local hassdk=$(operatorsdk_is_available)
+	        if [ "$hassdk" == "OK" ]; then
+	            operator-sdk generate k8s
+	            operator-sdk generate openapi
+	        else
+	            # display warning message and move on
+	            printf "$hassdk\n\n"
+	        fi
+	        go generate ./pkg/...
+    	    go mod tidy
         else
-            # display warning message and move on
-            printf "$hassdk\n\n"
+        	echo "skipping source generation"
         fi
-
-        go generate ./pkg/...
 
         echo building executable
         go test -test.short -mod=vendor ./cmd/... ./pkg/...

--- a/install/operator/build.sh
+++ b/install/operator/build.sh
@@ -13,10 +13,11 @@ source "$(pwd)/../../tools/bin/commands/util/openshift_funcs"
 source "./.lib.sh"
 
 OPERATOR_IMAGE_NAME="$(readopt --image-name         docker.io/syndesis/syndesis-operator)"
-OPERATOR_IMAGE_TAG="$(readopt --image-tag           latest)"
+OPERATOR_IMAGE_TAG="$(readopt  --image-tag          latest)"
 S2I_STREAM_NAME="$(readopt     --s2i-stream-name    syndesis-operator)"
 OPERATOR_BUILD_MODE="$(readopt --operator-build     auto)"
 IMAGE_BUILD_MODE="$(readopt    --image-build        auto)"
+SOURCE_GEN="$(readopt          --source-gen         on)"
 GO_BUILD_OPTIONS="$(readopt    --go-options         '')"
 
 if [[ -n "$(readopt --help)" ]] ; then
@@ -26,6 +27,7 @@ usage: ./build.sh [options]
 
 where options are:
   --help                                  display this help messages
+  --source-gen <on|skip>                  should the source generators be run (default: on)
   --operator-build <auto|docker|go|skip>  how to build the operator executable (default: auto)
   --image-build <auto|docker|s2i|skip>    how to build the image (default: auto)
   --image-name <name>                     docker image name (default: syndesis/syndesis-operator)
@@ -38,7 +40,7 @@ ENDHELP
 fi
 
 if [ $OPERATOR_BUILD_MODE != "skip" ] ; then
-  build_operator $OPERATOR_BUILD_MODE -ldflags "-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorImage=$OPERATOR_IMAGE_NAME -X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorTag=$OPERATOR_IMAGE_TAG" $GO_BUILD_OPTIONS
+  build_operator $OPERATOR_BUILD_MODE "$SOURCE_GEN" -ldflags "-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorImage=$OPERATOR_IMAGE_NAME -X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorTag=$OPERATOR_IMAGE_TAG" $GO_BUILD_OPTIONS
 fi
 
 if [ $IMAGE_BUILD_MODE != "skip" ] ; then

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -185,9 +185,9 @@ do_operator() {
 
     pushd "$top_dir/install/operator" > /dev/null
     if [ $(hasflag -i --image --docker) ]; then
-        ./build.sh --image-build=docker --image-name="${OPERATOR_IMAGE}" --image-tag="$tag"
+        ./build.sh --source-gen skip --image-build=docker --image-name="${OPERATOR_IMAGE}" --image-tag="$tag"
     else
-        ./build.sh --image-build=s2i
+        ./build.sh --source-gen skip --image-build=s2i
     fi
     popd >/dev/null
 }


### PR DESCRIPTION
This allows you to build the operator offline.