### PR TITLE
refactor: proper exception assertion

### DIFF
--- a/app/common/util/src/test/java/io/syndesis/common/util/RandomValueGeneratorTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/RandomValueGeneratorTest.java
@@ -15,12 +15,13 @@
  */
 package io.syndesis.common.util;
 
-import org.junit.Test;
-
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Unit tests for RandomValueGenerator
@@ -28,26 +29,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RandomValueGeneratorTest {
 
     @Test
+    public void testNegativeValue() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> RandomValueGenerator.generate("alphanum:-1"))
+            .withMessage("Cannot generate a string of negative length");
+    }
+
+    @Test
     public void testPatternRespectedWithDefault() {
-        for (int i=0; i<20; i++) {
-            String value = RandomValueGenerator.generate("alphanum");
+        for (int i = 0; i < 20; i++) {
+            final String value = RandomValueGenerator.generate("alphanum");
             assertThat(value).matches("[A-Za-z0-9]{40}");
         }
     }
 
     @Test
     public void testPatternRespectedWithLength() {
-        for (int i=0; i<20; i++) {
-            String value = RandomValueGenerator.generate("alphanum:12");
+        for (int i = 0; i < 20; i++) {
+            final String value = RandomValueGenerator.generate("alphanum:12");
             assertThat(value).matches("[A-Za-z0-9]{12}");
         }
     }
 
     @Test
     public void testTrueRandom() {
-        Set<String> gen = new HashSet<>();
-        for (int i=0; i<20; i++) {
-            String value = RandomValueGenerator.generate("alphanum:80");
+        final Set<String> gen = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            final String value = RandomValueGenerator.generate("alphanum:80");
             assertThat(value).matches("[A-Za-z0-9]{80}");
             gen.add(value);
         }
@@ -56,24 +63,21 @@ public class RandomValueGeneratorTest {
     }
 
     @Test
-    public void testZeroValue() {
-        String value = RandomValueGenerator.generate("alphanum:0");
-        assertThat(value).isEqualTo("");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void testUnknownGenerator() {
-        RandomValueGenerator.generate("alphanumx");
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> RandomValueGenerator.generate("alphanumx"))
+            .withMessage("Unsupported generator scheme: alphanumx");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongValueType() {
-        RandomValueGenerator.generate("alphanum:aa");
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> RandomValueGenerator.generate("alphanum:aa"))
+            .withMessage("Unexpected string after the alphanum scheme: expected length");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNegativeValue() {
-        RandomValueGenerator.generate("alphanum:-1");
+    @Test
+    public void testZeroValue() {
+        final String value = RandomValueGenerator.generate("alphanum:0");
+        assertThat(value).isEqualTo("");
     }
 
 }

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorMissingDatabaseOptionsTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorMissingDatabaseOptionsTest.java
@@ -18,21 +18,21 @@ package io.syndesis.connector.mongo;
 import java.util.List;
 
 import io.syndesis.common.model.integration.Step;
+
+import org.apache.camel.FailedToCreateRouteException;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class MongoDBConnectorMissingDatabaseOptionsTest extends MongoDBConnectorTestSupport {
 
     @Override
     @Before
     public void setUp() {
-        try {
-            super.setUp();
-            fail("Setup should have thrown an exception!");
-        } catch (Exception e) {
-            // We do expect a failure cause the operation provided is not
-            // supported
-        }
+        assertThatExceptionOfType(FailedToCreateRouteException.class).isThrownBy(() -> super.setUp())
+            .withMessageContaining("Failed to create Producer")
+            .withMessageContaining("databaseName is not empty");
     }
 
     @Override

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
@@ -16,8 +16,12 @@
 package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
+
+import org.apache.camel.FailedToCreateRouteException;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 
@@ -30,13 +34,9 @@ public class MongoDBConnectorNotSupportedCamelOperationTest extends MongoDBConne
     @Override
     @Before
     public void setUp() {
-        try {
-            super.setUp();
-            fail("Setup should have thrown an exception!");
-        } catch (Exception e) {
-            // We do expect a failure cause the operation provided is not
-            // supported
-        }
+        assertThatExceptionOfType(FailedToCreateRouteException.class).isThrownBy(() -> super.setUp())
+            .withMessageContaining("Failed to resolve endpoint")
+            .withMessageContaining("Operation not supported");
     }
 
     @Override

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
@@ -16,8 +16,12 @@
 package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
-import org.junit.Before;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.component.mongodb3.CamelMongoDbException;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 
@@ -33,10 +37,11 @@ public class MongoDBConnectorNotSupportedSyndesisOperationTest extends MongoDBCo
     // Tests
     // **************************
 
-    @Test(expected = Exception.class)
+    @Test
     public void mongoTest() {
-        template().sendBody("direct:start","Anything....");
-        fail("Aggregate operation is not allowed, should thrown an exception!");
+        assertThatExceptionOfType(CamelExecutionException.class).isThrownBy(() -> template().sendBody("direct:start","Anything...."))
+            .withMessageContaining("Exception occurred during execution on the exchange")
+            .withCause(new CamelMongoDbException("Invalid payload for aggregate"));
     }
 
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class SqlParserTest {
 
     @ClassRule
@@ -261,10 +263,12 @@ public class SqlParserTest {
         Assert.assertEquals("LASTNAME", info.getInParams().get(0).getColumn());
     }
 
-    @Test(expected=SQLException.class)
+    @Test
     public void parseSelectFromNoneExistingTable() throws SQLException {
         final SqlStatementParser parser = new SqlStatementParser(db.connection,
             "SELECT FIRSTNAME, LASTNAME FROM NAME-NOTEXIST WHERE FIRSTNAME LIKE :#first");
-        parser.parse();
+
+        assertThatExceptionOfType(SQLException.class).isThrownBy(() -> parser.parse())
+            .withMessage("Table 'NAME-NOTEXIST' does not exist in schema 'SA'");
     }
 }

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentDefinitionTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentDefinitionTest.java
@@ -16,19 +16,16 @@
 
 package io.syndesis.integration.component.proxy;
 
+import java.io.IOException;
+
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ComponentDefinitionTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-    
     @Test
     public void testForScheme() throws IOException {
         ComponentDefinition definition = ComponentDefinition.forScheme(new DefaultCamelCatalog(), "direct");
@@ -37,10 +34,8 @@ public class ComponentDefinitionTest {
     }
 
     @Test
-    public void testForSchemeNotFound() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Failed to find component definition for scheme 'unknown'");
-        
-        ComponentDefinition.forScheme(new DefaultCamelCatalog(), "unknown");
+    public void testForSchemeNotFound() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ComponentDefinition.forScheme(new DefaultCamelCatalog(), "unknown"))
+            .withMessage("Failed to find component definition for scheme 'unknown'. Missing component definition in classpath 'org/apache/camel/catalog/components/unknown.json'");
     }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingTest.java
@@ -25,9 +25,9 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.ObjectHelper;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class ActivityLoggingTest extends AbstractActivityLoggingTest {
 
@@ -93,12 +93,9 @@ public class ActivityLoggingTest extends AbstractActivityLoggingTest {
 
     @Test
     public void testLoggingWithErrorStep() {
-        try {
-            context.createProducerTemplate().sendBody("direct:start", "Hello Error");
-            fail("Expected exception");
-        } catch (CamelExecutionException e) {
-            // expected.
-        }
+        assertThatExceptionOfType(CamelExecutionException.class).isThrownBy(() -> context.createProducerTemplate().sendBody("direct:start", "Hello Error"))
+            .withMessageStartingWith("Exception occurred during execution on the exchange: Exchange")
+            .withCause(new RuntimeException("Bean Error"));
 
         // There should be 1 exchanges logged
         assertEquals(1, findExchangesLogged().size());

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingWithSplitTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/ActivityLoggingWithSplitTest.java
@@ -25,9 +25,9 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.util.ObjectHelper;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class ActivityLoggingWithSplitTest extends AbstractActivityLoggingTest {
 
@@ -74,7 +74,7 @@ public class ActivityLoggingWithSplitTest extends AbstractActivityLoggingTest {
     public void testLoggingWithSuccessStep() throws Exception {
         final MockEndpoint result = context.getEndpoint("mock:end", MockEndpoint.class);
         result.expectedBodiesReceived("Hello", "World");
-        context.createProducerTemplate().sendBody("direct:start", new String[]{"Hello", "World"});
+        context.createProducerTemplate().sendBody("direct:start", new String[] {"Hello", "World"});
         result.assertIsSatisfied();
 
         // There should be 1 exchanges logged.
@@ -97,12 +97,10 @@ public class ActivityLoggingWithSplitTest extends AbstractActivityLoggingTest {
 
     @Test
     public void testLoggingWithErrorStep() {
-        try {
-            context.createProducerTemplate().sendBody("direct:start", new String[]{"Hello", "error"});
-            fail("Expected exception");
-        } catch (CamelExecutionException e) {
-            // expected.
-        }
+        assertThatExceptionOfType(CamelExecutionException.class)
+            .isThrownBy(() -> context.createProducerTemplate().sendBody("direct:start", new String[] {"Hello", "error"}))
+            .withMessageStartingWith("Exception occurred during execution on the exchange: Exchange")
+            .withCause(new RuntimeException("Bean Error"));
 
         // There should be 1 exchanges logged.
         assertEquals(1, findExchangesLogged().size());

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialProviderRegistryTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialProviderRegistryTest.java
@@ -15,25 +15,27 @@
  */
 package io.syndesis.server.credential;
 
-import io.syndesis.server.credential.TestCredentialProviderFactory.TestCredentialProvider;
-import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
+import io.syndesis.server.credential.TestCredentialProviderFactory.TestCredentialProvider;
+import io.syndesis.server.dao.manager.DataManager;
 
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CredentialProviderRegistryTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldComplainAboutUnregisteredProviders() {
         final DataManager dataManager = mock(DataManager.class);
         final CredentialProviderRegistry registry = new CredentialProviderRegistry(dataManager);
 
-        registry.providerWithId("unregistered");
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> registry.providerWithId("unregistered"))
+            .withMessage("Unable to find connector with id: unregistered");
     }
 
     @Test

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/DataManagerTest.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/DataManagerTest.java
@@ -39,8 +39,8 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -180,15 +180,16 @@ public class DataManagerTest {
             "prop2", "value2")).isEmpty();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void multiplePropertyValuePairsShouldCheckInput() {
         @SuppressWarnings("unchecked")
         final DataAccessObject<Extension> extensionDao = mock(DataAccessObject.class);
         when(extensionDao.getType()).thenReturn(Extension.class);
         dataManager.registerDataAccessObject(extensionDao);
 
-        dataManager.fetchIdsByPropertyValue(Extension.class, "prop1", "value1","prop2");
-        fail("Should fail before getting here");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> dataManager.fetchIdsByPropertyValue(Extension.class, "prop1", "value1", "prop2"))
+            .withMessage("You must provide a even number of additional property/value pairs. Found: 1");
     }
 
     @Test

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import io.syndesis.common.model.ListResult;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -74,14 +75,18 @@ public class ReflectiveSorterTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void invalidType() {
-        getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("blub", "asc")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("blub", "asc"))))
+            .withMessage("Cannot find field blub in io.syndesis.server.endpoint.util.ReflectiveSorterTest$TestPersonInterface as int or String field");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void invalidDirection() {
-        getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("lastName", "blub")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("lastName", "blub"))))
+            .withMessage("No enum constant io.syndesis.server.endpoint.util.SortOptions.SortDirection.BLUB");
     }
 
     @Test
@@ -105,7 +110,7 @@ public class ReflectiveSorterTest {
 
     }
 
-    private SortOptions getOptions(String type, String direction) {
+    private static SortOptions getOptions(String type, String direction) {
         return new SortOptions() {
             @Override
             public String getSortField() {
@@ -119,7 +124,7 @@ public class ReflectiveSorterTest {
         };
     }
 
-    private List<TestPersonInterface> getTestData() {
+    private static List<TestPersonInterface> getTestData() {
         return Arrays.asList(
 
             new TestPerson( "Erwin", "Schrödinger", 1887),
@@ -141,9 +146,9 @@ public class ReflectiveSorterTest {
 
     static class TestPerson implements TestPersonInterface {
 
-        private String firstName;
-        private String lastName;
-        private int birthYear;
+        private final String firstName;
+        private final String lastName;
+        private final int birthYear;
 
         TestPerson(String firstName, String lastName, int birthYear) {
             this.firstName = firstName;

--- a/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonDBTest.java
+++ b/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonDBTest.java
@@ -18,7 +18,7 @@ package io.syndesis.server.jsondb.impl;
 
 import static io.syndesis.common.util.Resources.getResourceAsText;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,10 +48,10 @@ import io.syndesis.server.jsondb.JsonDBException;
 public class JsonDBTest {
 
     private SqlJsonDB jsondb;
-    private ObjectMapper mapper = new ObjectMapper()
+    private final ObjectMapper mapper = new ObjectMapper()
         .setSerializationInclusion(JsonInclude.Include.ALWAYS);
 
-    private GetOptions prettyPrint = new GetOptions().prettyPrint(true);
+    private final GetOptions prettyPrint = new GetOptions().prettyPrint(true);
 
     @Before
     public void before() {
@@ -78,25 +78,15 @@ public class JsonDBTest {
     public void testInvalidKeys() throws IOException {
 
         for (String s : Arrays.asList("[", "]", ".", "%", "$", "#", "\n")) {
-            try {
-                jsondb.set("/test"+s, mapper.writeValueAsString(map(
-                    "key", "Hiram Chirino"
-                )));
-                fail("Excpected JsonDBException");
-            } catch (JsonDBException e) {
-                assertThat(e.getMessage()).startsWith("Invalid key.");
-            }
+            assertThatExceptionOfType(JsonDBException.class).isThrownBy(() -> jsondb.set("/test" + s, mapper.writeValueAsString(map(
+                "key", "Hiram Chirino"))))
+                .withMessageStartingWith("Invalid key.");
         }
 
         for (String s : Arrays.asList("[", "]", ".", "%", "$", "#", "/", "\n")) {
-            try {
-                jsondb.set("/test", mapper.writeValueAsString(map(
-                    "bad"+s+"key", "Hiram Chirino"
-                )));
-                fail("Excpected JsonDBException");
-            } catch (JsonDBException e) {
-                assertThat(e.getMessage()).startsWith("Invalid key.");
-            }
+            assertThatExceptionOfType(JsonDBException.class).isThrownBy(() -> jsondb.set("/test", mapper.writeValueAsString(map(
+                "bad" + s + "key", "Hiram Chirino"))))
+                .withMessageStartingWith("Invalid key.");
         }
 
     }

--- a/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/SqlJsonDBIntegrationTest.java
+++ b/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/SqlJsonDBIntegrationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -62,18 +62,14 @@ public class SqlJsonDBIntegrationTest {
 
     @Test
     public void shouldNotCommitWhenIssuesArise() {
-        try {
-            jsonDB.withGlobalTransaction(checkpointed -> {
-                checkpointed.set("failed", JSON);
+        assertThatExceptionOfType(SyndesisServerException.class).isThrownBy(() -> jsonDB.withGlobalTransaction(checkpointed -> {
+            checkpointed.set("failed", JSON);
 
-                assertThat(checkpointed.getAsString("failed")).isNotNull();
+            assertThat(checkpointed.getAsString("failed")).isNotNull();
 
-                throw new SyndesisServerException("expected");
-            });
-            fail("No SyndesisServerException was propagated");
-        } catch (final SyndesisServerException e) {
-            assertThat(e.getMessage()).isEqualTo("expected");
-        }
+            throw new SyndesisServerException("expected");
+        }))
+            .withMessage("expected");
 
         assertThat(jsonDB.getAsString("failed")).isNull();
         verifyNoMoreInteractions(bus);

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/DataManagerITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/DataManagerITCase.java
@@ -17,32 +17,38 @@ package io.syndesis.server.runtime;
 
 import javax.persistence.EntityExistsException;
 
-import org.junit.Test;
-
 import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.Connection;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 public class DataManagerITCase extends BaseITCase {
 
-    @Test(expected=EntityExistsException.class)
+    @Test
     public void createDuplicateConnection() {
-        ListResult<Connection> connections = dataManager.fetchAll(Connection.class);
-        Connection c = connections.getItems().get(0);
-        Connection connection = new Connection.Builder()
-                .id(c.getId())
-                .name(c.getName())
-                .build();
-        dataManager.create(connection);
+        final ListResult<Connection> connections = dataManager.fetchAll(Connection.class);
+        final Connection c = connections.getItems().get(0);
+        final Connection connection = new Connection.Builder()
+            .id(c.getId())
+            .name(c.getName())
+            .build();
+
+        assertThatExceptionOfType(EntityExistsException.class).isThrownBy(() -> dataManager.create(connection))
+            .withMessage("There already exists a connection with id 5");
     }
 
-    @Test(expected=EntityExistsException.class)
+    @Test
     public void createDuplicateName() {
-        ListResult<Connection> connections = dataManager.fetchAll(Connection.class);
-        Connection c = connections.getItems().get(0);
-        Connection connection = new Connection.Builder()
-                .name(c.getName())
-                .build();
-        dataManager.create(connection);
+        final ListResult<Connection> connections = dataManager.fetchAll(Connection.class);
+        final Connection c = connections.getItems().get(0);
+        final Connection connection = new Connection.Builder()
+            .name(c.getName())
+            .build();
+
+        assertThatExceptionOfType(EntityExistsException.class).isThrownBy(() -> dataManager.create(connection))
+            .withMessage("There already exists a Connection with name PostgresDB");
     }
 
 }


### PR DESCRIPTION
Annotating tests with `@Test(expected = SomeException.class)` does poor assertion of the exception that's expected to be thrown and possibly fails the assertion as the exception can be thrown from any line in the test method and with any arbitrary message or cause.

This construct should be replaced with AssertJ's `assertThatExceptionOfType` et al. exception assertions[1].

[1] https://joel-costigliola.github.io/assertj/assertj-core-features-highlight.html#exception-assertion