### PR TITLE
ENTESB-11789 Resolves issue with create virtualization

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -35,6 +35,7 @@ export const useVirtualizationHelpers = () => {
     const newVirtualization = {
       keng__id: `${virtName}`,
       tko__description: virtDesc ? `${virtDesc}` : '',
+      usedBy: [] as string[]
     } as RestDataService;
 
     const response = await callFetch({


### PR DESCRIPTION
Resolves issue with creating a virtualization.  The usedBy attribute must be initialized on create - it is expected to be present when the virtualization views page is initialized.