### PR TITLE
fix(cards): update static use of pf3 cards to pf4 react components

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import { Alert } from 'patternfly-react';
 import * as React from 'react';
@@ -51,13 +51,13 @@ export class ConnectorConfigurationForm extends React.Component<
     return (
       <Container>
         <div className="row row-cards-pf">
-          <div className="card-pf">
-            <div className="card-pf-heading">
+          <Card>
+            <CardHeader>
               {this.props.i18nFormTitle && (
-                <div className="card-pf-title">{this.props.i18nFormTitle}</div>
+                <Title headingLevel="h2" size="lg">{this.props.i18nFormTitle}</Title>
               )}
-            </div>
-            <div className="card-pf-body">
+            </CardHeader>
+            <CardBody>
               {this.props.validationResults!.map((e, idx) => (
                 <Alert key={idx} type={e.type}>
                   {e.message}
@@ -74,8 +74,8 @@ export class ConnectorConfigurationForm extends React.Component<
               >
                 {this.props.children}
               </Form>
-            </div>
-            <div className="card-pf-footer">
+            </CardBody>
+            <CardFooter>
               <ButtonLink
                 data-testid={'connection-creator-layout-back-button'}
                 href={this.props.backHref}
@@ -126,8 +126,8 @@ export class ConnectorConfigurationForm extends React.Component<
                   </>
                 )}
               </ButtonLink>
-            </div>
-          </div>
+            </CardFooter>
+          </Card>
         </div>
       </Container>
     );

--- a/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
@@ -52,9 +52,9 @@ export class ConnectorConfigurationForm extends React.Component<
       <Container>
         <div className="row row-cards-pf">
           <Card>
-            <CardHeader>
+            <CardHeader className="syn-card__header--border">
               {this.props.i18nFormTitle && (
-                <Title headingLevel="h2" size="lg">{this.props.i18nFormTitle}</Title>
+                <Title className="syn-card__title" headingLevel="h2" size="md">{this.props.i18nFormTitle}</Title>
               )}
             </CardHeader>
             <CardBody>
@@ -75,7 +75,7 @@ export class ConnectorConfigurationForm extends React.Component<
                 {this.props.children}
               </Form>
             </CardBody>
-            <CardFooter>
+            <CardFooter className="syn-card__footer">
               <ButtonLink
                 data-testid={'connection-creator-layout-back-button'}
                 href={this.props.backHref}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActionSelectorCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActionSelectorCard.tsx
@@ -13,7 +13,7 @@ export const IntegrationActionSelectorCard: React.FunctionComponent<
 > = ({ content, title }) => (
   <Card>
     <CardHeader>
-      <Title headingLevel="h2" size="lg">{title}</Title>
+      <Title className="syn-card__title" headingLevel="h2" size="md">{title}</Title>
     </CardHeader>
     <CardBody>{content}</CardBody>
   </Card>

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActionSelectorCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActionSelectorCard.tsx
@@ -1,5 +1,6 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IIntegrationActionSelectorCardProps {
@@ -10,8 +11,10 @@ export interface IIntegrationActionSelectorCardProps {
 export const IntegrationActionSelectorCard: React.FunctionComponent<
   IIntegrationActionSelectorCardProps
 > = ({ content, title }) => (
-  <div className="card-pf">
-    <div className="card-pf-title">{title}</div>
-    <div className="card-pf-body">{content}</div>
-  </div>
+  <Card>
+    <CardHeader>
+      <Title headingLevel="h2" size="lg">{title}</Title>
+    </CardHeader>
+    <CardBody>{content}</CardBody>
+  </Card>
 );

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -42,7 +42,7 @@ export class IntegrationEditorForm extends React.Component<
             <Card>
               {this.props.i18nFormTitle && (
                 <CardHeader>
-                  <Title headingLevel="h2" size="lg">{this.props.i18nFormTitle}</Title>
+                  <Title className="syn-card__title" headingLevel="h2" size="md">{this.props.i18nFormTitle}</Title>
                 </CardHeader>
               )}
               {this.props.error ? (
@@ -57,7 +57,7 @@ export class IntegrationEditorForm extends React.Component<
                   </Form>
                 </Container>
               </CardBody>
-              <CardFooter>
+              <CardFooter className="syn-card__footer">
                 {this.props.backActionHref && (
                   <>
                     <ButtonLink

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Form, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import { Alert } from 'patternfly-react';
 import * as React from 'react';

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@patternfly/react-core';
+import { Card, CardHeader, CardBody, CardFooter, Form, Title } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import { Alert } from 'patternfly-react';
 import * as React from 'react';
@@ -39,23 +39,25 @@ export class IntegrationEditorForm extends React.Component<
       <PageSection>
         <Container>
           <div className="row row-cards-pf">
-            <div className="card-pf">
+            <Card>
               {this.props.i18nFormTitle && (
-                <div className="card-pf-title">{this.props.i18nFormTitle}</div>
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">{this.props.i18nFormTitle}</Title>
+                </CardHeader>
               )}
               {this.props.error ? (
                 <Alert type={'warning'}>
                   <span>{this.props.error}</span>
                 </Alert>
               ) : null}
-              <div className="card-pf-body">
+              <CardBody>
                 <Container>
                   <Form isHorizontal={true} onSubmit={this.props.handleSubmit}>
                     {this.props.children}
                   </Form>
                 </Container>
-              </div>
-              <div className="card-pf-footer">
+              </CardBody>
+              <CardFooter>
                 {this.props.backActionHref && (
                   <>
                     <ButtonLink
@@ -82,8 +84,8 @@ export class IntegrationEditorForm extends React.Component<
                     </>
                   ) : null}
                 </ButtonLink>
-              </div>
-            </div>
+              </CardFooter>
+            </Card>
           </div>
         </Container>
       </PageSection>

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
@@ -35,7 +35,7 @@ export class IntegrationEditorNothingToConfigure extends React.Component<
                   </Text>
                 </Container>
               </CardBody>
-              <CardFooter>
+              <CardFooter className="syn-card__footer">
                 <ButtonLink
                   data-testid={
                     'integration-editor-nothing-to-configure-back-button'

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, Text } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../Layout';
@@ -26,16 +26,16 @@ export class IntegrationEditorNothingToConfigure extends React.Component<
       <PageSection>
         <Container>
           <div className="row row-cards-pf">
-            <div className="card-pf">
-              <div className="card-pf-body">
+            <Card>
+              <CardBody>
                 <Container>
                   <Text className="alert alert-info">
                     <span className="pficon pficon-info" />
                     {this.props.i18nAlert}
                   </Text>
                 </Container>
-              </div>
-              <div className="card-pf-footer">
+              </CardBody>
+              <CardFooter>
                 <ButtonLink
                   data-testid={
                     'integration-editor-nothing-to-configure-back-button'
@@ -55,8 +55,8 @@ export class IntegrationEditorNothingToConfigure extends React.Component<
                 >
                   {this.props.i18nNext}
                 </ButtonLink>
-              </div>
-            </div>
+              </CardFooter>
+            </Card>
           </div>
         </Container>
       </PageSection>

--- a/app/ui-react/packages/ui/src/Integration/Editor/apiProvider/ApiProviderSetInfo.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/apiProvider/ApiProviderSetInfo.tsx
@@ -1,3 +1,4 @@
+import { Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
 import { Container } from '../../../Layout';
 
@@ -21,9 +22,9 @@ export class ApiProviderSetInfo extends React.Component<
           onSubmit={this.props.handleSubmit}
         >
           <div className="row row-cards-pf">
-            <div className="card-pf">
-              <div className="card-pf-body">{this.props.children}</div>
-            </div>
+            <Card>
+              <CardBody>{this.props.children}</CardBody>
+            </Card>
           </div>
         </form>
       </Container>

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceCardHeader.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceCardHeader.tsx
@@ -7,4 +7,4 @@ export interface IChoiceCardHeaderProps {
 
 export const ChoiceCardHeader: React.FunctionComponent<
   IChoiceCardHeaderProps
-> = ({ i18nConditions }) => <Title headingLevel="h2" size="lg">{i18nConditions}</Title>;
+> = ({ i18nConditions }) => <Title className="syn-card__title" headingLevel="h2" size="md">{i18nConditions}</Title>;

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceCardHeader.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoiceCardHeader.tsx
@@ -1,3 +1,4 @@
+import { Title } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IChoiceCardHeaderProps {
@@ -6,4 +7,4 @@ export interface IChoiceCardHeaderProps {
 
 export const ChoiceCardHeader: React.FunctionComponent<
   IChoiceCardHeaderProps
-> = ({ i18nConditions }) => <h2 className="card-pf-title">{i18nConditions}</h2>;
+> = ({ i18nConditions }) => <Title headingLevel="h2" size="lg">{i18nConditions}</Title>;

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Form } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../../Layout';

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@patternfly/react-core';
+import { Card, CardHeader, CardBody, CardFooter, Form } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../../Layout';
@@ -21,16 +21,16 @@ export class ChoicePageCard extends React.Component<IChoicePageCardProps> {
       <PageSection>
         <Container>
           <div className="row row-cards-pf">
-            <div className="card-pf">
+            <Card>
               {this.props.header && (
-                <div className="card-pf-header">{this.props.header}</div>
+                <CardHeader>{this.props.header}</CardHeader>
               )}
-              <div className="card-pf-body">
+              <CardBody>
                 <Container>
                   <Form className={'conditional-flow__form'} isHorizontal={true}>{this.props.children}</Form>
                 </Container>
-              </div>
-              <div className="card-pf-footer">
+              </CardBody>
+              <CardFooter>
                 {this.props.backHref && (
                   <>
                     <ButtonLink
@@ -52,8 +52,8 @@ export class ChoicePageCard extends React.Component<IChoicePageCardProps> {
                 >
                   {this.props.i18nDone}
                 </ButtonLink>
-              </div>
-            </div>
+              </CardFooter>
+            </Card>
           </div>
         </Container>
       </PageSection>

--- a/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/choice/ChoicePageCard.tsx
@@ -30,7 +30,7 @@ export class ChoicePageCard extends React.Component<IChoicePageCardProps> {
                   <Form className={'conditional-flow__form'} isHorizontal={true}>{this.props.children}</Form>
                 </Container>
               </CardBody>
-              <CardFooter>
+              <CardFooter className="syn-card__footer">
                 {this.props.backHref && (
                   <>
                     <ButtonLink

--- a/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as H from '@syndesis/history';
 import { ControlLabel, FormControl, FormGroup } from 'patternfly-react';
@@ -63,8 +63,8 @@ export class DescribeDataShapeForm extends React.Component<
       <PageSection>
         <Container>
           <div className="row row-cards-pf">
-            <div className="card-pf">
-              <div className="card-pf-body">
+            <Card>
+              <CardBody>
                 <form>
                   <FormGroup>
                     <ControlLabel>{this.props.i18nSelectType}</ControlLabel>
@@ -160,8 +160,8 @@ export class DescribeDataShapeForm extends React.Component<
                     </>
                   )}
                 </form>
-              </div>
-              <div className="card-pf-footer">
+              </CardBody>
+              <CardFooter>
                 {this.props.backActionHref && (
                   <>
                     <ButtonLink
@@ -181,8 +181,8 @@ export class DescribeDataShapeForm extends React.Component<
                 >
                   {this.props.i18nNext}
                 </ButtonLink>
-              </div>
-            </div>
+              </CardFooter>
+            </Card>
           </div>
         </Container>
       </PageSection>

--- a/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
@@ -161,7 +161,7 @@ export class DescribeDataShapeForm extends React.Component<
                   )}
                 </form>
               </CardBody>
-              <CardFooter>
+              <CardFooter className="syn-card__footer">
                 {this.props.backActionHref && (
                   <>
                     <ButtonLink

--- a/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
@@ -24,7 +24,7 @@ export class EditorPageCard extends React.Component<IEditorPageCardProps> {
                   <Form isHorizontal={true}>{this.props.children}</Form>
                 </Container>
               </CardBody>
-              <CardFooter>
+              <CardFooter className="syn-card__footer">
                 <ButtonLink
                   data-testid={'editor-page-card-done-button'}
                   onClick={this.props.submitForm}

--- a/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardHeader, CardBody, CardFooter, Form } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../../Layout';
 

--- a/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/shared/EditorPageCard.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@patternfly/react-core';
+import { Card, CardHeader, CardBody, CardFooter, Form } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../../Layout';
 
@@ -15,16 +15,16 @@ export class EditorPageCard extends React.Component<IEditorPageCardProps> {
       <PageSection>
         <Container>
           <div className="row row-cards-pf">
-            <div className="card-pf">
+            <Card>
               {this.props.header && (
-                <div className="card-pf-header">{this.props.header}</div>
+                <CardHeader>{this.props.header}</CardHeader>
               )}
-              <div className="card-pf-body">
+              <CardBody>
                 <Container>
                   <Form isHorizontal={true}>{this.props.children}</Form>
                 </Container>
-              </div>
-              <div className="card-pf-footer">
+              </CardBody>
+              <CardFooter>
                 <ButtonLink
                   data-testid={'editor-page-card-done-button'}
                   onClick={this.props.submitForm}
@@ -33,8 +33,8 @@ export class EditorPageCard extends React.Component<IEditorPageCardProps> {
                 >
                   {this.props.i18nDone}
                 </ButtonLink>
-              </div>
-            </div>
+              </CardFooter>
+            </Card>
           </div>
         </Container>
       </PageSection>

--- a/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
@@ -1,4 +1,4 @@
-import { Form } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardHeader, Form, Title } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, Loader, PageSection } from '../Layout';
 
@@ -48,24 +48,26 @@ export const IntegrationSaveForm: React.FunctionComponent<
   return (
     <PageSection>
       <div className="row row-cards-pf">
-        <div className="card-pf"
+        <Card
              style={{
                margin: 'auto',
                maxWidth: 600,
              }}
         >
           {i18nFormTitle && (
-            <div className="card-pf-title">{i18nFormTitle}</div>
+            <CardHeader>
+              <Title headingLevel="h2" size="lg">{i18nFormTitle}</Title>
+            </CardHeader>
           )}
-          <div className="card-pf-body">
+          <CardBody>
             <Form
               isHorizontal={true}
               onSubmit={handleSubmit}
             >
               {children}
             </Form>
-          </div>
-          <div className="card-pf-footer">
+          </CardBody>
+          <CardFooter>
             <ButtonLink
               id={'integration-editor-save-button'}
               onClick={onSave}
@@ -83,8 +85,8 @@ export const IntegrationSaveForm: React.FunctionComponent<
             >
               {i18nSaveAndPublish}
             </ButtonLink>
-          </div>
-        </div>
+          </CardFooter>
+        </Card>
       </div>
     </PageSection>
   );

--- a/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
@@ -56,7 +56,7 @@ export const IntegrationSaveForm: React.FunctionComponent<
         >
           {i18nFormTitle && (
             <CardHeader>
-              <Title headingLevel="h2" size="lg">{i18nFormTitle}</Title>
+              <Title className="syn-card__title" headingLevel="h2" size="md">{i18nFormTitle}</Title>
             </CardHeader>
           )}
           <CardBody>
@@ -67,7 +67,7 @@ export const IntegrationSaveForm: React.FunctionComponent<
               {children}
             </Form>
           </CardBody>
-          <CardFooter>
+          <CardFooter className="syn-card__footer">
             <ButtonLink
               id={'integration-editor-save-button'}
               onClick={onSave}

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -195,3 +195,20 @@ body {
   white-space: normal;
   word-break: break-word;
 }
+
+.syn-card__title.pf-c-title.pf-m-md {
+  font-size: 16px;
+}
+
+.syn-card__header--border.pf-c-card__header {
+  --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-c-card--first-child--PaddingTop);
+  border-bottom: 1px solid #d1d1d1;
+  margin-bottom: var(--pf-c-card__header--not-last-child--PaddingBottom);
+}
+
+.syn-card__footer.pf-c-card__footer {
+  padding-top: var(--pf-global--spacer--lg);
+  padding-bottom: var(--pf-global--spacer--md);
+  background-color: #fafafa;
+  border-top: 1px solid #d1d1d1;
+}


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis/issues/6240

@amysueg @dongniwang 

Here is a sample card using the PF3 card component

<img width="1470" alt="Screen Shot 2019-10-01 at 5 31 40 PM" src="https://user-images.githubusercontent.com/35148959/66005549-7660bf00-e471-11e9-87ae-31539a93cfcb.png">

Here is that card updated to a PF4 card with no additional modifications to the card. Note that the PF4 card doesn't have a border below the title or a border/background color on the footer

<img width="1470" alt="Screen Shot 2019-10-01 at 5 31 08 PM" src="https://user-images.githubusercontent.com/35148959/66005575-8a0c2580-e471-11e9-9c33-02931bf9b5d1.png">

Here is the PF4 card with additional styles to mimic the PF3 card

<img width="1470" alt="Screen Shot 2019-10-01 at 5 30 34 PM" src="https://user-images.githubusercontent.com/35148959/66005626-aad47b00-e471-11e9-9c2f-dd774f00014c.png">

What do you think? I've included the last variation (PF4 cards updated to look like PF3) in this PR, but the additional styling on top of the base PF4 card component is an additional commit, so it's easy to revert if we just want to use the card styles provided by PF4.

---

Also for testing, I don't know how to find/test all of these locations in the application, but here is a list of the component that was updated to use the PF4 card, and all of the pages in the app I saw that component code used.

#### ConnectorConfigurationForm
* syndesis/src//modules/connections/components/WithConnectorForm.tsx
* syndesis/src//modules/connections/pages/create/ReviewPage.tsx
* syndesis/src//modules/connections/pages/create/ConfigurationPage.tsx

#### ViewConfigurationForm
* syndesis/src//modules/data/pages/viewCreate/SelectNamePage.tsx

#### IntegrationActionSelectorCard
* ?? - don't see it used in ui-react/syndesis/src or ui-react/packages/ui

#### IntegrationEditorForm
* syndesis/src//modules/integrations/components/editor/step/WithConfigurationForm.tsx
* syndesis/src//modules/integrations/components/editor/endpoint/ConfigurationForm.tsx

#### IntegrationEditorNothingToConfigure
* syndesis/src//modules/integrations/components/editor/endpoint/NothingToConfigure.tsx

#### ApiProviderSetInfo
* ?? - don't see it used in ui-react/syndesis/src or ui-react/packages/ui

#### ChoiceCardHeader
* syndesis/src//modules/integrations/components/editor/choice/ChoiceStepPage.tsx

#### ChoicePageCard
* syndesis/src//modules/integrations/components/editor/choice/ChoiceStepPage.tsx

#### DescribeDataShapeForm
* syndesis/src//modules/integrations/components/editor/shape/WithDescribeDataShapeForm.tsx
* syndesis/src//modules/integrations/components/editor/choice/DescribeChoiceDataShapePage.tsx
* syndesis/src//modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx

#### EditorPageCard
* syndesis/src//modules/integrations/components/editor/ruleFilter/RuleFilterStepPage.tsx
* syndesis/src//modules/integrations/components/editor/template/TemplateStepPage.tsx

#### IntegrationSaveForm
* syndesis/src//modules/integrations/components/editor/SaveIntegrationPage.tsx