### PR TITLE
fix(release): non-staging profile

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -140,9 +140,6 @@
     <module>server</module>
     <module>s2i</module>
     <module>meta</module>
-    <module>ui-react</module>
-    <module>../doc</module>
-    <module>test</module>
   </modules>
 
   <profiles>
@@ -290,6 +287,21 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>non-staging</id>
+      <activation>
+        <property>
+          <name>!stagingDescription</name>
+        </property>
+      </activation>
+
+      <modules>
+        <module>ui-react</module>
+        <module>../doc</module>
+        <module>test</module>
+      </modules>
     </profile>
 
     <!-- Like 'no-checks' but even more aggresive (like even no tests)  -->

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -353,7 +353,7 @@ release_staging_repo() {
 
     echo "==== Releasing Sonatype staging repo"
     cd $topdir/app
-    ./mvnw ${maven_opts} -Prelease -pl \!:syndesis-docs,\!:test-parent,\!:ui-react nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
+    ./mvnw ${maven_opts} -Prelease nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
 }
 
 git_commit_files() {


### PR DESCRIPTION
This adds a profile active when `stagingDescription` property is not defined to include docs, ui-react and test Maven modules; otherwise when it's defined, at the point we stage artifacts for publishing to Maven central those modules are excluded from the reactor.