### PR TITLE
user doc: Remove Tech Preview note

### DIFF
--- a/doc/assemblies/connecting/as_connecting-to-jira.adoc
+++ b/doc/assemblies/connecting/as_connecting-to-jira.adoc
@@ -13,19 +13,6 @@ Each Jira environment allows customization of the workflow, which
 has an effect on the details for connecting to Jira in an integration. 
 Consulting with your Jira administrator should clarify the details. 
 
-ifeval::["{location}" == "downstream"]
-[IMPORTANT]
-====
-Connecting to Jira is a Technology Preview feature only. Technology Preview features are 
-not supported with Red Hat production service level agreements (SLAs) and might not be 
-functionally complete. Red Hat does not recommend using them in production. 
-These features provide early access to upcoming product features, enabling 
-customers to test functionality and provide feedback during the development process. 
-For more information about the support scope of Red Hat Technology Preview features, 
-see link:https://access.redhat.com/support/offerings/techpreview/[]. 
-====
-endif::[]
-
 The following topics provide information and procedures for creating integrations 
 that connect to a Jira server:
 


### PR DESCRIPTION
This just removes the Tech Preview note from the doc for the Jira connector. 