### PR TITLE
Release syndesis binaries for real

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,7 +849,7 @@ jobs:
               fi
             done
             cd ${BASEDIR}
-            ghr -u ${GITHUB_USER} -t ${GITHUB_TOKEN} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease -draft ${VERSION} "${BASEDIR}/archives"
+            ghr -u ${GITHUB_USER} -t ${GITHUB_TOKEN} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} "${BASEDIR}/archives"
 workflows:
   version: 2
   release:


### PR DESCRIPTION
The [release section](https://github.com/syndesisio/syndesis/releases) has a zipped content of the github repo, which doesn't add much value. I want to start releasing the syndesis binaries instead of what it is released right now.

@zregvart suggested that currently this is set up in the github project. I didn't find how to disable this, but my access is restricted (I don't see the settings tab).

My long term goal is to use those binaries to replace the installation methods in `tools/bin/commands/minishift`, in [quickstart](http://syndesis.io/quickstart/) point users to the binaries.