### PR TITLE
fix(ENTESB-11787): Reconfiguration of SQL query step changes text to dropdown

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
@@ -83,7 +83,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
         final SqlStatementMetaData sqlStatementMetaData = (SqlStatementMetaData) metadata.getPayload();
 
         if (sqlStatementMetaData != null) {
-            enrichedProperties.put(QUERY, Collections.singletonList(new PropertyPair(sqlStatementMetaData.getSqlStatement(), QUERY)));
+            enrichedProperties.put(QUERY, Collections.singletonList(new PropertyPair(sqlStatementMetaData.getSqlStatement())));
 
             // build the input and output schemas
             final JsonSchema specIn;

--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -44,7 +44,7 @@
                 "order": 1,
                 "required": true,
                 "secret": false,
-                "type": "text"
+                "type": "dataList"
               },
               "batch": {
                 "defaultValue": false,
@@ -112,7 +112,7 @@
                 "order": "1",
                 "required": true,
                 "secret": false,
-                "type": "text"
+                "type": "dataList"
               },
               "schedulerExpression": {
                 "defaultValue": 60000,

--- a/app/connector/sql/src/test/resources/sql/name_sql_batch_update_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_batch_update_metadata.json
@@ -15,7 +15,7 @@
   },
   "properties" : {
     "query" : [ {
-      "displayValue" : "query",
+      "displayValue" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)",
       "value" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)"
     } ]
   }

--- a/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_metadata.json
@@ -21,7 +21,7 @@
   },
   "properties" : {
     "query" : [ {
-      "displayValue" : "query",
+      "displayValue" : "SELECT * FROM NAME WHERE ID=:#id",
       "value" : "SELECT * FROM NAME WHERE ID=:#id"
     } ]
   }

--- a/app/connector/sql/src/test/resources/sql/name_sql_no_param_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_no_param_metadata.json
@@ -15,7 +15,7 @@
   },
   "properties" : {
     "query" : [ {
-      "displayValue" : "query",
+      "displayValue" : "SELECT * FROM NAME",
       "value" : "SELECT * FROM NAME"
     } ]
   }

--- a/app/connector/sql/src/test/resources/sql/name_sql_update_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_update_metadata.json
@@ -15,7 +15,7 @@
   },
   "properties" : {
     "query" : [ {
-      "displayValue" : "query",
+      "displayValue" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)",
       "value" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES (:#firstname, :#lastname)"
     } ]
   }

--- a/app/connector/sql/src/test/resources/sql/name_sql_update_no_param_metadata.json
+++ b/app/connector/sql/src/test/resources/sql/name_sql_update_no_param_metadata.json
@@ -9,7 +9,7 @@
   },
   "properties" : {
     "query" : [ {
-      "displayValue" : "query",
+      "displayValue" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES ('Sheldon', 'Cooper')",
       "value" : "INSERT INTO NAME (FIRSTNAME, LASTNAME) VALUES ('Sheldon', 'Cooper')"
     } ]
   }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -207,7 +207,7 @@ public class ConnectionActionHandler {
                                             .stream()
                                             .map(ConfigurationProperty.PropertyValue.Builder::value)::iterator);
                                 });
-                    } else if ("select".equalsIgnoreCase(property.getType())) {
+                    } else {
                         enriched.replaceConfigurationProperty(suggestions.getKey(),
                                 builder -> {
                                     if (suggestions.getValue().size() == 1) {
@@ -217,13 +217,6 @@ public class ConnectionActionHandler {
                                     builder.addAllEnum(suggestions.getValue()
                                             .stream()
                                             .map(ConfigurationProperty.PropertyValue.Builder::from)::iterator);
-                                });
-                    } else {
-                        enriched.replaceConfigurationProperty(suggestions.getKey(),
-                                builder -> {
-                                    if (suggestions.getValue().size() == 1) {
-                                        builder.defaultValue(suggestions.getValue().get(0).value());
-                                    }
                                 });
                     }
                 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -88,7 +88,7 @@ public class ConnectionActionHandlerTest {
                         .displayName("Salesforce object type")//
                         .group("common")//
                         .required(true)//
-                        .type("select")//
+                        .type("string")//
                         .javaType("java.lang.String")//
                         .componentProperty(false)//
                         .description("Salesforce object type to create")//


### PR DESCRIPTION
Use dataList component for SQL query so we can revert meta data lookup on server to use the original logic. This way other connectors that rely on "text"/"string" getting automatically rendered as dropdown are not affected.

We will straighten the meta logic and the connector json property types on master as part of https://issues.jboss.org/browse/ENTESB-11969