### PR TITLE
fix(ENTESB-11945): roll back to use Json schema draft 4

### DIFF
--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/ResponseCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/ResponseCustomizer.java
@@ -81,7 +81,7 @@ public final class ResponseCustomizer implements ComponentProxyCustomizer, Outpu
             return false;
         }
 
-        final JsonNode id = jsonSchema.get("$id");
+        final JsonNode id = jsonSchema.get("id");
 
         return !isNullNode(id) && "io:syndesis:wrapped".equals(id.asText());
     }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/ResponseCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/ResponseCustomizerTest.java
@@ -37,6 +37,6 @@ public class ResponseCustomizerTest {
     @Test
     public void shouldDetermineAddingResponseConverterWithWrappedSchema() {
         assertThat(ResponseCustomizer
-            .isUnifiedDataShape(new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA).specification("{\"$id\":\"io:syndesis:wrapped\"}").build())).isTrue();
+            .isUnifiedDataShape(new DataShape.Builder().kind(DataShapeKinds.JSON_SCHEMA).specification("{\"id\":\"io:syndesis:wrapped\"}").build())).isTrue();
     }
 }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
@@ -379,7 +379,7 @@ public class RestSwaggerConnectorIntegrationTest {
             .addFlow(oAuthAuthorizationFlow())
             .addFlow(testFlow("getPetById", "unifiedResponse", JSON_SCHEMA_SHAPE, new DataShape.Builder()
                 .kind(DataShapeKinds.JSON_SCHEMA)
-                .specification("{\"$id\":\"io:syndesis:wrapped\"}")
+                .specification("{\"id\":\"io:syndesis:wrapped\"}")
                 .build()))
             .addFlow(oAuthRefreshFlow())
             .addFlow(oAuthRetryFlow())

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/UnifiedJsonDataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/UnifiedJsonDataShapeGenerator.java
@@ -304,7 +304,8 @@ public class UnifiedJsonDataShapeGenerator extends BaseDataShapeGenerator {
         }
 
         final ObjectNode unifiedSchema = JsonSchemaHelper.newJsonObjectSchema();
-        unifiedSchema.put("$id", "io:syndesis:wrapped");
+        // we're using Draft 4, in Draft 6+ this should be `$id`
+        unifiedSchema.put("id", "io:syndesis:wrapped");
         final ObjectNode properties = unifiedSchema.putObject("properties");
 
         if (parametersSchema != null) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/util/JsonSchemaHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/util/JsonSchemaHelper.java
@@ -40,7 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class JsonSchemaHelper {
 
-    private static final String JSON_SCHEMA_URI = "http://json-schema.org/schema#";
+    private static final String JSON_SCHEMA_URI = "http://json-schema.org/draft-04/schema#";
 
     private JsonSchemaHelper() {
         // utility class

--- a/app/server/api-generator/src/test/resources/swagger/damage_service.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/damage_service.unified_connector.json
@@ -26,7 +26,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of a gesture event.\",\"required\":[\"vibrationClass\",\"sensorId\",\"machineId\",\"confidencePercentage\"],\"properties\":{\"sensorId\":{\"type\":\"string\"},\"machineId\":{\"type\":\"number\"},\"vibrationClass\":{\"type\":\"number\"},\"confidencePercentage\":{\"type\":\"number\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of a gesture event.\",\"required\":[\"vibrationClass\",\"sensorId\",\"machineId\",\"confidencePercentage\"],\"properties\":{\"sensorId\":{\"type\":\"string\"},\"machineId\":{\"type\":\"number\"},\"vibrationClass\":{\"type\":\"number\"},\"confidencePercentage\":{\"type\":\"number\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -35,7 +35,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of a damage event.\",\"required\":[\"damage\",\"machineId\"],\"properties\":{\"machineId\":{\"type\":\"number\"},\"damage\":{\"type\":\"integer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of a damage event.\",\"required\":[\"damage\",\"machineId\"],\"properties\":{\"machineId\":{\"type\":\"number\"},\"damage\":{\"type\":\"integer\"}}}}}"
         }
       },
       "id": "_id_:operation-1",
@@ -68,7 +68,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"Represents a request to apply damage to the state of a machine\",\"required\":[\"confidencePercentage\",\"damage\",\"downTimePrice\",\"machineId\",\"machineInitialHealth\",\"sensorId\",\"vibrationClass\"],\"properties\":{\"sensorId\":{\"type\":\"string\"},\"machineId\":{\"type\":\"number\"},\"vibrationClass\":{\"type\":\"number\"},\"confidencePercentage\":{\"type\":\"number\"},\"damage\":{\"type\":\"integer\"},\"machineInitialHealth\":{\"type\":\"integer\"},\"downTimePrice\":{\"type\":\"integer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"Represents a request to apply damage to the state of a machine\",\"required\":[\"confidencePercentage\",\"damage\",\"downTimePrice\",\"machineId\",\"machineInitialHealth\",\"sensorId\",\"vibrationClass\"],\"properties\":{\"sensorId\":{\"type\":\"string\"},\"machineId\":{\"type\":\"number\"},\"vibrationClass\":{\"type\":\"number\"},\"confidencePercentage\":{\"type\":\"number\"},\"damage\":{\"type\":\"integer\"},\"machineInitialHealth\":{\"type\":\"integer\"},\"downTimePrice\":{\"type\":\"integer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/api-generator/src/test/resources/swagger/kie-server.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/kie-server.unified_connector.json
@@ -15,7 +15,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -24,7 +24,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstances",
@@ -49,7 +49,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be canceled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be canceled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -77,7 +77,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be requeued\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be requeued\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -105,7 +105,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be retrieved\"},\"withErrors\":{\"type\":\"boolean\",\"title\":\"withErrors\",\"description\":\"optional flag that indicats if errors should be loaded as well\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag that indicats if input/output data should be loaded as well\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be retrieved\"},\"withErrors\":{\"type\":\"boolean\",\"title\":\"withErrors\",\"description\":\"optional flag that indicats if errors should be loaded as well\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag that indicats if input/output data should be loaded as well\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -114,7 +114,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"xml\":{\"name\":\"request-info-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"xml\":{\"name\":\"request-info-instance\"}}}}"
         }
       },
       "id": "_id_:getRequestById",
@@ -139,7 +139,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\",\"title\":\"key\",\"description\":\"identifier of the business key that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\",\"title\":\"key\",\"description\":\"identifier of the business key that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -148,7 +148,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
         }
       },
       "id": "_id_:getRequestsByBusinessKey",
@@ -173,7 +173,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"cmd\":{\"type\":\"string\",\"title\":\"cmd\",\"description\":\"name of the command that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"cmd\":{\"type\":\"string\",\"title\":\"cmd\",\"description\":\"name of the command that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -182,7 +182,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
         }
       },
       "id": "_id_:getRequestsByCommand",
@@ -207,7 +207,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"identifier of the container that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"identifier of the container that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -216,7 +216,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
         }
       },
       "id": "_id_:getRequestsByContainer",
@@ -241,7 +241,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that asynchornous jobs should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -250,7 +250,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
         }
       },
       "id": "_id_:getRequestsByProcessInstance",
@@ -275,7 +275,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional job status (QUEUED, DONE, CANCELLED, ERROR, RETRYING, RUNNING)\",\"items\":{\"type\":\"string\",\"enum\":[\"QUEUED\",\"DONE\",\"CANCELLED\",\"ERROR\",\"RETRYING\",\"RUNNING\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -284,7 +284,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"request-info-instance\":{\"items\":{\"properties\":{\"request-business-key\":{\"type\":\"string\"},\"request-command\":{\"type\":\"string\"},\"request-container-id\":{\"type\":\"string\"},\"request-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"request-errors\":{\"properties\":{\"error-info-instance\":{\"items\":{\"properties\":{\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-instance-id\":{\"type\":\"integer\"},\"error-message\":{\"type\":\"string\"},\"error-stacktrace\":{\"type\":\"string\"},\"request-instance-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"error-info-instance-list\"}},\"request-executions\":{\"type\":\"integer\"},\"request-instance-id\":{\"type\":\"integer\"},\"request-message\":{\"type\":\"string\"},\"request-retries\":{\"type\":\"integer\"},\"request-scheduled-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"request-status\":{\"type\":\"string\"},\"response-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"request-info-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"request-info-instance-list\"}}}}"
         }
       },
       "id": "_id_:getRequestsByStatus",
@@ -309,7 +309,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -318,7 +318,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:scheduleRequest",
@@ -343,7 +343,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be updated\"},\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"jobId\":{\"type\":\"integer\",\"title\":\"jobId\",\"description\":\"identifier of the asynchronous job to be updated\"},\"containerId\":{\"type\":\"string\",\"title\":\"containerId\",\"description\":\"optional container id that the job should be associated with\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -371,7 +371,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -399,7 +399,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic subprocess should be added\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic subprocess should be added\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id of the subprocess to be added\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -427,7 +427,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -455,7 +455,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic task should be added\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where dynamic task should be added\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -483,7 +483,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -511,7 +511,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be set\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be aded to case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be aded to case role for given case instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be set\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be aded to case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be aded to case role for given case instance\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -539,7 +539,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"destroy\":{\"type\":\"boolean\",\"title\":\"destroy\",\"description\":\"allows to destroy (permanently) case instance as part of the cancel operation, defaults to false\",\"default\":\"false\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"destroy\":{\"type\":\"boolean\",\"title\":\"destroy\",\"description\":\"allows to destroy (permanently) case instance as part of the cancel operation, defaults to false\",\"default\":\"false\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -567,7 +567,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -595,7 +595,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -623,7 +623,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item to be added to case file\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item to be added to case file\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given data should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -651,7 +651,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"array\",\"title\":\"dataId\",\"description\":\"one or more names of the data items to be removed from case file\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"array\",\"title\":\"dataId\",\"description\":\"one or more names of the data items to be removed from case file\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -679,7 +679,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be removed\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be removed\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -707,7 +707,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be removed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be removed from case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be removed from case role for given case instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"name of the case role the assignment should be removed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"user to be removed from case role for given case instance\"},\"group\":{\"type\":\"string\",\"title\":\"group\",\"description\":\"group to be removed from case role for given case instance\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -735,7 +735,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -763,7 +763,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag to load data when loading case instance\",\"default\":\"false\"},\"withRoles\":{\"type\":\"boolean\",\"title\":\"withRoles\",\"description\":\"optional flag to load roles when loading case instance\",\"default\":\"false\"},\"withMilestones\":{\"type\":\"boolean\",\"title\":\"withMilestones\",\"description\":\"optional flag to load milestones when loading case instance\",\"default\":\"false\"},\"withStages\":{\"type\":\"boolean\",\"title\":\"withStages\",\"description\":\"optional flag to load stages when loading case instance\",\"default\":\"false\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"withData\":{\"type\":\"boolean\",\"title\":\"withData\",\"description\":\"optional flag to load data when loading case instance\",\"default\":\"false\"},\"withRoles\":{\"type\":\"boolean\",\"title\":\"withRoles\",\"description\":\"optional flag to load roles when loading case instance\",\"default\":\"false\"},\"withMilestones\":{\"type\":\"boolean\",\"title\":\"withMilestones\",\"description\":\"optional flag to load milestones when loading case instance\",\"default\":\"false\"},\"withStages\":{\"type\":\"boolean\",\"title\":\"withStages\",\"description\":\"optional flag to load stages when loading case instance\",\"default\":\"false\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -772,7 +772,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-instance\"}}}}"
         }
       },
       "id": "_id_:getCaseInstance",
@@ -797,7 +797,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -806,7 +806,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-adhoc-fragment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-adhoc-fragment-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceAdHocFragments",
@@ -831,7 +831,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be loaded\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be loaded\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -840,7 +840,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"milestones\":{\"items\":{\"properties\":{\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"},\"milestone-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone-def\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"roles\":{\"additionalProperties\":{\"type\":\"integer\"},\"type\":\"object\"},\"stages\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage-def\"}},\"type\":\"array\"},\"version\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-definition\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"milestones\":{\"items\":{\"properties\":{\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"},\"milestone-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone-def\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"roles\":{\"additionalProperties\":{\"type\":\"integer\"},\"type\":\"object\"},\"stages\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage-def\"}},\"type\":\"array\"},\"version\":{\"type\":\"string\"}},\"xml\":{\"name\":\"case-definition\"}}}}"
         }
       },
       "id": "_id_:getCaseDefinitionsByDefinition",
@@ -865,7 +865,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -874,7 +874,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"definitions\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"milestones\":{\"items\":{\"properties\":{\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"},\"milestone-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone-def\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"roles\":{\"additionalProperties\":{\"type\":\"integer\"},\"type\":\"object\"},\"stages\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage-def\"}},\"type\":\"array\"},\"version\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-definition-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"definitions\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"case-id-prefix\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"milestones\":{\"items\":{\"properties\":{\"milestone-id\":{\"type\":\"string\"},\"milestone-mandatory\":{\"type\":\"boolean\"},\"milestone-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone-def\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"roles\":{\"additionalProperties\":{\"type\":\"integer\"},\"type\":\"object\"},\"stages\":{\"items\":{\"properties\":{\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage-def\"}},\"type\":\"array\"},\"version\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-definition-list\"}}}}"
         }
       },
       "id": "_id_:getCaseDefinitionsByContainer",
@@ -899,7 +899,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optional name(s) of the data items to retrieve\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optional name(s) of the data items to retrieve\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -908,7 +908,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceData",
@@ -933,7 +933,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item within case file to retrieve\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"dataId\":{\"type\":\"string\",\"title\":\"dataId\",\"description\":\"name of the data item within case file to retrieve\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -942,7 +942,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
         }
       },
       "id": "_id_:getCaseInstanceDataByName",
@@ -967,7 +967,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -976,7 +976,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstancesByDefinition",
@@ -1001,7 +1001,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that should be used to filter case instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1010,7 +1010,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstancesByContainer",
@@ -1035,7 +1035,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1044,7 +1044,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"comments\":{\"items\":{\"properties\":{\"added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"author\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"restricted-to\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"restricted-to\"}},\"type\":\"array\"},\"text\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-comment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-comment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"comments\":{\"items\":{\"properties\":{\"added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"author\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"restricted-to\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"restricted-to\"}},\"type\":\"array\"},\"text\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-comment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-comment-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceComments",
@@ -1069,7 +1069,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"achievedOnly\":{\"type\":\"boolean\",\"title\":\"achievedOnly\",\"description\":\"optional flag that allows to control which milestones to load - achieved only or actives ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"achievedOnly\":{\"type\":\"boolean\",\"title\":\"achievedOnly\",\"description\":\"optional flag that allows to control which milestones to load - achieved only or actives ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1078,7 +1078,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-milestone-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-milestone-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceMilestones",
@@ -1103,7 +1103,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"completed\":{\"type\":\"boolean\",\"title\":\"completed\",\"description\":\"optional flag that allows to control which node instances to load - active or completed, defaults to false loading only active ones\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"completed\":{\"type\":\"boolean\",\"title\":\"completed\",\"description\":\"optional flag that allows to control which node instances to load - active or completed, defaults to false loading only active ones\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1112,7 +1112,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceActiveNodes",
@@ -1137,7 +1137,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1146,7 +1146,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceProcessInstance",
@@ -1171,7 +1171,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1180,7 +1180,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"role-assignments\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-role-assignment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"role-assignments\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-role-assignment-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceRoleAssignments",
@@ -1205,7 +1205,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that allows to control which stages to load - active only or completed ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that allows to control which stages to load - active only or completed ones too, defaults to true\",\"default\":\"true\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1214,7 +1214,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-stage-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-stage-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceStages",
@@ -1239,7 +1239,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the case definition resides\"},\"caseDefId\":{\"type\":\"string\",\"title\":\"caseDefId\",\"description\":\"case definition id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1248,7 +1248,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:startCase",
@@ -1273,7 +1273,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1301,7 +1301,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where adhoc fragment should be triggered\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseStageId\":{\"type\":\"string\",\"title\":\"caseStageId\",\"description\":\"identifier of the stage within case instance where adhoc fragment should be triggered\"},\"nodeName\":{\"type\":\"string\",\"title\":\"nodeName\",\"description\":\"name of the adhoc fragment to be triggered\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1329,7 +1329,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be updated\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that case instance belongs to\"},\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"identifier of the case instance\"},\"caseCommentId\":{\"type\":\"string\",\"title\":\"caseCommentId\",\"description\":\"identifier of the comment to be updated\"},\"author\":{\"type\":\"string\",\"title\":\"author\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"restrictedTo\":{\"type\":\"array\",\"title\":\"restrictedTo\",\"description\":\"optional role name(s) that given comment should be restricted to\",\"items\":{\"type\":\"string\"}}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1357,7 +1357,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1385,7 +1385,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"orderBy\":{\"type\":\"string\",\"title\":\"orderBy\",\"description\":\"optional sort order\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"orderBy\":{\"type\":\"string\",\"title\":\"orderBy\",\"description\":\"optional sort order\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1394,7 +1394,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\"}}}}"
         }
       },
       "id": "_id_:runQuery",
@@ -1419,7 +1419,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"builder\":{\"type\":\"string\",\"title\":\"builder\",\"description\":\"optional identifier of the query builder to be used for query conditions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be used for query\"},\"mapper\":{\"type\":\"string\",\"title\":\"mapper\",\"description\":\"identifier of the query mapper to be used when transforming results\"},\"builder\":{\"type\":\"string\",\"title\":\"builder\",\"description\":\"optional identifier of the query builder to be used for query conditions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1428,7 +1428,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
         }
       },
       "id": "_id_:runQueryFiltered",
@@ -1453,7 +1453,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be registered\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be registered\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1481,7 +1481,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be replaced\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be replaced\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1509,7 +1509,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be retrieved\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"queryName\":{\"type\":\"string\",\"title\":\"queryName\",\"description\":\"identifier of the query definition to be retrieved\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1518,7 +1518,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"query-expression\":{\"type\":\"string\"},\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"xml\":{\"name\":\"query-definition\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"query-expression\":{\"type\":\"string\"},\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"xml\":{\"name\":\"query-definition\"}}}}"
         }
       },
       "id": "_id_:getQuery",
@@ -1543,7 +1543,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1552,7 +1552,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"queries\":{\"items\":{\"properties\":{\"query-expression\":{\"type\":\"string\"},\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"query-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"query-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"queries\":{\"items\":{\"properties\":{\"query-expression\":{\"type\":\"string\"},\"query-name\":{\"type\":\"string\"},\"query-source\":{\"type\":\"string\"},\"query-target\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"query-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"query-definitions\"}}}}"
         }
       },
       "id": "_id_:getQueries",
@@ -1577,7 +1577,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be used to evaluate decisions on\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be used to evaluate decisions on\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1586,7 +1586,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:evaluateDecisions",
@@ -1611,7 +1611,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that modesl should be loaded from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that modesl should be loaded from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1620,7 +1620,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getModels",
@@ -1645,7 +1645,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1654,7 +1654,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:createDocument",
@@ -1679,7 +1679,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1707,7 +1707,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be retruned\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be retruned\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1716,7 +1716,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"document-content\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"document-content\"}},\"type\":\"array\"},\"document-id\":{\"type\":\"string\"},\"document-last-mod\":{\"format\":\"date-time\",\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"document-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"document-content\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"document-content\"}},\"type\":\"array\"},\"document-id\":{\"type\":\"string\"},\"document-last-mod\":{\"format\":\"date-time\",\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"document-instance\"}}}}"
         }
       },
       "id": "_id_:getDocument",
@@ -1741,7 +1741,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that content should be retruned from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that content should be retruned from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1750,7 +1750,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}"
         }
       },
       "id": "_id_:getDocumentContent",
@@ -1775,7 +1775,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1784,7 +1784,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"document-instances\":{\"items\":{\"properties\":{\"document-content\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"document-content\"}},\"type\":\"array\"},\"document-id\":{\"type\":\"string\"},\"document-last-mod\":{\"format\":\"date-time\",\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"document-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"document-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"document-instances\":{\"items\":{\"properties\":{\"document-content\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"document-content\"}},\"type\":\"array\"},\"document-id\":{\"type\":\"string\"},\"document-last-mod\":{\"format\":\"date-time\",\"type\":\"string\"},\"document-link\":{\"type\":\"string\"},\"document-name\":{\"type\":\"string\"},\"document-size\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"document-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"document-instance-list\"}}}}"
         }
       },
       "id": "_id_:listDocuments",
@@ -1809,7 +1809,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"documentId\":{\"type\":\"string\",\"title\":\"documentId\",\"description\":\"document id of a document that should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1837,7 +1837,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be assigned to deployed KIE Container\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be assigned to deployed KIE Container\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1846,7 +1846,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:createContainer",
@@ -1871,7 +1871,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be disposed (undeployed)\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be disposed (undeployed)\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1880,7 +1880,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:disposeContainer",
@@ -1908,7 +1908,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getInfo",
@@ -1933,7 +1933,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be retrieved\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id to be retrieved\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1942,7 +1942,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getContainerInfo",
@@ -1967,7 +1967,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"groupId\":{\"type\":\"string\",\"title\":\"groupId\",\"description\":\"optional groupId to filter containers by\"},\"artifactId\":{\"type\":\"string\",\"title\":\"artifactId\",\"description\":\"optional artifactId to filter containers by\"},\"version\":{\"type\":\"string\",\"title\":\"version\",\"description\":\"optional version to filter containers by\"},\"status\":{\"type\":\"string\",\"title\":\"status\",\"description\":\"optional status to filter containers by\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"groupId\":{\"type\":\"string\",\"title\":\"groupId\",\"description\":\"optional groupId to filter containers by\"},\"artifactId\":{\"type\":\"string\",\"title\":\"artifactId\",\"description\":\"optional artifactId to filter containers by\"},\"version\":{\"type\":\"string\",\"title\":\"version\",\"description\":\"optional version to filter containers by\"},\"status\":{\"type\":\"string\",\"title\":\"status\",\"description\":\"optional status to filter containers by\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -1976,7 +1976,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:listContainers",
@@ -2001,7 +2001,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be loaded from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be loaded from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2010,7 +2010,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getReleaseId",
@@ -2038,7 +2038,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getServerState",
@@ -2063,7 +2063,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be loaded\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be loaded\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2072,7 +2072,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:getScannerInfo",
@@ -2097,7 +2097,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be upgraded\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id that release id should be upgraded\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2106,7 +2106,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:updateReleaseId",
@@ -2131,7 +2131,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id for scanner to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2140,7 +2140,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:updateScanner",
@@ -2165,7 +2165,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2174,7 +2174,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"response\":{\"items\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"responses\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"response\":{\"items\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"responses\"}}}}"
         }
       },
       "id": "_id_:executeCommands",
@@ -2199,7 +2199,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2227,7 +2227,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver config resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver to create\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver config resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver to create\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2236,7 +2236,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
         }
       },
       "id": "_id_:createSolver",
@@ -2261,7 +2261,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2289,7 +2289,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2298,7 +2298,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
         }
       },
       "id": "_id_:getSolverWithBestSolution",
@@ -2323,7 +2323,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2332,7 +2332,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"xml\":{\"name\":\"solver-instance\"}}}}"
         }
       },
       "id": "_id_:getSolver",
@@ -2357,7 +2357,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solvers reside\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solvers reside\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2366,7 +2366,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"solver\":{\"items\":{\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"solver-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"solvers\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"solver\":{\"items\":{\"properties\":{\"best-solution\":{\"type\":\"object\"},\"container-id\":{\"type\":\"string\"},\"score\":{\"properties\":{\"value\":{\"type\":\"string\"}},\"type\":\"object\"},\"solver-config-file\":{\"type\":\"string\"},\"solver-id\":{\"type\":\"string\"},\"status\":{\"enum\":[\"NOT_SOLVING\",\"TERMINATING_EARLY\",\"SOLVING\"],\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"solver-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"solvers\"}}}}"
         }
       },
       "id": "_id_:getSolvers",
@@ -2391,7 +2391,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2400,7 +2400,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"boolean\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"boolean\"}}}"
         }
       },
       "id": "_id_:isEveryProblemFactChangeProcessed",
@@ -2425,7 +2425,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2453,7 +2453,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the solver resides\"},\"solverId\":{\"type\":\"string\",\"title\":\"solverId\",\"description\":\"identifier of the solver\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2481,7 +2481,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the involved actors and groups should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the involved actors and groups should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2490,7 +2490,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-associated-entities\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-associated-entities\"}}}}"
         }
       },
       "id": "_id_:getAssociatedEntities",
@@ -2515,7 +2515,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that input variable definitions should be retrieved for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that input variable definitions should be retrieved for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2524,7 +2524,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"taskInputs\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"inputs\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-task-inputs\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"taskInputs\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"inputs\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-task-inputs\"}}}}"
         }
       },
       "id": "_id_:getTaskInputMappings",
@@ -2549,7 +2549,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that output variable definitions should be retrieved for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that given task belongs to\"},\"taskName\":{\"type\":\"string\",\"title\":\"taskName\",\"description\":\"task name that output variable definitions should be retrieved for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2558,7 +2558,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"taskOutputs\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"outputs\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-task-outputs\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"taskOutputs\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"outputs\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-task-outputs\"}}}}"
         }
       },
       "id": "_id_:getTaskOutputMappings",
@@ -2583,7 +2583,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the definition should be retrieved for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the definition should be retrieved for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2592,7 +2592,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-definition\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-definition\"}}}}"
         }
       },
       "id": "_id_:getProcessDefinition",
@@ -2617,7 +2617,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the variable definitions should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the variable definitions should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2626,7 +2626,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"wrapped\":true}}},\"xml\":{\"name\":\"process-variables\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"wrapped\":true}}},\"xml\":{\"name\":\"process-variables\"}}}}"
         }
       },
       "id": "_id_:getProcessVariables",
@@ -2651,7 +2651,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the service task definitions should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the service task definitions should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2660,7 +2660,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-service-tasks\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-service-tasks\"}}}}"
         }
       },
       "id": "_id_:getServiceTasks",
@@ -2685,7 +2685,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that subprocesses should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that subprocesses should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2694,7 +2694,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"subProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"subprocesses\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-subprocesses\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"subProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"subprocesses\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-subprocesses\"}}}}"
         }
       },
       "id": "_id_:getReusableSubProcesses",
@@ -2719,7 +2719,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the user task definitions should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that the user task definitions should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2728,7 +2728,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task\":{\"items\":{\"properties\":{\"associatedEntities\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"task-comment\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-form-name\":{\"type\":\"string\"},\"task-id\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"taskInputMappings\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"task-inputs\",\"wrapped\":true}},\"taskOutputMappings\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"task-outputs\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"user-task-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"user-task-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task\":{\"items\":{\"properties\":{\"associatedEntities\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"task-comment\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-form-name\":{\"type\":\"string\"},\"task-id\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-priority\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"taskInputMappings\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"task-inputs\",\"wrapped\":true}},\"taskOutputMappings\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"task-outputs\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"user-task-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"user-task-definitions\"}}}}"
         }
       },
       "id": "_id_:getTasksDefinitions",
@@ -2753,7 +2753,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of process definition that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of process definition that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2762,7 +2762,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:getProcessForm",
@@ -2787,7 +2787,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance that form should be fetched for\"},\"lang\":{\"type\":\"string\",\"title\":\"lang\",\"description\":\"optional language that the form should be found for\",\"default\":\"en\"},\"filter\":{\"type\":\"boolean\",\"title\":\"filter\",\"description\":\"optional filter flag if form should be filtered or returned as is\"},\"type\":{\"type\":\"string\",\"title\":\"type\",\"description\":\"optional type of the form, defaults to ANY so system will find the most current one\",\"default\":\"ANY\"},\"marshallContent\":{\"type\":\"boolean\",\"title\":\"marshallContent\",\"description\":\"optional marshall content flag if the content should be transformed or not, defaults to true\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2796,7 +2796,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:getTaskForm",
@@ -2821,7 +2821,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of the process definition that image should be loaded for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"identifier of the process definition that image should be loaded for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2830,7 +2830,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:getProcessImage",
@@ -2855,7 +2855,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that image should be loaded for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that image should be loaded for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -2864,7 +2864,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:getProcessInstanceImage",
@@ -2889,7 +2889,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be aborted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be aborted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2917,7 +2917,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be aborted\",\"items\":{\"type\":\"integer\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be aborted\",\"items\":{\"type\":\"integer\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2945,7 +2945,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to abort\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to abort\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2973,7 +2973,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to complete\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to complete\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3001,7 +3001,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that signals should be collected for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that signals should be collected for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3010,7 +3010,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}"
         }
       },
       "id": "_id_:getAvailableSignals",
@@ -3035,7 +3035,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable should be retrieved from\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to be retrieved\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable should be retrieved from\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to be retrieved\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3044,7 +3044,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
         }
       },
       "id": "_id_:getProcessInstanceVariable",
@@ -3069,7 +3069,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables should be retrieved from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables should be retrieved from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3078,7 +3078,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceVariables",
@@ -3103,7 +3103,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that history should be collected for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"instructs if active nodes only should be collected, defaults to false\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"instructs if completed nodes only should be collected, defaults to false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that history should be collected for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"instructs if active nodes only should be collected, defaults to false\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"instructs if completed nodes only should be collected, defaults to false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3112,7 +3112,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceHistory",
@@ -3137,7 +3137,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3146,7 +3146,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
         }
       },
       "id": "_id_:getProcessesByDeploymentId",
@@ -3171,7 +3171,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be fetched\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"indicates if process instance variables should be loaded or not\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be fetched\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"indicates if process instance variables should be loaded or not\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3180,7 +3180,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
         }
       },
       "id": "_id_:getProcessInstance",
@@ -3205,7 +3205,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3214,7 +3214,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstancesByDeploymentId",
@@ -3239,7 +3239,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the parent process instance that process instances should be collected for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the parent process instance that process instances should be collected for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3248,7 +3248,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstances",
@@ -3273,7 +3273,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable history should be collected for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variables that history should be collected for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variable history should be collected for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variables that history should be collected for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3282,7 +3282,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
         }
       },
       "id": "_id_:getVariableHistory",
@@ -3307,7 +3307,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables state should be collected for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that variables state should be collected for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3316,7 +3316,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
         }
       },
       "id": "_id_:getVariablesCurrentState",
@@ -3341,7 +3341,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to retrieve\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"identifier of the work item to retrieve\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3350,7 +3350,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-id\":{\"type\":\"integer\"},\"node-instance-id\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"work-item-id\":{\"type\":\"integer\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-params\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"work-item-state\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"work-item-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-id\":{\"type\":\"integer\"},\"node-instance-id\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"work-item-id\":{\"type\":\"integer\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-params\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"work-item-state\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"work-item-instance\"}}}}"
         }
       },
       "id": "_id_:getWorkItem",
@@ -3375,7 +3375,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work items belong to\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance that work items belong to\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3384,7 +3384,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"work-item-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-id\":{\"type\":\"integer\"},\"node-instance-id\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"work-item-id\":{\"type\":\"integer\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-params\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"work-item-state\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"work-item-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"work-item-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"work-item-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-id\":{\"type\":\"integer\"},\"node-instance-id\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"work-item-id\":{\"type\":\"integer\"},\"work-item-name\":{\"type\":\"string\"},\"work-item-params\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"work-item-state\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"work-item-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"work-item-instance-list\"}}}}"
         }
       },
       "id": "_id_:getWorkItemByProcessInstance",
@@ -3409,7 +3409,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be signaled\"},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be signaled\"},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3437,7 +3437,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be signaled\",\"items\":{\"type\":\"integer\"}},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"instanceId\":{\"type\":\"array\",\"title\":\"instanceId\",\"description\":\"list of identifiers of the process instances to be signaled\",\"items\":{\"type\":\"integer\"}},\"sName\":{\"type\":\"string\",\"title\":\"sName\",\"description\":\"signal name to be send to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3465,7 +3465,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3474,7 +3474,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:startProcess",
@@ -3499,7 +3499,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"},\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to be assigned to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id where the process definition resides\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id that new instance should be created from\"},\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to be assigned to process instance\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3508,7 +3508,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:startProcessWithCorrelation",
@@ -3533,7 +3533,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable to be set/updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable to be set/updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3561,7 +3561,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of the process instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3589,7 +3589,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be acknowledged\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be acknowledged\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3617,7 +3617,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of error identifiers to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of error identifiers to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3645,7 +3645,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be canceled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be canceled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3673,7 +3673,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance to be migrated\"},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instance should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance to be migrated\"},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instance should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3682,7 +3682,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"migration-end\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-logs\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}},\"type\":\"array\"},\"migration-start\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-successful\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"migration-report-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"migration-end\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-logs\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}},\"type\":\"array\"},\"migration-start\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-successful\":{\"type\":\"boolean\"}},\"xml\":{\"name\":\"migration-report-instance\"}}}}"
         }
       },
       "id": "_id_:migrateProcessInstance",
@@ -3707,7 +3707,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instances belongs to\"},\"pInstanceId\":{\"type\":\"array\",\"title\":\"pInstanceId\",\"description\":\"list of identifiers of process instance to be migrated\",\"items\":{\"type\":\"integer\"}},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instances should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instances belongs to\"},\"pInstanceId\":{\"type\":\"array\",\"title\":\"pInstanceId\",\"description\":\"list of identifiers of process instance to be migrated\",\"items\":{\"type\":\"integer\"}},\"targetContainerId\":{\"type\":\"string\",\"title\":\"targetContainerId\",\"description\":\"container id that new process definition belongs to\"},\"targetProcessId\":{\"type\":\"string\",\"title\":\"targetProcessId\",\"description\":\"process definition that process instances should be migrated to\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3716,7 +3716,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"migration-report-instance\":{\"items\":{\"properties\":{\"migration-end\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-logs\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}},\"type\":\"array\"},\"migration-start\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-successful\":{\"type\":\"boolean\"}},\"type\":\"object\",\"xml\":{\"name\":\"migration-report-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"migration-report-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"migration-report-instance\":{\"items\":{\"properties\":{\"migration-end\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-logs\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"migration-logs\"}},\"type\":\"array\"},\"migration-start\":{\"format\":\"date-time\",\"type\":\"string\"},\"migration-successful\":{\"type\":\"boolean\"}},\"type\":\"object\",\"xml\":{\"name\":\"migration-report-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"migration-report-instance-list\"}}}}"
         }
       },
       "id": "_id_:migrateProcessInstances",
@@ -3741,7 +3741,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be loaded\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of error to be loaded\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3750,7 +3750,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"execution-error\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"execution-error\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrorById",
@@ -3775,7 +3775,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that active nodes instances should be collected for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that active nodes instances should be collected for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3784,7 +3784,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
         }
       },
       "id": "_id_:getActiveNodeInstances",
@@ -3809,7 +3809,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer instances should be collected for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer instances should be collected for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3818,7 +3818,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"timer-instance\":{\"items\":{\"properties\":{\"activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"delay\":{\"type\":\"integer\"},\"id\":{\"type\":\"integer\"},\"last-fire-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"next-fire-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"period\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"repeat-limit\":{\"type\":\"integer\"},\"session-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"timer-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"timer-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"timer-instance\":{\"items\":{\"properties\":{\"activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"delay\":{\"type\":\"integer\"},\"id\":{\"type\":\"integer\"},\"last-fire-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"next-fire-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"period\":{\"type\":\"integer\"},\"process-instance-id\":{\"type\":\"integer\"},\"repeat-limit\":{\"type\":\"integer\"},\"session-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"timer-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"timer-instance-list\"}}}}"
         }
       },
       "id": "_id_:getTimerInstances",
@@ -3843,7 +3843,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that process nodes should be collected from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that process nodes should be collected from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3852,7 +3852,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-node\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-node\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-node-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-node\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-node\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-node-list\"}}}}"
         }
       },
       "id": "_id_:getNodes",
@@ -3877,7 +3877,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3886,7 +3886,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrors",
@@ -3911,7 +3911,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"node\":{\"type\":\"string\",\"title\":\"node\",\"description\":\"optional name of the node in the process instance to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"node\":{\"type\":\"string\",\"title\":\"node\",\"description\":\"optional name of the node in the process instance to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -3920,7 +3920,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrorsByProcessInstance",
@@ -3945,7 +3945,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be retriggered\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that node instance belongs to\"},\"nodeInstanceId\":{\"type\":\"integer\",\"title\":\"nodeInstanceId\",\"description\":\"identifier of node instance that should be retriggered\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3973,7 +3973,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance where node should be triggered\"},\"nodeId\":{\"type\":\"integer\",\"title\":\"nodeId\",\"description\":\"identifier of the node to be triggered\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance where node should be triggered\"},\"nodeId\":{\"type\":\"integer\",\"title\":\"nodeId\",\"description\":\"identifier of the node to be triggered\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4001,7 +4001,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer belongs to\"},\"timerId\":{\"type\":\"integer\",\"title\":\"timerId\",\"description\":\"identifier of timer instance to be updated\"},\"relative\":{\"type\":\"boolean\",\"title\":\"relative\",\"description\":\"optional flag that indicates if the time expression is relative to the current date or not, defaults to true\",\"default\":\"true\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process instance belongs to\"},\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"identifier of process instance that timer belongs to\"},\"timerId\":{\"type\":\"integer\",\"title\":\"timerId\",\"description\":\"identifier of timer instance to be updated\"},\"relative\":{\"type\":\"boolean\",\"title\":\"relative\",\"description\":\"optional flag that indicates if the time expression is relative to the current date or not, defaults to true\",\"default\":\"true\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4029,7 +4029,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"case definition id or name that case definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"case definition id or name that case definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4038,7 +4038,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseDefinitions",
@@ -4063,7 +4063,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that data items should belong to\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optionally filter by data item names\",\"items\":{\"type\":\"string\"}},\"type\":{\"type\":\"array\",\"title\":\"type\",\"description\":\"optionally filter by data item types\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that data items should belong to\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"optionally filter by data item names\",\"items\":{\"type\":\"string\"}},\"type\":{\"type\":\"array\",\"title\":\"type\",\"description\":\"optionally filter by data item types\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4072,7 +4072,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceDataItems",
@@ -4097,7 +4097,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4106,7 +4106,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceTasksAsAdmin",
@@ -4131,7 +4131,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4140,7 +4140,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceTasksAsPotentialOwner",
@@ -4165,7 +4165,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseId\":{\"type\":\"string\",\"title\":\"caseId\",\"description\":\"case instance identifier that tasks should belong to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4174,7 +4174,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstanceTasksAsStakeholder",
@@ -4199,7 +4199,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"case role that instances should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"caseRoleName\":{\"type\":\"string\",\"title\":\"caseRoleName\",\"description\":\"case role that instances should be found for\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4208,7 +4208,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstancesByRole",
@@ -4233,7 +4233,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"dataItemName\":{\"type\":\"string\",\"title\":\"dataItemName\",\"description\":\"data item name that case instances will be filtered by\"},\"dataItemValue\":{\"type\":\"string\",\"title\":\"dataItemValue\",\"description\":\"data item value that case instances will be filtered by\"},\"owner\":{\"type\":\"string\",\"title\":\"owner\",\"description\":\"case instance owner that case instances will be filtered by\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"dataItemName\":{\"type\":\"string\",\"title\":\"dataItemName\",\"description\":\"data item name that case instances will be filtered by\"},\"dataItemValue\":{\"type\":\"string\",\"title\":\"dataItemValue\",\"description\":\"data item value that case instances will be filtered by\"},\"owner\":{\"type\":\"string\",\"title\":\"owner\",\"description\":\"case instance owner that case instances will be filtered by\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional case instance status (open, closed, canceled) - defaults ot open (1) only\",\"items\":{\"type\":\"string\",\"enum\":[\"open\",\"closed\",\"cancelled\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4242,7 +4242,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getCaseInstances1",
@@ -4267,7 +4267,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definitions should be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definitions should be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4276,7 +4276,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessDefinitionsByContainer",
@@ -4301,7 +4301,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process definition id or name that process definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process definition id or name that process definitions will be filtered by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4310,7 +4310,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"instances\":{\"items\":{\"properties\":{\"case-completed-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-completion-msg\":{\"type\":\"string\"},\"case-definition-id\":{\"type\":\"string\"},\"case-description\":{\"type\":\"string\"},\"case-file\":{\"properties\":{\"case-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"case-data-restrictions\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\"},\"case-group-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"},\"case-user-assignments\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-file\"}},\"case-id\":{\"type\":\"string\"},\"case-milestones\":{\"items\":{\"properties\":{\"milestone-achieved\":{\"type\":\"boolean\"},\"milestone-achieved-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"milestone-id\":{\"type\":\"string\"},\"milestone-name\":{\"type\":\"string\"},\"milestone-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-milestone\"}},\"type\":\"array\"},\"case-owner\":{\"type\":\"string\"},\"case-roles\":{\"items\":{\"properties\":{\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"name\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-role-assignment\"}},\"type\":\"array\"},\"case-stages\":{\"items\":{\"properties\":{\"active-nodes\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"},\"adhoc-fragments\":{\"items\":{\"properties\":{\"name\":{\"type\":\"string\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-adhoc-fragment\"}},\"type\":\"array\"},\"stage-id\":{\"type\":\"string\"},\"stage-name\":{\"type\":\"string\"},\"stage-status\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-stage\"}},\"type\":\"array\"},\"case-started-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"case-status\":{\"type\":\"integer\"},\"container-id\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"case-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"case-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessDefinitions",
@@ -4335,7 +4335,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to retrieve node instance for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id that work item belongs to\"},\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to retrieve node instance for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4344,7 +4344,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"node-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"node-instance\"}}}}"
         }
       },
       "id": "_id_:getNodeInstanceForWorkItem",
@@ -4369,7 +4369,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to to retrive history for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"include active nodes only\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"include completed nodes only\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to to retrive history for\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"include active nodes only\"},\"completedOnly\":{\"type\":\"boolean\",\"title\":\"completedOnly\",\"description\":\"include completed nodes only\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4378,7 +4378,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"node-instance\":{\"items\":{\"properties\":{\"container-id\":{\"type\":\"string\"},\"node-completed\":{\"type\":\"boolean\"},\"node-connection\":{\"type\":\"string\"},\"node-id\":{\"type\":\"string\"},\"node-instance-id\":{\"type\":\"integer\"},\"node-name\":{\"type\":\"string\"},\"node-type\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"reference-id\":{\"type\":\"integer\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"node-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"node-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceHistory1",
@@ -4403,7 +4403,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that process definition belongs to\"},\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4412,7 +4412,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-definition\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"xml\":{\"name\":\"process-definition\"}}}}"
         }
       },
       "id": "_id_:getProcessesByDeploymentIdProcessId",
@@ -4437,7 +4437,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to load process definition\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4446,7 +4446,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
         }
       },
       "id": "_id_:getProcessesById",
@@ -4471,7 +4471,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process id or name to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"process id or name to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4480,7 +4480,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
         }
       },
       "id": "_id_:getProcessesByFilter",
@@ -4505,7 +4505,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process definitions\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4514,7 +4514,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"processes\":{\"items\":{\"properties\":{\"associatedEntities\":{\"additionalProperties\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"type\":\"object\",\"xml\":{\"name\":\"associated-entities\",\"wrapped\":true}},\"container-id\":{\"type\":\"string\"},\"dynamic\":{\"type\":\"boolean\"},\"package\":{\"type\":\"string\"},\"process-id\":{\"type\":\"string\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"processVariables\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"process-variables\",\"wrapped\":true}},\"reusableSubProcesses\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"process-subprocesses\",\"wrapped\":true}},\"serviceTasks\":{\"additionalProperties\":{\"type\":\"string\"},\"type\":\"object\",\"xml\":{\"name\":\"service-tasks\",\"wrapped\":true}}},\"type\":\"object\",\"xml\":{\"name\":\"process-definition\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-definitions\"}}}}"
         }
       },
       "id": "_id_:getProcessesByDeploymentId1",
@@ -4539,7 +4539,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key associated with process instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key associated with process instance\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4548,7 +4548,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceByCorrelationKey",
@@ -4573,7 +4573,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to retrieve process instance\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"load process instance variables or not, defaults to false\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to retrieve process instance\"},\"withVars\":{\"type\":\"boolean\",\"title\":\"withVars\",\"description\":\"load process instance variables or not, defaults to false\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4582,7 +4582,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"xml\":{\"name\":\"process-instance\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceById",
@@ -4607,7 +4607,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to filter process instance\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"variable value to filter process instance, optional when filtering by name only required when filtering by name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name to filter process instance\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"variable value to filter process instance, optional when filtering by name only required when filtering by name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4616,7 +4616,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstanceByVariables",
@@ -4641,7 +4641,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4650,7 +4650,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstancesByDeploymentId1",
@@ -4675,7 +4675,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to filter process instance, can be given as partial correlation key like in starts with approach\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"correlationKey\":{\"type\":\"string\",\"title\":\"correlationKey\",\"description\":\"correlation key to filter process instance, can be given as partial correlation key like in starts with approach\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4684,7 +4684,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstancesByCorrelationKey",
@@ -4709,7 +4709,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optinal process instance initiator - user who started process instance to filtr process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pId\":{\"type\":\"string\",\"title\":\"pId\",\"description\":\"process id to filter process instance\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optinal process instance initiator - user who started process instance to filtr process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4718,7 +4718,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstancesByProcessId",
@@ -4743,7 +4743,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optional process instance initiator - user who started process instance to filter process instances\"},\"processName\":{\"type\":\"string\",\"title\":\"processName\",\"description\":\"optional process name to filter process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional process instance status (active, completed, aborted) - defaults ot active (1) only\",\"items\":{\"type\":\"integer\",\"enum\":[\"1\",\"2\",\"3\"]}},\"initiator\":{\"type\":\"string\",\"title\":\"initiator\",\"description\":\"optional process instance initiator - user who started process instance to filter process instances\"},\"processName\":{\"type\":\"string\",\"title\":\"processName\",\"description\":\"optional process name to filter process instances\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4752,7 +4752,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"process-instance\":{\"items\":{\"properties\":{\"active-user-tasks\":{\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary-list\"}},\"container-id\":{\"type\":\"string\"},\"correlation-key\":{\"type\":\"string\"},\"initiator\":{\"type\":\"string\"},\"parent-instance-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-desc\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"process-instance-state\":{\"type\":\"integer\"},\"process-instance-variables\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"process-name\":{\"type\":\"string\"},\"process-version\":{\"type\":\"string\"},\"start-date\":{\"format\":\"date-time\",\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"process-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"process-instance-list\"}}}}"
         }
       },
       "id": "_id_:getProcessInstances1",
@@ -4777,7 +4777,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to load task associated with\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"workItemId\":{\"type\":\"integer\",\"title\":\"workItemId\",\"description\":\"work item id to load task associated with\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4786,7 +4786,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
         }
       },
       "id": "_id_:getTaskByWorkItemId",
@@ -4811,7 +4811,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task instance\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task instance\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4820,7 +4820,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
         }
       },
       "id": "_id_:getTaskById",
@@ -4845,7 +4845,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task events for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"task id to load task events for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4854,7 +4854,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-event-instance\":{\"items\":{\"properties\":{\"task-event-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-event-id\":{\"type\":\"integer\"},\"task-event-message\":{\"type\":\"string\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-event-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-event-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-event-instance\":{\"items\":{\"properties\":{\"task-event-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-event-id\":{\"type\":\"integer\"},\"task-event-message\":{\"type\":\"string\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-event-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-event-instance-list\"}}}}"
         }
       },
       "id": "_id_:getTaskEvents1",
@@ -4879,7 +4879,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4888,7 +4888,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getTasksAssignedAsBusinessAdministratorByStatus",
@@ -4913,7 +4913,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"groups\":{\"type\":\"array\",\"title\":\"groups\",\"description\":\"optional group names to include in the query\",\"items\":{\"type\":\"string\"}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"},\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"optional custom filter for task data\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"groups\":{\"type\":\"array\",\"title\":\"groups\",\"description\":\"optional group names to include in the query\",\"items\":{\"type\":\"string\"}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"},\"filter\":{\"type\":\"string\",\"title\":\"filter\",\"description\":\"optional custom filter for task data\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4922,7 +4922,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getTasksAssignedAsPotentialOwner",
@@ -4947,7 +4947,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to filter task instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to filter task instances\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4956,7 +4956,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getTasksByStatusByProcessInstanceId",
@@ -4981,7 +4981,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable used to fiter tasks\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"value of the variable used to fiter tasks, optional when filtering only by name, required when filtering by both name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"name of the variable used to fiter tasks\"},\"varValue\":{\"type\":\"string\",\"title\":\"varValue\",\"description\":\"value of the variable used to fiter tasks, optional when filtering only by name, required when filtering by both name and value\"},\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -4990,7 +4990,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getTasksByVariables",
@@ -5015,7 +5015,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"optional task status (Created, Ready, Reserved, InProgress, Suspended, Completed, Failed, Error, Exited, Obsolete)\",\"items\":{\"type\":\"string\",\"enum\":[\"Created\",\"Ready\",\"Reserved\",\"InProgress\",\"Suspended\",\"Completed\",\"Failed\",\"Error\",\"Exited\",\"Obsolete\"]}},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5024,7 +5024,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getTasksOwnedByStatus",
@@ -5049,7 +5049,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5058,7 +5058,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-summary\":{\"items\":{\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-container-id\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-is-skipable\":{\"type\":\"boolean\"},\"task-name\":{\"type\":\"string\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-priority\":{\"type\":\"integer\"},\"task-proc-def-id\":{\"type\":\"string\"},\"task-proc-inst-id\":{\"type\":\"integer\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-summary\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-summary-list\"}}}}"
         }
       },
       "id": "_id_:getAllAuditTask",
@@ -5083,7 +5083,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variable history for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name that history should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variable history for\"},\"varName\":{\"type\":\"string\",\"title\":\"varName\",\"description\":\"variable name that history should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5092,7 +5092,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
         }
       },
       "id": "_id_:getVariableHistory1",
@@ -5117,7 +5117,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variables current state (latest value) for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"pInstanceId\":{\"type\":\"integer\",\"title\":\"pInstanceId\",\"description\":\"process instance id to load variables current state (latest value) for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5126,7 +5126,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"variable-instance\":{\"items\":{\"properties\":{\"modification-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"old-value\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"value\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"variable-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"variable-instance-list\"}}}}"
         }
       },
       "id": "_id_:getVariablesCurrentState1",
@@ -5151,7 +5151,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id where rules should be evaluated on\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"Container id where rules should be evaluated on\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5160,7 +5160,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"xml\":{\"name\":\"response\"}}}}"
         }
       },
       "id": "_id_:manageContainer",
@@ -5185,7 +5185,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be activated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be activated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5213,7 +5213,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment should be added to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"name of the attachment to be added\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment should be added to\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"name of the attachment to be added\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5222,7 +5222,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:addAttachment",
@@ -5247,7 +5247,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment should be added to\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment should be added to\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5256,7 +5256,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:addComment1",
@@ -5281,7 +5281,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be claimed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be claimed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5309,7 +5309,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be completed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"auto-progress\":{\"type\":\"boolean\",\"title\":\"auto-progress\",\"description\":\"optional flag that allows to directlu claim and start task (if needed) before completion\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be completed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"auto-progress\":{\"type\":\"boolean\",\"title\":\"auto-progress\",\"description\":\"optional flag that allows to directlu claim and start task (if needed) before completion\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5337,7 +5337,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be delegated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that task should be dalegated to\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be delegated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that task should be dalegated to\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5365,7 +5365,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5393,7 +5393,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5421,7 +5421,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that content belongs to\"},\"contentId\":{\"type\":\"integer\",\"title\":\"contentId\",\"description\":\"identifier of the content to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that content belongs to\"},\"contentId\":{\"type\":\"integer\",\"title\":\"contentId\",\"description\":\"identifier of the content to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5449,7 +5449,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be exited\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be exited\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5477,7 +5477,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be failed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be failed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5505,7 +5505,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be forwarded\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that the task should be forwarded to\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be forwarded\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"targetUser\":{\"type\":\"string\",\"title\":\"targetUser\",\"description\":\"user that the task should be forwarded to\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5533,7 +5533,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be nominated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"potOwner\":{\"type\":\"array\",\"title\":\"potOwner\",\"description\":\"list of users that the task should be nominated to\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be nominated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"},\"potOwner\":{\"type\":\"array\",\"title\":\"potOwner\",\"description\":\"list of users that the task should be nominated to\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5561,7 +5561,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be released\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be released\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5589,7 +5589,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be resumed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be resumed\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5617,7 +5617,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be loaded\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment to be loaded\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5626,7 +5626,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"attachment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-content-id\":{\"type\":\"integer\"},\"attachment-id\":{\"type\":\"integer\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\"},\"attachment-type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-attachment\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"attachment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-content-id\":{\"type\":\"integer\"},\"attachment-id\":{\"type\":\"integer\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\"},\"attachment-type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"task-attachment\"}}}}"
         }
       },
       "id": "_id_:getAttachmentById",
@@ -5651,7 +5651,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment that content should be loaded from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachment belongs to\"},\"attachmentId\":{\"type\":\"integer\",\"title\":\"attachmentId\",\"description\":\"identifier of the attachment that content should be loaded from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5660,7 +5660,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\"}}}"
         }
       },
       "id": "_id_:getAttachmentContentById",
@@ -5685,7 +5685,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachments should be loaded for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that attachments should be loaded for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5694,7 +5694,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-attachment\":{\"items\":{\"properties\":{\"attachment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-content-id\":{\"type\":\"integer\"},\"attachment-id\":{\"type\":\"integer\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\"},\"attachment-type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-attachment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-attachment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-attachment\":{\"items\":{\"properties\":{\"attachment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"attachment-added-by\":{\"type\":\"string\"},\"attachment-content-id\":{\"type\":\"integer\"},\"attachment-id\":{\"type\":\"integer\"},\"attachment-name\":{\"type\":\"string\"},\"attachment-size\":{\"type\":\"integer\"},\"attachment-type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-attachment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-attachment-list\"}}}}"
         }
       },
       "id": "_id_:getAttachmentsByTaskId",
@@ -5719,7 +5719,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be loaded\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comment belongs to\"},\"commentId\":{\"type\":\"integer\",\"title\":\"commentId\",\"description\":\"identifier of the comment to be loaded\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5728,7 +5728,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"comment\":{\"type\":\"string\"},\"comment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-comment\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"comment\":{\"type\":\"string\"},\"comment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-comment\"}}}}"
         }
       },
       "id": "_id_:getCommentById",
@@ -5753,7 +5753,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comments should be loaded for\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that comments should be loaded for\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5762,7 +5762,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-comment\":{\"items\":{\"properties\":{\"comment\":{\"type\":\"string\"},\"comment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-comment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-comment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-comment\":{\"items\":{\"properties\":{\"comment\":{\"type\":\"string\"},\"comment-added-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"comment-added-by\":{\"type\":\"string\"},\"comment-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-comment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-comment-list\"}}}}"
         }
       },
       "id": "_id_:getCommentsByTaskId",
@@ -5787,7 +5787,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that input data should be loaded from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that input data should be loaded from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5796,7 +5796,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
         }
       },
       "id": "_id_:getTaskInputContentByTaskId",
@@ -5821,7 +5821,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that output data should be loaded from\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that output data should be loaded from\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5830,7 +5830,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"object\"}}}}"
         }
       },
       "id": "_id_:getTaskOutputContentByTaskId",
@@ -5855,7 +5855,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that events should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that events should be loaded for\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5864,7 +5864,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-event-instance\":{\"items\":{\"properties\":{\"task-event-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-event-id\":{\"type\":\"integer\"},\"task-event-message\":{\"type\":\"string\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-event-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-event-instance-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-event-instance\":{\"items\":{\"properties\":{\"task-event-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-event-id\":{\"type\":\"integer\"},\"task-event-message\":{\"type\":\"string\"},\"task-event-type\":{\"type\":\"string\"},\"task-event-user\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-work-item-id\":{\"type\":\"integer\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-event-instance\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-event-instance-list\"}}}}"
         }
       },
       "id": "_id_:getTaskEvents",
@@ -5889,7 +5889,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be loaded\"},\"withInputData\":{\"type\":\"boolean\",\"title\":\"withInputData\",\"description\":\"optionally loads task input data\"},\"withOutputData\":{\"type\":\"boolean\",\"title\":\"withOutputData\",\"description\":\"optionally loads task output data\"},\"withAssignments\":{\"type\":\"boolean\",\"title\":\"withAssignments\",\"description\":\"optionally loads task people assignments\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be loaded\"},\"withInputData\":{\"type\":\"boolean\",\"title\":\"withInputData\",\"description\":\"optionally loads task input data\"},\"withOutputData\":{\"type\":\"boolean\",\"title\":\"withOutputData\",\"description\":\"optionally loads task output data\"},\"withAssignments\":{\"type\":\"boolean\",\"title\":\"withAssignments\",\"description\":\"optionally loads task people assignments\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -5898,7 +5898,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-activation-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-actual-owner\":{\"type\":\"string\"},\"task-business-admins\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-business-admins\"}},\"type\":\"array\",\"xml\":{\"name\":\"business-admins\",\"wrapped\":true}},\"task-container-id\":{\"type\":\"string\"},\"task-correlation-key\":{\"type\":\"string\"},\"task-created-by\":{\"type\":\"string\"},\"task-created-on\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-description\":{\"type\":\"string\"},\"task-excl-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-excl-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"excluded-owners\",\"wrapped\":true}},\"task-expiration-time\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-form\":{\"type\":\"string\"},\"task-id\":{\"type\":\"integer\"},\"task-input-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-last-modificaiton-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"task-last-modification-user\":{\"type\":\"string\"},\"task-name\":{\"type\":\"string\"},\"task-output-data\":{\"additionalProperties\":{\"type\":\"object\"},\"type\":\"object\"},\"task-parent-id\":{\"type\":\"integer\"},\"task-pot-owners\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"task-pot-owners\"}},\"type\":\"array\",\"xml\":{\"name\":\"potential-owners\",\"wrapped\":true}},\"task-priority\":{\"type\":\"integer\"},\"task-process-id\":{\"type\":\"string\"},\"task-process-instance-id\":{\"type\":\"integer\"},\"task-skippable\":{\"type\":\"boolean\"},\"task-status\":{\"type\":\"string\"},\"task-subject\":{\"type\":\"string\"},\"task-type\":{\"type\":\"string\"},\"task-workitem-id\":{\"type\":\"integer\"}},\"xml\":{\"name\":\"task-instance\"}}}}"
         }
       },
       "id": "_id_:getTask",
@@ -5923,7 +5923,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that data should be saved into\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that data should be saved into\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5951,7 +5951,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where description should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where description should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -5979,7 +5979,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where expiration date should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where expiration date should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6007,7 +6007,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where name should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where name should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6035,7 +6035,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where priority should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where priority should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6063,7 +6063,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where skipable flag should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance where skipable flag should be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6091,7 +6091,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be skipped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be skipped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6119,7 +6119,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be started\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be started\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6147,7 +6147,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be stopped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be stopped\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6175,7 +6175,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be suspended\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be suspended\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6203,7 +6203,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be updated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that should be updated\"},\"user\":{\"type\":\"string\",\"title\":\"user\",\"description\":\"optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6231,7 +6231,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to be acknowledged\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to be acknowledged\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6259,7 +6259,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of identifiers of execution errors to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that errors belong to\"},\"errorId\":{\"type\":\"array\",\"title\":\"errorId\",\"description\":\"list of identifiers of execution errors to be acknowledged\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6287,7 +6287,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing business admins should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing business admins should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6315,7 +6315,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing excluded owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing excluded owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6343,7 +6343,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing potential owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"remove\":{\"type\":\"boolean\",\"title\":\"remove\",\"description\":\"optional flag that indicates if existing potential owners should be removed, defaults to false\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6371,7 +6371,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6399,7 +6399,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"notificationId\":{\"type\":\"integer\",\"title\":\"notificationId\",\"description\":\"identifier of notification to be canceled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"notificationId\":{\"type\":\"integer\",\"title\":\"notificationId\",\"description\":\"identifier of notification to be canceled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6427,7 +6427,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"reassignmentId\":{\"type\":\"integer\",\"title\":\"reassignmentId\",\"description\":\"identifier of reassignment to be canceled\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"reassignmentId\":{\"type\":\"integer\",\"title\":\"reassignmentId\",\"description\":\"identifier of reassignment to be canceled\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6455,7 +6455,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from business admin list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from business admin list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6483,7 +6483,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from business admin list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from business admin list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6511,7 +6511,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from excluded owners list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from excluded owners list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6539,7 +6539,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from excluded owners list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from excluded owners list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6567,7 +6567,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from potantial owners list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of groups to be removed from potantial owners list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6595,7 +6595,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from potantial owners list\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"entityId\":{\"type\":\"string\",\"title\":\"entityId\",\"description\":\"list of users to be removed from potantial owners list\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6623,7 +6623,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task inputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task inputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6651,7 +6651,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task outputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"name\":{\"type\":\"array\",\"title\":\"name\",\"description\":\"one or more names of task outputs to be removed\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -6679,7 +6679,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to load\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that error belongs to\"},\"errorId\":{\"type\":\"string\",\"title\":\"errorId\",\"description\":\"identifier of the execution error to load\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6688,7 +6688,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"execution-error\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"xml\":{\"name\":\"execution-error\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrorById1",
@@ -6713,7 +6713,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"optional name of the task to filter by\"},\"process\":{\"type\":\"string\",\"title\":\"process\",\"description\":\"optional process id that the task belongs to to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"optional name of the task to filter by\"},\"process\":{\"type\":\"string\",\"title\":\"process\",\"description\":\"optional process id that the task belongs to to filter by\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6722,7 +6722,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrors1",
@@ -6747,7 +6747,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of the task instance that errors should be collected for\"},\"includeAck\":{\"type\":\"boolean\",\"title\":\"includeAck\",\"description\":\"optional flag that indicates if acknowledged errors should also be collected, defaults to false\",\"default\":\"false\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"description\":\"optional pagination - at which page to start, defaults to 0 (meaning first)\",\"default\":\"0\"},\"pageSize\":{\"type\":\"integer\",\"title\":\"pageSize\",\"description\":\"optional pagination - size of the result, defaults to 10\",\"default\":\"10\"},\"sort\":{\"type\":\"string\",\"title\":\"sort\",\"description\":\"optional sort column, no default\"},\"sortOrder\":{\"type\":\"boolean\",\"title\":\"sortOrder\",\"description\":\"optional sort direction (asc, desc) - defaults to asc\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6756,7 +6756,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"error-instance\":{\"items\":{\"properties\":{\"acknowledged\":{\"type\":\"boolean\"},\"acknowledged-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"acknowledged-by\":{\"type\":\"string\"},\"activity-id\":{\"type\":\"integer\"},\"activity-name\":{\"type\":\"string\"},\"container-id\":{\"type\":\"string\"},\"error\":{\"type\":\"string\"},\"error-date\":{\"format\":\"date-time\",\"type\":\"string\"},\"error-msg\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"job-id\":{\"type\":\"integer\"},\"process-id\":{\"type\":\"string\"},\"process-instance-id\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"execution-error\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"execution-error-list\"}}}}"
         }
       },
       "id": "_id_:getExecutionErrorsByTask",
@@ -6781,7 +6781,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only notifications should be collected, defaults to true\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only notifications should be collected, defaults to true\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6790,7 +6790,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-notification\":{\"items\":{\"properties\":{\"active\":{\"type\":\"boolean\"},\"content\":{\"type\":\"string\"},\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"notify-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"subject\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-notification\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-notification-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-notification\":{\"items\":{\"properties\":{\"active\":{\"type\":\"boolean\"},\"content\":{\"type\":\"string\"},\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"notify-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"subject\":{\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-notification\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-notification-list\"}}}}"
         }
       },
       "id": "_id_:getTaskNotifications",
@@ -6815,7 +6815,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only reassignmnets should be collected, defaults to true\",\"default\":\"true\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"activeOnly\":{\"type\":\"boolean\",\"title\":\"activeOnly\",\"description\":\"optional flag that indicates if active only reassignmnets should be collected, defaults to true\",\"default\":\"true\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6824,7 +6824,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-reassignment\":{\"items\":{\"properties\":{\"active\":{\"type\":\"boolean\"},\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"reassign-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-reassignment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-reassignment-list\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"task-reassignment\":{\"items\":{\"properties\":{\"active\":{\"type\":\"boolean\"},\"groups\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"groups\"}},\"type\":\"array\"},\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"reassign-at\":{\"format\":\"date-time\",\"type\":\"string\"},\"users\":{\"items\":{\"type\":\"string\",\"xml\":{\"name\":\"users\"}},\"type\":\"array\"}},\"type\":\"object\",\"xml\":{\"name\":\"task-reassignment\"}},\"type\":\"array\"}},\"xml\":{\"name\":\"task-reassignment-list\"}}}}"
         }
       },
       "id": "_id_:getTaskReassignments",
@@ -6849,7 +6849,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for notification\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for notification\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of notification, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6858,7 +6858,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:notify",
@@ -6883,7 +6883,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for reassignmnet\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"container id that task instance belongs to\"},\"tInstanceId\":{\"type\":\"integer\",\"title\":\"tInstanceId\",\"description\":\"identifier of task instance to be updated\"},\"expiresAt\":{\"type\":\"string\",\"title\":\"expiresAt\",\"description\":\"time expression for reassignmnet\"},\"whenNotStarted\":{\"type\":\"boolean\",\"title\":\"whenNotStarted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"},\"whenNotCompleted\":{\"type\":\"boolean\",\"title\":\"whenNotCompleted\",\"description\":\"optional flag that indicates the type of reassignment, either whenNotStarted or whenNotCompleted must be set\",\"default\":\"false\"}}},\"body\":{\"type\":\"string\"}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -6892,7 +6892,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"integer\"}}}"
         }
       },
       "id": "_id_:reassign",

--- a/app/server/api-generator/src/test/resources/swagger/machine_history.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/machine_history.unified_connector.json
@@ -26,7 +26,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -35,7 +35,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of the current state of a machine\",\"properties\":{\"health\":{\"description\":\"The machine health\",\"type\":\"integer\"},\"id\":{\"description\":\"The machine ID\",\"type\":\"integer\"},\"lifetimeCost\":{\"type\":\"integer\"},\"name\":{\"description\":\"The machine name\",\"type\":\"string\"}},\"required\":[\"id\",\"name\",\"health\"]}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"The representation of the current state of a machine\",\"properties\":{\"health\":{\"description\":\"The machine health\",\"type\":\"integer\"},\"id\":{\"description\":\"The machine ID\",\"type\":\"integer\"},\"lifetimeCost\":{\"type\":\"integer\"},\"name\":{\"description\":\"The machine name\",\"type\":\"string\"}},\"required\":[\"id\",\"name\",\"health\"]}}}"
         }
       },
       "id": "_id_:getMachine",
@@ -71,7 +71,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"A Machine\",\"properties\":{\"id\":{\"description\":\"The Machine ID\",\"type\":\"integer\"},\"name\":{\"description\":\"The machine name\",\"type\":\"string\"}},\"required\":[\"id\",\"name\"]}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"A Machine\",\"properties\":{\"id\":{\"description\":\"The Machine ID\",\"type\":\"integer\"},\"name\":{\"description\":\"The machine name\",\"type\":\"string\"}},\"required\":[\"id\",\"name\"]}}}}"
         }
       },
       "id": "_id_:getAllMachines",

--- a/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore.unified_connector.json
@@ -15,7 +15,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"category\": {\"properties\": {\"id\": { \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Category\"}}, \"id\": { \"type\": \"integer\"}, \"name\": {\"example\": \"doggie\", \"type\": \"string\"}, \"photoUrls\": {\"items\": {\"type\": \"string\"}, \"type\": \"array\", \"xml\": {\"name\": \"photoUrl\", \"wrapped\": true}}, \"status\": {\"description\": \"pet status in the store\", \"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\": \"string\"}, \"tags\": {\"items\": {\"properties\": {\"id\": { \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Tag\"}}, \"type\": \"array\", \"xml\": {\"name\": \"tag\", \"wrapped\": true}}}, \"required\": [ \"name\", \"photoUrls\" ], \"type\": \"object\", \"xml\": {\"name\": \"Pet\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"category\": {\"properties\": {\"id\": { \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Category\"}}, \"id\": { \"type\": \"integer\"}, \"name\": {\"example\": \"doggie\", \"type\": \"string\"}, \"photoUrls\": {\"items\": {\"type\": \"string\"}, \"type\": \"array\", \"xml\": {\"name\": \"photoUrl\", \"wrapped\": true}}, \"status\": {\"description\": \"pet status in the store\", \"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\": \"string\"}, \"tags\": {\"items\": {\"properties\": {\"id\": { \"type\": \"integer\"}, \"name\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Tag\"}}, \"type\": \"array\", \"xml\": {\"name\": \"tag\", \"wrapped\": true}}}, \"required\": [ \"name\", \"photoUrls\" ], \"type\": \"object\", \"xml\": {\"name\": \"Pet\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -43,7 +43,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"body\" : {\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"], \"type\" : \"string\"}},\"xml\":{\"name\":\"Pet\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"body\" : {\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"], \"type\" : \"string\"}},\"xml\":{\"name\":\"Pet\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -71,7 +71,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"status\": {\"description\": \"Status values that need to be considered for filter\", \"items\": {\"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\" : \"string\"}, \"title\": \"status\", \"type\": \"array\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"status\": {\"description\": \"Status values that need to be considered for filter\", \"items\": {\"enum\": [ \"available\", \"pending\", \"sold\" ], \"type\" : \"string\"}, \"title\": \"status\", \"type\": \"array\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -80,7 +80,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\",  \"$id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"category\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Category\"}},\"id\":{\"type\":\"integer\"},\"name\":{\"example\":\"doggie\",\"type\":\"string\"},\"photoUrls\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true}},\"status\":{\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"],\"type\":\"string\"},\"tags\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Tag\"}},\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true}}},\"required\":[\"name\",\"photoUrls\"],\"type\":\"object\",\"xml\":{\"name\":\"Pet\"}},\"type\":\"array\" }}, \"type\":\"object\" }"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\",  \"id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"category\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Category\"}},\"id\":{\"type\":\"integer\"},\"name\":{\"example\":\"doggie\",\"type\":\"string\"},\"photoUrls\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true}},\"status\":{\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"],\"type\":\"string\"},\"tags\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Tag\"}},\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true}}},\"required\":[\"name\",\"photoUrls\"],\"type\":\"object\",\"xml\":{\"name\":\"Pet\"}},\"type\":\"array\" }}, \"type\":\"object\" }"
         }
       },
       "id": "_id_:findPetsByStatus",
@@ -105,7 +105,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"tags\": {\"description\": \"Tags to filter by\", \"items\": {\"type\": \"string\"}, \"title\": \"tags\", \"type\": \"array\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"tags\": {\"description\": \"Tags to filter by\", \"items\": {\"type\": \"string\"}, \"title\": \"tags\", \"type\": \"array\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -114,7 +114,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\",  \"$id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"category\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Category\"}},\"id\":{\"type\":\"integer\"},\"name\":{\"example\":\"doggie\",\"type\":\"string\"},\"photoUrls\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true}},\"status\":{\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"],\"type\":\"string\"},\"tags\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Tag\"}},\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true}}},\"required\":[\"name\",\"photoUrls\"],\"type\":\"object\",\"xml\":{\"name\":\"Pet\"}},\"type\":\"array\"}},\"type\":\"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\",  \"id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"category\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Category\"}},\"id\":{\"type\":\"integer\"},\"name\":{\"example\":\"doggie\",\"type\":\"string\"},\"photoUrls\":{\"items\":{\"type\":\"string\"},\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true}},\"status\":{\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"],\"type\":\"string\"},\"tags\":{\"items\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"Tag\"}},\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true}}},\"required\":[\"name\",\"photoUrls\"],\"type\":\"object\",\"xml\":{\"name\":\"Pet\"}},\"type\":\"array\"}},\"type\":\"object\"}"
         }
       },
       "id": "_id_:findPetsByTags",
@@ -139,7 +139,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"petId\": {\"description\": \"ID of pet to return\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"petId\": {\"description\": \"ID of pet to return\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -148,7 +148,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"required\":[\"name\",\"photoUrls\"],\"properties\":{\"id\":{\"type\":\"integer\"},\"category\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Category\"}},\"name\":{\"type\":\"string\",\"example\":\"doggie\"},\"photoUrls\":{\"type\":\"array\",\"xml\":{\"name\":\"photoUrl\",\"wrapped\":true},\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"xml\":{\"name\":\"tag\",\"wrapped\":true},\"items\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"xml\":{\"name\":\"Tag\"}}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}},\"xml\":{\"name\":\"Pet\"}}}}"
         }
       },
       "id": "_id_:getPetById",
@@ -173,7 +173,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"name\": {\"description\": \"Updated name of the pet\", \"title\": \"name\", \"type\": \"string\"}, \"petId\": {\"description\": \"ID of pet that needs to be updated\", \"title\": \"petId\", \"type\": \"integer\"}, \"status\": {\"description\": \"Updated status of the pet\", \"title\": \"status\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"name\": {\"description\": \"Updated name of the pet\", \"title\": \"name\", \"type\": \"string\"}, \"petId\": {\"description\": \"ID of pet that needs to be updated\", \"title\": \"petId\", \"type\": \"integer\"}, \"status\": {\"description\": \"Updated status of the pet\", \"title\": \"status\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -201,7 +201,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"api_key\": {\"title\": \"api_key\", \"type\": \"string\"}, \"petId\": {\"description\": \"Pet id to delete\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"api_key\": {\"title\": \"api_key\", \"type\": \"string\"}, \"petId\": {\"description\": \"Pet id to delete\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -229,7 +229,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"additionalMetadata\": {\"description\": \"Additional data to pass to server\", \"title\": \"additionalMetadata\", \"type\": \"string\"}, \"petId\": {\"description\": \"ID of pet to update\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"additionalMetadata\": {\"description\": \"Additional data to pass to server\", \"title\": \"additionalMetadata\", \"type\": \"string\"}, \"petId\": {\"description\": \"ID of pet to update\", \"title\": \"petId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -238,7 +238,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"},\"message\":{\"type\":\"string\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"integer\"},\"type\":{\"type\":\"string\"},\"message\":{\"type\":\"string\"}}}}}"
         }
       },
       "id": "_id_:uploadFile",
@@ -266,7 +266,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\"}}}}"
         }
       },
       "id": "_id_:getInventory",
@@ -291,7 +291,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"complete\": {\"default\": false, \"type\": \"boolean\"}, \"id\": { \"type\": \"integer\"}, \"petId\": { \"type\": \"integer\"}, \"quantity\": { \"type\": \"integer\"}, \"shipDate\": {\"format\": \"date-time\", \"type\": \"string\"}, \"status\": {\"description\": \"Order Status\", \"enum\": [ \"placed\", \"approved\", \"delivered\" ], \"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Order\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"complete\": {\"default\": false, \"type\": \"boolean\"}, \"id\": { \"type\": \"integer\"}, \"petId\": { \"type\": \"integer\"}, \"quantity\": { \"type\": \"integer\"}, \"shipDate\": {\"format\": \"date-time\", \"type\": \"string\"}, \"status\": {\"description\": \"Order Status\", \"enum\": [ \"placed\", \"approved\", \"delivered\" ], \"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"Order\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -300,7 +300,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"}}}}"
         }
       },
       "id": "_id_:placeOrder",
@@ -325,7 +325,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"orderId\": {\"description\": \"ID of pet that needs to be fetched\", \"title\": \"orderId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"orderId\": {\"description\": \"ID of pet that needs to be fetched\", \"title\": \"orderId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -334,7 +334,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"]},\"complete\":{\"type\":\"boolean\",\"default\":false}},\"xml\":{\"name\":\"Order\"}}}}"
         }
       },
       "id": "_id_:getOrderById",
@@ -359,7 +359,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"orderId\": {\"description\": \"ID of the order that needs to be deleted\", \"title\": \"orderId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"orderId\": {\"description\": \"ID of the order that needs to be deleted\", \"title\": \"orderId\", \"type\": \"integer\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -387,7 +387,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": { \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\",  \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": { \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\",  \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}}, \"type\": \"object\", \"xml\": {\"name\": \"User\"}}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -415,7 +415,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"User\"}},\"type\":\"array\"}},\"type\":\"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"User\"}},\"type\":\"array\"}},\"type\":\"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -443,7 +443,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"User\"}},\"type\":\"array\"}},\"type\":\"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\":{\"body\":{\"items\":{\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"type\":\"object\",\"xml\":{\"name\":\"User\"}},\"type\":\"array\"}},\"type\":\"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -471,7 +471,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"password\": {\"description\": \"The password for login in clear text\", \"title\": \"password\", \"type\": \"string\"}, \"username\": {\"description\": \"The user name for login\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"password\": {\"description\": \"The password for login in clear text\", \"title\": \"password\", \"type\": \"string\"}, \"username\": {\"description\": \"The user name for login\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -480,7 +480,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:loginUser",
@@ -527,7 +527,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"username\": {\"description\": \"The name that needs to be fetched. Use user1 for testing.\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"username\": {\"description\": \"The name that needs to be fetched. Use user1 for testing.\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -536,7 +536,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"username\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"description\":\"User Status\"}},\"xml\":{\"name\":\"User\"}}}}"
         }
       },
       "id": "_id_:getUserByName",
@@ -561,7 +561,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": { \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\",  \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}},\"type\": \"object\", \"xml\": {\"name\": \"User\"}}, \"parameters\": {\"properties\": {\"username\": {\"description\": \"name that need to be updated\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"body\": {\"properties\": {\"email\": {\"type\": \"string\"}, \"firstName\": {\"type\": \"string\"}, \"id\": { \"type\": \"integer\"}, \"lastName\": {\"type\": \"string\"}, \"password\": {\"type\": \"string\"}, \"phone\": {\"type\": \"string\"}, \"userStatus\": {\"description\": \"User Status\",  \"type\": \"integer\"}, \"username\": {\"type\": \"string\"}},\"type\": \"object\", \"xml\": {\"name\": \"User\"}}, \"parameters\": {\"properties\": {\"username\": {\"description\": \"name that need to be updated\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -589,7 +589,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\", \"$id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"username\": {\"description\": \"The name that needs to be deleted\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\", \"id\": \"io:syndesis:wrapped\", \"properties\": {\"parameters\": {\"properties\": {\"username\": {\"description\": \"The name that needs to be deleted\", \"title\": \"username\", \"type\": \"string\"}}, \"type\": \"object\"}}, \"type\": \"object\"}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/petstore_xml.unified_connector.json
@@ -43,7 +43,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"api_key\":{\"type\":\"string\",\"title\":\"api_key\"},\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"Pet id to delete\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"api_key\":{\"type\":\"string\",\"title\":\"api_key\"},\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"Pet id to delete\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -71,7 +71,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet to return\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet to return\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -105,7 +105,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"Status values that need to be considered for filter\",\"items\":{\"type\":\"string\",\"enum\":[\"available\",\"pending\",\"sold\"]}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"array\",\"title\":\"status\",\"description\":\"Status values that need to be considered for filter\",\"items\":{\"type\":\"string\",\"enum\":[\"available\",\"pending\",\"sold\"]}}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -139,7 +139,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tags\":{\"type\":\"array\",\"title\":\"tags\",\"description\":\"Tags to filter by\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"tags\":{\"type\":\"array\",\"title\":\"tags\",\"description\":\"Tags to filter by\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -201,7 +201,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet that needs to be updated\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"Updated name of the pet\"},\"status\":{\"type\":\"string\",\"title\":\"status\",\"description\":\"Updated status of the pet\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet that needs to be updated\"},\"name\":{\"type\":\"string\",\"title\":\"name\",\"description\":\"Updated name of the pet\"},\"status\":{\"type\":\"string\",\"title\":\"status\",\"description\":\"Updated status of the pet\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -229,7 +229,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet to update\"},\"additionalMetadata\":{\"type\":\"string\",\"title\":\"additionalMetadata\",\"description\":\"Additional data to pass to server\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"petId\":{\"type\":\"integer\",\"title\":\"petId\",\"description\":\"ID of pet to update\"},\"additionalMetadata\":{\"type\":\"string\",\"title\":\"additionalMetadata\",\"description\":\"Additional data to pass to server\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -263,7 +263,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"orderId\":{\"type\":\"integer\",\"title\":\"orderId\",\"description\":\"ID of the order that needs to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"orderId\":{\"type\":\"integer\",\"title\":\"orderId\",\"description\":\"ID of the order that needs to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -291,7 +291,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"orderId\":{\"type\":\"integer\",\"title\":\"orderId\",\"description\":\"ID of pet that needs to be fetched\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"orderId\":{\"type\":\"integer\",\"title\":\"orderId\",\"description\":\"ID of pet that needs to be fetched\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -325,7 +325,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"complete\":{\"default\":false,\"type\":\"boolean\"},\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"format\":\"date-time\",\"type\":\"string\"},\"status\":{\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"],\"type\":\"string\"}},\"xml\":{\"name\":\"Order\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"complete\":{\"default\":false,\"type\":\"boolean\"},\"id\":{\"type\":\"integer\"},\"petId\":{\"type\":\"integer\"},\"quantity\":{\"type\":\"integer\"},\"shipDate\":{\"format\":\"date-time\",\"type\":\"string\"},\"status\":{\"description\":\"Order Status\",\"enum\":[\"placed\",\"approved\",\"delivered\"],\"type\":\"string\"}},\"xml\":{\"name\":\"Order\"}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -381,7 +381,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -409,7 +409,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -437,7 +437,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -465,7 +465,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The name that needs to be deleted\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The name that needs to be deleted\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -493,7 +493,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The name that needs to be fetched. Use user1 for testing.\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The name that needs to be fetched. Use user1 for testing.\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -549,7 +549,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The user name for login\"},\"password\":{\"type\":\"string\",\"title\":\"password\",\"description\":\"The password for login in clear text\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"The user name for login\"},\"password\":{\"type\":\"string\",\"title\":\"password\",\"description\":\"The password for login in clear text\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -558,7 +558,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"string\"}}}"
         }
       },
       "id": "_id_:loginUser",
@@ -583,7 +583,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"name that need to be updated\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"type\":\"object\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"username\":{\"type\":\"string\",\"title\":\"username\",\"description\":\"name that need to be updated\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\"},\"firstName\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"},\"lastName\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"description\":\"User Status\",\"type\":\"integer\"},\"username\":{\"type\":\"string\"}},\"xml\":{\"name\":\"User\"}}}}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/reverb.unified_connector.json
@@ -16,7 +16,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"What's being searched for\"},\"exclude_featured\":{\"type\":\"integer\",\"title\":\"exclude_featured\",\"description\":\"Number of featured articles to exclude\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"What's being searched for\"},\"exclude_featured\":{\"type\":\"integer\",\"title\":\"exclude_featured\",\"description\":\"Number of featured articles to exclude\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -46,7 +46,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -76,7 +76,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -106,7 +106,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"uuid\":{\"type\":\"string\",\"title\":\"uuid\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"uuid\":{\"type\":\"string\",\"title\":\"uuid\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -136,7 +136,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\"},\"category\":{\"type\":\"string\",\"title\":\"category\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\"},\"category\":{\"type\":\"string\",\"title\":\"category\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -166,7 +166,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -196,7 +196,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -226,7 +226,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"description\":\"Condition of the listing\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"description\":\"Condition of the listing\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -256,7 +256,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -286,7 +286,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"ID of the comparison shopping page\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\",\"description\":\"Slug of the comparison shopping page\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\",\"description\":\"ID of the comparison shopping page\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\",\"description\":\"Slug of the comparison shopping page\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -316,7 +316,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -346,7 +346,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"conversation_id\":{\"type\":\"string\",\"title\":\"conversation_id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"shipping_price\":{\"type\":\"object\",\"description\":\"Shipping price (sellers only)\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"offer_items\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"string\"},\"shipping_price\":{\"type\":\"string\"},\"listing_id\":{\"type\":\"string\"}},\"required\":[\"listing_id\",\"price\",\"shipping_price\"]}},\"country_code\":{\"type\":\"string\"},\"region_code\":{\"type\":\"string\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"conversation_id\":{\"type\":\"string\",\"title\":\"conversation_id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"shipping_price\":{\"type\":\"object\",\"description\":\"Shipping price (sellers only)\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"offer_items\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"string\"},\"shipping_price\":{\"type\":\"string\"},\"listing_id\":{\"type\":\"string\"}},\"required\":[\"listing_id\",\"price\",\"shipping_price\"]}},\"country_code\":{\"type\":\"string\"},\"region_code\":{\"type\":\"string\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -376,7 +376,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -406,7 +406,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -436,7 +436,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -466,7 +466,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -496,7 +496,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"feedback_id\":{\"type\":\"string\",\"title\":\"feedback_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"feedback_id\":{\"type\":\"string\",\"title\":\"feedback_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -526,7 +526,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -556,7 +556,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -586,7 +586,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -616,7 +616,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"budget_type\":{\"type\":\"string\",\"title\":\"budget_type\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"budget_type\":{\"type\":\"string\",\"title\":\"budget_type\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -646,7 +646,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"make\":{\"type\":\"string\",\"description\":\"ex: Fender, Gibson\"},\"model\":{\"type\":\"string\",\"description\":\"ex: Stratocaster, SG\"},\"publish\":{\"type\":\"boolean\",\"description\":\"Publish your listing if draft\"},\"categories\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"UUID of the category for this listing.\"}}}},\"sold_as_is\":{\"type\":\"boolean\",\"description\":\"This item is sold As-Is and cannot be returned\"},\"photos\":{\"type\":\"array\",\"description\":\"An array of image URLs. Ex: ['http://my.site.com/image.jpg']\",\"items\":{\"type\":\"string\"}},\"condition\":{\"type\":\"object\",\"description\":\"Condition\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"Condition UUID\",\"enum\":[\"fbf35668-96a0-4baa-bcde-ab18d6b1b329\",\"6a9dfcad-600b-46c8-9e08-ce6e5057921e\",\"98777886-76d0-44c8-865e-bb40e669e934\",\"f7a3f48c-972a-44c6-b01a-0cd27488d3f6\",\"ae4d9114-1bd7-4ec5-a4ba-6653af5ac84d\",\"df268ad1-c462-4ba6-b6db-e007e23922ea\",\"ac5b9c1e-dc78-466d-b0b3-7cf712967a48\",\"6db7df88-293b-4017-a1c1-cdb5e599fa1a\",\"9225283f-60c2-4413-ad18-1f5eba7a856f\",\"7c3f45de-2ae0-4c81-8400-fdb6b1d74890\"]}},\"required\":[\"uuid\"]},\"has_inventory\":{\"type\":\"boolean\",\"description\":\"Set true if selling more than one\"},\"inventory\":{\"type\":\"integer\",\"description\":\"Number of items available for sale. Reverb will increment and decrement automatically.\"},\"storage_location\":{\"type\":\"string\",\"description\":\"Internal note used by sellers to back reference their catalog system when entering a listing\"},\"description\":{\"type\":\"string\",\"description\":\"Product description. Please keep formatting to a minimum.\"},\"finish\":{\"type\":\"string\",\"description\":\"Finish, e.g. 'Sunburst'\"},\"title\":{\"type\":\"string\",\"description\":\"Title of your listing\"},\"year\":{\"type\":\"string\",\"description\":\"Supports many formats. Ex: 1979, mid-70s, late 90s\"},\"sku\":{\"type\":\"string\",\"description\":\"Unique identifier for product\"},\"upc\":{\"type\":\"string\",\"description\":\"Valid UPC code\"},\"upc_does_not_apply\":{\"type\":\"string\",\"description\":\"True if a brand new product has no UPC code, ie for a handmade or custom item\"},\"offers_enabled\":{\"type\":\"boolean\",\"description\":\"Whether the listing accepts negotiated offers (default: true)\"},\"shipping_profile_id\":{\"type\":\"string\",\"description\":\"id of a shop's shipping profile\"},\"shipping_profile_name\":{\"type\":\"string\",\"description\":\"DEPRECATED, please use shipping_profile_id. Name of a shipping profile\"},\"location\":{\"type\":\"object\",\"properties\":{\"locality\":{\"type\":\"string\",\"description\":\"Ex: Chicago\"},\"region\":{\"type\":\"string\",\"description\":\"Ex: IL\"},\"country_code\":{\"type\":\"string\",\"description\":\"Ex: US\"}}},\"origin_country_code\":{\"type\":\"string\",\"description\":\"Country of origin/manufacture, ISO code (e.g: US)\"},\"shipping\":{\"type\":\"object\",\"properties\":{\"local\":{\"type\":\"boolean\",\"description\":\"True if you offer local pickup\"},\"rates\":{\"type\":\"array\",\"description\":\"List of shipping rates. Set to null to clear rates.\",\"items\":{\"type\":\"object\",\"properties\":{\"region_code\":{\"type\":\"string\",\"description\":\"Country code or subregion/superregion code. Full list of codes at /api/shipping/regions\"},\"rate\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]}}}}}},\"seller\":{\"type\":\"object\",\"properties\":{\"paypal_email\":{\"type\":\"string\"}}},\"seller_cost\":{\"type\":\"string\",\"description\":\"Cost of goods in your currency as a POSIX-compliant decimal number (internal use only, not shown to buyers)\"},\"tax_exempt\":{\"type\":\"boolean\",\"description\":\"Listing is exempt from taxes / VAT\"},\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"exclusive_channel\":{\"type\":\"string\",\"description\":\"Currently for users of seller sites only, this allows you to have a listing available only to your seller site by setting this to 'seller_site'\",\"enum\":[\"seller_site\"]}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"make\":{\"type\":\"string\",\"description\":\"ex: Fender, Gibson\"},\"model\":{\"type\":\"string\",\"description\":\"ex: Stratocaster, SG\"},\"publish\":{\"type\":\"boolean\",\"description\":\"Publish your listing if draft\"},\"categories\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"UUID of the category for this listing.\"}}}},\"sold_as_is\":{\"type\":\"boolean\",\"description\":\"This item is sold As-Is and cannot be returned\"},\"photos\":{\"type\":\"array\",\"description\":\"An array of image URLs. Ex: ['http://my.site.com/image.jpg']\",\"items\":{\"type\":\"string\"}},\"condition\":{\"type\":\"object\",\"description\":\"Condition\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"Condition UUID\",\"enum\":[\"fbf35668-96a0-4baa-bcde-ab18d6b1b329\",\"6a9dfcad-600b-46c8-9e08-ce6e5057921e\",\"98777886-76d0-44c8-865e-bb40e669e934\",\"f7a3f48c-972a-44c6-b01a-0cd27488d3f6\",\"ae4d9114-1bd7-4ec5-a4ba-6653af5ac84d\",\"df268ad1-c462-4ba6-b6db-e007e23922ea\",\"ac5b9c1e-dc78-466d-b0b3-7cf712967a48\",\"6db7df88-293b-4017-a1c1-cdb5e599fa1a\",\"9225283f-60c2-4413-ad18-1f5eba7a856f\",\"7c3f45de-2ae0-4c81-8400-fdb6b1d74890\"]}},\"required\":[\"uuid\"]},\"has_inventory\":{\"type\":\"boolean\",\"description\":\"Set true if selling more than one\"},\"inventory\":{\"type\":\"integer\",\"description\":\"Number of items available for sale. Reverb will increment and decrement automatically.\"},\"storage_location\":{\"type\":\"string\",\"description\":\"Internal note used by sellers to back reference their catalog system when entering a listing\"},\"description\":{\"type\":\"string\",\"description\":\"Product description. Please keep formatting to a minimum.\"},\"finish\":{\"type\":\"string\",\"description\":\"Finish, e.g. 'Sunburst'\"},\"title\":{\"type\":\"string\",\"description\":\"Title of your listing\"},\"year\":{\"type\":\"string\",\"description\":\"Supports many formats. Ex: 1979, mid-70s, late 90s\"},\"sku\":{\"type\":\"string\",\"description\":\"Unique identifier for product\"},\"upc\":{\"type\":\"string\",\"description\":\"Valid UPC code\"},\"upc_does_not_apply\":{\"type\":\"string\",\"description\":\"True if a brand new product has no UPC code, ie for a handmade or custom item\"},\"offers_enabled\":{\"type\":\"boolean\",\"description\":\"Whether the listing accepts negotiated offers (default: true)\"},\"shipping_profile_id\":{\"type\":\"string\",\"description\":\"id of a shop's shipping profile\"},\"shipping_profile_name\":{\"type\":\"string\",\"description\":\"DEPRECATED, please use shipping_profile_id. Name of a shipping profile\"},\"location\":{\"type\":\"object\",\"properties\":{\"locality\":{\"type\":\"string\",\"description\":\"Ex: Chicago\"},\"region\":{\"type\":\"string\",\"description\":\"Ex: IL\"},\"country_code\":{\"type\":\"string\",\"description\":\"Ex: US\"}}},\"origin_country_code\":{\"type\":\"string\",\"description\":\"Country of origin/manufacture, ISO code (e.g: US)\"},\"shipping\":{\"type\":\"object\",\"properties\":{\"local\":{\"type\":\"boolean\",\"description\":\"True if you offer local pickup\"},\"rates\":{\"type\":\"array\",\"description\":\"List of shipping rates. Set to null to clear rates.\",\"items\":{\"type\":\"object\",\"properties\":{\"region_code\":{\"type\":\"string\",\"description\":\"Country code or subregion/superregion code. Full list of codes at /api/shipping/regions\"},\"rate\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]}}}}}},\"seller\":{\"type\":\"object\",\"properties\":{\"paypal_email\":{\"type\":\"string\"}}},\"seller_cost\":{\"type\":\"string\",\"description\":\"Cost of goods in your currency as a POSIX-compliant decimal number (internal use only, not shown to buyers)\"},\"tax_exempt\":{\"type\":\"boolean\",\"description\":\"Listing is exempt from taxes / VAT\"},\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"exclusive_channel\":{\"type\":\"string\",\"description\":\"Currently for users of seller sites only, this allows you to have a listing available only to your seller site by setting this to 'seller_site'\",\"enum\":[\"seller_site\"]}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -676,7 +676,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -706,7 +706,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -736,7 +736,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -766,7 +766,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"image_id\":{\"type\":\"string\",\"title\":\"image_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"image_id\":{\"type\":\"string\",\"title\":\"image_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -796,7 +796,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -826,7 +826,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"for_seller\":{\"type\":\"boolean\",\"title\":\"for_seller\",\"description\":\"Pass to see non-live bundles as the seller\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"},\"for_seller\":{\"type\":\"boolean\",\"title\":\"for_seller\",\"description\":\"Pass to see non-live bundles as the seller\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -856,7 +856,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"required\":[\"reason\"],\"properties\":{\"reason\":{\"type\":\"string\",\"description\":\"Valid reasons: 'Sexuality/nudity', 'Hateful or inappropriate speech', 'Item not as described or potential fraud', 'Trademark infringement', 'Other'\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"required\":[\"reason\"],\"properties\":{\"reason\":{\"type\":\"string\",\"description\":\"Valid reasons: 'Sexuality/nudity', 'Hateful or inappropriate speech', 'Item not as described or potential fraud', 'Trademark infringement', 'Other'\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -886,7 +886,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -916,7 +916,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -946,7 +946,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -976,7 +976,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"price\"],\"properties\":{\"price\":{\"type\":\"string\",\"description\":\"Offer price\"},\"shipping_price\":{\"type\":\"string\",\"description\":\"Shipping price (sellers only)\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"price\"],\"properties\":{\"price\":{\"type\":\"string\",\"description\":\"Offer price\"},\"shipping_price\":{\"type\":\"string\",\"description\":\"Shipping price (sellers only)\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1006,7 +1006,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1036,7 +1036,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1066,7 +1066,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"body\":{\"type\":\"string\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"body\":{\"type\":\"string\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1096,7 +1096,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"publish\":{\"type\":\"boolean\",\"description\":\"Publish your listing if draft\"},\"make\":{\"type\":\"string\",\"description\":\"ex: Fender, Gibson\"},\"model\":{\"type\":\"string\",\"description\":\"ex: Stratocaster, SG\"},\"categories\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"UUID of the category for this listing.\"}}}},\"sold_as_is\":{\"type\":\"boolean\",\"description\":\"This item is sold As-Is and cannot be returned\"},\"photos\":{\"type\":\"array\",\"description\":\"An array of image URLs. Ex: ['http://my.site.com/image.jpg']\",\"items\":{\"type\":\"string\"}},\"condition\":{\"type\":\"object\",\"description\":\"Condition\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"Condition UUID\",\"enum\":[\"fbf35668-96a0-4baa-bcde-ab18d6b1b329\",\"6a9dfcad-600b-46c8-9e08-ce6e5057921e\",\"98777886-76d0-44c8-865e-bb40e669e934\",\"f7a3f48c-972a-44c6-b01a-0cd27488d3f6\",\"ae4d9114-1bd7-4ec5-a4ba-6653af5ac84d\",\"df268ad1-c462-4ba6-b6db-e007e23922ea\",\"ac5b9c1e-dc78-466d-b0b3-7cf712967a48\",\"6db7df88-293b-4017-a1c1-cdb5e599fa1a\",\"9225283f-60c2-4413-ad18-1f5eba7a856f\",\"7c3f45de-2ae0-4c81-8400-fdb6b1d74890\"]}},\"required\":[\"uuid\"]},\"has_inventory\":{\"type\":\"boolean\",\"description\":\"Set true if selling more than one\"},\"inventory\":{\"type\":\"integer\",\"description\":\"Number of items available for sale. Reverb will increment and decrement automatically.\"},\"storage_location\":{\"type\":\"string\",\"description\":\"Internal note used by sellers to back reference their catalog system when entering a listing\"},\"description\":{\"type\":\"string\",\"description\":\"Product description. Please keep formatting to a minimum.\"},\"finish\":{\"type\":\"string\",\"description\":\"Finish, e.g. 'Sunburst'\"},\"title\":{\"type\":\"string\",\"description\":\"Title of your listing\"},\"year\":{\"type\":\"string\",\"description\":\"Supports many formats. Ex: 1979, mid-70s, late 90s\"},\"sku\":{\"type\":\"string\",\"description\":\"Unique identifier for product\"},\"upc\":{\"type\":\"string\",\"description\":\"Valid UPC code\"},\"upc_does_not_apply\":{\"type\":\"string\",\"description\":\"True if a brand new product has no UPC code, ie for a handmade or custom item\"},\"offers_enabled\":{\"type\":\"boolean\",\"description\":\"Whether the listing accepts negotiated offers (default: true)\"},\"shipping_profile_id\":{\"type\":\"string\",\"description\":\"id of a shop's shipping profile\"},\"shipping_profile_name\":{\"type\":\"string\",\"description\":\"DEPRECATED, please use shipping_profile_id. Name of a shipping profile\"},\"location\":{\"type\":\"object\",\"properties\":{\"locality\":{\"type\":\"string\",\"description\":\"Ex: Chicago\"},\"region\":{\"type\":\"string\",\"description\":\"Ex: IL\"},\"country_code\":{\"type\":\"string\",\"description\":\"Ex: US\"}}},\"origin_country_code\":{\"type\":\"string\",\"description\":\"Country of origin/manufacture, ISO code (e.g: US)\"},\"shipping\":{\"type\":\"object\",\"properties\":{\"local\":{\"type\":\"boolean\",\"description\":\"True if you offer local pickup\"},\"rates\":{\"type\":\"array\",\"description\":\"List of shipping rates. Set to null to clear rates.\",\"items\":{\"type\":\"object\",\"properties\":{\"region_code\":{\"type\":\"string\",\"description\":\"Country code or subregion/superregion code. Full list of codes at /api/shipping/regions\"},\"rate\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]}}}}}},\"seller\":{\"type\":\"object\",\"properties\":{\"paypal_email\":{\"type\":\"string\"}}},\"seller_cost\":{\"type\":\"string\",\"description\":\"Cost of goods in your currency as a POSIX-compliant decimal number (internal use only, not shown to buyers)\"},\"tax_exempt\":{\"type\":\"boolean\",\"description\":\"Listing is exempt from taxes / VAT\"},\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"exclusive_channel\":{\"type\":\"string\",\"description\":\"Currently for users of seller sites only, this allows you to have a listing available only to your seller site by setting this to 'seller_site'\",\"enum\":[\"seller_site\"]}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"publish\":{\"type\":\"boolean\",\"description\":\"Publish your listing if draft\"},\"make\":{\"type\":\"string\",\"description\":\"ex: Fender, Gibson\"},\"model\":{\"type\":\"string\",\"description\":\"ex: Stratocaster, SG\"},\"categories\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"UUID of the category for this listing.\"}}}},\"sold_as_is\":{\"type\":\"boolean\",\"description\":\"This item is sold As-Is and cannot be returned\"},\"photos\":{\"type\":\"array\",\"description\":\"An array of image URLs. Ex: ['http://my.site.com/image.jpg']\",\"items\":{\"type\":\"string\"}},\"condition\":{\"type\":\"object\",\"description\":\"Condition\",\"properties\":{\"uuid\":{\"type\":\"string\",\"description\":\"Condition UUID\",\"enum\":[\"fbf35668-96a0-4baa-bcde-ab18d6b1b329\",\"6a9dfcad-600b-46c8-9e08-ce6e5057921e\",\"98777886-76d0-44c8-865e-bb40e669e934\",\"f7a3f48c-972a-44c6-b01a-0cd27488d3f6\",\"ae4d9114-1bd7-4ec5-a4ba-6653af5ac84d\",\"df268ad1-c462-4ba6-b6db-e007e23922ea\",\"ac5b9c1e-dc78-466d-b0b3-7cf712967a48\",\"6db7df88-293b-4017-a1c1-cdb5e599fa1a\",\"9225283f-60c2-4413-ad18-1f5eba7a856f\",\"7c3f45de-2ae0-4c81-8400-fdb6b1d74890\"]}},\"required\":[\"uuid\"]},\"has_inventory\":{\"type\":\"boolean\",\"description\":\"Set true if selling more than one\"},\"inventory\":{\"type\":\"integer\",\"description\":\"Number of items available for sale. Reverb will increment and decrement automatically.\"},\"storage_location\":{\"type\":\"string\",\"description\":\"Internal note used by sellers to back reference their catalog system when entering a listing\"},\"description\":{\"type\":\"string\",\"description\":\"Product description. Please keep formatting to a minimum.\"},\"finish\":{\"type\":\"string\",\"description\":\"Finish, e.g. 'Sunburst'\"},\"title\":{\"type\":\"string\",\"description\":\"Title of your listing\"},\"year\":{\"type\":\"string\",\"description\":\"Supports many formats. Ex: 1979, mid-70s, late 90s\"},\"sku\":{\"type\":\"string\",\"description\":\"Unique identifier for product\"},\"upc\":{\"type\":\"string\",\"description\":\"Valid UPC code\"},\"upc_does_not_apply\":{\"type\":\"string\",\"description\":\"True if a brand new product has no UPC code, ie for a handmade or custom item\"},\"offers_enabled\":{\"type\":\"boolean\",\"description\":\"Whether the listing accepts negotiated offers (default: true)\"},\"shipping_profile_id\":{\"type\":\"string\",\"description\":\"id of a shop's shipping profile\"},\"shipping_profile_name\":{\"type\":\"string\",\"description\":\"DEPRECATED, please use shipping_profile_id. Name of a shipping profile\"},\"location\":{\"type\":\"object\",\"properties\":{\"locality\":{\"type\":\"string\",\"description\":\"Ex: Chicago\"},\"region\":{\"type\":\"string\",\"description\":\"Ex: IL\"},\"country_code\":{\"type\":\"string\",\"description\":\"Ex: US\"}}},\"origin_country_code\":{\"type\":\"string\",\"description\":\"Country of origin/manufacture, ISO code (e.g: US)\"},\"shipping\":{\"type\":\"object\",\"properties\":{\"local\":{\"type\":\"boolean\",\"description\":\"True if you offer local pickup\"},\"rates\":{\"type\":\"array\",\"description\":\"List of shipping rates. Set to null to clear rates.\",\"items\":{\"type\":\"object\",\"properties\":{\"region_code\":{\"type\":\"string\",\"description\":\"Country code or subregion/superregion code. Full list of codes at /api/shipping/regions\"},\"rate\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]}}}}}},\"seller\":{\"type\":\"object\",\"properties\":{\"paypal_email\":{\"type\":\"string\"}}},\"seller_cost\":{\"type\":\"string\",\"description\":\"Cost of goods in your currency as a POSIX-compliant decimal number (internal use only, not shown to buyers)\"},\"tax_exempt\":{\"type\":\"boolean\",\"description\":\"Listing is exempt from taxes / VAT\"},\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"exclusive_channel\":{\"type\":\"string\",\"description\":\"Currently for users of seller sites only, this allows you to have a listing available only to your seller site by setting this to 'seller_site'\",\"enum\":[\"seller_site\"]}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1126,7 +1126,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1156,7 +1156,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1186,7 +1186,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"listing_id\":{\"type\":\"string\",\"title\":\"listing_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1216,7 +1216,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\",\"description\":\"Message to include with accepted offer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\",\"description\":\"Message to include with accepted offer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1246,7 +1246,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1276,7 +1276,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"shipping_price\":{\"type\":\"object\",\"description\":\"Shipping price (sellers only)\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"offer_items\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"string\"},\"shipping_price\":{\"type\":\"string\"},\"listing_id\":{\"type\":\"string\"}},\"required\":[\"listing_id\",\"price\",\"shipping_price\"]}},\"country_code\":{\"type\":\"string\"},\"region_code\":{\"type\":\"string\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"object\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"shipping_price\":{\"type\":\"object\",\"description\":\"Shipping price (sellers only)\",\"properties\":{\"amount\":{\"type\":\"string\",\"description\":\"The amount of money being expressed, as a POSIX-compliant decimal number\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency the money will be expressed in\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]}},\"required\":[\"amount\",\"currency\"]},\"offer_items\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"string\"},\"shipping_price\":{\"type\":\"string\"},\"listing_id\":{\"type\":\"string\"}},\"required\":[\"listing_id\",\"price\",\"shipping_price\"]}},\"country_code\":{\"type\":\"string\"},\"region_code\":{\"type\":\"string\"},\"message\":{\"type\":\"string\",\"description\":\"Message to include with counter offer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1306,7 +1306,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1336,7 +1336,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_id\":{\"type\":\"string\",\"title\":\"product_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_id\":{\"type\":\"string\",\"title\":\"product_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1366,7 +1366,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1396,7 +1396,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1426,7 +1426,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1456,7 +1456,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"address_id\":{\"type\":\"string\",\"title\":\"address_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"address_id\":{\"type\":\"string\",\"title\":\"address_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1486,7 +1486,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1516,7 +1516,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"required\":[\"reason\"],\"properties\":{\"reason\":{\"type\":\"string\",\"description\":\"The reason this listing is being ended. Valid reasons: [\\\"not_sold\\\", \\\"reverb_sale\\\"].\",\"enum\":[\"not_sold\",\"reverb_sale\"]}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}},\"body\":{\"type\":\"object\",\"required\":[\"reason\"],\"properties\":{\"reason\":{\"type\":\"string\",\"description\":\"The reason this listing is being ended. Valid reasons: [\\\"not_sold\\\", \\\"reverb_sale\\\"].\",\"enum\":[\"not_sold\",\"reverb_sale\"]}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1546,7 +1546,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1576,7 +1576,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1606,7 +1606,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1636,7 +1636,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1666,7 +1666,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency to be used for the price filters\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]},\"year_max\":{\"type\":\"integer\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"description\":\"Type of listing: auctions,offers\",\"enum\":[\"auctions\",\"offers\"]},\"ships_to\":{\"type\":\"string\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"integer\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency to be used for the price filters\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]},\"year_max\":{\"type\":\"integer\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"description\":\"Type of listing: auctions,offers\",\"enum\":[\"auctions\",\"offers\"]},\"ships_to\":{\"type\":\"string\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"integer\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1696,7 +1696,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1726,7 +1726,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1756,7 +1756,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1786,7 +1786,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1816,7 +1816,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1846,7 +1846,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1876,7 +1876,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1906,7 +1906,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1936,7 +1936,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1966,7 +1966,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -1996,7 +1996,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2026,7 +2026,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2056,7 +2056,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2086,7 +2086,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2116,7 +2116,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"search\":{\"type\":\"string\",\"title\":\"search\",\"description\":\"Query string to search conversations by\"},\"unread_only\":{\"type\":\"boolean\",\"title\":\"unread_only\",\"description\":\"Show unread conversations only\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"search\":{\"type\":\"string\",\"title\":\"search\",\"description\":\"Query string to search conversations by\"},\"unread_only\":{\"type\":\"boolean\",\"title\":\"unread_only\",\"description\":\"Show unread conversations only\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2146,7 +2146,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2176,7 +2176,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2206,7 +2206,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2236,7 +2236,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2266,7 +2266,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2296,7 +2296,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2326,7 +2326,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2356,7 +2356,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\",\"description\":\"Look up payments by order id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\",\"description\":\"Look up payments by order id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2386,7 +2386,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2416,7 +2416,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"created_start_date\":{\"type\":\"string\",\"title\":\"created_start_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"created_end_date\":{\"type\":\"string\",\"title\":\"created_end_date\",\"description\":\"Filter by date created in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_start_date\":{\"type\":\"string\",\"title\":\"updated_start_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"updated_end_date\":{\"type\":\"string\",\"title\":\"updated_end_date\",\"description\":\"Filter by date modified in ISO8601 format - e.g: 2015-04-09T10:52:23-00:00\"},\"page\":{\"type\":\"integer\",\"title\":\"page\",\"default\":\"1\"},\"per_page\":{\"type\":\"integer\",\"title\":\"per_page\",\"default\":\"24\"},\"offset\":{\"type\":\"integer\",\"title\":\"offset\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2446,7 +2446,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2476,7 +2476,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2506,7 +2506,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2536,7 +2536,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2566,7 +2566,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2596,7 +2596,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"read\":{\"type\":\"boolean\",\"description\":\"Should the conversation be marked as read\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"read\":{\"type\":\"boolean\",\"description\":\"Should the conversation be marked as read\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2626,7 +2626,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"date\":{\"type\":\"string\",\"description\":\"Date the item was picked up.\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"date\":{\"type\":\"string\",\"description\":\"Date the item was picked up.\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2656,7 +2656,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2686,7 +2686,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"provider\",\"send_notification\",\"tracking_number\"],\"properties\":{\"provider\":{\"type\":\"string\",\"description\":\"Shipping provider: One of UPS, USPS, FedEx, DHL, DHLExpress, DHLGlobalMail, DHL Germany, Canada Post, Royal Mail, PostNL, Australia Post, EMS, La Poste, China Post, GLS, Parcelforce, Purolator, Interlogistica, Correos España, Ukraine Post, DPD, Other\"},\"tracking_number\":{\"type\":\"string\",\"description\":\"Tracking number provided by the shipping provider\"},\"send_notification\":{\"type\":\"boolean\",\"description\":\"Should we send an email notification to the buyer\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"provider\",\"send_notification\",\"tracking_number\"],\"properties\":{\"provider\":{\"type\":\"string\",\"description\":\"Shipping provider: One of UPS, USPS, FedEx, DHL, DHLExpress, DHLGlobalMail, DHL Germany, Canada Post, Royal Mail, PostNL, Australia Post, EMS, La Poste, China Post, GLS, Parcelforce, Purolator, Interlogistica, Correos España, Ukraine Post, DPD, Other\"},\"tracking_number\":{\"type\":\"string\",\"description\":\"Tracking number provided by the shipping provider\"},\"send_notification\":{\"type\":\"boolean\",\"description\":\"Should we send an email notification to the buyer\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2716,7 +2716,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_id\":{\"type\":\"string\",\"title\":\"product_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"product_id\":{\"type\":\"string\",\"title\":\"product_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2746,7 +2746,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"follow_id\":{\"type\":\"string\",\"title\":\"follow_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2776,7 +2776,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2806,7 +2806,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2836,7 +2836,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"state\":{\"type\":\"string\",\"title\":\"state\",\"description\":\"Available: [\\\"all\\\", \\\"draft\\\", \\\"ended\\\", \\\"live\\\", \\\"ordered\\\", \\\"sold_out\\\", \\\"suspended\\\", \\\"seller_unavailable\\\"]. Defaults to 'live'\",\"default\":\"live\"},\"sku\":{\"type\":\"string\",\"title\":\"sku\",\"description\":\"Find a listing by sku\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}},\"state\":{\"type\":\"string\",\"title\":\"state\",\"description\":\"Available: [\\\"all\\\", \\\"draft\\\", \\\"ended\\\", \\\"live\\\", \\\"ordered\\\", \\\"sold_out\\\", \\\"suspended\\\", \\\"seller_unavailable\\\"]. Defaults to 'live'\",\"default\":\"live\"},\"sku\":{\"type\":\"string\",\"title\":\"sku\",\"description\":\"Find a listing by sku\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2866,7 +2866,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"query\":{\"type\":\"string\",\"title\":\"query\",\"description\":\"Search query.\"},\"auction_price_max\":{\"type\":\"number\",\"title\":\"auction_price_max\",\"description\":\"Maximum current auction price\"},\"category\":{\"type\":\"string\",\"title\":\"category\",\"description\":\"Category slug from /api/categories\"},\"product_type\":{\"type\":\"string\",\"title\":\"product_type\",\"description\":\"Product type slug from /api/categories\"},\"conditions\":{\"type\":\"array\",\"title\":\"conditions\",\"description\":\"Condition: all,new,b-stock,used,non-functioning\",\"items\":{\"type\":\"string\"}},\"decade\":{\"type\":\"string\",\"title\":\"decade\",\"description\":\"Decade: e.g. 1970s, early 70s\"},\"finish\":{\"type\":\"string\",\"title\":\"finish\",\"description\":\"Visual finish of the item, common for guitars\"},\"handmade\":{\"type\":\"boolean\",\"title\":\"handmade\",\"description\":\"Handmade items only\"},\"item_city\":{\"type\":\"string\",\"title\":\"item_city\",\"description\":\"City where item is located\"},\"item_country\":{\"type\":\"string\",\"title\":\"item_country\",\"description\":\"DEPRECATED - Country code where item is located\"},\"item_region\":{\"type\":\"string\",\"title\":\"item_region\",\"description\":\"Country code where item is located\"},\"item_state\":{\"type\":\"string\",\"title\":\"item_state\",\"description\":\"State or region code where item is located\"},\"make\":{\"type\":\"array\",\"title\":\"make\",\"description\":\"Make(s)/brand of item (e.g. Fender). Can take a single value or an array.\",\"items\":{\"type\":\"string\"}},\"model\":{\"type\":\"string\",\"title\":\"model\",\"description\":\"Model of item (e.g. Stratocaster)\"},\"must_not\":{\"type\":\"string\",\"title\":\"must_not\",\"description\":\"Search term negation. If you want to exclude a term, add it here\"},\"price_max\":{\"type\":\"number\",\"title\":\"price_max\",\"description\":\"Maximum price of search results (USD)\"},\"price_min\":{\"type\":\"number\",\"title\":\"price_min\",\"description\":\"Minimum price of search results (USD)\"},\"currency\":{\"type\":\"string\",\"title\":\"currency\",\"description\":\"The currency to be used for the price filters\"},\"year_max\":{\"type\":\"integer\",\"title\":\"year_max\",\"description\":\"Maximum year of manufacture\"},\"year_min\":{\"type\":\"integer\",\"title\":\"year_min\",\"description\":\"Minumum year of manufacture\"},\"accepts_gift_cards\":{\"type\":\"boolean\",\"title\":\"accepts_gift_cards\",\"description\":\"If true, include only items that accept gift cards\"},\"preferred_seller\":{\"type\":\"boolean\",\"title\":\"preferred_seller\",\"description\":\"If true, include only items by Reverb Preferred Sellers\"},\"shop\":{\"type\":\"string\",\"title\":\"shop\",\"description\":\"Slug of shop to search\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\",\"description\":\"ID of shop to search\"},\"listing_type\":{\"type\":\"string\",\"title\":\"listing_type\",\"description\":\"Type of listing: auctions,offers\"},\"ships_to\":{\"type\":\"string\",\"title\":\"ships_to\",\"description\":\"Limit search to items that ship to this country code\"},\"exclude_auctions\":{\"type\":\"boolean\",\"title\":\"exclude_auctions\",\"description\":\"If true, exclude auctions\"},\"accepts_payment_plans\":{\"type\":\"boolean\",\"title\":\"accepts_payment_plans\",\"description\":\"If true, only show items that can be purchased with a payment plan\"},\"watchers_count_min\":{\"type\":\"integer\",\"title\":\"watchers_count_min\",\"description\":\"Minimum number of watchers (used to find popular items)\"},\"not_ids\":{\"type\":\"array\",\"title\":\"not_ids\",\"description\":\"Listing ID negation. If you want to exclude a listing, add it here.\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2896,7 +2896,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2926,7 +2926,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2956,7 +2956,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -2986,7 +2986,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3016,7 +3016,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3046,7 +3046,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3076,7 +3076,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"buyer_id\":{\"type\":\"string\",\"title\":\"buyer_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"buyer_id\":{\"type\":\"string\",\"title\":\"buyer_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3106,7 +3106,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3136,7 +3136,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"conversation_id\":{\"type\":\"string\",\"title\":\"conversation_id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"body\":{\"type\":\"string\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"conversation_id\":{\"type\":\"string\",\"title\":\"conversation_id\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"body\":{\"type\":\"string\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3166,7 +3166,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"category_uuids\"],\"properties\":{\"category_uuids\":{\"type\":\"string\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"category_uuids\"],\"properties\":{\"category_uuids\":{\"type\":\"string\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3196,7 +3196,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"recipient_id\":{\"type\":\"integer\",\"description\":\"The id of the user you are trying to contact\"},\"listing_id\":{\"type\":\"integer\",\"description\":\"The id of the listing being discussed\"},\"shop_id\":{\"type\":\"string\",\"description\":\"The id of the shop you are trying to contact\"},\"body\":{\"type\":\"string\",\"description\":\"The body of the message\"},\"cloudinary_photos\":{\"type\":\"array\",\"description\":\"An array of cloudinary data hashes (Reverb internal use only).\",\"items\":{\"type\":\"string\"}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"body\"],\"properties\":{\"recipient_id\":{\"type\":\"integer\",\"description\":\"The id of the user you are trying to contact\"},\"listing_id\":{\"type\":\"integer\",\"description\":\"The id of the listing being discussed\"},\"shop_id\":{\"type\":\"string\",\"description\":\"The id of the shop you are trying to contact\"},\"body\":{\"type\":\"string\",\"description\":\"The body of the message\"},\"cloudinary_photos\":{\"type\":\"array\",\"description\":\"An array of cloudinary data hashes (Reverb internal use only).\",\"items\":{\"type\":\"string\"}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3226,7 +3226,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3256,7 +3256,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"identifier\":{\"type\":\"string\",\"title\":\"identifier\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3286,7 +3286,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3316,7 +3316,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3346,7 +3346,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3376,7 +3376,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"category\":{\"type\":\"string\",\"title\":\"category\"},\"subcategory\":{\"type\":\"string\",\"title\":\"subcategory\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3406,7 +3406,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3436,7 +3436,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"first_name\":{\"type\":\"string\",\"description\":\"The first name of the account holder\"},\"last_name\":{\"type\":\"string\",\"description\":\"The last name of the account holder\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency preference for the account\"},\"shipping_region_code\":{\"type\":\"string\",\"description\":\"The shipping region preference for the account\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"first_name\":{\"type\":\"string\",\"description\":\"The first name of the account holder\"},\"last_name\":{\"type\":\"string\",\"description\":\"The last name of the account holder\"},\"currency\":{\"type\":\"string\",\"description\":\"The currency preference for the account\"},\"shipping_region_code\":{\"type\":\"string\",\"description\":\"The shipping region preference for the account\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3466,7 +3466,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"address_id\":{\"type\":\"string\",\"title\":\"address_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"address_id\":{\"type\":\"string\",\"title\":\"address_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3496,7 +3496,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3526,7 +3526,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3556,7 +3556,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3586,7 +3586,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3616,7 +3616,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3646,7 +3646,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"order_id\":{\"type\":\"string\",\"title\":\"order_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3676,7 +3676,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3706,7 +3706,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"default\":\"used\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"default\":\"used\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3736,7 +3736,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"number_of_months\":{\"type\":\"integer\",\"title\":\"number_of_months\",\"default\":\"3\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"default\":\"used\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"},\"number_of_months\":{\"type\":\"integer\",\"title\":\"number_of_months\",\"default\":\"3\"},\"condition\":{\"type\":\"string\",\"title\":\"condition\",\"default\":\"used\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3766,7 +3766,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3796,7 +3796,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3826,7 +3826,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"rating\":{\"type\":\"integer\",\"description\":\"Rating from 1 to 5\"},\"body\":{\"type\":\"string\",\"description\":\"Content of the review\"},\"title\":{\"type\":\"string\",\"description\":\"Title for the review\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"rating\":{\"type\":\"integer\",\"description\":\"Rating from 1 to 5\"},\"body\":{\"type\":\"string\",\"description\":\"Content of the review\"},\"title\":{\"type\":\"string\",\"description\":\"Title for the review\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3856,7 +3856,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3886,7 +3886,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3916,7 +3916,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"sale_id\":{\"type\":\"string\",\"title\":\"sale_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"sale_id\":{\"type\":\"string\",\"title\":\"sale_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3946,7 +3946,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -3976,7 +3976,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"sale_id\":{\"type\":\"string\",\"title\":\"sale_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"sale_id\":{\"type\":\"string\",\"title\":\"sale_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4006,7 +4006,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4036,7 +4036,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4066,7 +4066,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4096,7 +4096,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4126,7 +4126,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4156,7 +4156,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4186,7 +4186,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4216,7 +4216,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4246,7 +4246,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4276,7 +4276,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4306,7 +4306,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"description\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"currency\":{\"type\":\"string\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]},\"payment_policy\":{\"type\":\"string\"},\"return_policy\":{\"type\":\"string\"},\"shipping_policy\":{\"type\":\"string\"},\"website\":{\"type\":\"string\"},\"legal_country_code\":{\"type\":\"string\",\"enum\":[\"AD\",\"AE\",\"AF\",\"AG\",\"AI\",\"AL\",\"AM\",\"AO\",\"AR\",\"AS\",\"AT\",\"AU\",\"AW\",\"AX\",\"AZ\",\"BA\",\"BB\",\"BD\",\"BE\",\"BF\",\"BG\",\"BH\",\"BI\",\"BJ\",\"BL\",\"BM\",\"BN\",\"BO\",\"BQ\",\"BR\",\"BS\",\"BT\",\"BV\",\"BW\",\"BY\",\"BZ\",\"CA\",\"CC\",\"CD\",\"CF\",\"CG\",\"CH\",\"CI\",\"CK\",\"CL\",\"CM\",\"CN\",\"CO\",\"CR\",\"CU\",\"CV\",\"CW\",\"CX\",\"CY\",\"CZ\",\"DE\",\"DJ\",\"DK\",\"DM\",\"DO\",\"DZ\",\"EC\",\"EE\",\"EG\",\"EH\",\"ER\",\"ES\",\"ET\",\"FI\",\"FJ\",\"FK\",\"FM\",\"FO\",\"FR\",\"GA\",\"GB\",\"GD\",\"GE\",\"GF\",\"GG\",\"GH\",\"GI\",\"GL\",\"GM\",\"GN\",\"GP\",\"GQ\",\"GR\",\"GS\",\"GT\",\"GU\",\"GW\",\"GY\",\"HK\",\"HM\",\"HN\",\"HR\",\"HT\",\"HU\",\"ID\",\"IE\",\"IL\",\"IM\",\"IN\",\"IO\",\"IQ\",\"IR\",\"IS\",\"IT\",\"JE\",\"JM\",\"JO\",\"JP\",\"KE\",\"KG\",\"KH\",\"KI\",\"KM\",\"KN\",\"KP\",\"KR\",\"KW\",\"KY\",\"KZ\",\"LA\",\"LB\",\"LC\",\"LI\",\"LK\",\"LR\",\"LS\",\"LT\",\"LU\",\"LV\",\"LY\",\"MA\",\"MC\",\"MD\",\"ME\",\"MF\",\"MG\",\"MH\",\"MK\",\"ML\",\"MM\",\"MN\",\"MO\",\"MP\",\"MQ\",\"MR\",\"MS\",\"MT\",\"MU\",\"MV\",\"MW\",\"MX\",\"MY\",\"MZ\",\"NA\",\"NC\",\"NE\",\"NF\",\"NG\",\"NI\",\"NL\",\"NO\",\"NP\",\"NR\",\"NU\",\"NZ\",\"OM\",\"PA\",\"PE\",\"PF\",\"PG\",\"PH\",\"PK\",\"PL\",\"PM\",\"PN\",\"PS\",\"PT\",\"PW\",\"PY\",\"QA\",\"RE\",\"RO\",\"RS\",\"RU\",\"RW\",\"SA\",\"SB\",\"SC\",\"SD\",\"SE\",\"SG\",\"SH\",\"SI\",\"SJ\",\"SK\",\"SL\",\"SM\",\"SN\",\"SO\",\"SR\",\"SS\",\"ST\",\"SV\",\"SX\",\"SY\",\"SZ\",\"TC\",\"TD\",\"TF\",\"TG\",\"TH\",\"TJ\",\"TK\",\"TL\",\"TM\",\"TN\",\"TO\",\"TR\",\"TT\",\"TV\",\"TW\",\"TZ\",\"UA\",\"UG\",\"UM\",\"US\",\"UY\",\"UZ\",\"VA\",\"VC\",\"VE\",\"VG\",\"VI\",\"VN\",\"VU\",\"WF\",\"WS\",\"YE\",\"YT\",\"ZA\",\"ZM\",\"ZW\"]},\"legal_country_code_confirmed\":{\"type\":\"boolean\"},\"address\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"street_address\":{\"type\":\"string\"},\"extended_address\":{\"type\":\"string\"},\"locality\":{\"type\":\"string\"},\"region\":{\"type\":\"string\"},\"postal_code\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"country_code\":{\"type\":\"string\"}}}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"description\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"currency\":{\"type\":\"string\",\"enum\":[\"USD\",\"CAD\",\"EUR\",\"GBP\",\"AUD\",\"JPY\",\"NZD\",\"MXN\"]},\"payment_policy\":{\"type\":\"string\"},\"return_policy\":{\"type\":\"string\"},\"shipping_policy\":{\"type\":\"string\"},\"website\":{\"type\":\"string\"},\"legal_country_code\":{\"type\":\"string\",\"enum\":[\"AD\",\"AE\",\"AF\",\"AG\",\"AI\",\"AL\",\"AM\",\"AO\",\"AR\",\"AS\",\"AT\",\"AU\",\"AW\",\"AX\",\"AZ\",\"BA\",\"BB\",\"BD\",\"BE\",\"BF\",\"BG\",\"BH\",\"BI\",\"BJ\",\"BL\",\"BM\",\"BN\",\"BO\",\"BQ\",\"BR\",\"BS\",\"BT\",\"BV\",\"BW\",\"BY\",\"BZ\",\"CA\",\"CC\",\"CD\",\"CF\",\"CG\",\"CH\",\"CI\",\"CK\",\"CL\",\"CM\",\"CN\",\"CO\",\"CR\",\"CU\",\"CV\",\"CW\",\"CX\",\"CY\",\"CZ\",\"DE\",\"DJ\",\"DK\",\"DM\",\"DO\",\"DZ\",\"EC\",\"EE\",\"EG\",\"EH\",\"ER\",\"ES\",\"ET\",\"FI\",\"FJ\",\"FK\",\"FM\",\"FO\",\"FR\",\"GA\",\"GB\",\"GD\",\"GE\",\"GF\",\"GG\",\"GH\",\"GI\",\"GL\",\"GM\",\"GN\",\"GP\",\"GQ\",\"GR\",\"GS\",\"GT\",\"GU\",\"GW\",\"GY\",\"HK\",\"HM\",\"HN\",\"HR\",\"HT\",\"HU\",\"ID\",\"IE\",\"IL\",\"IM\",\"IN\",\"IO\",\"IQ\",\"IR\",\"IS\",\"IT\",\"JE\",\"JM\",\"JO\",\"JP\",\"KE\",\"KG\",\"KH\",\"KI\",\"KM\",\"KN\",\"KP\",\"KR\",\"KW\",\"KY\",\"KZ\",\"LA\",\"LB\",\"LC\",\"LI\",\"LK\",\"LR\",\"LS\",\"LT\",\"LU\",\"LV\",\"LY\",\"MA\",\"MC\",\"MD\",\"ME\",\"MF\",\"MG\",\"MH\",\"MK\",\"ML\",\"MM\",\"MN\",\"MO\",\"MP\",\"MQ\",\"MR\",\"MS\",\"MT\",\"MU\",\"MV\",\"MW\",\"MX\",\"MY\",\"MZ\",\"NA\",\"NC\",\"NE\",\"NF\",\"NG\",\"NI\",\"NL\",\"NO\",\"NP\",\"NR\",\"NU\",\"NZ\",\"OM\",\"PA\",\"PE\",\"PF\",\"PG\",\"PH\",\"PK\",\"PL\",\"PM\",\"PN\",\"PS\",\"PT\",\"PW\",\"PY\",\"QA\",\"RE\",\"RO\",\"RS\",\"RU\",\"RW\",\"SA\",\"SB\",\"SC\",\"SD\",\"SE\",\"SG\",\"SH\",\"SI\",\"SJ\",\"SK\",\"SL\",\"SM\",\"SN\",\"SO\",\"SR\",\"SS\",\"ST\",\"SV\",\"SX\",\"SY\",\"SZ\",\"TC\",\"TD\",\"TF\",\"TG\",\"TH\",\"TJ\",\"TK\",\"TL\",\"TM\",\"TN\",\"TO\",\"TR\",\"TT\",\"TV\",\"TW\",\"TZ\",\"UA\",\"UG\",\"UM\",\"US\",\"UY\",\"UZ\",\"VA\",\"VC\",\"VE\",\"VG\",\"VI\",\"VN\",\"VU\",\"WF\",\"WS\",\"YE\",\"YT\",\"ZA\",\"ZM\",\"ZW\"]},\"legal_country_code_confirmed\":{\"type\":\"boolean\"},\"address\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"street_address\":{\"type\":\"string\"},\"extended_address\":{\"type\":\"string\"},\"locality\":{\"type\":\"string\"},\"region\":{\"type\":\"string\"},\"postal_code\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"country_code\":{\"type\":\"string\"}}}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4336,7 +4336,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"},\"include_listing_count\":{\"type\":\"boolean\",\"title\":\"include_listing_count\",\"description\":\"Include the live listing count in the response.\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"},\"include_listing_count\":{\"type\":\"boolean\",\"title\":\"include_listing_count\",\"description\":\"Include the live listing count in the response.\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4366,7 +4366,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4396,7 +4396,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4426,7 +4426,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"slug\":{\"type\":\"string\",\"title\":\"slug\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4456,7 +4456,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"shop_id\":{\"type\":\"string\",\"title\":\"shop_id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4486,7 +4486,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4516,7 +4516,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4546,7 +4546,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4576,7 +4576,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4606,7 +4606,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4636,7 +4636,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"topic\",\"url\"],\"properties\":{\"url\":{\"type\":\"string\"},\"topic\":{\"type\":\"string\",\"description\":\"Valid values: listings/update, listings/publish, listings/bumps-ran-out, orders/create, orders/update, payments/create, payments/update, app/uninstalled\",\"enum\":[\"listings/update\",\"listings/publish\",\"listings/bumps-ran-out\",\"orders/create\",\"orders/update\",\"payments/create\",\"payments/update\",\"app/uninstalled\"]}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"}}},\"body\":{\"type\":\"object\",\"required\":[\"topic\",\"url\"],\"properties\":{\"url\":{\"type\":\"string\"},\"topic\":{\"type\":\"string\",\"description\":\"Valid values: listings/update, listings/publish, listings/bumps-ran-out, orders/create, orders/update, payments/create, payments/update, app/uninstalled\",\"enum\":[\"listings/update\",\"listings/publish\",\"listings/bumps-ran-out\",\"orders/create\",\"orders/update\",\"payments/create\",\"payments/update\",\"app/uninstalled\"]}}}}}"
         },
         "outputDataShape": {
           "kind": "none"
@@ -4666,7 +4666,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"Accept-Version\":{\"type\":\"string\",\"title\":\"Accept-Version\",\"default\":\"3.0\"},\"id\":{\"type\":\"string\",\"title\":\"id\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/api-generator/src/test/resources/swagger/todo.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/swagger/todo.unified_connector.json
@@ -18,7 +18,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"items\":{\"properties\":{\"completed\":{\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"title\":\"Task completition status\",\"type\":\"integer\"},\"id\":{\"description\":\"Unique task identifier\",\"title\":\"Task ID\",\"type\":\"integer\"},\"task\":{\"description\":\"Task line\",\"title\":\"The task\",\"type\":\"string\"}},\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"items\":{\"properties\":{\"completed\":{\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"title\":\"Task completition status\",\"type\":\"integer\"},\"id\":{\"description\":\"Unique task identifier\",\"title\":\"Task ID\",\"type\":\"integer\"},\"task\":{\"description\":\"Task line\",\"title\":\"The task\",\"type\":\"string\"}},\"type\":\"object\"},\"type\":\"array\"}},\"type\":\"object\"}"
         }
       },
       "id": "_id_:operation-0",
@@ -44,7 +44,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -53,7 +53,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         }
       },
       "id": "_id_:operation-1",
@@ -79,7 +79,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -88,7 +88,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         }
       },
       "id": "_id_:operation-2",
@@ -114,7 +114,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         },
         "outputDataShape": {
           "description": "API response payload",
@@ -123,7 +123,7 @@
             "unified": "true"
           },
           "name": "Response",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"body\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"Task ID\",\"description\":\"Unique task identifier\"},\"task\":{\"type\":\"string\",\"title\":\"The task\",\"description\":\"Task line\"},\"completed\":{\"type\":\"integer\",\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"minimum\":0,\"maximum\":1}}}}}"
         }
       },
       "id": "_id_:operation-3",
@@ -149,7 +149,7 @@
             "unified": "true"
           },
           "name": "Request",
-          "specification": "{\"$schema\": \"http://json-schema.org/schema#\",\"$id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier to delete\"}}}}}"
+          "specification": "{\"$schema\": \"http://json-schema.org/draft-04/schema#\",\"id\":\"io:syndesis:wrapped\",\"type\":\"object\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier to delete\"}}}}}"
         },
         "outputDataShape": {
           "kind": "none"

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonSchemaInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonSchemaInspector.java
@@ -49,8 +49,7 @@ public class JsonSchemaInspector implements Inspector {
         try {
             schema = MAPPER.readerFor(JsonSchema.class).readValue(specification);
         } catch (final IOException e) {
-            LOG.warn(
-                "Unable to parse the given JSON schema, increase log level to DEBUG to see the schema being parsed");
+            LOG.warn("Unable to parse the given JSON schema, increase log level to DEBUG to see the schema being parsed", e);
             LOG.debug(specification);
 
             return Collections.emptyList();
@@ -102,7 +101,10 @@ public class JsonSchemaInspector implements Inspector {
                 fetchPaths(path, paths, subschema.asObjectSchema().getProperties());
             } else if (subschema.isArraySchema()) {
                 COLLECTION_PATHS.stream().map(p -> path + "." + p).forEach(paths::add);
-                fetchPaths(path + ARRAY_CONTEXT, paths, getItemSchema(subschema.asArraySchema()).getProperties());
+                ObjectSchema itemSchema = getItemSchema(subschema.asArraySchema());
+                if (itemSchema != null) {
+                    fetchPaths(path + ARRAY_CONTEXT, paths, itemSchema.getProperties());
+                }
             }
         }
     }

--- a/app/server/inspector/src/test/resources/petstore-unified-schema.json
+++ b/app/server/inspector/src/test/resources/petstore-unified-schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "id": "io:syndesis:wrapped",
+  "properties": {
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "body": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "category": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "photoUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "status": {
+          "description": "pet status in the store",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ],
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Json schema draft 6 was causing problems in jackson library when parsing unified Json data shapes. So roll back to using jackson compatible draft version.

Started to incorporate a library that supports Json schema draft 6 but this is a really big change as we use the jackson schema quite a lot in server, meta and connectors. so we would need a bigger refactoring. so being a little less hip might do the trick for us, too.