### PR TITLE
fix(TEIIDTOOLS-792) - Virtualization Description Issues

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
@@ -36,7 +36,7 @@ export const VirtualizationDetailsHeader: React.FunctionComponent<
   IVirtualizationDetailsHeaderProps
 > = props => {
   return (
-    <PageSection variant={'light'}>
+    <PageSection className={'virtualization-details-header'} variant={'light'}>
       <Stack gutter="md">
         <StackItem>
           <Split gutter="md" className={'virtualization-details-header__row'}>
@@ -79,9 +79,7 @@ export const VirtualizationDetailsHeader: React.FunctionComponent<
                 </span>
               )}
             </SplitItem>
-            <SplitItem>
-              {props.i18nInUseText}
-            </SplitItem>
+            <SplitItem>{props.i18nInUseText}</SplitItem>
           </Split>
         </StackItem>
         <StackItem>

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.css
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.css
@@ -1,0 +1,13 @@
+.virtualization-sql-client-page .inline-text-editwidget textarea {
+  height: 8.5em;
+  font-size: 1.0em;
+  line-height: 1.25em;
+}
+
+.virtualization-sql-client-page .virtualization-details-header .inline-text-readwidget {
+  display: inline-block;
+  line-height: 1.25em;
+  max-height: 6.25em;
+  overflow: auto;
+  white-space: pre-wrap;
+}

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
@@ -4,8 +4,9 @@ import {
   useVirtualization,
   useVirtualizationHelpers,
 } from '@syndesis/api';
-import { RestDataService, 
-         VirtualizationPublishingDetails
+import {
+  RestDataService,
+  VirtualizationPublishingDetails,
 } from '@syndesis/models';
 import {
   PageSection,
@@ -28,6 +29,7 @@ import {
   getOdataUrl,
   getPublishingDetails,
 } from '../shared/VirtualizationUtils';
+import './VirtualizationSqlClientPage.css';
 
 /**
  * @param virtualizationId - the ID of the virtualization shown by this page.
@@ -70,7 +72,7 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
   const [publishedState, setPublishedState] = React.useState(
     {} as VirtualizationPublishingDetails
   );
-  const [usedBy, setUsedBy] = React.useState( state.virtualization.usedBy );
+  const [usedBy, setUsedBy] = React.useState(state.virtualization.usedBy);
 
   const {
     resource: viewDefinitionDescriptors,
@@ -98,7 +100,7 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
 
     return t('usedByMulti', { count: integrationNames.length });
   };
-  
+
   const doDelete = async (pVirtualizationId: string) => {
     const success = await handleDeleteVirtualization(pVirtualizationId);
     if (success) {
@@ -113,7 +115,6 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
   const doUnpublish = async (virtualizationName: string) => {
     await handleUnpublishVirtualization(virtualizationName);
   };
-
 
   const doSetDescription = async (newDescription: string) => {
     const previous = description;
@@ -169,7 +170,11 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
           usedInIntegration={usedBy.length > 0}
         />
       </PageSection>
-      <PageSection variant={'light'} noPadding={true}>
+      <PageSection
+        className={'virtualization-sql-client-page'}
+        variant={'light'}
+        noPadding={true}
+      >
         <VirtualizationDetailsHeader
           i18nDescriptionPlaceholder={t(
             'virtualization.descriptionPlaceholder'

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.css
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.css
@@ -1,0 +1,13 @@
+.virtualization-views-page .inline-text-editwidget textarea {
+  height: 8.5em;
+  font-size: 1.0em;
+  line-height: 1.25em;
+}
+
+.virtualization-views-page .virtualization-details-header .inline-text-readwidget {
+  display: inline-block;
+  line-height: 1.25em;
+  max-height: 6.25em;
+  overflow: auto;
+  white-space: pre-wrap;
+}

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -39,6 +39,7 @@ import {
 import { WithListViewToolbarHelpers, WithLoader } from '@syndesis/utils';
 import { AppContext, UIContext } from '../../../app';
 import resolvers from '../../resolvers';
+import './VirtualizationViewsPage.css';
 
 /**
  * @param virtualizationId - the ID of the virtualization whose details are being shown by this page.
@@ -117,7 +118,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   const [publishedState, setPublishedState] = React.useState(
     {} as VirtualizationPublishingDetails
   );
-  const [usedBy, setUsedBy] = React.useState( state.virtualization.usedBy );
+  const [usedBy, setUsedBy] = React.useState(state.virtualization.usedBy);
   const {
     deleteViewDefinition,
     updateVirtualizationDescription,
@@ -161,7 +162,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
     if (integrationNames.length === 1) {
       return t('usedByOne');
     }
-  
+
     return t('usedByMulti', { count: integrationNames.length });
   };
 
@@ -281,7 +282,11 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
                 usedInIntegration={usedBy.length > 0}
               />
             </PageSection>
-            <PageSection variant={'light'} noPadding={true}>
+            <PageSection
+              className={'virtualization-views-page'}
+              variant={'light'}
+              noPadding={true}
+            >
               {virtualization ? (
                 <VirtualizationDetailsHeader
                   i18nDescriptionPlaceholder={t(

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -97,6 +97,23 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
     alert('Export virtualization ');
   } */
 
+  /**
+   *
+   * @param virtualization the virtualization whose description is being returned
+   * @returns the description truncated at 150 chars if necessary
+   */
+  const getDescription = (virtualization: RestDataService): string => {
+    if (virtualization.tko__description) {
+      if (virtualization.tko__description.length > 150) {
+        return virtualization.tko__description.substring(0, 150) + ' ...';
+      }
+
+      return virtualization.tko__description;
+    }
+
+    return '';
+  };
+
   const getUsedByMessage = (integrationNames: string[]): string => {
     if (integrationNames.length === 1) {
       return t('usedByOne');
@@ -201,11 +218,9 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
                             )}
                             hasViews={!virtualization.empty}
                             virtualizationName={virtualization.keng__id}
-                            virtualizationDescription={
-                              virtualization.tko__description
-                                ? virtualization.tko__description
-                                : ''
-                            }
+                            virtualizationDescription={getDescription(
+                              virtualization
+                            )}
                             odataUrl={getOdataUrl(virtualization)}
                             i18nCancelText={t('shared:Cancel')}
                             i18nDelete={t('shared:Delete')}
@@ -226,7 +241,9 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
                             i18nError={t('shared:Error')}
                             /* TD-636: Commented out for TP
                                 i18nExport={t('shared:Export')} */
-                            i18nInUseText={getUsedByMessage(virtualization.usedBy)}
+                            i18nInUseText={getUsedByMessage(
+                              virtualization.usedBy
+                            )}
                             i18nPublish={t('shared:Publish')}
                             i18nPublished={t(
                               'virtualization.publishedDataVirtualization'


### PR DESCRIPTION
- see [TEIIDTOOLS-792](https://issues.jboss.org/browse/TEIIDTOOLS-792)
- the components used for viewing and editing the virtualization description will show a max of 5 lines and provide a scrollbar to view the rest if needed
- added a CSS to style the virtualization description on the `VirtualizationSqlClientPage`
- added a CSS to style the virtualization description on the `VirtualizationViewsPage`
- truncating the virtualization descriptions on the list items of the `VirtualizationsPage` if greater than 150 chars