### PR TITLE
WIP Allow specifying CR for standalone install

### DIFF
--- a/install/operator/pkg/cmd/internal/install/install.go
+++ b/install/operator/pkg/cmd/internal/install/install.go
@@ -42,6 +42,7 @@ type Install struct {
 	image      string
 	tag        string
 	addons     string
+    customResource string
 	devSupport bool
 
 	// processing state
@@ -112,6 +113,7 @@ func New(parent *internal.Options) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&o.tag, "tag", "", pkg.DefaultOperatorTag, "sets operator tag that gets installed")
 	cmd.PersistentFlags().BoolVarP(&o.wait, "wait", "w", false, "waits for the application to be running")
 	cmd.PersistentFlags().BoolVarP(&o.devSupport, "dev", "", false, "enable development mode by loading images from image stream tags.")
+	cmd.PersistentFlags().StringVarP(&o.customResource, "custom-resource", "", "", "path to a custom resource to use when deploying")
 	cmd.PersistentFlags().AddFlagSet(util.FlagSet)
 	return &cmd
 }

--- a/install/operator/pkg/cmd/internal/install/install_standalone.go
+++ b/install/operator/pkg/cmd/internal/install/install_standalone.go
@@ -72,16 +72,33 @@ func (o *Install) installStandalone() error {
 		return err
 	}
 
-	syndesis := &v1alpha1.Syndesis{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: o.Namespace,
-		},
-		Spec: v1alpha1.SyndesisSpec{
-			DevSupport: o.devSupport,
-			Addons:     v1alpha1.AddonsSpec{},
-		},
-	}
+    // create custom resource
+	syndesis := &v1alpha1.Syndesis{ }
+
+    if(o.customResource == "") {
+        syndesis = &v1alpha1.Syndesis{
+            ObjectMeta: metav1.ObjectMeta{
+                Namespace: o.Namespace,
+            },
+            Spec: v1alpha1.SyndesisSpec{
+                DevSupport: o.devSupport,
+                Addons:     v1alpha1.AddonsSpec{},
+            },
+        }
+    } else {
+        customResource, err := util.LoadJsonFromFile(o.customResource)
+        if err != nil {
+            return err
+        }
+
+        err = json.Unmarshal(customResource, syndesis)
+        if err != nil {
+            return err
+        }
+    }
+
 	gen.Syndesis = syndesis
+    // end CR
 
 	addons := make([]string, 0)
 	if o.addons != "" {


### PR DESCRIPTION
Add loading configuration from Custom Resource file when installing using `operator install standalone`. 

@lgarciaaco let me know if this is the right direction and I can polish it a bit and rebase on master as well. 

Verified locally that I can now deploy productized builds into openshift without cluster admin with this change.