### PR TITLE
Bump db to 9.6

### DIFF
--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -35,7 +35,7 @@ Tags:
   Komodo: latest
   OAuthProxy: v4.0.0
   PostgresExporter: v0.4.7
-  Postgresql: "9.5"
+  Postgresql: "9.6"
   Prometheus: v2.13.0
   Syndesis: latest
   Upgrade: latest


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/ENTESB-12039
Fixes https://github.com/syndesisio/fuse-online-install/issues/188