### PR TITLE
fix(connector): adapting producer input

### DIFF
--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoClientCustomizer.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoClientCustomizer.java
@@ -104,7 +104,7 @@ public class MongoClientCustomizer implements ComponentProxyCustomizer, CamelCon
             String jsonResult = String.format(JSON_COUNT_RESULT, in.getBody(Long.class));
             result.add(jsonResult);
         } else {
-            LOGGER.warn("Impossible to convert the body, type was {}", in.getBody().getClass());
+            LOGGER.warn("Impossible to convert the body, type was {}", in.getBody() == null? null : in.getBody().getClass());
             // return without setting the converted result
             return;
         }

--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoProducerCustomizer.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoProducerCustomizer.java
@@ -20,8 +20,14 @@ import java.util.Map;
 
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import org.apache.camel.Exchange;
+import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MongoProducerCustomizer implements ComponentProxyCustomizer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoProducerCustomizer.class);
+
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         Object operation = options.get("operation");
@@ -31,10 +37,44 @@ public class MongoProducerCustomizer implements ComponentProxyCustomizer {
                 throw new IllegalArgumentException(String.format("Operation %s is not supported. " +
                     "Supported operations are %s", operation, Arrays.toString(MongoProducerOperation.values())));
             }
+            // Input format conversion to text
+            if (MongoProducerOperation.findById.name().equals(textOperation)){
+                component.setBeforeProducer(this::inputToObjectId);
+            } else if (MongoProducerOperation.update.name().equals(textOperation)){
+                component.setBeforeProducer(exchange -> {
+                    exchange.getIn().getHeaders().put("CamelMongoDbMultiUpdate","true");
+                    this.inputToText(exchange);
+                });
+            } else {
+                component.setBeforeProducer(this::inputToText);
+            }
         } else {
             throw new IllegalArgumentException(String.format("You must provide a text `operation` option. " +
                 "Supported operations are %s", Arrays.toString(MongoProducerOperation.values())));
         }
+    }
+
+    private void inputToObjectId(Exchange exchange) {
+        String body = exchange.getIn().getBody(String.class);
+        if (body != null) {
+            // input stream new line cleaning
+            body = body.replaceAll("\n", "");
+        }
+        if (ObjectId.isValid(body)) {
+            LOGGER.debug("Converting text to ObjectId type with value `{}`", body);
+            exchange.getIn().setBody(new ObjectId(body));
+        } else {
+            // fallback as text value
+            LOGGER.debug("Setting text input as `{}`", body);
+            exchange.getIn().setBody(body);
+        }
+    }
+
+    private void inputToText(Exchange exchange) {
+        String body = exchange.getIn().getBody(String.class);
+        // Always set body to text (actual expected input format)
+        LOGGER.debug("Setting text input as `{}`", body);
+        exchange.getIn().setBody(body);
     }
 }
 

--- a/app/connector/mongodb/src/main/resources/META-INF/syndesis/connector/mongodb3.json
+++ b/app/connector/mongodb/src/main/resources/META-INF/syndesis/connector/mongodb3.json
@@ -3,17 +3,17 @@
   "actions": [
     {
       "actionType": "connector",
-      "connectorCustomizers": [
-        "io.syndesis.connector.mongo.MongoProducerCustomizer"
-      ],
       "description": "Mongo DB producer",
       "descriptor": {
         "componentScheme": "mongodb3",
+        "connectorCustomizers": [
+          "io.syndesis.connector.mongo.MongoProducerCustomizer"
+        ],
         "inputDataShape": {
-          "kind": "json-schema"
+          "kind": "json-instance"
         },
         "outputDataShape": {
-          "kind": "json-schema"
+          "kind": "json-instance"
         },
         "propertyDefinitionSteps": [
           {
@@ -91,7 +91,7 @@
           "kind": "none"
         },
         "outputDataShape": {
-          "kind": "json-schema"
+          "kind": "json-instance"
         },
         "propertyDefinitionSteps": [
           {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorFindByIdTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorFindByIdTest.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -43,20 +44,28 @@ public class MongoDBConnectorFindByIdTest extends MongoDBConnectorTestSupport {
         // When
         String uniqueId = UUID.randomUUID().toString();
         Document doc = new Document();
-        doc.append("_id", 1);
+        doc.append("_id", "1");
         doc.append("unique", uniqueId);
         collection.insertOne(doc);
         String uniqueId2 = UUID.randomUUID().toString();
         Document doc2 = new Document();
-        doc2.append("_id", 2);
+        doc2.append("_id", "2");
         doc2.append("unique", uniqueId2);
         collection.insertOne(doc2);
+        Document doc3 = new Document();
+        String uniqueId3 = UUID.randomUUID().toString();
+        ObjectId objectId = new ObjectId();
+        doc3.append("_id", objectId);
+        doc3.append("unique", uniqueId3);
+        collection.insertOne(doc3);
         // Given
-        Document result = Document.parse((String)template.requestBody("direct:start", 1, List.class).get(0));
+        Document result = Document.parse((String)template.requestBody("direct:start", "1", List.class).get(0));
         Document result2 = Document.parse((String)template.requestBody("direct:start", 2, List.class).get(0));
+        Document result3 = Document.parse((String)template.requestBody("direct:start", objectId, List.class).get(0));
         // Then
         assertEquals(uniqueId, result.get("unique"));
         assertEquals(uniqueId2, result2.get("unique"));
+        assertEquals(uniqueId3, result3.get("unique"));
     }
 
 }

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
@@ -44,7 +44,7 @@ public class MongoDBConnectorInsertTest extends MongoDBConnectorTestSupport {
     // **************************
 
     @Test
-    public void mongoInsertTest() {
+    public void mongoInsertSingleTest() {
         // When
         String uniqueId = UUID.randomUUID().toString();
         String message = String.format("{\"test\":\"unit\",\"uniqueId\":\"%s\"}", uniqueId);
@@ -61,19 +61,17 @@ public class MongoDBConnectorInsertTest extends MongoDBConnectorTestSupport {
     }
 
     @Test
-    public void mongoInsertMultipleDocuments() {
+    public void mongoInsertArrayTest() {
         // When
-        int iteration = 10;
-        int batchId = 432;
-        List<Document> batchMessage = formatBatchMessageDocument(iteration, batchId);
+        String uniqueId1 = UUID.randomUUID().toString();
+        String uniqueId2 = UUID.randomUUID().toString();
+        String message = String.format("[{\"test\":\"array\",\"uniqueId\":\"%s\"}, {\"test\":\"array\",\"uniqueId\":\"%s\"}]", uniqueId1, uniqueId2);
         // Given
-        @SuppressWarnings("unchecked")
-        List<String> resultsAsString = template.requestBody("direct:start", batchMessage, List.class);
-        List<Document> result = resultsAsString.stream().map(s -> Document.parse(s)).collect(Collectors.toList());
+        @SuppressWarnings(value="unchecked")
+        List<Document> result = template.requestBody("direct:start", message, List.class);
         // Then
-        List<Document> docsFound = collection.find(Filters.eq("batchNo", batchId)).into(new ArrayList<Document>());
-        assertEquals(iteration, docsFound.size());
-        assertThat(result, containsInAnyOrder(docsFound.toArray()));
+        List<Document> docsFound = collection.find(Filters.eq("test", "array")).into(new ArrayList<Document>());
+        assertEquals(2, docsFound.size());
     }
 
     private List<Document> formatBatchMessageDocument(int nDocs, int batchNo) {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
@@ -17,26 +17,26 @@ package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.isA;
+
 public class MongoDBConnectorNotSupportedCamelOperationTest extends MongoDBConnectorTestSupport {
 
-    // **************************
-    // Set up
-    // **************************
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Override
     @Before
-    public void setUp() {
-        try {
-            super.setUp();
-            fail("Setup should have thrown an exception!");
-        } catch (Exception e) {
-            // We do expect a failure cause the operation provided is not
-            // supported
-        }
+    public void setUp() throws Exception {
+        expectedException.expectCause(isA(IllegalArgumentException.class));
+        expectedException.expectMessage("Operation somethingNotSupported is not supported");
+        super.setUp();
+        fail("Setup should have thrown an exception!");
     }
 
     @Override
@@ -44,10 +44,6 @@ public class MongoDBConnectorNotSupportedCamelOperationTest extends MongoDBConne
         return fromDirectToMongo("start", "io.syndesis.connector:connector-mongodb-producer", DATABASE,
             COLLECTION, "somethingNotSupported");
     }
-
-    // **************************
-    // Tests
-    // **************************
 
     @Test
     public void mongoTest() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
@@ -17,11 +17,27 @@ package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.isA;
+
 public class MongoDBConnectorNotSupportedSyndesisOperationTest extends MongoDBConnectorTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        expectedException.expectCause(isA(IllegalArgumentException.class));
+        expectedException.expectMessage("Operation aggregate is not supported");
+        super.setUp();
+        fail("Setup should have thrown an exception!");
+    }
 
     @Override
     protected List<Step> createSteps() {
@@ -29,14 +45,9 @@ public class MongoDBConnectorNotSupportedSyndesisOperationTest extends MongoDBCo
             COLLECTION, "aggregate");
     }
 
-    // **************************
-    // Tests
-    // **************************
-
-    @Test(expected = Exception.class)
+    @Test
     public void mongoTest() {
-        template().sendBody("direct:start","Anything....");
-        fail("Aggregate operation is not allowed, should thrown an exception!");
+        assertTrue(true);
     }
 
 }

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorUpdateTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorUpdateTest.java
@@ -68,8 +68,7 @@ public class MongoDBConnectorUpdateTest extends MongoDBConnectorTestSupport {
         // { $set: { <field1>: <value1>, ... } }
         String updateArguments = "[{\"batchNo\":33},{$set: {\"test\":\"updated!\"}}]";
         // Need the header to enable multiple updates!
-        Document result = Document.parse((String)template.requestBodyAndHeader("direct:start", updateArguments,
-            "CamelMongoDbMultiUpdate", "true", List.class).get(0));
+        Document result = Document.parse((String)template.requestBody("direct:start", updateArguments, List.class).get(0));
         // Then
         List<Document> docsFound = collection.find(Filters.eq("batchNo", 33)).into(new ArrayList<Document>());
         assertEquals(2, docsFound.size());


### PR DESCRIPTION
* Converting input to raw text (as supported at the moment) or ObjectID (only for id related operations)
* Setting data type as json-instance (to be replaced eventually by ENTESB-11588)
* Improving exception checks unit test cases

fixes ENTESB-11867
