### PR TITLE
TEIIDTOOLS-803 Redirect to editor after view creation

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -163,6 +163,31 @@ export const useVirtualizationHelpers = () => {
   };
 
   /**
+   * Get ViewDefinition for the supplied virtualization and view name
+   * @param virtualizationName the name of the virtualization
+   * @param viewName the name of the view
+   */
+  const getView = async (
+    virtualizationName: string,
+    viewName: string
+  ): Promise<ViewDefinition> => {
+    const encodedName = encodeURIComponent(viewName);
+    const response = await callFetch({
+      headers: {},
+      method: 'GET',
+      url: `${
+        apiContext.dvApiUri
+      }workspace/dataservices/${virtualizationName}/views/${encodedName}`,
+    });
+
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+
+    return (await response.json()) as ViewDefinition;
+  };
+
+  /**
    * Get ViewDefinition for the supplied id
    * @param viewDefinitionId the id of the view definition
    */
@@ -401,6 +426,7 @@ export const useVirtualizationHelpers = () => {
     deleteViewDefinition,
     deleteVirtualization,
     getSourceInfoForView,
+    getView,
     getViewDefinition,
     importSource,
     publishVirtualization,

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -6,7 +6,6 @@
   "createDataVirtualizationTitle": "Create New $t(shared:DataVirtualization)",
   "createView": "Create a View",
   "createViewFailed": "Create view failed. Details: {{details}}",
-  "createViewSuccess": "Created view named: {{name}}.",
   "createViewTip": "Create a new View for this virtualization",
   "createViewWizardStep1": "Select Sources",
   "createViewWizardStep2": "Select Name",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -6,7 +6,6 @@
   "createDataVirtualizationTitle": "Crea Nuova $t(shared:DataVirtualization)",
   "createView": "Crea una Vista",
   "createViewFailed": "Creazione vista non riuscita. Dettagli: {{details}}",
-  "createViewSuccess": "Vista creata denominata: {{name}}.",
   "createViewTip": "Crea una nuova Vista per questa virtualizzazione",
   "createViewWizardStep1": "Seleziona Fonti",
   "createViewWizardStep2": "Seleziona il Nome",


### PR DESCRIPTION
When a new view is created via the 'Create a View' wizard, now redirects to the View Editor page rather than the Virtualization details page.
- Added getView function to useVirtualizationHelpers, to allow retrieval of View using the virtualization and view names
- Adapt SelectNamePage from the wizard - now redirects to editor page upon successful view creation.   Also removed the toast notification for success