### PR TITLE
Revert "fix(server): make CORS great again"

### DIFF
--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
@@ -36,11 +36,6 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesUserDetailsService;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedGrantedAuthoritiesWebAuthenticationDetails;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Profile("!development")
 @Configuration
@@ -64,13 +59,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     protected void configure(HttpSecurity http) throws Exception {
-        http
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
-
-            .cors()
-            .and()
-
             .addFilter(requestHeaderAuthenticationFilter())
             .addFilter(new AnonymousAuthenticationFilter("anonymous"))
             .authorizeRequests()
@@ -78,34 +68,13 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers(COMMON_NON_SECURED_PATHS).permitAll()
             .antMatchers(HttpMethod.GET, "/api/v1/credentials/callback").permitAll()
             .antMatchers("/api/v1/**").hasRole("AUTHENTICATED")
-            .anyRequest().permitAll()
+            .anyRequest().permitAll();
 
-            .and()
-
-            .csrf()
+        http.csrf()
             .ignoringAntMatchers(COMMON_NON_SECURED_PATHS)
             .ignoringAntMatchers("/api/v1/credentials/callback")
             .ignoringAntMatchers("/api/v1/atlas/**")
             .csrfTokenRepository(new SyndesisCsrfRepository());
-    }
-
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(CorsConfiguration.ALL));
-        configuration.setAllowedMethods(Arrays.asList(
-            HttpMethod.HEAD.name(),
-            HttpMethod.GET.name(),
-            HttpMethod.OPTIONS.name(),
-            HttpMethod.POST.name(),
-            HttpMethod.PUT.name(),
-            HttpMethod.DELETE.name(),
-            HttpMethod.PATCH.name()
-        ));
-        configuration = configuration.applyPermitDefaultValues();
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCorsConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCorsConfiguration.java
@@ -15,13 +15,15 @@
  */
 package io.syndesis.server.runtime;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.cors.CorsConfiguration;
-
 import java.util.Arrays;
 import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableConfigurationProperties
@@ -37,4 +39,23 @@ public class SyndesisCorsConfiguration {
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
     }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        return new CorsFilter(request -> {
+            String pathInfo = request.getPathInfo();
+            if (pathInfo != null &&
+                (pathInfo.endsWith("/swagger.json") ||
+                 pathInfo.endsWith("/swagger.yaml"))) {
+                return new CorsConfiguration().applyPermitDefaultValues();
+            }
+
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedOrigins(allowedOrigins);
+            config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
+            config.applyPermitDefaultValues();
+            return config;
+        });
+    }
+
 }


### PR DESCRIPTION
This reverts commit 02bd7dc69d53c02cbe65b4fbcb14be0a752971b5.

Since we don't need CORS in production, it's better not to keep it enabled all the time.
This reverts the configuration to the original, CORS-less state until we figure out a way to enable it on some per-install/config premise.