### PR TITLE
TEIIDTOOLS-801 disables create virtualization button if name is empty

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationCreateForm.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationCreateForm.tsx
@@ -23,6 +23,11 @@ export interface IVirtualizationCreateFormProps {
   i18nCreateLabel: string;
 
   /**
+   * `true` if create should be disabled.
+   */
+  isDisableCreate: boolean;
+
+  /**
    * `true` if work in progress and this form should disable user input.
    */
   isWorking: boolean;
@@ -66,7 +71,7 @@ export const VirtualizationCreateForm: React.FunctionComponent<
               data-testid={'virtualization-create-form-save-button'}
               bsStyle="primary"
               style={{ marginRight: 0 }}
-              disabled={props.isWorking}
+              disabled={props.isWorking || props.isDisableCreate}
               onClick={props.handleSubmit}
             >
               {props.i18nCreateLabel}

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationCreateForm.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationCreateForm.stories.tsx
@@ -43,6 +43,7 @@ stories.add(
       handleSubmit={action(createText)}
       i18nCancelLabel={cancelLabel}
       i18nCreateLabel={createLabel}
+      isDisableCreate={boolean('isDisableCreate', false)}
       isWorking={boolean('isWorking', false)}
       validationResults={validationResults}
       onCancel={action(cancelText)}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -25,7 +25,6 @@
     "publishedDataVirtualization": "Published",
     "publishInProgress": "publish in progress...",
     "unpublishInProgress": "unpublish in progress...",
-    "requiredPropertyText": "This property is required",
     "virtualizationDescriptionDisplay": "Description",
     "virtualizationNameDisplay": "Virtualization Name",
     "virtualizationsPageDescription": "Syndesis creates and manages data virtualizations to expose as data source connections.",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -25,7 +25,6 @@
     "publishedDataVirtualization": "Published",
     "publishInProgress": "publish in progress...",
     "unpublishInProgress": "unpublish in progress...",
-    "requiredPropertyText": "This property is required",
     "virtualizationDescriptionDisplay": "Description",
     "virtualizationNameDisplay": "Virtualization Name",
     "virtualizationsPageDescription": "Syndesis creates and manages data virtualizations to expose as data source connections.",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationCreatePage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationCreatePage.tsx
@@ -2,7 +2,10 @@ import {
   IDvNameValidationResult,
   useVirtualizationHelpers,
 } from '@syndesis/api';
-import { AutoForm, IFormDefinition } from '@syndesis/auto-form';
+import { AutoForm, IFormDefinition, IFormValue } from '@syndesis/auto-form';
+import {
+  validateRequiredProperties,
+} from '@syndesis/utils';
 
 import { Breadcrumb, IVirtualizationCreateValidationResult, PageSection, VirtualizationCreateForm } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
@@ -126,6 +129,13 @@ export const VirtualizationCreatePage: React.FunctionComponent = () => {
     }
   };
 
+  const validator = (values: IFormValue) =>
+  validateRequiredProperties(
+    formDefinition,
+    (name: string) => `${name} is required`,
+    values
+  );
+
   return (
     <>
       <Breadcrumb>
@@ -161,21 +171,27 @@ export const VirtualizationCreatePage: React.FunctionComponent = () => {
       <PageSection>
         <AutoForm
           definition={formDefinition}
-          initialValue={''}
           i18nRequiredProperty={t(
-            'data:virtualization.requiredPropertyText'
+            'shared:requiredFieldMessage'
           )}
+          initialValue={{
+            virtDescription: '',
+            virtName: '',
+          }}
+          validate={validator}
+          validateInitial={validator}
           onSave={(properties, actions) => {
             handleCreate(properties).finally(() => {
               actions.setSubmitting(false);
             });
           }}
         >
-          {({ fields, handleSubmit, isSubmitting, isValidating }) => (
+          {({ fields, handleSubmit, isSubmitting, isValid, isValidating }) => (
             <VirtualizationCreateForm
               handleSubmit={handleSubmit}
               i18nCancelLabel={t('shared:Cancel')}
               i18nCreateLabel={t('shared:Create')}
+              isDisableCreate={!isValid}
               isWorking={isSubmitting || isValidating}
               validationResults={validationResults}
               onCancel={doCancel}


### PR DESCRIPTION
The create button on the create virtualization page is now disabled if the name entry is empty.
- added isDisableCreate property to the VirtualizationCreateForm for disabling the button
- adapted the AutoForm in VirtualizationCreatePage to validate the required properties set the createForm property
- remove requiredPropertyText from our data translations and now using the shared equivalent