### PR TITLE
refactor: cleanup PublicApiHandlerTest

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
@@ -77,7 +77,10 @@ public interface ListResult<T> extends Iterable<T> {
     }
 
     static <T> Collector<T, Builder<T>, Builder<T>> collector() {
-        return Collector.of(Builder::new, Builder::addItem, (b1, b2) -> b1.addAllItems(b2.build().getItems()));
+        return Collector.of(Builder::new,
+            Builder::addItem,
+            (b1, b2) -> b1.addAllItems(b2.build().getItems()),
+            b -> b.totalCount(b.build().getItems().size()));
     }
 
 }

--- a/app/common/model/src/test/java/io/syndesis/common/model/ListResultTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/ListResultTest.java
@@ -29,6 +29,7 @@ public class ListResultTest {
         final ListResult<Object> collected = Stream.of().collect(ListResult.collector()).build();
         assertThat(collected).isNotNull();
         assertThat(collected.getItems()).isEmpty();
+        assertThat(collected.getTotalCount()).isZero();
     }
 
     @Test
@@ -36,6 +37,7 @@ public class ListResultTest {
         final ListResult<String> collected = Stream.of("item").collect(ListResult.collector()).build();
         assertThat(collected).isNotNull();
         assertThat(collected.getItems()).containsExactly("item");
+        assertThat(collected.getTotalCount()).isOne();
     }
 
     @Test
@@ -44,5 +46,6 @@ public class ListResultTest {
             .collect(ListResult.collector()).build();
         assertThat(collected).isNotNull();
         assertThat(collected.getItems()).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+        assertThat(collected.getTotalCount()).isEqualTo(10);
     }
 }

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -374,11 +374,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
@@ -391,8 +391,7 @@ public class PublicApiHandler {
     public void stopIntegration(@Context final SecurityContext sec, @NotNull @PathParam("id") @ApiParam(required = true) final String integrationId) {
 
         final Integration integration = getIntegration(integrationId);
-        IntegrationDeploymentHandler.TargetStateRequest targetState = new IntegrationDeploymentHandler.TargetStateRequest();
-        targetState.setTargetState(IntegrationDeploymentState.Unpublished);
+        IntegrationDeploymentHandler.TargetStateRequest targetState = new IntegrationDeploymentHandler.TargetStateRequest(IntegrationDeploymentState.Unpublished);
 
         // find current deployment
         final String id = integration.getId().get();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
@@ -17,6 +17,7 @@ package io.syndesis.server.endpoint.v1.handler.integration;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
@@ -51,6 +52,9 @@ import io.syndesis.server.openshift.OpenShiftService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 @Path("/integrations/{id}/deployments")
 @Api(value = "integration-deployments")
 @Component
@@ -62,12 +66,27 @@ public final class IntegrationDeploymentHandler extends BaseHandler {
     public static class TargetStateRequest {
         private IntegrationDeploymentState targetState;
 
+        @JsonCreator
+        public TargetStateRequest(@JsonProperty("targetState") IntegrationDeploymentState targetState) {
+            this.targetState = Objects.requireNonNull(targetState, "targetState");
+        }
+
         public IntegrationDeploymentState getTargetState() {
             return targetState;
         }
 
-        public void setTargetState(IntegrationDeploymentState targetState) {
-            this.targetState = targetState;
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TargetStateRequest)) {
+                return false;
+            }
+
+            return targetState == ((TargetStateRequest) obj).targetState;
+        }
+
+        @Override
+        public int hashCode() {
+            return targetState.hashCode();
         }
     }
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
@@ -16,439 +16,546 @@
 package io.syndesis.server.endpoint.v1.handler.external;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.StreamingOutput;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import io.syndesis.common.model.ListResult;
-import io.syndesis.common.model.WithResourceId;
+import io.syndesis.common.model.WithName;
 import io.syndesis.common.model.environment.Environment;
 import io.syndesis.common.model.integration.ContinuousDeliveryEnvironment;
+import io.syndesis.common.model.integration.ContinuousDeliveryImportResults;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.IntegrationDeployment;
 import io.syndesis.common.model.integration.IntegrationDeploymentState;
 import io.syndesis.common.model.integration.IntegrationOverview;
+import io.syndesis.common.model.monitoring.IntegrationDeploymentStateDetails;
 import io.syndesis.server.dao.manager.DataManager;
-import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.monitoring.MonitoringProvider;
-import io.syndesis.server.endpoint.v1.handler.connection.ConnectionHandler;
 import io.syndesis.server.endpoint.v1.handler.environment.EnvironmentHandler;
 import io.syndesis.server.endpoint.v1.handler.integration.IntegrationDeploymentHandler;
+import io.syndesis.server.endpoint.v1.handler.integration.IntegrationDeploymentHandler.TargetStateRequest;
 import io.syndesis.server.endpoint.v1.handler.integration.IntegrationHandler;
 import io.syndesis.server.endpoint.v1.handler.integration.support.IntegrationSupportHandler;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Unit test for {@link PublicApiHandler}.
- */
 public class PublicApiHandlerTest {
 
-    private static final String INTEGRATION_ID = "integration-id";
-    private static final String INTEGRATION_NAME = "integration-name";
-    private static final String ENVIRONMENT = "environment";
-    private static final String ENVIRONMENT_ID = ENVIRONMENT + "-id";
-    private static final String ENVIRONMENT2 = "new-" + ENVIRONMENT;
-    private static final String ENVIRONMENT2_ID = ENVIRONMENT2 + "-id";
-    private static final String NAME_PROPERTY = "name";
-    private static final String INTEGRATION_ID_PROPERTY = "integrationId";
-    private static final String RENAMED_SUFFIX = "-renamed";
+    @Test
+    public void exportResources() throws IOException {
+        final DataManager dataManager = mock(DataManager.class);
 
-    private final DataManager dataManager = mock(DataManager.class);
-    private final IntegrationSupportHandler supportHandler = mock(IntegrationSupportHandler.class);
-    private final EncryptionComponent encryptionComponent = mock(EncryptionComponent.class);
-    private final IntegrationHandler integrationHandler = mock(IntegrationHandler.class);
-    private final IntegrationDeploymentHandler deploymentHandler = mock(IntegrationDeploymentHandler.class);
-    private final ConnectionHandler connectionHandler = mock(ConnectionHandler.class);
-    private final MonitoringProvider monitoringProvider = mock(MonitoringProvider.class);
+        final Environment env = newEnvironment("env");
+        final String envId = env.getId().get();
 
-    // initialized after mock objects in setup
-    private PublicApiHandler handler;
-    private Integration integration;
-    private IntegrationDeploymentState targetState;
-    private EnvironmentHandler environmentHandler;
-    private List<Environment> environments;
+        final Integration integration1 = new Integration.Builder()
+            .id("integration1")
+            .putContinuousDeliveryState(envId, new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
+        final Integration integration2 = new Integration.Builder()
+            .id("integration2")
+            .putContinuousDeliveryState(envId, new ContinuousDeliveryEnvironment.Builder().build())
+            .putContinuousDeliveryState("different-env", new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
 
-    @Before
-    @SuppressWarnings("unchecked")
-    public void setUp() throws Exception {
-        // prime mock objects
-        final HashMap<String, ContinuousDeliveryEnvironment> deliveryState = new HashMap<>();
-        deliveryState.put(ENVIRONMENT_ID, ContinuousDeliveryEnvironment.Builder.createFrom(ENVIRONMENT_ID, new Date()));
-        integration = new Integration.Builder()
-                .id(INTEGRATION_ID)
-                .name(INTEGRATION_NAME)
-                .continuousDeliveryState(deliveryState)
-                .build();
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        final Class<Function<ListResult<Integration>, ListResult<Integration>>[]> filterVarArgsType = (Class) Function[].class;
 
-        // handle dataManager calls for environments
-        environments = new ArrayList<>();
-        environments.add(new Environment.Builder().id(ENVIRONMENT_ID).name(ENVIRONMENT).build());
-        doAnswer(invocation -> ListResult.of(environments)).when(dataManager).fetchAll(Environment.class);
-        doAnswer(invocation -> {
-            final Environment env = invocation.getArgument(0);
-            environments.removeIf(e -> e.getId().get().equals(env.getId().get()));
-            environments.add(env);
-            return env;
-        }).when(dataManager).update(any(Environment.class));
-        doAnswer(invocation -> {
-            final String id = invocation.getArgument(1);
-            return environments.stream().filter(e -> e.getId().get().equals(id)).findFirst().get();
-        }).when(dataManager).fetch(eq(Environment.class), any());
-        doAnswer(invocation -> {
-            final String name = invocation.getArgument(2);
-            return environments.stream().filter(e -> e.getName().equals(name)).findFirst();
-        }).when(dataManager).fetchByPropertyValue(eq(Environment.class), eq(NAME_PROPERTY), any());
-        doAnswer(invocation -> {
-            final Environment env = invocation.getArgument(0);
-            final Environment newEnv = new Environment.Builder().createFrom(env).id(ENVIRONMENT2_ID).build();
-            environments.add(newEnv);
-            return newEnv;
-        }).when(dataManager).create(any(Environment.class));
-        doAnswer(invocation -> {
-            final String id = invocation.getArgument(1);
-            return environments.removeIf(e -> e.getId().get().equals(id));
-        }).when(dataManager).delete(eq(Environment.class), any());
+        final ArgumentCaptor<Function<ListResult<Integration>, ListResult<Integration>>[]> filter = ArgumentCaptor.forClass(filterVarArgsType);
 
-        // handle dataManager calls for integrations
-        doAnswer(invocation -> integration).when(dataManager).fetch(Integration.class, INTEGRATION_ID);
-        doAnswer(invocation -> Optional.of(integration)).when(dataManager).fetchByPropertyValue(Integration.class,
-                NAME_PROPERTY, INTEGRATION_NAME);
-        doAnswer(invocation -> Stream.of(integration)).when(dataManager).fetchAllByPropertyValue(Integration.class,
-                NAME_PROPERTY, INTEGRATION_NAME);
-        doAnswer(invocation -> ListResult.of(integration)).when(dataManager).fetchAll(eq(Integration.class));
-        doAnswer(invocation -> {
-            ListResult<Integration> result = ListResult.of(integration);
-            final Object[] args = invocation.getArguments();
-            if (args.length < 2) {
-                return result;
-            }
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
+        when(dataManager.fetchAll(eq(Integration.class), filter.capture())).thenReturn(ListResult.of(integration1, integration2));
 
-            for (Object arg : Arrays.copyOfRange(args, 1, args.length)) {
-                Function<ListResult<Integration>, ListResult<Integration>> operator = (Function<ListResult<Integration>, ListResult<Integration>>) arg;
-                result = operator.apply(result);
-            }
-            return result;
-        }).when(dataManager).fetchAll(eq(Integration.class), any());
-        doAnswer(invocation -> integration = invocation.getArgument(0)).when(dataManager).update(any(Integration.class));
+        final StreamingOutput someStream = mock(StreamingOutput.class);
 
-        when(supportHandler.export(any())).thenReturn(out -> out.write('b'));
-        final HashMap<String, List<WithResourceId>> importResult = new HashMap<>();
-        importResult.put(INTEGRATION_ID, Collections.singletonList(integration));
-        when(supportHandler.importIntegration(any(), any())).thenReturn(importResult);
+        // too convoluted to use the implementation directly
+        final IntegrationSupportHandler integrationSupportHandler = mock(IntegrationSupportHandler.class);
+        when(integrationSupportHandler.export(Arrays.asList("integration1", "integration2"))).thenReturn(someStream);
 
-        targetState = IntegrationDeploymentState.Unpublished;
-        doAnswer(invocation -> new IntegrationOverview.Builder()
-                .id(INTEGRATION_ID)
-                .currentState(IntegrationDeploymentState.Unpublished)
-                .targetState(targetState)
-                .deploymentVersion(1)
-                .build()).when(integrationHandler).get(any());
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(dataManager, null, null, null, null, environmentHandler, integrationSupportHandler, null);
 
-        final IntegrationDeployment.Builder deploymentBuilder = new IntegrationDeployment.Builder()
-                .integrationId(Optional.of(INTEGRATION_ID))
-                .currentState(IntegrationDeploymentState.Unpublished)
-                .targetState(IntegrationDeploymentState.Unpublished);
-        IntegrationDeployment[] deployments = new IntegrationDeployment[] {
-                deploymentBuilder.targetState(IntegrationDeploymentState.Unpublished).version(1).build(),
-                deploymentBuilder.version(2).targetState(IntegrationDeploymentState.Published).build()
-        };
+        try (Response response = handler.exportResources("env", false)) {
+            assertThat(response).isNotNull();
+            assertThat(response.getStatusInfo().toEnum()).isEqualTo(Status.OK);
+            assertThat(response.getEntity()).isSameAs(someStream);
+        }
 
-        doAnswer(invocation -> Stream.of(deployments))
-                .when(dataManager)
-                .fetchAllByPropertyValue(IntegrationDeployment.class, INTEGRATION_ID_PROPERTY, INTEGRATION_ID);
-        doAnswer(invocation -> deploymentBuilder.targetState(targetState = IntegrationDeploymentState.Published).build())
-                .when(deploymentHandler).update(any(), any());
+        verify(dataManager).update(withLastExportedTimestamp(integration1, envId));
+        verify(dataManager).update(withLastExportedTimestamp(integration2, envId));
 
-        environmentHandler = new EnvironmentHandler(dataManager);
-        handler = new PublicApiHandler(dataManager, encryptionComponent, deploymentHandler, connectionHandler,
-                monitoringProvider, environmentHandler, supportHandler, integrationHandler);
+        final Integration integration3 = new Integration.Builder()
+            .id("integration3")
+            .putContinuousDeliveryState("different-env", new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
+
+        final List<Function<ListResult<Integration>, ListResult<Integration>>[]> filters = filter.getAllValues();
+        assertThat(filters).hasSize(1).as("Varargs capture should give us single Function").hasOnlyElementsOfType(Function.class);
+
+        @SuppressWarnings("unchecked")
+        final Function<ListResult<Integration>, ListResult<Integration>> filterFunction = (Function<ListResult<Integration>, ListResult<Integration>>) (Object) filters
+            .get(0);
+
+        assertThat(filterFunction.apply(ListResult.of(integration1, integration2, integration3))).isEqualTo(ListResult.of(integration1, integration2));
     }
 
-
     @Test
-    public void testGetReleaseEnvironments() {
-        final List<String> environments = handler.getReleaseEnvironments();
+    public void importResources() {
+        final DataManager dataManager = mock(DataManager.class);
 
-        assertThat(environments, is(notNullValue()));
-        assertThat(environments, hasItem(ENVIRONMENT));
+        final SecurityContext securityContext = newMockSecurityContext();
 
-        verify(dataManager).fetchAll(eq(Environment.class));
+        final InputStream givenDataStream = new ByteArrayInputStream(new byte[0]);
+
+        final Environment env = newEnvironment("env");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
+
+        // too convoluted to use the implementation directly
+        final IntegrationSupportHandler supportHandler = mock(IntegrationSupportHandler.class);
+
+        final Integration integration = new Integration.Builder()
+            .id("integration-id")
+            .build();
+        when(supportHandler.importIntegration(securityContext, givenDataStream))
+            .thenReturn(Collections.singletonMap("integration-id", Collections.singletonList(integration)));
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        final IntegrationDeploymentHandler deploymentHandler = mock(IntegrationDeploymentHandler.class);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, deploymentHandler, null, null, environmentHandler, supportHandler, null);
+
+        final PublicApiHandler.ImportFormDataInput formInput = new PublicApiHandler.ImportFormDataInput();
+        formInput.setData(givenDataStream);
+        formInput.setProperties(new ByteArrayInputStream("test-connection.prop=value".getBytes(StandardCharsets.UTF_8)));
+        formInput.setEnvironment("env");
+        formInput.setDeploy(Boolean.TRUE);
+
+        final ContinuousDeliveryImportResults importResults = handler.importResources(securityContext, formInput);
+
+        verify(deploymentHandler).update(securityContext, "integration-id");
+
+        assertThat(importResults.getLastImportedAt()).isNotNull();
+        assertThat(importResults.getResults()).containsOnly(integration);
     }
 
     @Test
     public void testAddNewEnvironment() {
-        handler.addNewEnvironment(ENVIRONMENT2);
-        final List<String> environments = handler.getReleaseEnvironments();
+        final DataManager dataManager = mock(DataManager.class);
 
-        assertThat(environments, is(notNullValue()));
-        assertThat(environments, hasItem(ENVIRONMENT2));
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
 
-        verify(dataManager).fetchAll(eq(Environment.class));
-        verify(dataManager).create(any(Environment.class));
-    }
+        handler.addNewEnvironment("new-env");
 
-    @Test
-    public void testPutTagsForRelease() throws Exception {
-        final Date now = new Date();
-        // delay to avoid false positives in Date::after
-        Thread.sleep(10);
-
-        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.putTagsForRelease(INTEGRATION_ID,
-                Collections.singletonList(ENVIRONMENT));
-
-        assertThat(continuousDeliveryEnvironment, is(notNullValue()));
-        assertThat(continuousDeliveryEnvironment.keySet(), hasItem(ENVIRONMENT));
-        assertThat(continuousDeliveryEnvironment.get(ENVIRONMENT).getLastTaggedAt().after(now), is(true));
-
-        verify(dataManager).update(notNull());
-        verify(dataManager).fetch(Integration.class, INTEGRATION_ID);
-    }
-
-    @Test
-    public void testPatchTagsForRelease() throws Exception {
-        // delay to avoid false positives in Date::before
-        Thread.sleep(10);
-        final Date now = new Date();
-        // delay to avoid false positives in Date::after
-        Thread.sleep(10);
-
-        // add new environment first
-        handler.addNewEnvironment(ENVIRONMENT2);
-
-        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.patchTagsForRelease(INTEGRATION_ID,
-                Collections.singletonList(ENVIRONMENT2));
-
-        assertThat(continuousDeliveryEnvironment, is(notNullValue()));
-        assertThat(continuousDeliveryEnvironment.keySet(), hasItem(ENVIRONMENT));
-        assertThat(continuousDeliveryEnvironment.keySet(), hasItem(ENVIRONMENT2));
-        assertThat(continuousDeliveryEnvironment.get(ENVIRONMENT).getLastTaggedAt().before(now), is(true));
-        assertThat(continuousDeliveryEnvironment.get(ENVIRONMENT2).getLastTaggedAt().after(now), is(true));
-
-        verify(dataManager).update(notNull());
-        verify(dataManager).fetch(Integration.class, INTEGRATION_ID);
-    }
-
-    @Test(expected = ClientErrorException.class)
-    public void testEmptyTagForRelease() {
-        handler.putTagsForRelease(INTEGRATION_ID, Collections.singletonList(""));
-    }
-
-    @Test(expected = ClientErrorException.class)
-    public void testInvalidTagForRelease() {
-        handler.putTagsForRelease(INTEGRATION_ID, Collections.singletonList("%test}"));
-    }
-
-    @Test
-    public void testPutTagsForReleaseByName() throws Exception {
-        final Date now = new Date();
-        // delay to avoid false positives in Date::after
-        Thread.sleep(10);
-
-        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.putTagsForRelease(INTEGRATION_NAME,
-                Collections.singletonList(ENVIRONMENT));
-
-        assertThat(continuousDeliveryEnvironment, is(notNullValue()));
-        assertThat(continuousDeliveryEnvironment.keySet(), hasItem(ENVIRONMENT));
-        assertThat(continuousDeliveryEnvironment.get(ENVIRONMENT).getLastTaggedAt().after(now), is(true));
-
-        verify(dataManager).update(notNull());
-        verify(dataManager).fetchAllByPropertyValue(Integration.class, NAME_PROPERTY, INTEGRATION_NAME);
-    }
-
-    @Test
-    public void testGetReleaseTags() {
-        final Map<String, ContinuousDeliveryEnvironment> releaseTags = handler.getReleaseTags(INTEGRATION_ID);
-
-        assertThat(releaseTags, notNullValue());
-        assertThat(releaseTags.keySet(), hasItem(ENVIRONMENT));
-
-        verify(dataManager).fetch(Integration.class, INTEGRATION_ID);
-    }
-
-    @Test
-    public void testDeleteReleaseTag() {
-        handler.deleteReleaseTag(INTEGRATION_ID, ENVIRONMENT);
-
-        final Map<String, ContinuousDeliveryEnvironment> releaseTags = handler.getReleaseTags(INTEGRATION_ID);
-
-        assertThat(releaseTags, notNullValue());
-        // only integration, therefore environment is deleted and map will be empty
-        assertThat(releaseTags.isEmpty(), is(true));
-
-        verify(dataManager, times(2)).fetch(Integration.class, INTEGRATION_ID);
-        verify(dataManager).update(any(Integration.class));
+        verify(dataManager).create(withName(Environment.class, "new-env"));
     }
 
     @Test
     public void testDeleteEnvironment() {
-        handler.deleteEnvironment(ENVIRONMENT);
+        final DataManager dataManager = mock(DataManager.class);
 
-        final List<String> environments = handler.getReleaseEnvironments();
+        final Environment env = newEnvironment("env");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
 
-        assertThat(environments, notNullValue());
-        assertThat(environments.isEmpty(), is(true));
+        final String envId = env.getId().get();
+        final Integration integration1 = new Integration.Builder()
+            .id("integration1")
+            .putContinuousDeliveryState(envId, new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
+        final Integration integration2 = new Integration.Builder()
+            .id("integration2")
+            .putContinuousDeliveryState(envId, new ContinuousDeliveryEnvironment.Builder().build())
+            .putContinuousDeliveryState("different-env", new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
+        final Integration integration3 = new Integration.Builder()
+            .id("integration3")
+            .putContinuousDeliveryState("different-env", new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
 
-        final Map<String, ContinuousDeliveryEnvironment> releaseTags = handler.getReleaseTags(INTEGRATION_ID);
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integration1, integration2, integration3));
 
-        assertThat(releaseTags, notNullValue());
-        assertThat(releaseTags.isEmpty(), is(true));
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
 
-        // create an unassigned environment and delete it
-        handler.addNewEnvironment(ENVIRONMENT2);
-        handler.deleteEnvironment(ENVIRONMENT2);
+        handler.deleteEnvironment("env");
 
-        verify(dataManager).update(any(Integration.class));
-        verify(dataManager).fetch(Integration.class, INTEGRATION_ID);
+        verify(dataManager).update(integration1.builder()
+            .continuousDeliveryState(Collections.emptyMap())
+            .build());
+
+        verify(dataManager).update(integration2.builder()
+            .continuousDeliveryState(Collections.singletonMap("different-env", new ContinuousDeliveryEnvironment.Builder().build()))
+            .build());
+
+        verify(dataManager).delete(Environment.class, envId);
     }
 
     @Test
-    public void testRenameEnvironment() {
-        handler.renameEnvironment(ENVIRONMENT, ENVIRONMENT + RENAMED_SUFFIX);
-        List<String> environments = handler.getReleaseEnvironments();
+    public void testDeleteReleaseTag() {
+        final DataManager dataManager = mock(DataManager.class);
 
-        assertThat(environments, notNullValue());
-        assertThat(environments, hasItem(ENVIRONMENT + RENAMED_SUFFIX));
+        final Environment env = newEnvironment("env");
+        final Integration integration = new Integration.Builder()
+            .putContinuousDeliveryState(env.getId().get(), new ContinuousDeliveryEnvironment.Builder().build())
+            .build();
 
-        // do the same for an unassigned environment
-        handler.addNewEnvironment(ENVIRONMENT2);
-        handler.renameEnvironment(ENVIRONMENT2, ENVIRONMENT2 + RENAMED_SUFFIX);
-        environments = handler.getReleaseEnvironments();
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
+        when(dataManager.fetch(Integration.class, "integration-id")).thenReturn(integration);
 
-        assertThat(environments, notNullValue());
-        assertThat(environments, hasItem(ENVIRONMENT2 + RENAMED_SUFFIX));
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        handler.deleteReleaseTag("integration-id", "env");
+
+        verify(dataManager).update(integration.builder()
+            .continuousDeliveryState(Collections.emptyMap())
+            .build());
     }
 
-    @Test(expected = ClientErrorException.class)
+    @Test
     public void testDuplicateRenameEnvironment() {
-        handler.addNewEnvironment(ENVIRONMENT2);
-        handler.renameEnvironment(ENVIRONMENT, ENVIRONMENT2);
+        final DataManager dataManager = mock(DataManager.class);
+
+        final Environment env1 = newEnvironment("env1");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env1")).thenReturn(Optional.of(env1));
+        final Environment env2 = newEnvironment("env2");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env2")).thenReturn(Optional.of(env2));
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        assertThatExceptionOfType(ClientErrorException.class).isThrownBy(() -> handler.renameEnvironment("env1", "env2"))
+            .withMessage("Duplicate environment env2")
+            .satisfies(e -> assertThat(e.getResponse().getStatusInfo().toEnum()).isEqualTo(Status.BAD_REQUEST));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void exportResources() throws Exception {
-        final Response response = handler.exportResources(ENVIRONMENT, false);
-        assertThat(response, is(notNullValue()));
-        assertThat(response.getStatusInfo().toEnum(), is(Response.Status.OK));
+    public void testEmptyTagForRelease() {
+        final DataManager dataManager = mock(DataManager.class);
 
-        verify(dataManager).fetchAll(eq(Integration.class), any(Function.class));
-        verify(dataManager).update(any(Integration.class));
-    }
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
 
-    @Test
-    public void importResources() throws Exception {
-        // export integration
-        final Response response = handler.exportResources(ENVIRONMENT, false);
-
-        // import it back
-        final SecurityContext security = getSecurityContext();
-
-        PublicApiHandler.ImportFormDataInput formInput = new PublicApiHandler.ImportFormDataInput();
-        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        ((StreamingOutput)response.getEntity()).write(bytes);
-        formInput.setData(new ByteArrayInputStream(bytes.toByteArray()));
-        formInput.setProperties(new ByteArrayInputStream("test-connection.prop=value".getBytes(StandardCharsets.UTF_8)));
-        formInput.setEnvironment(ENVIRONMENT);
-        formInput.setDeploy(Boolean.TRUE);
-
-        handler.importResources(security, formInput);
-
-        // assert that integration was recreated
-        verify(dataManager).fetchAll(eq(Integration.class), any());
-        verify(dataManager, times(2)).update(any(Integration.class));
-
-    }
-
-    @Test
-    public void importResourcesNewEnvironment() throws Exception {
-        // export integration
-        final Response response = handler.exportResources(ENVIRONMENT, false);
-
-        handler.deleteEnvironment(ENVIRONMENT);
-        handler.addNewEnvironment(ENVIRONMENT2);
-
-        // import it back
-        final SecurityContext security = getSecurityContext();
-
-        PublicApiHandler.ImportFormDataInput formInput = new PublicApiHandler.ImportFormDataInput();
-        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        ((StreamingOutput)response.getEntity()).write(bytes);
-        formInput.setData(new ByteArrayInputStream(bytes.toByteArray()));
-        formInput.setProperties(new ByteArrayInputStream("test-connection.prop=value".getBytes(StandardCharsets.UTF_8)));
-        formInput.setEnvironment(ENVIRONMENT2);
-        formInput.setDeploy(Boolean.TRUE);
-
-        handler.importResources(security, formInput);
-
-        // validate that new environment tag was created
-        final Integration integration = dataManager.fetch(Integration.class, INTEGRATION_ID);
-        assertThat(integration.getContinuousDeliveryState().containsKey(ENVIRONMENT_ID), is(true));
-        assertThat(integration.getContinuousDeliveryState().containsKey(ENVIRONMENT2_ID), is(true));
-
-        // assert that integration was recreated
-        verify(dataManager).fetchAll(eq(Integration.class), any());
-        verify(dataManager, times(3)).update(any(Integration.class));
-    }
-
-    private SecurityContext getSecurityContext() {
-        final SecurityContext security = mock(SecurityContext.class);
-        final Principal principal = mock(Principal.class);
-        when(security.getUserPrincipal()).thenReturn(principal);
-        when(principal.getName()).thenReturn("user");
-        return security;
+        assertThatExceptionOfType(ClientErrorException.class)
+            .isThrownBy(() -> handler.putTagsForRelease("some-integration-id", Collections.singletonList("")))
+            .withMessageStartingWith("Missing environment")
+            .satisfies(e -> assertThat(e.getResponse().getStatusInfo().toEnum()).isEqualTo(Status.NOT_FOUND));
     }
 
     @Test
     public void testGetIntegrationState() {
-        final PublicApiHandler.IntegrationState integrationState = handler.getIntegrationState(getSecurityContext(),
-                INTEGRATION_NAME);
-        assertThat(integrationState, is(notNullValue()));
-        assertThat(integrationState.getCurrentState(), is(IntegrationDeploymentState.Unpublished));
+        final DataManager dataManager = mock(DataManager.class);
+
+        final Integration integration = new Integration.Builder()
+            .id("integration-id")
+            .name("integration-name")
+            .build();
+        when(dataManager.fetch(Integration.class, "integration-name")).thenReturn(integration);
+
+        final IntegrationHandler integrationHandler = mock(IntegrationHandler.class);
+        when(integrationHandler.get("integration-id")).thenReturn(new IntegrationOverview.Builder()
+            .createFrom(integration)
+            .currentState(IntegrationDeploymentState.Unpublished)
+            .build());
+
+        final MonitoringProvider monitoringProvider = mock(MonitoringProvider.class);
+        final IntegrationDeploymentStateDetails stateDetails = new IntegrationDeploymentStateDetails.Builder()
+            .build();
+        when(monitoringProvider.getIntegrationStateDetails("integration-id")).thenReturn(stateDetails);
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(dataManager, null, null, null, monitoringProvider, null, null, integrationHandler);
+
+        final PublicApiHandler.IntegrationState integrationState = handler.getIntegrationState(newMockSecurityContext(),
+            "integration-name");
+
+        assertThat(integrationState.getCurrentState()).isEqualTo(IntegrationDeploymentState.Unpublished);
+        assertThat(integrationState.getStateDetails()).isEqualTo(stateDetails);
+    }
+
+    @Test
+    public void testGetReleaseEnvironments() {
+        final DataManager dataManager = mock(DataManager.class);
+        when(dataManager.fetchAll(Environment.class)).thenReturn(ListResult.of(newEnvironment("env1"), newEnvironment("env2")));
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        final List<String> environments = handler.getReleaseEnvironments();
+
+        assertThat(environments).containsOnly("env1", "env2");
+    }
+
+    @Test
+    public void testGetReleaseTags() {
+        final DataManager dataManager = mock(DataManager.class);
+
+        final Environment env = newEnvironment("env");
+        final String envId = env.getId().get();
+        final ContinuousDeliveryEnvironment deliveryEnvironment = new ContinuousDeliveryEnvironment.Builder()
+            .environmentId(envId)
+            .build();
+        final Integration integration = new Integration.Builder()
+            .putContinuousDeliveryState(envId, deliveryEnvironment)
+            .build();
+        when(dataManager.fetch(Integration.class, "integration-id")).thenReturn(integration);
+        when(dataManager.fetch(Environment.class, envId)).thenReturn(env);
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        final Map<String, ContinuousDeliveryEnvironment> releaseTags = handler.getReleaseTags("integration-id");
+
+        assertThat(releaseTags).containsOnly(entry("env", deliveryEnvironment));
+    }
+
+    @Test
+    public void testInvalidTagForRelease() {
+        final DataManager dataManager = mock(DataManager.class);
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        assertThatExceptionOfType(ClientErrorException.class)
+            .isThrownBy(() -> handler.putTagsForRelease("some-integration-id", Collections.singletonList("%test}")))
+            .withMessageStartingWith("Missing environment")
+            .satisfies(e -> assertThat(e.getResponse().getStatusInfo().toEnum()).isEqualTo(Status.NOT_FOUND));
+    }
+
+    @Test
+    public void testPatchTagsForRelease() throws Exception {
+        final DataManager dataManager = mock(DataManager.class);
+
+        final Environment env1 = newEnvironment("env1");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env1"))
+            .thenReturn(Optional.of(env1));
+        when(dataManager.fetch(Environment.class, env1.getId().get())).thenReturn(env1);
+
+        final Environment env2 = newEnvironment("env2");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env2"))
+            .thenReturn(Optional.of(env2));
+        when(dataManager.fetch(Environment.class, env2.getId().get())).thenReturn(env2);
+
+        final ContinuousDeliveryEnvironment existingContinuousDeliveryEntry = new ContinuousDeliveryEnvironment.Builder()
+            .environmentId(env1.getId().get())
+            .lastTaggedAt(new Date(0))
+            .build();
+        final Integration integration = new Integration.Builder()
+            .putContinuousDeliveryState(env1.getId().get(), existingContinuousDeliveryEntry)
+            .build();
+        when(dataManager.fetch(Integration.class, "integration-id")).thenReturn(integration);
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.patchTagsForRelease("integration-id",
+            Collections.singletonList("env2"));
+
+        assertThat(continuousDeliveryEnvironment).containsEntry("env1", existingContinuousDeliveryEntry);
+        assertThat(continuousDeliveryEnvironment).hasEntrySatisfying("env2", containsContinuousDeliveryEntry());
+        assertThat(continuousDeliveryEnvironment.get("env1").getLastTaggedAt()).isBefore(continuousDeliveryEnvironment.get("env2").getLastTaggedAt());
+
+        verify(dataManager).update(integration.builder()
+            // see javadoc for continous delivery state
+            .putContinuousDeliveryState(env2.getId().get(), continuousDeliveryEnvironment.get("env2"))
+            .build());
     }
 
     @Test
     public void testPublishIntegration() {
-        final IntegrationDeployment deployment = handler.publishIntegration(getSecurityContext(), INTEGRATION_NAME);
+        final DataManager dataManager = mock(DataManager.class);
+        final Integration integration = new Integration.Builder()
+            .id("integration-id")
+            .build();
 
-        assertThat(deployment, is(notNullValue()));
-        assertThat(deployment.getTargetState(), is(IntegrationDeploymentState.Published));
+        final SecurityContext securityContext = newMockSecurityContext();
+
+        when(dataManager.fetchAllByPropertyValue(Integration.class, "name", "integration-name")).thenReturn(Stream.of(integration));
+
+        final IntegrationDeploymentHandler deploymentHandler = mock(IntegrationDeploymentHandler.class);
+        when(deploymentHandler.update(securityContext, "integration-id")).thenReturn(new IntegrationDeployment.Builder()
+            .spec(integration)
+            .targetState(IntegrationDeploymentState.Published)
+            .build());
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(dataManager, null, deploymentHandler, null, null, null, null, null);
+
+        final IntegrationDeployment deployment = handler.publishIntegration(securityContext, "integration-name");
+
+        assertThat(deployment.getTargetState()).isEqualTo(IntegrationDeploymentState.Published);
+    }
+
+    @Test
+    public void testPutTagsForRelease() throws Exception {
+        final Environment environment = newEnvironment("env");
+        final Integration integration = new Integration.Builder().build();
+
+        final DataManager dataManager = mock(DataManager.class);
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env"))
+            .thenReturn(Optional.of(environment));
+        when(dataManager.fetch(Environment.class, environment.getId().get())).thenReturn(environment);
+        when(dataManager.fetch(Integration.class, "integration-id")).thenReturn(integration);
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.putTagsForRelease("integration-id",
+            Collections.singletonList("env"));
+
+        assertThat(continuousDeliveryEnvironment).hasEntrySatisfying("env", containsContinuousDeliveryEntry());
+
+        verify(dataManager).update(integration.builder()
+            // see javadoc for continous delivery state
+            .putContinuousDeliveryState(environment.getId().get(), continuousDeliveryEnvironment.get("env"))
+            .build());
+    }
+
+    @Test
+    public void testPutTagsForReleaseByName() throws Exception {
+        final Environment environment = newEnvironment("env");
+        final Integration integration = new Integration.Builder().build();
+
+        final DataManager dataManager = mock(DataManager.class);
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env"))
+            .thenReturn(Optional.of(environment));
+        when(dataManager.fetch(Environment.class, environment.getId().get())).thenReturn(environment);
+        when(dataManager.fetchAllByPropertyValue(Integration.class, "name", "integration-name")).thenReturn(Stream.of(integration));
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        final Map<String, ContinuousDeliveryEnvironment> continuousDeliveryEnvironment = handler.putTagsForRelease("integration-name",
+            Collections.singletonList("env"));
+
+        assertThat(continuousDeliveryEnvironment).hasEntrySatisfying("env", containsContinuousDeliveryEntry());
+
+        verify(dataManager).update(integration.builder()
+            // see javadoc for continous delivery state
+            .putContinuousDeliveryState(environment.getId().get(), continuousDeliveryEnvironment.get("env"))
+            .build());
+    }
+
+    @Test
+    public void testRenameEnvironment() {
+        final DataManager dataManager = mock(DataManager.class);
+
+        final Environment env = newEnvironment("env");
+        when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
+
+        final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(null, null, null, null, null, environmentHandler, null, null);
+
+        handler.renameEnvironment("env", "new-env");
+
+        verify(dataManager).update(new Environment.Builder().createFrom(env)
+            .name("new-env")
+            .build());
     }
 
     @Test
     public void testStopIntegration() {
-        targetState = IntegrationDeploymentState.Published;
-        handler.stopIntegration(getSecurityContext(), INTEGRATION_NAME);
+        final DataManager dataManager = mock(DataManager.class);
+        final Integration integration = new Integration.Builder()
+            .id("integration-id")
+            .build();
 
-        verify(deploymentHandler).updateTargetState(eq(INTEGRATION_ID), eq(2), argThat(targetState -> targetState.getTargetState() == IntegrationDeploymentState.Unpublished));
+        final SecurityContext securityContext = newMockSecurityContext();
+
+        when(dataManager.fetchAllByPropertyValue(Integration.class, "name", "integration-name")).thenReturn(Stream.of(integration));
+        when(dataManager.fetchAllByPropertyValue(IntegrationDeployment.class, "integrationId", "integration-id"))
+            .thenReturn(Stream.of(new IntegrationDeployment.Builder()
+                .targetState(IntegrationDeploymentState.Published)
+                .version(2)
+                .spec(integration)
+                .build()));
+
+        final IntegrationDeploymentHandler deploymentHandler = mock(IntegrationDeploymentHandler.class);
+
+        // null's are not used
+        final PublicApiHandler handler = new PublicApiHandler(dataManager, null, deploymentHandler, null, null, null, null, null);
+
+        handler.stopIntegration(securityContext, "integration-name");
+
+        verify(deploymentHandler).updateTargetState("integration-id", 2, new TargetStateRequest(IntegrationDeploymentState.Unpublished));
+    }
+
+    private static Condition<ContinuousDeliveryEnvironment> containsContinuousDeliveryEntry() {
+        return new Condition<ContinuousDeliveryEnvironment>("With releaseTag and lastTaggedAt") {
+            @Override
+            public boolean matches(final ContinuousDeliveryEnvironment value) {
+                return !value.getReleaseTag().isEmpty()
+                    && value.getLastTaggedAt() != null;
+            }
+        };
+    }
+
+    private static Environment newEnvironment(final String name) {
+        return new Environment.Builder()
+            .id(RandomStringUtils.randomAlphabetic(5))
+            .name(name)
+            .build();
+    }
+
+    private static SecurityContext newMockSecurityContext() {
+        final SecurityContext security = mock(SecurityContext.class);
+        final Principal principal = mock(Principal.class);
+        when(security.getUserPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("user");
+
+        return security;
+    }
+
+    private static Integration withLastExportedTimestamp(final Integration base, final String envId) {
+        return ArgumentMatchers.argThat(integration -> integration.idEquals(base.getId().get())
+            && integration.getContinuousDeliveryState().get(envId).getLastExportedAt() != null);
+    }
+
+    private static <T extends WithName> T withName(final Class<T> type, final String name) {
+        return ArgumentMatchers.argThat(argument -> type.isInstance(argument) && name.equals(argument.getName()));
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandlerTest.java
@@ -165,8 +165,7 @@ public class IntegrationDeploymentHandlerTest {
 
     @Test
     public void shouldUpdateIntegrationDeploymentTargetState() {
-        final TargetStateRequest targetState = new TargetStateRequest();
-        targetState.setTargetState(IntegrationDeploymentState.Published);
+        final TargetStateRequest targetState = new TargetStateRequest(IntegrationDeploymentState.Published);
 
         final IntegrationDeployment existing = deployment(0);
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelperTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelperTest.java
@@ -15,11 +15,11 @@
  */
 package io.syndesis.server.endpoint.v1.handler.integration;
 
-import com.google.common.collect.Sets;
-import io.syndesis.common.model.DataShape;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 import io.syndesis.common.model.ListResult;
-import io.syndesis.common.model.action.Action;
-import io.syndesis.common.model.action.ActionDescriptor;
 import io.syndesis.common.model.action.StepAction;
 import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
@@ -28,17 +28,11 @@ import io.syndesis.common.model.integration.IntegrationDeploymentState;
 import io.syndesis.common.model.integration.IntegrationOverview;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.server.dao.manager.DataManager;
-import io.syndesis.server.dao.manager.operators.IdPrefixFilter;
-import io.syndesis.server.dao.manager.operators.ReverseFilter;
 import io.syndesis.server.openshift.ExposureHelper;
+
 import org.junit.Test;
 
-import javax.validation.constraints.NotNull;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedSet;
+import com.google.common.collect.Sets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
`PublicApiHandlerTest` much like the whole public API is a convoluted mess. At least having the test cleaned could help with refactoring it to a smaller mess.

Several issues with the test:
 - test mostly exercised mocks
 - assertions tested to broadly (i.e. _some_ integration was updated)
 - spaghetti mock usage, where by any change to a mock configuration
   would introduce issues in several test cases
 - no exception assertions were used

This refactors the test to use AssertJ instead of JUnit Hamcrest assertions which are much more versatile; cleans up mock usage and does general refactoring for code quality.