### PR TITLE
fix: fetch updates on the detail page when change events are received

### DIFF
--- a/app/ui-react/packages/api/src/useConnection.tsx
+++ b/app/ui-react/packages/api/src/useConnection.tsx
@@ -7,6 +7,8 @@ import {
 } from './helpers';
 import { useApiResource } from './useApiResource';
 import { transformConnectorResponse } from './useConnector';
+import { useServerEvents } from './useServerEvents';
+import { IChangeEvent } from './WithServerEvents';
 
 export const transformConnectionResponse = (
   connection: IConnectionOverview
@@ -27,9 +29,10 @@ export const transformConnectionResponse = (
 
 export const useConnection = (
   connectionId: string,
-  initialValue?: IConnectionOverview
+  initialValue?: IConnectionOverview,
+  disableUpdates: boolean = false
 ) => {
-  return useApiResource<IConnectionOverview>({
+  const { read, ...rest } = useApiResource<IConnectionOverview>({
     defaultValue: {
       isConfigRequired: false,
       isTechPreview: false,
@@ -42,4 +45,13 @@ export const useConnection = (
     },
     url: `/connections/${connectionId}`,
   });
+  useServerEvents({
+    disableUpdates,
+    filter: (change: IChangeEvent) => change.id === connectionId,
+    read,
+  });
+  return {
+    ...rest,
+    read,
+  };
 };

--- a/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
@@ -109,11 +109,9 @@ export const ConnectionDetailsPage: React.FunctionComponent<
   const getUsedByMessage = (c: IConnectionOverview): string => {
     // TODO: Schema is currently wrong as it has 'uses' as an OptionalInt. Remove cast when schema is fixed.
     const numUsedBy = c.uses as number;
-
     if (numUsedBy === 1) {
       return i18n.t('connections:usedByOne');
     }
-
     return i18n.t('connections:usedByMulti', { count: numUsedBy });
   };
 
@@ -136,11 +134,6 @@ export const ConnectionDetailsPage: React.FunctionComponent<
     );
     try {
       await saveConnection(updatedConnection);
-      history.push(
-        resolvers.connections.connection.details({
-          connection: updatedConnection,
-        })
-      );
       return true;
     } catch (error) {
       pushNotification(t('errorSavingConnection'), 'error');
@@ -264,7 +257,7 @@ export const ConnectionDetailsPage: React.FunctionComponent<
             initialValue={connection.configuredProperties}
             disabled={!edit}
             onSave={saveConnector}
-            key={location.key}
+            key={`${location.key} - ${connection.lastUpdated}`}
           >
             {({
               fields,


### PR DESCRIPTION
for [ENTESB-11405](https://issues.jboss.org/browse/ENTESB-11405)

@claudio4j this is what I was thinking in regards to the server events.

Looking deeper I think I led you astray a bit, `useConnection` returns a `read()` function that can be used to trigger a fetch, so another option would have been to call `read()` after calling the save function.  But this approach should work as well, after going through the oauth dance once there's a change made to the connection the UI should then fetch an updated connection.

I can't seem to fully see this working in development mode though, it seems like the dev proxy isn't receiving the change events for some reason.  Can you test this in your environment?  You'd want to build the console and deploy it to verify I think, open the network tab and you should see a `GET` occur shortly after the ui does that `PUT`.