### PR TITLE
[Prometheus] Fix docker tag for Prometheus

### DIFF
--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -36,7 +36,7 @@ Tags:
   OAuthProxy: v4.0.0
   PostgresExporter: v0.4.7
   Postgresql: "9.5"
-  Prometheus: v3.9
+  Prometheus: v2.13.0
   Syndesis: latest
   Upgrade: latest
   CamelKBase: 3.0-java8


### PR DESCRIPTION
`v3.9` doesn't exist in upstream prometheus: https://hub.docker.com/r/prom/prometheus/tags , so changing it to latest stable available