### PR TITLE
Preview results in view editor are not horizontally scrollable

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/ExpandablePreview.tsx
@@ -91,7 +91,11 @@ export const ExpandablePreview: React.FunctionComponent<
   };
 
   return (
-    <PageSection className={'expandable-preview__section'} isFilled={expanded} variant="light">
+    <PageSection
+      className={'expandable-preview__section'}
+      isFilled={expanded}
+      variant="light"
+    >
       <Expandable
         toggleText={expanded ? i18nHidePreview : i18nShowPreview}
         onToggle={toggleExpanded}
@@ -114,7 +118,7 @@ export const ExpandablePreview: React.FunctionComponent<
             </Button>
           </SplitItem>
         </Split>
-        <Stack>
+        <Stack gutter={'sm'}>
           {queryResultRows.length > 0 && (
             <StackItem isFilled={false}>
               <TextContent>

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/PreviewResults.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/PreviewResults.tsx
@@ -42,16 +42,20 @@ export interface IColumn {
 
 const defaultCellFormat = (value: any) => {
   // strings over 20 chars - shorten and use tooltip
-  if (typeof value === "string" && value.length > 20) {
-    const displayedString = `${value.substring(0,15)}...${value.substring(value.length-5)}`;
-    return <OverlayTrigger
-      overlay={<Tooltip id="queryResultsCellTip">{value}</Tooltip>}
-      placement="top"
-    >
-      <Table.Heading>{displayedString}</Table.Heading>
-    </OverlayTrigger>;
+  if (typeof value === 'string' && value.length > 20) {
+    const displayedString = `${value.substring(0, 15)}...${value.substring(
+      value.length - 5
+    )}`;
+    return (
+      <OverlayTrigger
+        overlay={<Tooltip id="queryResultsCellTip">{value}</Tooltip>}
+        placement="top"
+      >
+        <Table.Heading>{displayedString}</Table.Heading>
+      </OverlayTrigger>
+    );
   }
-  return <Table.Heading>{value}</Table.Heading>
+  return <Table.Heading>{value}</Table.Heading>;
 };
 const defaultHeaderFormat = (value: any) => <Table.Cell>{value}</Table.Cell>;
 
@@ -71,7 +75,7 @@ export const PreviewResults: React.FunctionComponent<
       ) : (
         <>
           {props.queryResultCols.length > 0 ? (
-            <div className="generic-table_content">
+            <div style={{ overflowX: 'auto' }}>
               <GenericTable
                 columns={props.queryResultCols.map(col => ({
                   cell: {

--- a/app/ui-react/packages/ui/stories/Data/ViewEditor/PreviewResults.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/ViewEditor/PreviewResults.stories.tsx
@@ -1,6 +1,6 @@
+import { PageSection } from '@patternfly/react-core';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { PreviewResults } from '../../../src';
 
 const stories = storiesOf('Data/ViewEditor/PreviewResults', module);
@@ -13,37 +13,95 @@ const resultCols = [
   { id: 'FirstName', label: 'First Name' },
   { id: 'LastName', label: 'Last Name' },
   { id: 'Country', label: 'Country' },
+  { id: 'Address', label: 'Address' },
 ];
 
 const resultRows = [
-  { FirstName: 'Jean', LastName: 'Frissilla', Country: 'Italy' },
-  { FirstName: 'John', LastName: 'Johnson', Country: 'US' },
-  { FirstName: 'Juan', LastName: 'Bautista', Country: 'Brazil' },
-  { FirstName: 'Jordan', LastName: 'Dristol', Country: 'Ontario' },
-  { FirstName: 'Jenny', LastName: 'Clayton', Country: 'US' },
-  { FirstName: 'Jorge', LastName: 'Rivera', Country: 'Mexico' },
-  { FirstName: 'Jake', LastName: 'Klein', Country: 'US' },
-  { FirstName: 'Julia', LastName: 'Zhang', Country: 'China' },
+  {
+    FirstName: 'Jean',
+    LastName: 'Frissilla',
+    Country: 'Italy',
+    Address: '1234 Orange Avenue, Daytona Beach, FL',
+  },
+  {
+    FirstName: 'John',
+    LastName: 'Johnson',
+    Country: 'US',
+    Address: '2345 Browns Boulevard, Cleveland, OH',
+  },
+  {
+    FirstName: 'Juan',
+    LastName: 'Bautista',
+    Country: 'Brazil',
+    Address: '3456 Peach Tree Place, Atlanta, GA',
+  },
+  {
+    FirstName: 'Jordan',
+    LastName: 'Dristol',
+    Country: 'Ontario',
+    Address: '4567 Surfboard Circle, San Diego, CA',
+  },
+  {
+    FirstName: 'Jenny',
+    LastName: 'Clayton',
+    Country: 'US',
+    Address: '5678 Triple Crown Terrace, Louisville, KY',
+  },
+  {
+    FirstName: 'Jorge',
+    LastName: 'Rivera',
+    Country: 'Mexico',
+    Address: '6789 Snakeskin Street, El Paso, TX',
+  },
+  {
+    FirstName: 'Jake',
+    LastName: 'Klein',
+    Country: 'US',
+    Address: '7890 Bolo Tie Terrace, Alamogordo, NM',
+  },
+  {
+    FirstName: 'Julia',
+    LastName: 'Zhang',
+    Country: 'China',
+    Address: '8901 Music City, Nashville, TN',
+  },
 ];
 
 stories.add('No results', () => (
-  <Router>
-    <PreviewResults
-      queryResultRows={[]}
-      queryResultCols={[]}
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-    />
-  </Router>
+  <PreviewResults
+    queryResultRows={[]}
+    queryResultCols={[]}
+    i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+    i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+    i18nLoadingQueryResults={'Loading'}
+    isLoadingPreview={false}
+  />
 ));
 
-stories.add('With results', () => (
-  <Router>
-    <PreviewResults
-      queryResultRows={resultRows}
-      queryResultCols={resultCols}
-      i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
-      i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
-    />
-  </Router>
+stories.add(
+  'With results',
+  () => (
+    <PageSection>
+      <PreviewResults
+        queryResultRows={resultRows}
+        queryResultCols={resultCols}
+        i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+        i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+        i18nLoadingQueryResults={'Loading'}
+        isLoadingPreview={false}
+      />
+    </PageSection>
+  ),
+  { notes: 'Resize window and make sure table can scroll horizontally' }
+);
+
+stories.add('Loading', () => (
+  <PreviewResults
+    queryResultRows={[]}
+    queryResultCols={[]}
+    i18nEmptyResultsTitle={queryResultsTableEmptyStateTitle}
+    i18nEmptyResultsMsg={queryResultsTableEmptyStateInfo}
+    i18nLoadingQueryResults={'Loading'}
+    isLoadingPreview={true}
+  />
 ));


### PR DESCRIPTION
- QE reported this issue while testing the [ENTESB-11672](https://issues.jboss.org/browse/ENTESB-11672) issue
- results table can now be horizontally scrolled when table is wider than the window
- changes to story to allow testing the scrolling