### PR TITLE
fix: tidy up the api provider response error handling form thingy

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.css
@@ -1,8 +1,7 @@
 .auto-form-legend {
   white-space: nowrap;
-  margin-top: 1em;
 }
-.auto-form-legend h5 {
-  margin-bottom: 0;
-  font-weight: 600;
+
+.auto-form-legend .auto-form-legend__text {
+  margin-bottom: 0 !important;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLegendComponent.tsx
@@ -6,6 +6,7 @@ export const FormLegendComponent: React.FunctionComponent<
   IFormControlProps
 > = props => (
   <TextContent className={'pf-c-form__group auto-form-legend'}>
-    <Text component={TextVariants.h5}>{props.property.displayName}</Text>
+
+    <Text className={'auto-form-legend__text'} component={TextVariants.h3}>{props.property.displayName}</Text>
   </TextContent>
 );

--- a/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.css
@@ -1,0 +1,4 @@
+.form-mapset-component__data-list-cell-secondary > .pf-c-form__group {
+  display: inline-block !important;
+
+}

--- a/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormMapsetComponent.tsx
@@ -5,11 +5,9 @@ import {
   DataListItemCells,
   DataListItemRow,
   FormGroup,
-  Popover,
   Text,
   TextVariants,
 } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import {
   IFormControlProps,
@@ -19,6 +17,8 @@ import {
 } from '../models';
 import { useFormBuilder } from '../useFormBuilder';
 import { getValidationState, toValidHtmlId } from './helpers';
+
+import './FormMapsetComponent.css';
 
 export const FormMapsetComponent: React.FunctionComponent<
   IFormControlProps
@@ -36,30 +36,14 @@ export const FormMapsetComponent: React.FunctionComponent<
   return (
     <>
       <FormGroup
-        label={
-          props.property.displayName ? (
-            <>
-              {props.property.displayName}
-              {props.property.labelHint && (
-                <Popover
-                  aria-label={props.property.labelHint}
-                  bodyContent={props.property.labelHint}
-                >
-                  <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-                </Popover>
-              )}
-            </>
-          ) : (
-            undefined
-          )
-        }
         {...props.property.formGroupAttributes}
+        className={'form-mapset-component__form-group'}
         fieldId={id}
         isValid={getValidationState(props)}
-        helperText={props.property.description}
+        helperText={''}
         helperTextInvalid={props.form.errors[props.field.name]}
       />
-        <DataList id={id} aria-label={field.name}>
+        <DataList id={id} aria-label={field.name} className={'form-mapset-component__data-list'}>
           <DataListItem aria-labelledby={'key-label'}>
             <DataListItemRow>
               <DataListItemCells
@@ -100,7 +84,7 @@ export const FormMapsetComponent: React.FunctionComponent<
                           </Text>
                         </DataListCell>,
                         <DataListCell key={'secondary'}>
-                          <div className="pf-c-form">
+                          <div className="form-mapset-component__data-list-cell-secondary pf-c-form">
                             {getField({
                               allFieldsRequired: false,
                               property: {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -90,6 +90,10 @@ export const ConfigurationForm: React.FunctionComponent<
         (name: string) => `${name} is required`,
         values
       );
+    const formTitle =
+      typeof step.description === 'undefined'
+        ? action.name
+        : `${action.name} - ${step.description}`;
     return (
       <AutoForm<IFormValue>
         i18nRequiredProperty={t('shared:requiredFieldMessage')}
@@ -105,7 +109,7 @@ export const ConfigurationForm: React.FunctionComponent<
         {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => (
           <>
             <IntegrationEditorForm
-              i18nFormTitle={`${action.name} - ${step.description}`}
+              i18nFormTitle={formTitle}
               i18nBackAction={'Choose Action'}
               i18nNext={'Next'}
               isValid={isValid}


### PR DESCRIPTION
fixes [ENTESB-12004](https://issues.jboss.org/browse/ENTESB-12004)

Updates the layout of the error handling form a bit, had to really force a couple things too:

![image](https://user-images.githubusercontent.com/351660/66853701-e67d4380-ef4d-11e9-825d-53affae06af6.png)
