### PR TITLE
[ENTESB-11971] Fixing configuration of AWS DDB

### DIFF
--- a/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/aws-ddb.json
+++ b/app/connector/aws-ddb/src/main/resources/META-INF/syndesis/connector/aws-ddb.json
@@ -30,7 +30,7 @@
                 "controlHint": "{\"key\" : \":#MYPARAMNAME\"}",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               },
               "attributes": {
                 "deprecated": false,
@@ -45,7 +45,7 @@
 
                 "secret": false,
                 "multiple": true,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }
@@ -88,7 +88,7 @@
                 "controlHint": "{\"key\" : \":#MYPARAMNAME\"}",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }
@@ -131,7 +131,7 @@
                 "controlHint": "{\"key\" : \":#MYPARAMNAME\"}",
                 "required": true,
                 "secret": false,
-                "type": "string"
+                "type": "dataList"
               }
             }
           }


### PR DESCRIPTION
Using dataList instead of the string type to make sure we have input type text.