### PR TITLE
refactor: remove unsafe usage of SimpleDateFormat

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
@@ -16,11 +16,12 @@
 package io.syndesis.common.model.metrics;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationDeploymentMetrics.Builder.class)
@@ -40,11 +41,11 @@ public interface IntegrationDeploymentMetrics extends Serializable {
      * @return most recent (re-) start Date of the integration, empty if no live pods
      * are found for this integration, which would mean that the integration is currently down.
      */
-    Optional<Date> getStart();
+    Optional<Instant> getStart();
     /**
      * @return the TimeStamp of when the last message for processed
      */
-    Optional<Date> getLastProcessed();
+    Optional<Instant> getLastProcessed();
     /**
      * @return the duration this deployment is up and running.
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
@@ -16,57 +16,67 @@
 package io.syndesis.common.model.metrics;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithId;
+
 import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationMetricsSummary.Builder.class)
 @SuppressWarnings("immutables")
-public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSummary>, Serializable{
+public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSummary>, Serializable {
+
+    class Builder extends ImmutableIntegrationMetricsSummary.Builder {
+        // allow access to ImmutablIntegrationMetricsSummary.Builder
+    }
+
+    /**
+     * @return Number of messages that resulted in error
+     */
+    Long getErrors();
+
+    Optional<List<IntegrationDeploymentMetrics>> getIntegrationDeploymentMetrics();
 
     @Override
     default Kind getKind() {
         return Kind.IntegrationMetricsSummary;
     }
-    String getMetricsProvider();
+
+    /**
+     * @return the TimeStamp of when the last message for processed
+     */
+    Optional<Instant> getLastProcessed();
+
     /**
      * @return Number of successful messages
      */
     Long getMessages();
+
+    String getMetricsProvider();
+
     /**
-     * @return Number of messages that resulted in error
+     * @return most recent (re-) start Date of the integration, empty if no live
+     *         pods are found for this integration, which would mean that the
+     *         integration is currently down.
      */
-    Long getErrors();
+    Optional<Instant> getStart();
+
     /**
-     * @return most recent (re-) start Date of the integration, empty if no live pods
-     * are found for this integration, which would mean that the integration is currently down.
+     * @return Map of top 'N' (configured in metrics service, default 5)
+     *         integrations by total messages. Only valid when retrieving total
+     *         metrics summary.
      */
-    Optional<Date> getStart();
-    /**
-     * @return the TimeStamp of when the last message for processed
-     */
-    Optional<Date> getLastProcessed();
+    Optional<Map<String, Long>> getTopIntegrations();
+
     /**
      * @return the duration this application is up and running.
      */
     Long getUptimeDuration();
-
-    Optional<List<IntegrationDeploymentMetrics>> getIntegrationDeploymentMetrics();
-
-    /**
-     * @return Map of top 'N' (configured in metrics service, default 5) integrations by total messages.
-     * Only valid when retrieving total metrics summary.
-     */
-    Optional<Map<String, Long>> getTopIntegrations();
-
-    class Builder extends ImmutableIntegrationMetricsSummary.Builder {
-        // allow access to ImmutablIntegrationMetricsSummary.Builder
-    }
 }

--- a/app/common/util/pom.xml
+++ b/app/common/util/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/app/common/util/src/main/java/io/syndesis/common/util/Json.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/Json.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * JSON helper class.
@@ -41,7 +42,7 @@ public final class Json {
 
     static {
         OBJECT_MAPPER = new ObjectMapper()
-            .registerModules(new Jdk8Module())
+            .registerModules(new Jdk8Module(), new JavaTimeModule())
             // keep using the deprecated method here in order to align with the jackson version (2.8.11) being used at integration runtime
             .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY))
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -209,6 +209,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <scope>runtime</scope>

--- a/app/server/metrics/jsondb/pom.xml
+++ b/app/server/metrics/jsondb/pom.xml
@@ -146,12 +146,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jdbi</groupId>
       <artifactId>jdbi</artifactId>
       <scope>runtime</scope>

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
@@ -15,8 +15,9 @@
  */
 package io.syndesis.server.metrics.jsondb;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,6 @@ import java.util.Set;
 import io.syndesis.common.model.metrics.IntegrationDeploymentMetrics;
 import io.syndesis.common.model.metrics.IntegrationMetricsSummary;
 import io.syndesis.server.dao.manager.DataManager;
-import lombok.Data;
 
 public class IntegrationMetricsHandler {
 
@@ -97,7 +97,7 @@ public class IntegrationMetricsHandler {
                     .errors(mh.getErrors())
                     .start(mh.getStartDate())
                     .lastProcessed(mh.getLastProcessed())
-                    .uptimeDuration(mh.getStartDate().map(date -> System.currentTimeMillis() - date.getTime()).orElse(0L))
+                    .uptimeDuration(mh.getStartDate().map(date -> Duration.between(date, Instant.now()).toMillis()).orElse(0L))
                     .build();
             dmList.add(dm);
         }
@@ -107,18 +107,17 @@ public class IntegrationMetricsHandler {
                 .errors(tm.getErrors())
                 .start(tm.getStartDate())
                 .lastProcessed(tm.getLastProcessed())
-                .uptimeDuration(tm.getStartDate().map(date -> System.currentTimeMillis() - date.getTime()).orElse(0L))
+                .uptimeDuration(tm.getStartDate().map(date -> Duration.between(date, Instant.now()).toMillis()).orElse(0L))
                 .integrationDeploymentMetrics(dmList)
                 .build();
     }
 
-    @Data
     static class Metrics {
 
         private Long messages = 0L;
         private Long errors = 0L;
-        private Optional<Date> lastProcessed = Optional.empty();
-        private Optional<Date> startDate = Optional.empty(); //we may have no more live pods for this integration
+        private Optional<Instant> lastProcessed = Optional.empty();
+        private Optional<Instant> startDate = Optional.empty(); //we may have no more live pods for this integration
         private String version;
 
         public Metrics add(Set<String> livePodIds, RawMetrics raw) {
@@ -129,7 +128,7 @@ public class IntegrationMetricsHandler {
             //Let's simply grab the oldest living pod, we will need to revisit when doing rolling upgrades etc
             if (livePodIds.contains(raw.getPod())) {
                 if (this.startDate.isPresent()) {
-                    if (raw.getStartDate().get().before(this.startDate.get())) {
+                    if (raw.getStartDate().get().isBefore(this.startDate.get())) {
                         this.setStartDate(raw.getStartDate());
                     }
                 } else {
@@ -138,12 +137,52 @@ public class IntegrationMetricsHandler {
             }
             if (raw.getLastProcessed().isPresent()) {
                 if (this.getLastProcessed().isPresent()) {
-                    this.setLastProcessed(raw.getLastProcessed().get().after(this.getLastProcessed().get()) ? raw.getLastProcessed() : this.getLastProcessed());
+                    this.setLastProcessed(raw.getLastProcessed().get().isAfter(this.getLastProcessed().get()) ? raw.getLastProcessed() : this.getLastProcessed());
                 } else {
                     this.setLastProcessed(raw.getLastProcessed());
                 }
             }
             return this;
+        }
+
+        public Long getMessages() {
+            return messages;
+        }
+
+        public void setMessages(Long messages) {
+            this.messages = messages;
+        }
+
+        public Long getErrors() {
+            return errors;
+        }
+
+        public void setErrors(Long errors) {
+            this.errors = errors;
+        }
+
+        public Optional<Instant> getLastProcessed() {
+            return lastProcessed;
+        }
+
+        public void setLastProcessed(Optional<Instant> lastProcessed) {
+            this.lastProcessed = lastProcessed;
+        }
+
+        public Optional<Instant> getStartDate() {
+            return startDate;
+        }
+
+        public void setStartDate(Optional<Instant> startDate) {
+            this.startDate = startDate;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
         }
     }
 }

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/JsonDBRawMetrics.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/JsonDBRawMetrics.java
@@ -21,7 +21,7 @@ import io.syndesis.server.jsondb.JsonDB;
 import io.syndesis.common.util.Json;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -115,7 +115,7 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
                     //add to existing history
                     RawMetrics history = metrics.get(historyKey);
                     RawMetrics dead = entry.getValue();
-                    Date lastProcessed = history.getLastProcessed().orElse(new Date(0)).after(dead.getLastProcessed().orElse(new Date(0)))
+                    Instant lastProcessed = history.getLastProcessed().orElse(Instant.EPOCH).isAfter(dead.getLastProcessed().orElse(Instant.EPOCH))
                             ? history.getLastProcessed().orElse(null) : dead.getLastProcessed().orElse(null);
                     RawMetrics updatedHistoryMetrics = new RawMetrics.Builder()
                             .integrationId(integrationId)

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/RawMetrics.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/RawMetrics.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.server.metrics.jsondb;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Optional;
 
 import org.immutables.value.Value;
@@ -27,17 +27,23 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @SuppressWarnings("immutables")
 public interface RawMetrics {
 
-    String getIntegrationId();
-    String getVersion();
-    String getPod();
-
-    Long getMessages();
-    Long getErrors();
-    Optional<Date> getStartDate();
-    Optional<Date> getResetDate();
-    Optional<Date> getLastProcessed();
-
     class Builder extends ImmutableRawMetrics.Builder {
         // allow access to ImmutableRawMetrics.Builder
     }
+
+    Long getErrors();
+
+    String getIntegrationId();
+
+    Optional<Instant> getLastProcessed();
+
+    Long getMessages();
+
+    String getPod();
+
+    Optional<Instant> getResetDate();
+
+    Optional<Instant> getStartDate();
+
+    String getVersion();
 }


### PR DESCRIPTION
This removes instances of SimpleDateFormat that are used in a thread unsafe manner and refactors the use of java.util.Date to java.time.Instant.

Also changes the model not to require lombok as it provides no value in the trivial usage it's applied to.