### PR TITLE
refactor: proper utility classes

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
@@ -18,7 +18,11 @@ package io.syndesis.common.model;
 /**
  * This class is used to track the current model schema version.
  */
-public class Schema {
+public final class Schema {
     // changing this will reset all the DB data.
     public static final int VERSION = 32;
+
+    private Schema() {
+      // quasi utility class
+    }
 }

--- a/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
@@ -15,8 +15,11 @@
  */
 package io.syndesis.common.util;
 
-public class ErrorCategory {
+public final class ErrorCategory {
 
-    public static final String SERVER_ERROR               = "SERVER_ERROR";
+    public static final String SERVER_ERROR = "SERVER_ERROR";
 
+    private ErrorCategory() {
+        // quasi utility class
+    }
 }

--- a/app/common/util/src/main/java/io/syndesis/common/util/Strings.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/Strings.java
@@ -25,11 +25,27 @@ public final class Strings {
     private Strings() {
     }
 
-    public static String utf8(byte[] data) {
-        return new String(data, StandardCharsets.UTF_8);
+    public static boolean isEmptyOrBlank(final String given) {
+        if (given == null || given.isEmpty()) {
+            return true;
+        }
+
+        final int len = given.length();
+        for (int i = 0; i < len; i++) {
+            final char ch = given.charAt(i);
+            if (!Character.isWhitespace(ch)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    public static String truncate(String name, int max) {
-          return name.length() > max ? name.substring(0, max) : name;
+    public static String truncate(final String name, final int max) {
+        return name.length() > max ? name.substring(0, max) : name;
+    }
+
+    public static String utf8(final byte[] data) {
+        return new String(data, StandardCharsets.UTF_8);
     }
 }

--- a/app/common/util/src/test/java/io/syndesis/common/util/StringsTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/StringsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringsTest {
+
+    @Test
+    public void shouldFindBlankStringsAsEmpty() {
+        assertThat(Strings.isEmptyOrBlank(" \t\r\n")).isTrue();
+    }
+
+    @Test
+    public void shouldFindEmptyStringsAsEmpty() {
+        assertThat(Strings.isEmptyOrBlank("")).isTrue();
+    }
+
+    @Test
+    public void shouldFindNonEmptyStringsAsNonEmpty() {
+        assertThat(Strings.isEmptyOrBlank("a")).isFalse();
+    }
+
+    @Test
+    public void shouldFindNonEmptyStringsWithWhitespaceAsNonEmpty() {
+        assertThat(Strings.isEmptyOrBlank(" \na\t")).isFalse();
+    }
+
+    @Test
+    public void shouldFindNullStringsAsEmpty() {
+        assertThat(Strings.isEmptyOrBlank(null)).isTrue();
+    }
+}

--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ErrorMapper.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ErrorMapper.java
@@ -28,9 +28,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.SyndesisConnectorException;
 
-public class ErrorMapper {
+public final class ErrorMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(ErrorMapper.class);
+
+    private ErrorMapper() {
+        // utility class
+    }
 
     public static Map<String, String> jsonToMap(String property) {
 

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
@@ -32,9 +32,13 @@ import org.slf4j.LoggerFactory;
 /**
  * Utility class for common procedures.
  */
-public class Util {
+public final class Util {
     public static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
+    private Util() {
+        // utility class
+     }
 
     /**
      * Extract a map from a JSON in a header as AttributeValue. Useful for the headers.

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
@@ -18,8 +18,6 @@ package io.syndesis.connector.aws.ddb;
 
 import com.amazonaws.regions.Regions;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-
 /**
  * To be able to run these integration tests you have to provide valid credentials, region
  * and a valid table name.
@@ -27,7 +25,7 @@ import com.amazonaws.regions.Regions;
  * These tests (at the moment) do write and read contents on your tables, so make sure
  * you use a table specifically for testing.
  */
-public class AWSDDBConfiguration {
+public final class AWSDDBConfiguration {
 
     public static final String ACCESSKEY_VALUE = "INVALID_KEY";
     public static final String SECRETKEY_VALUE = "INVALID_KEY";
@@ -40,9 +38,13 @@ public class AWSDDBConfiguration {
     public static final String TABLENAME = "tableName";
     public static final String ELEMENT = "element";
 
-    public static final Long randomId = System.currentTimeMillis();
+    public static final Long RANDOM_ID = System.currentTimeMillis();
 
     //TODO change this to your table constraints
-    public static final String ELEMENT_VALUE = "{\"clave\":\"" + randomId + "\"}";
+    public static final String ELEMENT_VALUE = "{\"clave\":\"" + RANDOM_ID + "\"}";
     //TODO change this to your table constraints
+
+    private AWSDDBConfiguration() {
+        // holds constants
+    }
 }

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/RouteUtils.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/RouteUtils.java
@@ -44,7 +44,7 @@ import io.syndesis.connector.email.server.EMailTestServer;
 import io.syndesis.connector.support.util.PropertyBuilder;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 
-public class RouteUtils {
+public final class RouteUtils {
 
     public static final int MOCK_TIMEOUT_MILLISECONDS = 60000;
 
@@ -54,6 +54,10 @@ public class RouteUtils {
     }
 
     private static Step mockStep;
+
+    private RouteUtils() {
+      // utility class, with state?!
+    }
 
     public static String componentScheme(EMailTestServer server) {
         String protocolId = server.getProtocol();

--- a/app/connector/kudu/src/main/java/org/apache/camel/component/kudu/KuduDbOperations.java
+++ b/app/connector/kudu/src/main/java/org/apache/camel/component/kudu/KuduDbOperations.java
@@ -16,9 +16,12 @@
 
 package org.apache.camel.component.kudu;
 
-public class KuduDbOperations {
+public final class KuduDbOperations {
     public static final String INSERT = "insert";
     public static final String CREATE_TABLE = "create_table";
     public static final String SCAN = "scan";
 
+    private KuduDbOperations() {
+      // holds constants
+    }
 }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Util.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Util.java
@@ -32,7 +32,11 @@ import org.apache.olingo.server.api.uri.UriParameter;
 import org.apache.olingo.server.api.uri.UriResource;
 import org.apache.olingo.server.api.uri.UriResourceEntitySet;
 
-public class Util {
+public final class Util {
+
+    private Util() {
+        // utility class
+    }
 
     public static EdmEntitySet getEdmEntitySet(UriInfoResource uriInfo) throws ODataApplicationException {
         List<UriResource> resourcePaths = uriInfo.getUriResourceParts();

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/PayloadConverterHelper.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/PayloadConverterHelper.java
@@ -25,6 +25,10 @@ final class PayloadConverterHelper {
 
     private static final CamelContext CONTEXT = new DefaultCamelContext();
 
+    private PayloadConverterHelper() {
+        // utility class
+    }
+
     static Exchange createExhangeWithBody(final String contentType, final String payload) {
         final Exchange exchange = new DefaultExchange(CONTEXT);
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/CamelSqlConstants.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/CamelSqlConstants.java
@@ -15,10 +15,14 @@
  */
 package io.syndesis.connector.sql.common;
 
-public class CamelSqlConstants {
+public final class CamelSqlConstants {
 
     public static final String SQL_UPDATE_COUNT            = "CamelSqlUpdateCount";
     public static final String SQL_ROW_COUNT               = "CamelSqlRowCount";
     public static final String SQL_RETRIEVE_GENERATED_KEYS = "CamelSqlRetrieveGeneratedKeys";
     public static final String SQL_GENERATED_KEYS_DATA     = "CamelSqlGeneratedKeyRows";
+
+    private CamelSqlConstants() {
+        // holds constants
+    }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
@@ -66,7 +66,7 @@ public class SqlParam {
         }
     }
 
-    public static class SqlSampleValue {
+    public static final class SqlSampleValue {
         public static final List<String> ARRAY_VALUE = Collections.unmodifiableList(Arrays.asList("1","2","3"));
         public static final byte[] BINARY_VALUE = {1,2,3};
         public static final String STRING_VALUE = "abc";
@@ -80,6 +80,10 @@ public class SqlParam {
         public static final Integer INTEGER_VALUE = 0;
         public static final Long LONG_VALUE = 0L;
         public static final Float FLOAT_VALUE = 0f;
+
+        private SqlSampleValue() {
+            // holds constants
+        }
     }
 
     @SuppressWarnings({"rawtypes", "PMD.CyclomaticComplexity"})

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlErrorCategory.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlErrorCategory.java
@@ -15,10 +15,13 @@
  */
 package io.syndesis.connector.sql.customizer;
 
-public class SqlErrorCategory {
+public final class SqlErrorCategory {
 
     public static final String SQL_CONNECTOR_ERROR        = "SQL_CONNECTOR_ERROR";
     public static final String SQL_DATA_ACCESS_ERROR      = "SQL_DATA_ACCESS_ERROR";
     public static final String SQL_ENTITY_NOT_FOUND_ERROR = "SQL_ENTITY_NOT_FOUND_ERROR";
 
+    private SqlErrorCategory() {
+        // holds constants
+    }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
@@ -15,17 +15,17 @@
  */
 package io.syndesis.connector.sql.stored;
 
-public class SampleStoredProcedures {
+public final class SampleStoredProcedures {
 
     /**
      * SQL to create the DEMO_ADD procedure in Apache Derby
      */
-    public static String DERBY_DEMO_ADD_SQL =
+    public static final String DERBY_DEMO_ADD_SQL =
             "CREATE PROCEDURE DEMO_ADD( IN A INTEGER, IN B INTEGER, OUT C INTEGER ) " +
             "PARAMETER STYLE JAVA " +
             "LANGUAGE JAVA " +
             "EXTERNAL NAME '" + SampleStoredProcedures.class.getName() + ".demo_add'";
-    public static String DERBY_DEMO_OUT_SQL =
+    public static final String DERBY_DEMO_OUT_SQL =
             "CREATE PROCEDURE DEMO_OUT( OUT C INTEGER ) " +
             "PARAMETER STYLE JAVA " +
             "LANGUAGE JAVA " +
@@ -34,7 +34,7 @@ public class SampleStoredProcedures {
     /**
      * SQL to create the DEMO_ADD procedure in Oracle
      */
-    public static String ORACLE_DEMO_ADD_SQL =
+    public static final String ORACLE_DEMO_ADD_SQL =
             "create or replace PROCEDURE DEMO_ADD \n" +
             "(\n" +
             "  A IN INTEGER\n" +
@@ -47,7 +47,7 @@ public class SampleStoredProcedures {
     /**
      * SQL to create the DEMO_APP procedure in Postgresql
      */
-    public static String POSTGRES_DEMO_ADD_SQL =
+    public static final String POSTGRES_DEMO_ADD_SQL =
             "CREATE OR REPLACE FUNCTION public.demo_add(\n" +
             "    a numeric,\n" +
             "    b numeric,\n" +
@@ -88,5 +88,9 @@ public class SampleStoredProcedures {
             int[] c /* OUT parameter */) {
 
         c[0] = 60;
+    }
+
+    private SampleStoredProcedures() {
+        // holds constants
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredCommon.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredCommon.java
@@ -31,8 +31,12 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.fail;
 
 
-public class SqlStoredCommon {
+public final class SqlStoredCommon {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStoredCommon.class);
+
+    private SqlStoredCommon() {
+        // utility class
+    }
 
     public static void setupStoredProcedure(Connection connection, Properties properties) throws Exception {
 

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
@@ -26,6 +26,10 @@ public final class ConnectorOptions {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConnectorOptions.class);
 
+    private ConnectorOptions() {
+        // utility class
+    }
+
     /**
      * Gets the value mapped to the given key,
      * converts to {@link String} & returns or defaultValue otherwise.
@@ -122,7 +126,7 @@ public final class ConnectorOptions {
      * @throws any exception that may result from the mapping function
      */
     public static <T> T extractOptionAndMap(Map<String, ?> options, String key,
-                                                                    Function<? super String, T> mappingFn) throws IllegalArgumentException {
+                                                                    Function<? super String, T> mappingFn) {
         if (options == null) {
             return null;
         }

--- a/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/TwitterErrorCategory.java
+++ b/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/TwitterErrorCategory.java
@@ -15,9 +15,13 @@
  */
 package io.syndesis.connector.twitter;
 
-public class TwitterErrorCategory {
+public final class TwitterErrorCategory {
 
     public static final String TWITTER_CONNECTOR_ERROR    = "TWITTER_CONNECTOR_ERROR";
 
     public static final String SERVER_ERROR               = "SERVER_ERROR";
+
+    private TwitterErrorCategory() {
+      // holds constants
+    }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteBuilderTest.java
@@ -20,10 +20,11 @@ import java.util.List;
 
 import io.syndesis.common.util.Resources;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
-import io.syndesis.integration.runtime.logging.IntegrationActivityTrackingPolicy;
-import io.syndesis.integration.runtime.logging.IntegrationActivityTrackingPolicyFactory;
 import io.syndesis.integration.runtime.logging.FlowActivityTrackingPolicy;
 import io.syndesis.integration.runtime.logging.FlowActivityTrackingPolicyFactory;
+import io.syndesis.integration.runtime.logging.IntegrationActivityTrackingPolicy;
+import io.syndesis.integration.runtime.logging.IntegrationActivityTrackingPolicyFactory;
+
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.model.ChoiceDefinition;
 import org.apache.camel.model.LogDefinition;
@@ -36,13 +37,15 @@ import org.apache.camel.model.SplitDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.getOutput;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class IntegrationRouteBuilderTest extends IntegrationTestSupport {
+public class IntegrationRouteBuilderTest {
 
-    private ActivityTracker tracker = new ActivityTracker.SysOut();
-    private List<ActivityTrackingPolicyFactory> policyFactories = Arrays.asList(new IntegrationActivityTrackingPolicyFactory(tracker),
+    private final ActivityTracker tracker = new ActivityTracker.SysOut();
+    private final List<ActivityTrackingPolicyFactory> policyFactories = Arrays.asList(new IntegrationActivityTrackingPolicyFactory(tracker),
                                                                                 new FlowActivityTrackingPolicyFactory(tracker));
 
     @Test

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/IntegrationRouteTest.java
@@ -23,6 +23,7 @@ import io.syndesis.common.model.integration.Scheduler;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.Resources;
+
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.model.PipelineDefinition;
@@ -35,10 +36,14 @@ import org.apache.camel.model.ToDefinition;
 import org.junit.Test;
 
 import static java.util.Collections.singleton;
+
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.getOutput;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD")
-public class IntegrationRouteTest extends IntegrationTestSupport {
+public class IntegrationRouteTest {
     @Test
     public void integrationWithSchedulerTest() throws Exception {
         final RouteBuilder routeBuilder = new IntegrationRouteBuilder("", Resources.loadServices(IntegrationStepHandler.class)) {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/MyBean.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/MyBean.java
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.syndesis.integration.runtime;
 
-package org.apache.camel.component.kudu;
+import java.util.Locale;
 
-public class KuduClientIntegrationTest {
+import org.apache.camel.Body;
 
+public final class MyBean {
+    @SuppressWarnings("static-method")
+    public String myProcessor(@Body String body) {
+        return body.toUpperCase(Locale.US);
+    }
 }

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AbstractTemplateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AbstractTemplateStepHandlerTest.java
@@ -15,28 +15,13 @@
  */
 package io.syndesis.integration.runtime.handlers;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.camel.CamelContext;
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.ProducerTemplate;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.mock.MockEndpoint;
-import org.apache.camel.impl.DefaultCamelContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.Dependency;
@@ -50,15 +35,41 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage.SymbolSyntax;
-import io.syndesis.common.util.StringConstants;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public abstract class AbstractTemplateStepHandlerTest extends IntegrationTestSupport {
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-    private DirectEndpoint directEndpoint = new DirectEndpoint();
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
-    private static ObjectMapper mapper = new ObjectMapper();
+import static io.syndesis.common.util.StringConstants.CLOSE_BRACKET;
+import static io.syndesis.common.util.StringConstants.EMPTY_STRING;
+import static io.syndesis.common.util.StringConstants.NEW_LINE;
+import static io.syndesis.common.util.StringConstants.OPEN_BRACKET;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.data;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dataPair;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegration;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractTemplateStepHandlerTest {
+
+    private final DirectEndpoint directEndpoint = new DirectEndpoint();
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     protected CamelContext context;
 
@@ -73,7 +84,7 @@ public abstract class AbstractTemplateStepHandlerTest extends IntegrationTestSup
         context = null;
     }
 
-    private String createSpec(Collection<Symbol> symbols) throws JsonProcessingException {
+    private static String createSpec(Collection<Symbol> symbols) throws JsonProcessingException {
         final ObjectNode schema = JsonNodeFactory.instance.objectNode();
         schema.put("$schema", "http://json-schema.org/schema#");
         schema.put("type", "object");
@@ -86,7 +97,7 @@ public abstract class AbstractTemplateStepHandlerTest extends IntegrationTestSup
             properties.set(symbol.id, property);
         }
         schema.set("properties", properties);
-        String inSpec = mapper.writeValueAsString(schema);
+        String inSpec = MAPPER.writeValueAsString(schema);
         return inSpec;
     }
 
@@ -164,10 +175,10 @@ public abstract class AbstractTemplateStepHandlerTest extends IntegrationTestSup
         }
     }
 
-    protected String toJson(String message) throws Exception {
-        ObjectNode node = mapper.createObjectNode();
+    protected static String toJson(String message) throws Exception {
+        ObjectNode node = MAPPER.createObjectNode();
         node.put("message", message);
-        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+        return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
     }
 
     protected void checkDynamicDependency(Integration integration) {
@@ -359,25 +370,25 @@ public abstract class AbstractTemplateStepHandlerTest extends IntegrationTestSup
         }
     }
 
-    private static class DirectEndpoint implements StringConstants {
-        private String schema = "direct";
-        private String name = "start";
+    private static class DirectEndpoint {
+        private final String schema = "direct";
+        private final String name = "start";
 
         public String id() {
-            return schema + HYPHEN + name;
+            return schema + "-" + name;
         }
 
         @Override
         public String toString() {
-            return schema + COLON + name;
+            return schema + ":" + name;
         }
     }
 
     protected class Symbol {
-        public String id;
-        public String type;
-        private String openSymbol;
-        private String closeSymbol;
+        public final String id;
+        public final String type;
+        private final String openSymbol;
+        private final String closeSymbol;
 
         public Symbol(String id, String type, String openSymbol, String closeSymbol) {
             this.id = id;

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AggregateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/AggregateStepHandlerTest.java
@@ -28,12 +28,12 @@ import io.syndesis.common.model.action.StepDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.BodyLogger;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -46,6 +46,9 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -56,8 +59,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class AggregateStepHandlerTest extends IntegrationTestSupport {
+public class AggregateStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(AggregateStepHandlerTest.class);
 
     private static final String START_STEP = "start-step";
@@ -66,7 +68,7 @@ public class AggregateStepHandlerTest extends IntegrationTestSupport {
     private static final String LOG_STEP = "log-step";
     private static final String MOCK_STEP = "mock-step";
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandlerTest.java
@@ -23,12 +23,12 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.BodyLogger;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
@@ -42,6 +42,9 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,15 +55,14 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class ChoiceStepHandlerTest extends IntegrationTestSupport {
+public class ChoiceStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChoiceStepHandlerTest.class);
 
     private static final String START_STEP = "start-step";
     private static final String CHOICE_STEP = "choice-step";
     private static final String MOCK_STEP = "mock-step";
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerTest.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.integration.runtime.handlers;
 
+import java.util.Properties;
+
 import io.syndesis.common.model.Dependency;
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
@@ -24,7 +26,7 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.integration.component.proxy.ComponentProxyEndpoint;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.builder.RouteBuilder;
@@ -33,12 +35,12 @@ import org.apache.camel.component.twitter.timeline.TwitterTimelineEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.Test;
 
-import java.util.Properties;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD.ExcessiveImports")
-public class ConnectorStepHandlerTest extends IntegrationTestSupport {
+public class ConnectorStepHandlerTest {
     private static final ConnectorAction TWITTER_MENTION_ACTION = new ConnectorAction.Builder()
         .id("twitter-mention-action")
         .descriptor(new ConnectorDescriptor.Builder()

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandlerTest.java
@@ -25,8 +25,8 @@ import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.capture.OutMessageCaptureProcessor;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -41,12 +41,14 @@ import org.apache.camel.model.SetHeaderDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
-public class DataMapperStepHandlerTest extends IntegrationTestSupport {
+public class DataMapperStepHandlerTest {
 
-    private CamelContext camelContext = new DefaultCamelContext();
+    private final CamelContext camelContext = new DefaultCamelContext();
 
     @Test
     public void testDataMapperStep() throws Exception {
@@ -217,11 +219,11 @@ public class DataMapperStepHandlerTest extends IntegrationTestSupport {
         }
     }
 
-    private Step[] getTestSteps() {
+    private static Step[] getTestSteps() {
         return getTestSteps("{}");
     }
 
-    private Step[] getTestSteps(String atlasMapping) {
+    private static Step[] getTestSteps(String atlasMapping) {
         return new Step[]{
                 new Step.Builder()
                         .id("step-1")

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandlerTest.java
@@ -25,7 +25,7 @@ import io.syndesis.common.model.action.StepAction;
 import io.syndesis.common.model.action.StepDescriptor;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.extension.api.Step;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
+
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Handler;
@@ -39,10 +39,12 @@ import org.apache.camel.model.SetHeaderDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings({"PMD.ExcessiveImports", "PMD.JUnitTestContainsTooManyAsserts"})
-public class ExtensionStepHandlerTest extends IntegrationTestSupport {
+public class ExtensionStepHandlerTest {
 
     @Test
     public void testEndpointExtensionStepHandler() throws Exception {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/FilterStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/FilterStepHandlerTest.java
@@ -29,11 +29,11 @@ import io.syndesis.common.model.filter.FilterPredicate;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
@@ -46,6 +46,9 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -57,15 +60,14 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class FilterStepHandlerTest extends IntegrationTestSupport {
+public class FilterStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterStepHandlerTest.class);
 
     private static final String START_STEP = "start-step";
     private static final String FILTER_STEP = "filter-step";
     private static final String MOCK_STEP = "mock-step";
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {
@@ -592,23 +594,23 @@ public class FilterStepHandlerTest extends IntegrationTestSupport {
         }
     }
 
-    private String buildPersonJson(String name) {
+    private static String buildPersonJson(String name) {
         return "{ \"name\": \"" + name + "\" }";
     }
 
-    private String buildPersonJsonArray(String ... names) {
+    private static String buildPersonJsonArray(String ... names) {
         return "[" + Stream.of(names)
-                        .map(this::buildPersonJson)
+                        .map(FilterStepHandlerTest::buildPersonJson)
                         .collect(Collectors.joining(",")) + "]";
     }
 
-    private String buildUserJson(String ... names) {
+    private static String buildUserJson(String ... names) {
         return Stream.of(names)
                 .map(name -> "{ \"user\": " + buildPersonJson(name) + " }")
                 .collect(Collectors.joining(","));
     }
 
-    private String buildUserJsonArray(String ... names) {
+    private static String buildUserJsonArray(String ... names) {
         return "[" + buildUserJson(names) + "]";
     }
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/HeadersStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/HeadersStepHandlerTest.java
@@ -20,7 +20,7 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -28,8 +28,10 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.Test;
 
-@SuppressWarnings("PMD.ExcessiveImports")
-public class HeadersStepHandlerTest extends IntegrationTestSupport {
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
+public class HeadersStepHandlerTest {
 
     @Test
     public void testSetHeadersStepHandler() throws Exception {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
@@ -24,12 +24,12 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.BodyLogger;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.ProducerTemplate;
@@ -44,6 +44,9 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -56,7 +59,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class LogStepHandlerTest extends IntegrationTestSupport {
+public class LogStepHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogStepHandlerTest.class);
 
@@ -66,7 +69,7 @@ public class LogStepHandlerTest extends IntegrationTestSupport {
 
     final LogStepHandler handler = new LogStepHandler();
 
-    final IntegrationRouteBuilder NOT_USED = null;
+    private static final IntegrationRouteBuilder NOT_USED = null;
 
     final ProcessorDefinition<?> route = spy(new RouteDefinition());
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogsAndErrorsTest.java
@@ -25,7 +25,7 @@ import io.syndesis.common.model.action.StepAction;
 import io.syndesis.common.model.action.StepDescriptor;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.extension.api.Step;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
@@ -36,13 +36,15 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.model.ProcessorDefinition;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Handy class to test logging of log messages and errors
  */
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class LogsAndErrorsTest extends IntegrationTestSupport {
+public class LogsAndErrorsTest {
 
     @Test
     public void testRoute() throws Exception {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SimpleEndpointStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SimpleEndpointStepHandlerTest.java
@@ -20,11 +20,11 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
@@ -36,6 +36,10 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.getDefaultCamelContextWithMyBeanInRegistry;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -46,11 +50,10 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
-public class SimpleEndpointStepHandlerTest extends IntegrationTestSupport {
+public class SimpleEndpointStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleEndpointStepHandlerTest.class);
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitAggregateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitAggregateStepHandlerTest.java
@@ -24,11 +24,11 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
@@ -43,6 +43,10 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.getDefaultCamelContextWithMyBeanInRegistry;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -53,8 +57,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class SplitAggregateStepHandlerTest extends IntegrationTestSupport {
+public class SplitAggregateStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SplitAggregateStepHandlerTest.class);
 
     private static final String START_STEP = "start-step";
@@ -62,7 +65,7 @@ public class SplitAggregateStepHandlerTest extends IntegrationTestSupport {
     private static final String AGGREGATE_STEP = "aggregate-step";
     private static final String MOCK_STEP = "mock-step";
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerJsonTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerJsonTest.java
@@ -22,8 +22,8 @@ import java.util.List;
 import io.syndesis.common.util.Resources;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 import io.syndesis.integration.runtime.IntegrationStepHandler;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.BodyLogger;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
@@ -33,10 +33,11 @@ import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.SimpleRegistry;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class SplitStepHandlerJsonTest extends IntegrationTestSupport {
+public class SplitStepHandlerJsonTest {
 
     /**
      * Test split to the very end of the integration - no aggregate
@@ -399,7 +400,7 @@ public class SplitStepHandlerJsonTest extends IntegrationTestSupport {
         }
     }
 
-    private void addBodyLogger(DefaultCamelContext context) {
+    private static void addBodyLogger(DefaultCamelContext context) {
         SimpleRegistry beanRegistry = new SimpleRegistry();
         beanRegistry.put("bodyLogger", new BodyLogger.Default());
         context.setRegistry(beanRegistry);

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/SplitStepHandlerTest.java
@@ -32,7 +32,6 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.common.util.IOStreams;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.logging.ActivityTracker;
 import io.syndesis.integration.runtime.logging.ActivityTrackingInterceptStrategy;
 import io.syndesis.integration.runtime.logging.IntegrationLoggingListener;
@@ -52,6 +51,9 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -62,16 +64,15 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @RunWith(JUnitParamsRunner.class)
-public class SplitStepHandlerTest extends IntegrationTestSupport {
+public class SplitStepHandlerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SplitStepHandlerTest.class);
 
     private static final String START_STEP = "start-step";
     private static final String SPLIT_STEP = "split-step";
     private static final String MOCK_STEP = "mock-step";
 
-    private ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
+    private final ActivityTracker activityTracker = Mockito.mock(ActivityTracker.class);
 
     @Before
     public void setupMocks() {
@@ -425,7 +426,7 @@ public class SplitStepHandlerTest extends IntegrationTestSupport {
         }
     }
 
-    private InputStream getPersonUnifiedSchema(String schemaPath) {
+    private static InputStream getPersonUnifiedSchema(String schemaPath) {
         return SplitStepHandlerTest.class.getResourceAsStream(schemaPath);
     }
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/AbstractActivityLoggingTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/AbstractActivityLoggingTest.java
@@ -26,8 +26,8 @@ import java.util.stream.Stream;
 
 import io.syndesis.common.util.Json;
 import io.syndesis.common.util.KeyGenerator;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
 import io.syndesis.integration.runtime.util.JsonSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -36,11 +36,7 @@ import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Christoph Deppisch
- */
-@SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes"})
-public abstract class AbstractActivityLoggingTest extends IntegrationTestSupport {
+public abstract class AbstractActivityLoggingTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActivityLoggingTest.class);
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/MustacheTemplateStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/MustacheTemplateStepHandlerTest.java
@@ -15,17 +15,24 @@
  */
 package io.syndesis.integration.runtime.template;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.Test;
+
 import io.syndesis.common.model.integration.step.template.TemplateStepConstants;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage;
 import io.syndesis.common.model.integration.step.template.TemplateStepLanguage.SymbolSyntax;
 import io.syndesis.integration.runtime.handlers.AbstractTemplateStepHandlerTest;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Test;
+
+import static io.syndesis.integration.runtime.IntegrationTestSupport.data;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dataPair;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MustacheTemplateStepHandlerTest extends AbstractTemplateStepHandlerTest implements TemplateStepConstants {
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/tracing/ActivityTracingWithSplitTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/tracing/ActivityTracingWithSplitTest.java
@@ -32,7 +32,7 @@ import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.common.util.Resources;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
 import io.syndesis.integration.runtime.IntegrationStepHandler;
-import io.syndesis.integration.runtime.IntegrationTestSupport;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.CamelExecutionException;
 import org.apache.camel.Handler;
@@ -43,10 +43,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.syndesis.integration.runtime.IntegrationTestSupport.dumpRoutes;
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegration;
+
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 
-public class ActivityTracingWithSplitTest extends IntegrationTestSupport {
+public class ActivityTracingWithSplitTest {
     protected CamelContext context;
     protected ArrayList<JaegerSpan> activityEvents;
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/HttpStatus.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/HttpStatus.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class HttpStatus {
+public final class HttpStatus {
 
     private static final Map<Integer, String> HTTP_STATUS_MAP =
         Stream.of(new Object[][] {
@@ -86,6 +86,10 @@ public class HttpStatus {
                 { 510, "510 Not Extended" },
                 { 522, "511 Network Authentication Required" },
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> (String) data[1]));
+
+    private HttpStatus() {
+      // utility class
+    }
 
     public static String message(Integer statusCode) {
         return HTTP_STATUS_MAP.get(statusCode);

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/ApiConnectorTemplate.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/ApiConnectorTemplate.java
@@ -26,9 +26,13 @@ import com.jayway.jsonpath.TypeRef;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
-public abstract class AbstractSwaggerConnectorTest {
+final class ApiConnectorTemplate {
 
     static final ConnectorTemplate SWAGGER_TEMPLATE = fetchSwaggerConnectorTemplateFromDeployment();
+
+    private ApiConnectorTemplate() {
+        // needed for loading the template
+    }
 
     private static ConnectorTemplate fetchSwaggerConnectorTemplateFromDeployment() {
         final Configuration configuration = Configuration.builder()//
@@ -37,7 +41,7 @@ public abstract class AbstractSwaggerConnectorTest {
             .build();
 
         final List<ConnectorTemplate> templates = JsonPath.using(configuration)
-            .parse(AbstractSwaggerConnectorTest.class.getResourceAsStream("/io/syndesis/server/dao/deployment.json"))
+            .parse(ApiConnectorTemplate.class.getResourceAsStream("/io/syndesis/server/dao/deployment.json"))
             .read("$..[?(@['id'] == 'swagger-connector-template')]", new TypeRef<List<ConnectorTemplate>>() {
                 // type token pattern
             });

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerConnectorGeneratorTest.java
@@ -54,7 +54,7 @@ import static io.syndesis.server.api.generator.swagger.TestHelper.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorTest {
+public class BaseSwaggerConnectorGeneratorTest {
 
     private final BaseSwaggerConnectorGenerator generator;
 
@@ -76,7 +76,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     @Test
     public void includesRestSwaggerConnectorCustomizers() throws IOException {
         final ConnectorSettings connectorSettings = createReverbSettings();
-        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector connector = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(connector.getConnectorCustomizers()).isNotEmpty();
         assertThat(connector.getConnectorCustomizers()).contains(
@@ -89,7 +89,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     @Test
     public void includesRestSwaggerConnectorDependency() throws IOException {
         final ConnectorSettings connectorSettings = createReverbSettings();
-        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector connector = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(connector.getDependencies()).isNotEmpty();
         assertThat(connector.getDependencies())
@@ -99,7 +99,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     @Test
     public void includesRestSwaggerConnectorFactory() throws IOException {
         final ConnectorSettings connectorSettings = createReverbSettings();
-        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector connector = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(connector.getConnectorFactory()).isPresent();
         assertThat(connector.getConnectorFactory()).hasValue("io.syndesis.connector.rest.swagger.ConnectorFactory");
@@ -143,7 +143,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty(PropertyGenerators.authenticationType.name(), "oauth2:concur_oauth2")
             .build();
 
-        final Connector generated = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector generated = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(generated.getProperties().keySet()).contains("accessToken", "authorizationEndpoint", "tokenEndpoint", "clientId",
             "clientSecret", "tokenStrategy", "authorizeUsingParameters");
@@ -163,7 +163,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty(PropertyGenerators.authenticationType.name(), "oauth2:oauth2")
             .build();
 
-        final Connector generated = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector generated = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(generated.getProperties().keySet()).contains("accessToken", "authorizationEndpoint", "tokenEndpoint", "clientId",
             "clientSecret");
@@ -175,28 +175,31 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
     public void shouldDetermineConnectorDescription() {
         final Swagger swagger = new Swagger();
 
-        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+        assertThat(generator.determineConnectorDescription(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger)))
+            .isEqualTo("unspecified");
 
         final Info info = new Info();
         swagger.info(info);
-        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+        assertThat(generator.determineConnectorDescription(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger)))
+            .isEqualTo("unspecified");
 
         info.description("description");
-        assertThat(generator.determineConnectorDescription(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("description");
+        assertThat(generator.determineConnectorDescription(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger)))
+            .isEqualTo("description");
     }
 
     @Test
     public void shouldDetermineConnectorName() {
         final Swagger swagger = new Swagger();
 
-        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+        assertThat(generator.determineConnectorName(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
 
         final Info info = new Info();
         swagger.info(info);
-        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
+        assertThat(generator.determineConnectorName(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("unspecified");
 
         info.title("title");
-        assertThat(generator.determineConnectorName(SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("title");
+        assertThat(generator.determineConnectorName(ApiConnectorTemplate.SWAGGER_TEMPLATE, createSettingsFrom(swagger))).isEqualTo("title");
     }
 
     @Test
@@ -211,7 +214,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty(PropertyGenerators.authenticationType.name(), "apiKey:two")
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(summary.getConfiguredProperties())
             .containsEntry("specification", specification)
@@ -233,7 +236,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", specification)//
             .putConfiguredProperty("tokenEndpoint", "http://some.token.url").build();
 
-        final Connector connector = generator.generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector connector = generator.generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(connector.getConfiguredProperties()).containsEntry("tokenEndpoint", "http://some.token.url");
     }
@@ -243,7 +246,8 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
         final Swagger swagger = new Swagger().path("/path", new Path().get(new Operation().operationId("foo"))
             .post(new Operation().operationId("foo")).put(new Operation().operationId("bar")));
 
-        final Connector generated = generator.configureConnector(SWAGGER_TEMPLATE, new Connector.Builder().id("connector1").build(),
+        final Connector generated = generator.configureConnector(ApiConnectorTemplate.SWAGGER_TEMPLATE,
+            new Connector.Builder().id("connector1").build(),
             createSettingsFrom(swagger));
         final List<ConnectorAction> actions = generated.getActions();
         assertThat(actions).hasSize(3);
@@ -258,7 +262,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", "{}")//
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
         assertThat(summary).isNotNull();
     }
 
@@ -269,7 +273,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
                 "{\"swagger\": \"2.0\",\"info\": {\"version\": \"0.0.0\",\"title\": \"title\",\"description\": \"description\"},\"paths\": {\"/operation\": {\"get\": {\"responses\": {\"200\": {\"description\": \"OK\"}}}}}}")//
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
         assertThat(summary).isNotNull();
     }
 
@@ -284,7 +288,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", specification)
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(summary.getProperties().keySet()).containsOnly(PropertyGenerators.authenticationType.name(), "basePath", "host", "specification");
     }
@@ -318,7 +322,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", specification)//
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         final ActionsSummary actionsSummary = new ActionsSummary.Builder().totalActions(20).putActionCountByTag("store", 4)
             .putActionCountByTag("user", 8).putActionCountByTag("pet", 8).build();
@@ -344,7 +348,7 @@ public class BaseSwaggerConnectorGeneratorTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", specification)//
             .build();
 
-        final APISummary summary = generator.info(SWAGGER_TEMPLATE, connectorSettings);
+        final APISummary summary = generator.info(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         assertThat(summary.getErrors()).hasSize(1);
         assertThat(summary.getWarnings()).hasSize(1);

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerGeneratorExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/BaseSwaggerGeneratorExampleTest.java
@@ -53,7 +53,7 @@ import static io.syndesis.server.api.generator.swagger.TestHelper.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-abstract class BaseSwaggerGeneratorExampleTest extends AbstractSwaggerConnectorTest {
+abstract class BaseSwaggerGeneratorExampleTest {
 
     private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
 
@@ -74,7 +74,7 @@ abstract class BaseSwaggerGeneratorExampleTest extends AbstractSwaggerConnectorT
             .putConfiguredProperty("specification", specification)//
             .build();
 
-        final Connector generated = generator().generate(SWAGGER_TEMPLATE, connectorSettings);
+        final Connector generated = generator().generate(ApiConnectorTemplate.SWAGGER_TEMPLATE, connectorSettings);
 
         final Map<String, String> generatedConfiguredProperties = generated.getConfiguredProperties();
         final String generatedSpecification = generatedConfiguredProperties.get("specification");

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/util/SwaggerHelperTest.java
@@ -29,7 +29,6 @@ import io.swagger.models.auth.In;
 import io.syndesis.common.model.Violation;
 import io.syndesis.common.util.openapi.OpenApiHelper;
 import io.syndesis.server.api.generator.APIValidationContext;
-import io.syndesis.server.api.generator.swagger.AbstractSwaggerConnectorTest;
 import io.syndesis.server.api.generator.swagger.SwaggerModelInfo;
 import io.syndesis.server.jsondb.impl.JsonRecordSupport;
 
@@ -46,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.entry;
 
-public class SwaggerHelperTest extends AbstractSwaggerConnectorTest {
+public class SwaggerHelperTest {
 
     @Test
     public void convertingToJsonShouldNotLooseSecurityDefinitions() throws JsonProcessingException, IOException {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/api/ApiGeneratorHelper.java
@@ -47,6 +47,10 @@ public final class ApiGeneratorHelper {
     private static final String API_PROVIDER_END_ACTION_ID = "io.syndesis:api-provider-end";
     private static final String API_PROVIDER_START_ACTION_ID = "io.syndesis:api-provider-start";
 
+    private ApiGeneratorHelper() {
+        // utility class
+    }
+
     public static APIIntegration generateIntegrationFrom(final APIFormData apiFormData, final DataManager dataManager, final APIGenerator apiGenerator) {
         Connection apiProviderConnection = dataManager.fetch(Connection.class, API_PROVIDER_CONNECTION_ID);
         if (apiProviderConnection == null) {

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/MemorySqlJsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/MemorySqlJsonDB.java
@@ -32,7 +32,7 @@ import io.syndesis.server.jsondb.NativeJsonDB;
 /**
  * Used to create in memory version impl of JsonDB
  */
-public class MemorySqlJsonDB {
+public final class MemorySqlJsonDB {
 
     private static class ClosableSqlJsonDB extends SqlJsonDB implements NativeJsonDB {
 
@@ -59,6 +59,10 @@ public class MemorySqlJsonDB {
         public DBI database() {
             return dbi;
         }
+    }
+
+    private MemorySqlJsonDB() {
+      // utility class
     }
 
     public static CloseableJsonDB create(Collection<Index> indexes) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/Recordings.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/Recordings.java
@@ -15,7 +15,10 @@
  */
 package io.syndesis.server.runtime;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +33,7 @@ import org.springframework.cglib.proxy.Enhancer;
  * method invocation done on those objects so that your test cases
  * can assert the your object has been called as expected.
  */
-public class Recordings {
+public final class Recordings {
 
     public static class Invocation {
         private final Method method;
@@ -103,6 +106,10 @@ public class Recordings {
     public interface RecordingProxy {
         // Use a weird method name to avoid conflicts with other methods the proxied class might declare.
         RecordingInvocationHandler getInvocationHandler$$$();
+    }
+
+    private Recordings() {
+        // utility class
     }
 
     static public <T> T recorder(Object object, Class<T> as) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
@@ -24,6 +24,10 @@ import io.syndesis.server.jsondb.JsonDB;
 
 final class MigrationsHelper {
 
+    private MigrationsHelper() {
+        // utility class
+    }
+
     static <T> List<T> load(final JsonDB jsondb, final String path, final Class<T> type) throws IOException {
         final List<T> items = new ArrayList<>();
         final String raw = jsondb.getAsString(path);


### PR DESCRIPTION
Utility classes, classes that contain only static methods or constants should not be instantiated or take part in object hierarchy. This marks those classes with `final` and declares a default private constructor.