### PR TITLE
refactor: remove redundant @SuppressWarnings

### DIFF
--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQConnectionTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQConnectionTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.springframework.jms.core.JmsTemplate;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ActiveMQConnectionTest extends ConnectorTestSupport {
     @Rule
     public TestName testName = new TestName();

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQPublishConnectorTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQPublishConnectorTest.java
@@ -26,7 +26,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.jms.core.JmsTemplate;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ActiveMQPublishConnectorTest extends ActiveMQConnectorTestSupport {
 
     // **************************

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSharedConnectionTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSharedConnectionTest.java
@@ -27,7 +27,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.jms.core.JmsTemplate;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ActiveMQSharedConnectionTest extends ActiveMQConnectorTestSupport {
 
     // **************************

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSubscribeConnectorTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSubscribeConnectorTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
 import org.springframework.jms.core.JmsTemplate;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ActiveMQSubscribeConnectorTest extends ActiveMQConnectorTestSupport {
 
     // **************************

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertItemTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertItemTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import io.syndesis.common.model.integration.Step;
 import org.junit.Ignore;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Ignore("Make sure the AWSDDBConfiguration has the proper credentials before running this test")
 public class AWSDDBInsertItemTest extends AWSDDBGenericOperation {
 

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBQueryItemTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBQueryItemTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import io.syndesis.common.model.integration.Step;
 import org.junit.Ignore;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Ignore("Make sure the AWSDDBConfiguration has the proper credentials before running this test")
 public class AWSDDBQueryItemTest extends AWSDDBGenericOperation {
 

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBRawOptionsTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBRawOptionsTest.java
@@ -36,7 +36,6 @@ import org.apache.camel.component.extension.ComponentVerifierExtension;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Ignore("Make sure the AWSDDBConfiguration has the proper credentials before running this test")
 public class AWSDDBRawOptionsTest extends ConnectorTestSupport {
     @Override

--- a/app/connector/aws-s3/src/test/java/io/syndesis/connector/aws/s3/AWSS3RawOptionsTest.java
+++ b/app/connector/aws-s3/src/test/java/io/syndesis/connector/aws/s3/AWSS3RawOptionsTest.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class AWSS3RawOptionsTest extends ConnectorTestSupport {
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirMetadataRetrievalTest.java
+++ b/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirMetadataRetrievalTest.java
@@ -24,11 +24,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class FhirMetadataRetrievalTest {
 
     private FhirMetadataRetrieval fhirMetadataRetrieval = new FhirMetadataRetrieval();
@@ -39,7 +39,7 @@ public class FhirMetadataRetrievalTest {
 
         String inspection;
         try (InputStream fileIn = Files.newInputStream(bundle)) {
-            inspection = IOUtils.toString(fileIn);
+            inspection = IOUtils.toString(fileIn, StandardCharsets.UTF_8);
         }
 
         String inspectionWithResources = fhirMetadataRetrieval.includeResources(inspection, "patient", "account");
@@ -65,7 +65,7 @@ public class FhirMetadataRetrievalTest {
 
         String inspection;
         try (InputStream fileIn = Files.newInputStream(patient)) {
-            inspection = IOUtils.toString(fileIn);
+            inspection = IOUtils.toString(fileIn, StandardCharsets.UTF_8);
         }
 
         String inspectionWithResources = new FhirMetadataRetrieval().includeResources(inspection, "person", "account");

--- a/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/processor/FhirResourceProcessorTest.java
+++ b/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/processor/FhirResourceProcessorTest.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class FhirResourceProcessorTest {
 
     @Test

--- a/app/connector/kafka/src/test/java/io/syndesis/connector/kafka/KafkaConnectorTest.java
+++ b/app/connector/kafka/src/test/java/io/syndesis/connector/kafka/KafkaConnectorTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class KafkaConnectorTest extends ConnectorTestSupport {
 
     @Override

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
 
     private final static String CONNECTOR_ID = "io.syndesis.connector:connector-mongodb-producer";

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -400,7 +400,6 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         testResult(result, 0, TEST_SERVER_DATA_1);
     }
 
-    @SuppressWarnings( "unchecked" )
     @Test
     public void testODataRouteWithCountQuery() throws Exception {
         String queryParams = "$count=true";
@@ -425,7 +424,6 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
     }
 
-    @SuppressWarnings( "unchecked" )
     @Test
     public void testODataRouteWithMoreComplexQuery() throws Exception {
         String queryParams = "$filter=ID le 2&$orderby=ID desc";
@@ -532,7 +530,6 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         assertEquals(initialDelayValue, consumerProperties.get(INITIAL_DELAY));
     }
 
-    @SuppressWarnings( "unchecked" )
     @Test
     public void testODataRouteAlreadySeen() throws Exception {
         String backoffIdleThreshold = "1";
@@ -597,7 +594,6 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         assertEquals(backoffMultiplier, consumerProperties.get(BACKOFF_MULTIPLIER));
     }
 
-    @SuppressWarnings( "unchecked" )
     @Test
     public void testReferenceODataRouteAlreadySeenWithKeyPredicate() throws Exception {
         String resourcePath = "Airports";

--- a/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizerTest.java
+++ b/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/customizer/DataShapeCustomizerTest.java
@@ -34,7 +34,6 @@ import org.apache.camel.processor.Pipeline;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class DataShapeCustomizerTest extends SalesforceTestSupport {
     private static final Processor BEFORE_PROCESSOR = exchange -> {
         // nop

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorBatchUpdateTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorBatchUpdateTest.java
@@ -30,7 +30,6 @@ import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
 import org.junit.Assert;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class SqlConnectorBatchUpdateTest extends SqlConnectorTestSupport {
 
     private final String sqlQuery = "INSERT INTO ADDRESS (street, number) VALUES (:#street, :#number)";

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorInputParamTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorInputParamTest.java
@@ -31,7 +31,6 @@ import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class SqlConnectorInputParamTest extends SqlConnectorTestSupport {
     private static final String STATEMENT = "INSERT INTO ALLTYPES " +
         "(charType, varcharType, numericType, decimalType, smallType) VALUES " +
@@ -88,10 +87,6 @@ public class SqlConnectorInputParamTest extends SqlConnectorTestSupport {
             stmt.execute("SELECT * FROM ALLTYPES");
             ResultSet resultSet = stmt.getResultSet();
             resultSet.next();
-            for (int i=1; i< 6; i++) {
-                System.out.print(resultSet.getString(i) + " ");
-            }
-            System.out.println(resultSet.getString(1));
             Assertions.assertThat(resultSet.getString(1)).isEqualTo(SqlParam.SqlSampleValue.CHAR_VALUE.toString());
             Assertions.assertThat(resultSet.getString(2)).isEqualTo(SqlParam.SqlSampleValue.STRING_VALUE);
             Assertions.assertThat(resultSet.getString(3)).isEqualTo(SqlParam.SqlSampleValue.DECIMAL_VALUE.toString());

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 @RunWith(Parameterized.class)
 public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
 

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorTest.java
@@ -33,7 +33,6 @@ import io.syndesis.connector.sql.common.DbEnum;
 import io.syndesis.connector.sql.common.JSONBeanUtil;
 import io.syndesis.connector.sql.util.SqlConnectorTestSupport;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 @RunWith(Parameterized.class)
 public class SqlConnectorTest extends SqlConnectorTestSupport {
 

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStartStoredConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStartStoredConnectorTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import static io.syndesis.connector.sql.stored.SqlStoredCommon.setupStoredProcedure;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class SqlStartStoredConnectorTest extends SqlConnectorTestSupport {
 
     // **************************

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.ProducerTemplate;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class SqlStoredConnectorTest extends SqlConnectorTestSupport {
 
     // **************************

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorWitDefaultsTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorWitDefaultsTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.ProducerTemplate;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class SqlStoredConnectorWitDefaultsTest extends SqlConnectorTestSupport {
 
     // **************************

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentOptionsTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentOptionsTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.SignatureDeclareThrowsException"})
 public class ComponentOptionsTest {
     private DataSource ds;
 
@@ -128,7 +127,7 @@ public class ComponentOptionsTest {
         }
     }
 
-    private void validateRegistryOption(CamelContext context) throws Exception {
+    private static void validateRegistryOption(CamelContext context) throws Exception {
         context.start();
 
         Collection<String> names = context.getComponentNames();

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyComponentTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyComponentTest.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.component.proxy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.RoutesBuilder;
@@ -27,7 +28,6 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class ComponentProxyComponentTest extends CamelTestSupport {
 
     // ***************************
@@ -65,23 +65,21 @@ public class ComponentProxyComponentTest extends CamelTestSupport {
     // Test
     // ***************************
 
-    @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
     @Test
     public void testRequest() {
         final String body = "hello";
         final String result = template().requestBody("direct:start", body, String.class);
 
-        Assertions.assertThat(result).isEqualTo(body.toUpperCase());
+        Assertions.assertThat(result).isEqualTo(body.toUpperCase(Locale.US));
     }
 
-    @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
     @Test
     public void testSend() throws Exception {
         final MockEndpoint mock = getMockEndpoint("mock:result");
         final String body = "hello";
 
         mock.expectedMessageCount(1);
-        mock.expectedBodiesReceived(body.toUpperCase());
+        mock.expectedBodiesReceived(body.toUpperCase(Locale.US));
 
         template().sendBody("direct:start", body);
 
@@ -93,9 +91,8 @@ public class ComponentProxyComponentTest extends CamelTestSupport {
     // ***************************
 
     public static class MyBean {
-        @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 }

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ComponentProxyWithCustomComponentTest {
     private DataSource ds;
 

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings({"PMD.SignatureDeclareThrowsException", "PMD.JUnitTestsShouldIncludeAssert"})
 public class ComponentProxyWithCustomEndpointTest {
 
     // *************************

--- a/app/integration/runtime-camelk/src/test/java/io/syndesis/integration/runtime/camelk/jmx/CamelContextMetadataMBeanTest.java
+++ b/app/integration/runtime-camelk/src/test/java/io/syndesis/integration/runtime/camelk/jmx/CamelContextMetadataMBeanTest.java
@@ -33,7 +33,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class CamelContextMetadataMBeanTest {
 
     private static final String[] ATTRIBUTES = {

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerAddPropertyTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerAddPropertyTest.java
@@ -16,6 +16,7 @@
 package io.syndesis.integration.component.proxy;
 
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -54,7 +55,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxyCustomizerAddPropertyTest.json"
     }
 )
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
 public class ComponentProxyCustomizerAddPropertyTest {
 
     @Autowired
@@ -106,7 +106,7 @@ public class ComponentProxyCustomizerAddPropertyTest {
     @Component("my-bean")
     public static class MyBean {
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerTest.java
@@ -18,6 +18,7 @@ package io.syndesis.integration.component.proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -55,7 +56,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxyCustomizerTest.json"
     }
 )
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
 public class ComponentProxyCustomizerTest {
 
     @Autowired
@@ -74,7 +74,7 @@ public class ComponentProxyCustomizerTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -86,7 +86,7 @@ public class ComponentProxyCustomizerTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);
@@ -107,7 +107,7 @@ public class ComponentProxyCustomizerTest {
     @Component("my-bean")
     public static class MyBean {
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerWithPlaceholdersTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyCustomizerWithPlaceholdersTest.java
@@ -18,6 +18,7 @@ package io.syndesis.integration.component.proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -56,7 +57,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "my.bean.name = my-bean"
     }
 )
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
 public class ComponentProxyCustomizerWithPlaceholdersTest {
 
     @Autowired
@@ -75,7 +75,7 @@ public class ComponentProxyCustomizerWithPlaceholdersTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -87,7 +87,7 @@ public class ComponentProxyCustomizerWithPlaceholdersTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);
@@ -108,7 +108,7 @@ public class ComponentProxyCustomizerWithPlaceholdersTest {
     @Component("my-bean")
     public static class MyBean {
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyFactoryTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyFactoryTest.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.component.proxy;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -54,7 +55,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxyFactoryTest.json"
     }
 )
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
 public class ComponentProxyFactoryTest {
 
     @Autowired
@@ -73,7 +73,7 @@ public class ComponentProxyFactoryTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final String body = "hello";
         final String result = template.requestBody("direct:start", body, String.class);
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         assertThat(result).isEqualTo(expected);
     }
@@ -85,7 +85,7 @@ public class ComponentProxyFactoryTest {
         final ProducerTemplate template = camelContext.createProducerTemplate();
         final MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
         final String body = "hello";
-        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".toUpperCase().getBytes(StandardCharsets.US_ASCII));
+        final String expected = Base64.getEncoder().encodeToString("HELLO WORLD!".getBytes(StandardCharsets.US_ASCII));
 
         mock.expectedMessageCount(1);
         mock.expectedBodiesReceived(expected);
@@ -106,7 +106,7 @@ public class ComponentProxyFactoryTest {
     @Component("my-bean")
     public static class MyBean {
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyGlobalCustomizerTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyGlobalCustomizerTest.java
@@ -16,6 +16,7 @@
 package io.syndesis.integration.component.proxy;
 
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.camel.Body;
 import org.apache.camel.CamelContext;
@@ -53,7 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxyGlobalCustomizerTest.json"
     }
 )
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.UseLocaleWithCaseConversions"})
 public class ComponentProxyGlobalCustomizerTest {
 
     @Autowired
@@ -105,7 +105,7 @@ public class ComponentProxyGlobalCustomizerTest {
     @Component("my-bean")
     public static class MyBean {
         public String process(@Body String body) {
-            return body.toUpperCase();
+            return body.toUpperCase(Locale.US);
         }
     }
 

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxySplitCollectionTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxySplitCollectionTest.java
@@ -47,7 +47,6 @@ import io.syndesis.integration.runtime.sb.IntegrationRuntimeAutoConfiguration;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxySplitCollectionTest.json"
     }
 )
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class ComponentProxySplitCollectionTest {
     @Autowired
     private CamelContext camelContext;

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxySplitTokenizeTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/component/proxy/ComponentProxySplitTokenizeTest.java
@@ -45,7 +45,6 @@ import io.syndesis.integration.runtime.sb.IntegrationRuntimeAutoConfiguration;
         "syndesis.integration.runtime.configuration-location = classpath:/syndesis/integration/component/proxy/ComponentProxySplitTokenizeTest.json"
     }
 )
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class ComponentProxySplitTokenizeTest {
     @Autowired
     private CamelContext camelContext;

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/capture/OutMessageCaptureProcessorTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/capture/OutMessageCaptureProcessorTest.java
@@ -65,7 +65,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "logging.level.io.syndesis.integration.runtime = DEBUG"
     }
 )
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class OutMessageCaptureProcessorTest extends IntegrationTestSupport {
     @Autowired
     private ApplicationContext applicationContext;

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/jmx/CamelContextMetadataMBeanTest.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/jmx/CamelContextMetadataMBeanTest.java
@@ -48,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
         "logging.level.io.syndesis.integration.runtime = DEBUG"
     }
 )
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class CamelContextMetadataMBeanTest {
 
     private static final String[] ATTRIBUTES = {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ExtensionStepHandler.java
@@ -116,8 +116,7 @@ public class ExtensionStepHandler implements IntegrationStepHandler{
                     // the handler method.
                     ObjectHelper.trySetCamelContext(stepExtension, context);
 
-                    @SuppressWarnings({"rawtypes", "unchecked"})
-                    final Optional<ProcessorDefinition<?>> configured = (Optional) stepExtension.configure(context, route, props);
+                    final Optional<ProcessorDefinition<?>> configured = stepExtension.configure(context, route, props);
 
                     return configured;
                 } catch (ClassNotFoundException e) {

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/DeploymentDescriptorIT.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/DeploymentDescriptorIT.java
@@ -65,7 +65,6 @@ public class DeploymentDescriptorIT {
     }
 
     @Test
-    @SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.JUnitTestContainsTooManyAsserts"})
     public void deploymentDescriptorTakeCueFromConnectorDescriptor() {
         for (final JsonNode entry : deployment) {
             if ("connector".equals(entry.get("kind").asText())) {


### PR DESCRIPTION
This removes `SuppressWarnings` annotation where they are either not needed or the reason behind adding them can be trivially refactored or fixed.

Funny how most of these are added without any reason behind them. Monkey see monkey do I guess.