### PR TITLE
change syndesis installation to use the operator binary for crc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ ui-react/*/.rts2_cache*
 
 # package-lock.json
 */ui-react/package-lock.json
+
+# operator binary
+tools/bin/commands/binaries/syndesis

--- a/doc/sdh/cli/cmd_crc.adoc
+++ b/doc/sdh/cli/cmd_crc.adoc
@@ -22,14 +22,12 @@ You can download it directly from https://cloud.redhat.com/openshift/install/crc
                               'crc stop && rm -rf ~/.crc/* && crc start'
     --operator-only           Only install the operator but no resource
                               connected cluster.
-    --memory <mem>            How much memory to use when doing a reset. Default: 4912
-    --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: 2
+    --memory <mem>            How much memory to use when doing a reset. Default: 8192
+    --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: 4
     --pull-secret-file <file> File holding the OCP4 pull secret
     --vm-driver <driver>      Which virtual machine driver to use (depends on OS)
     --bundle <path-to-bundle> Path to system bundle (required when using virtualbox vm-driver)
     --local                   Use the local resource files instead of fetching them from GitHub
--r  --route <route>           Use the given route.
-                              By default "syndesis-<project_name>.apps-crc.testing" is used.
 -o  --open                    Open Syndesis in the browser
 -y  --yes                     Assume 'yes' automatically when asking for deleting
                               a given project.
@@ -61,7 +59,7 @@ The quickest way to get a fresh Syndesis setup is to use `--project` which will 
 However, you can also recreate the whole CodeReady Containers installation with `--reset`. This will delete the CodeReady Containers VM (`crc delete`) and create a new one (`crc start`).
 It doesn't harm if the CodeReady Containers VM does not exist so that you can use `--reset` also on a fresh CodeReady Containers installation.
 
-If you want to get a real clean installation use `--full-reset` which deletes the `~/.crc` directory which holds downloaded artefacts like the ISO image for the CodeReady Containers VM.
+If you want to get a real clean installation use `--full-reset` which deletes the `~/.crc` directory which holds downloaded artifacts like the ISO image for the CodeReady Containers VM.
 Using `--full-reset` forces CodeReady Containers to re-download all those files.
 
 There are several options which influence the re-creation of the VM:
@@ -78,7 +76,7 @@ There are several options which influence the re-creation of the VM:
 
 |`--cpus`
 | Number of CPUs used for the CodeReady Containers VM.
-| 2
+| 4
 
 |`--pull-secret-file`
 | File holding the OCP4 pull secret

--- a/doc/sdh/cli/cmd_minishift.adoc
+++ b/doc/sdh/cli/cmd_minishift.adoc
@@ -7,6 +7,8 @@ This command is especially useful for a simple and self-contained development wo
 `syndesis minishift` requires that you have a current minishift in your path.
 You can download it directly from https://github.com/minishift/minishift/releases[GitHub].
 
+WARNING: `minishift` only supports up to Openshift 3.11. If you need to use Openshift 4.x please refer to https://doc.syndesis.io/#syndesis-crc[syndesis crc]
+
 [[syndesis-minishift-usage]]
 === Usage
 

--- a/tools/bin/commands/binaries/README.md
+++ b/tools/bin/commands/binaries/README.md
@@ -1,0 +1,1 @@
+### Binary files

--- a/tools/bin/commands/crc
+++ b/tools/bin/commands/crc
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 DEFAULT_OPENSHIFT_VERSION="v3.11.0"
-DEFAULT_CPUS="2"
-DEFAULT_RAM="8GB"
+DEFAULT_CPUS="4"
+DEFAULT_RAM="8192"
 
 crc::description() {
     echo "Initialize and manage a developer environment using OCP4 CodeReady Containers"
@@ -10,22 +10,20 @@ crc::description() {
 
 crc::usage() {
     cat <<EOT
-    --install                 Install templates to a running OCP4 CodeReady Containers cluster.
+    --install                 Install syndesis to a running OCP4 CodeReady Containers cluster.
 -p  --project                 Install into this project. Delete this project if it already exists.
                               By default, install into the current project (without deleting)
     --reset                   Reset and initialize the crc installation by
                               'crc delete && crc start'.
     --full-reset              Full reset and initialie by
                               'crc stop && rm -rf ~/.crc/* && crc start'
-    --operator-only           Only install the operator but no resource
-                              connected cluster.
+    --operator-only           Only install the operator but no custom resource
     --memory <mem>            How much memory to use when doing a reset. Default: $DEFAULT_RAM
     --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: $DEFAULT_CPUS
     --pull-secret-file <file> File holding the OCP4 pull secret
     --vm-driver <driver>      Which virtual machine driver to use (depends on OS)
     --bundle <path-to-bundle> Path to system bundle (required when using virtualbox vm-driver)
     --local                   Use the local resource files instead of fetching them from GitHub
--r  --route <route>           Use the given route.
                               By default "syndesis.<project_name>.apps-crc.testing" is used.
 -o  --open                    Open Syndesis in the browser
 -y  --yes                     Assume 'yes' automatically when asking for deleting
@@ -47,6 +45,11 @@ EOT
 crc::run() {
     source "$(basedir)/commands/util/openshift_funcs"
     source "$(basedir)/commands/util/camel_k_funcs"
+    source "$(basedir)/commands/util/operator_funcs"
+
+    OPERATOR_BINARY="$(basedir)/commands/binaries/syndesis"
+
+    download_operator_binary || print_error_and_exit "unable to download the operator binary, exit"
 
     # Check that crc is installed
     which crc &>/dev/null
@@ -101,28 +104,23 @@ crc::run() {
         echo "Switching to project \"$project\""
         oc project $project
 
-        # Login as admin to install CRDs
-        local user=$(oc whoami)
-        local revert_login=$(login_as_admin)
+        # Install Syndesis CRD
+        if ! $(oc get crd | grep "syndesises.syndesis.io" >/dev/null 2>&1); then
+            echo "Installing Syndesis CRD"
+            local result=$($OPERATOR_BINARY install cluster)
+            check_error "$result"
+        fi
 
-        # Install Syndesis CRD globally (if required)
-        echo "Installing Syndesis CRD"
-        local result=$(install_syndesis_crd)
-        check_error "$result"
-
-        # Install Camel-K CRD globally (if requested)
+        # Install Camel-K CRD
         if [ $(hasflag --camel-k) ]; then
           echo "Installing Camel-K CRDs"
           result=$(install_camel_k_crds "$(readopt --camel-k)")
           check_error "$result"
         fi
 
-        # Adapt
-        add_user_permissions_for_operator "$user" "true"
-
-        # Deploy operator and wait until its up
+        # Deploy operator
         echo "Deploying Syndesis operator"
-        result=$(deploy_syndesis_operator)
+        result=$($OPERATOR_BINARY install operator)
         check_error "$result"
 
         # Deploy Camel-K operator if requested
@@ -132,31 +130,20 @@ crc::run() {
           check_error "$result"
         fi
 
-        # Relogin with original user
-        echo "Switching to project \"$project\""
-        oc project $project >/dev/null 2>&1
-        $revert_login
-
         if [ $(hasflag --operator-only) ]; then
             echo "Deployed operator."
             exit 0
+        else
+            echo "Deploying syndesis app."
+            if [ $(hasflag --nodev) ] ; then
+                result=$($OPERATOR_BINARY install app)
+            else
+                result=$($OPERATOR_BINARY install app --dev)
+            fi
+            check_error "$result"
         fi
 
         wait_for_deployments 1 syndesis-operator
-
-        # Create syndesis resource
-        local route=$(readopt --route -r)
-        if [ -z "$route" ]; then
-            route="syndesis.$(crc ip).apps-crc.testing"
-        fi
-
-        local dev_images="with_dev_images"
-        if [ $(hasflag --nodev) ] ; then
-            dev_images=""
-        fi
-
-        result=$(create_syndesis "$route" "https://console-openshift-console.apps-crc.testing" "$dev_images")
-        check_error "$result"
 
         # Wait until everything's up and finally patch imagestreams for triggers
         wait_for_deployments 1 syndesis-server syndesis-ui syndesis-meta

--- a/tools/bin/commands/util/operator_func.bats
+++ b/tools/bin/commands/util/operator_func.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+load operator_funcs
+
+setup() {
+    touch /tmp/foo
+}
+
+teardown() {
+    rm /tmp/foo
+}
+
+@test "invoke check_for_command with wrong command, it should return 1" {
+    run check_for_command curll
+    [ "$status" -eq 1 ]
+}
+
+@test "invoke check_for_command with existing command, it should return 0" {
+    run check_for_command curl
+    [ "$status" -eq 0 ]
+}
+
+@test "invoke check_operator_binary with a nonexistent file returns returns 1" {
+    run check_operator_binary path file
+    [ "$status" -eq 1 ]
+}
+
+@test "check default binary path" {
+    fail=1
+    run default_binary_path
+    if [[ $output == *"syndesis/tools/bin/commands/binaries"* ]]; then
+        fail=0
+    fi
+
+    [ "$fail" -eq 0 ]
+}

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -36,3 +36,75 @@ check_operator_requirements() {
 
     echo "OK"
 }
+
+default_binary_path() {
+    local abs_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../binaries" >/dev/null 2>&1 && pwd )"
+
+    if [[ -z "$abs_path" ]] ; then
+      # error; for some reason, the path is not accessible
+      # to the script (e.g. permissions re-evaled after suid)
+      exit 1  # fail
+    fi
+
+    echo ${abs_path}
+}
+
+# check that a given binary is in $PATH
+check_for_command() {
+    local cmd=${1:-curl}
+
+    if $(which ${cmd} >/dev/null 2>&1); then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# check that the operator binary is in place
+check_operator_binary() {
+    local location=${1}
+    local binary=${2}
+
+    if [[ -x ${location}/${binary} ]]; then
+        if [[ $(${location}/${binary} -h | grep 'syndesis') ]]; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# download the operator binary
+download_operator_binary() {
+    local location=${1:-"$(default_binary_path)"}
+    local binary=${2:-"syndesis"}
+    local base_url="https://github.com/syndesisio/syndesis/releases/download/1.8.1-20191004/syndesis-1.8.1-20191004-"
+
+    check_operator_binary ${location} ${binary} && return
+
+    echo "operator binary not found under ${location}/${binary}, attempting to download..."
+    case "$OSTYPE" in
+        darwin*)  base_url="${base_url}mac-64bit.tgz" ;;
+        linux*)   base_url="${base_url}linux-64bit.tgz" ;;
+        *)        cmd="unknown" ;;
+    esac
+
+    if [[ "${base_url}" != "unknown" ]]; then
+        curl -sL ${base_url} | tar xz -C ${location}
+        chmod +x ${location}/${binary}
+        if $(check_operator_binary ${location} ${binary}); then
+            echo "operator binary successfully downloaded"
+            return 0
+        else
+            echo "operator binary download failed. Please try manually downloading from ${base_url} into ${location}"
+            return 1
+        fi
+    else
+        echo "Unknown platform [ ${OSTYPE} ], "
+        return 1
+    fi
+}
+
+print_error_and_exit() {
+    echo $1
+    exit 1
+}


### PR DESCRIPTION
Use the operator binary instead of old templates. Download the operator binary if it is not present

- `--route` is not needed anymore, the operator takes care of figuring it out
- change defaults so it works properly with latest crc version
- the whole login to a different user logic is removed, why: Is it anyone really using it? With CRC it is needed to pass a password when login as kubeadmin, so the current logic just doesnt work. We can keep it and ask the user for a password, but I would like to challenge an argument whether this is really needed or not.

I am picking the binary from a manual release, which is far from optimal, but with https://github.com/syndesisio/syndesis/pull/6841 I will improve it later