### PR TITLE
chore(ui): description for the Specify Security

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
@@ -1,6 +1,7 @@
 import { Card, CardBody, CardFooter, CardHeader, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import {
+  Alert,
   ControlLabel,
   FormControl,
   FormGroup,
@@ -49,6 +50,7 @@ export interface IApiClientConnectorCreateSecurityProps {
    */
   i18nNoSecurity: string;
   i18nTitle: string;
+  i18nDescription: string;
 
   /**
    * The action fired when the user presses the Next button
@@ -114,6 +116,9 @@ export class ApiClientConnectorCreateSecurity extends React.Component<
           <Title size="2xl">{this.props.i18nTitle}</Title>
         </CardHeader>
         <CardBody>
+          <Alert type={'info'}>
+            <span>{this.props.i18nDescription}</span>
+          </Alert>
           <FormGroup controlId={'authenticationType'} disabled={false}>
             {this.props.authenticationTypes!.map(
               (authType: IAuthenticationTypes, idx) => {

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
@@ -59,8 +59,9 @@
     },
     "security": {
       "accessTokenUrl": "Access Token URL",
-      "authorizationUrl": "Authorization URL",
       "authTypeLabel": "Authentication Type",
+      "authorizationUrl": "Authorization URL",
+      "description": "$t(shared:project.name) reads the OpenAPI definition to determine the information needed to configure the connector to meet the API’s security requirements. Connections created from this connector always use the authentication type that you select here.",
       "noSecurity": "No Security",
       "required": "All fields are required.",
       "title": "Specify Security"

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
@@ -98,6 +98,7 @@ export const SecurityPage: React.FunctionComponent = () => {
                         'apiClientConnectors:create:security:noSecurity'
                       )}
                       i18nTitle={t('apiClientConnectors:create:security:title')}
+                      i18nDescription={t('apiClientConnectors:create:security:description')}
                       onNext={onNext}
                     />
                   </PageSection>


### PR DESCRIPTION
This adds an info `Alert` on the `Specify Security` page of the API Client Connectors wizard page.

![Screenshot_2019-10-01 Specify Security - Syndesis](https://user-images.githubusercontent.com/1306050/65973733-1c112f80-e46c-11e9-99e2-1edcb65843ca.png)

Ref [ENTESB-11474](https://issues.jboss.org/browse/ENTESB-11474)