### PR TITLE
refactor: declare methods/classes as static

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/FreeMarkerTemplatePreProcessor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/FreeMarkerTemplatePreProcessor.java
@@ -30,7 +30,7 @@ class FreeMarkerTemplatePreProcessor extends AbstractTemplatePreProcessor {
 
     private static final Pattern SYMBOL_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9_@\\$\\.]+");
 
-    public FreeMarkerTemplatePreProcessor() {
+    FreeMarkerTemplatePreProcessor() {
         super(new SymbolSyntax(DOLLAR_SIGN + OPEN_BRACE, CLOSE_BRACE));
     }
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/MustacheTemplatePreProcessor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/MustacheTemplatePreProcessor.java
@@ -46,16 +46,16 @@ class MustacheTemplatePreProcessor extends AbstractTemplatePreProcessor {
 
     private boolean inSectionSymbol;
 
-    public MustacheTemplatePreProcessor() {
+    MustacheTemplatePreProcessor() {
         super(new SymbolSyntax(OPEN_BRACE + OPEN_BRACE, CLOSE_BRACE + CLOSE_BRACE));
     }
 
-    private boolean isOpeningSectionSymbol(String literal) {
+    private static boolean isOpeningSectionSymbol(String literal) {
         Matcher m = SYMBOL_OPEN_SECTION_PATTERN.matcher(literal);
         return m.matches();
     }
 
-    private boolean isClosingSectionSymbol(String literal) {
+    private static boolean isClosingSectionSymbol(String literal) {
         Matcher m = SYMBOL_CLOSE_SECTION_PATTERN.matcher(literal);
         return m.matches();
     }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/VelocityTemplatePreProcessor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/VelocityTemplatePreProcessor.java
@@ -40,7 +40,7 @@ class VelocityTemplatePreProcessor extends AbstractTemplatePreProcessor {
     // Flag if the symbol is a declaration for a velocity-only symbol
     private boolean vSymbolDeclaration;
 
-    public VelocityTemplatePreProcessor() {
+    VelocityTemplatePreProcessor() {
         super(
               new SymbolSyntax(DOLLAR_SIGN + OPEN_BRACE, CLOSE_BRACE),
               new SymbolSyntax(DOLLAR_SIGN, EMPTY_STRING));

--- a/app/common/model/src/main/java/io/syndesis/common/model/support/EquivContext.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/support/EquivContext.java
@@ -33,7 +33,7 @@ class EquivContext implements StringConstants {
 
     private String b;
 
-    public EquivContext(String name, Class<?> klazz) {
+    EquivContext(String name, Class<?> klazz) {
         this.name = name;
         this.type = klazz.getSimpleName().replaceAll("Immutable", EMPTY_STRING);
     }
@@ -64,7 +64,7 @@ class EquivContext implements StringConstants {
                         TAB + "=> " + QUOTE_MARK + this.b + QUOTE_MARK + NEW_LINE;
     }
 
-    private String truncate(String fullText, String diffText, int diffIndex) {
+    private static String truncate(String fullText, String diffText, int diffIndex) {
         StringBuilder truncated = new StringBuilder();
 
         //
@@ -107,7 +107,7 @@ class EquivContext implements StringConstants {
         this.b = truncate(bStr, bDiff, diffPos);
     }
 
-    private String toString(Object value) {
+    private static String toString(Object value) {
         if (value instanceof Optional) {
             Optional<?> ov = (Optional<?>) value;
             Object v = ov.orElse(null);

--- a/app/common/model/src/main/java/io/syndesis/common/model/support/Equivalencer.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/support/Equivalencer.java
@@ -41,7 +41,7 @@ public class Equivalencer implements StringConstants {
     private Deque<EquivContext> failureContext;
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private boolean isSameRef(Object one, Object another) {
+    private static boolean isSameRef(Object one, Object another) {
         return one == another;
     }
 
@@ -66,7 +66,7 @@ public class Equivalencer implements StringConstants {
         return false;
     }
 
-    private EquivPair pair(Object a, Object b, String name) {
+    private static EquivPair pair(Object a, Object b, String name) {
         return EquivPair.create(a, b, name);
     }
 

--- a/app/common/model/src/test/java/io/syndesis/common/model/DataShapeBuilderTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/DataShapeBuilderTest.java
@@ -184,7 +184,7 @@ public class DataShapeBuilderTest {
         Assert.assertEquals(variantSpecification, shape.decompress().decompress().build().getVariants().get(0).getSpecification());
     }
 
-    private void assertCompressedSpecification(String expected, String compressed) throws IOException {
+    private static void assertCompressedSpecification(String expected, String compressed) throws IOException {
         byte[] data = Base64.getDecoder().decode(compressed);
 
         try (InputStream is = new GZIPInputStream(new ByteArrayInputStream(data))) {

--- a/app/common/model/src/test/java/io/syndesis/common/model/support/EquivalencerTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/support/EquivalencerTest.java
@@ -52,7 +52,7 @@ public class EquivalencerTest implements StringConstants {
         return new NameTypePair(name, type);
     }
 
-    private ConnectorAction connectorAction(String name) {
+    private static ConnectorAction connectorAction(String name) {
         return new ConnectorAction.Builder()
                      .id("sql-connector")
                      .actionType("connector")
@@ -63,7 +63,7 @@ public class EquivalencerTest implements StringConstants {
                      .build();
     }
 
-    private Connector connector(ConnectorAction connectorAction) {
+    private static Connector connector(ConnectorAction connectorAction) {
         return new Connector.Builder()
                       .id("5")
                       .name("sql")
@@ -71,7 +71,7 @@ public class EquivalencerTest implements StringConstants {
                       .build();
     }
 
-    private Connector connectorWithDescription(ConnectorAction connectorAction, String description) {
+    private static Connector connectorWithDescription(ConnectorAction connectorAction, String description) {
         return new Connector.Builder()
                       .id("5")
                       .name("sql")
@@ -80,7 +80,7 @@ public class EquivalencerTest implements StringConstants {
                       .build();
     }
 
-    private Connection connection(Connector connector) {
+    private static Connection connection(Connector connector) {
         Map<String, String> configuredProperties = new HashMap<>();
         configuredProperties.put("password", "password");
         configuredProperties.put("user", "developer");
@@ -123,7 +123,7 @@ public class EquivalencerTest implements StringConstants {
         assertTrue(equiv.failureMessage().isEmpty());
     }
 
-    private String expectedMessage(String property, Object  value1, Object value2, NameTypePair... ctx) {
+    private static String expectedMessage(String property, Object  value1, Object value2, NameTypePair... ctx) {
         StringBuilder msg = new StringBuilder();
         msg.append(
             "Reason: '" + property + "' is different" + NEW_LINE +

--- a/app/common/util/src/main/java/io/syndesis/common/util/CollectionsUtils.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/CollectionsUtils.java
@@ -38,18 +38,6 @@ public final class CollectionsUtils {
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public static <K, V> Map<K, V> removeNullValues(Map<K, V> source) {
-        return removeNullValues(source, HashMap::new);
-    }
-
-    public static <K, V> Map<K, V> removeNullValues(Map<K, V> source, Supplier<Map<K, V>> supplier) {
-        final Map<K, V> answer = supplier.get();
-        answer.putAll(source);
-        answer.values().removeIf(Objects::isNull);
-
-        return answer;
-    }
-
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <C extends Collection<T>, T> C aggregate(Supplier<C> collectionFactory, Collection<T>... collections) {
@@ -60,6 +48,18 @@ public final class CollectionsUtils {
         }
 
         return result;
+    }
+
+    public static <K, V> Map<K, V> removeNullValues(Map<K, V> source) {
+        return removeNullValues(source, HashMap::new);
+    }
+
+    public static <K, V> Map<K, V> removeNullValues(Map<K, V> source, Supplier<Map<K, V>> supplier) {
+        final Map<K, V> answer = supplier.get();
+        answer.putAll(source);
+        answer.values().removeIf(Objects::isNull);
+
+        return answer;
     }
 
     public static <K, V> Stream<Map.Entry<K, V>> filter(Map<K, V> map, Predicate<Map.Entry<K, V>> predicate) {
@@ -85,15 +85,15 @@ public final class CollectionsUtils {
     }
 
     @SuppressWarnings("unchecked")
+    public static <K, V> Map<K, V> mapOf(K key, V value, Object... keyVals) {
+        return mapOf(HashMap::new, key, value, keyVals);
+    }
+
+    @SuppressWarnings("unchecked")
     public static <K, V> Map<K, V> immutableMapOf(Supplier<Map<K, V>> creator, K key, V value, Object... keyVals) {
         return Collections.unmodifiableMap(
             mapOf(creator, key, value, keyVals)
         );
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <K, V> Map<K, V> mapOf(K key, V value, Object... keyVals) {
-        return mapOf(HashMap::new, key, value, keyVals);
     }
 
     @SuppressWarnings("unchecked")

--- a/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
@@ -24,6 +24,7 @@ import java.util.StringJoiner;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.syndesis.common.util.Json;
+import io.syndesis.common.util.Strings;
 
 /**
  * Utilities for working with Json.
@@ -53,29 +54,33 @@ public final class JsonUtils {
     }
 
     /**
-     * Checks given value to be a proper Json object string.
+     * Checks given value could be JSON object string.
      * @param value
      * @return
      */
     public static boolean isJsonObject(String value) {
-        if (value == null) {
+        if (Strings.isEmptyOrBlank(value)) {
             return false;
         }
 
-        return value.trim().startsWith("{") && value.trim().endsWith("}");
+        final String trimmed = value.trim();
+
+        return trimmed.charAt(0) == '{' && trimmed.charAt(trimmed.length() - 1) == '}';
     }
 
     /**
-     * Checks given value to be a proper Json array string.
+     * Checks given value could be JSON array string.
      * @param value
      * @return
      */
     public static boolean isJsonArray(String value) {
-        if (value == null) {
+        if (Strings.isEmptyOrBlank(value)) {
             return false;
         }
 
-        return value.trim().startsWith("[") && value.trim().endsWith("]");
+        final String trimmed = value.trim();
+
+        return trimmed.charAt(0) == '[' && trimmed.charAt(trimmed.length() - 1) == ']';
     }
 
     /**

--- a/app/common/util/src/test/java/io/syndesis/common/util/cache/LRUSoftCacheTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/cache/LRUSoftCacheTest.java
@@ -47,7 +47,7 @@ public class LRUSoftCacheTest {
      * This test requires a cap of 200MB on the Java heap to work (it's set on surefire).
      * Run it with: "-Xmx200m"
      */
-    private void doTest(Cache<String, byte[]> cache) {
+    private static void doTest(Cache<String, byte[]> cache) {
         // Initial tests on the cache
         byte[] payload = new byte[]{1, 2, 3, 4, 5};
         cache.put("key", payload);

--- a/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnectorVerifierExtension.java
+++ b/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnectorVerifierExtension.java
@@ -60,11 +60,11 @@ public class ActiveMQConnectorVerifierExtension extends DefaultComponentVerifier
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-            .error(parameters, this::verifyCredentials)
+            .error(parameters, ActiveMQConnectorVerifierExtension::verifyCredentials)
             .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         final String brokerUrl = ConnectorOptions.extractOption(parameters, "brokerUrl");
         final String username = ConnectorOptions.extractOption(parameters, "username");
         final String password = ConnectorOptions.extractOption(parameters, "password");

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
@@ -64,11 +64,11 @@ public class AMQPVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyCredentials)
+                .error(parameters, AMQPVerifierExtension::verifyCredentials)
                 .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
         final String connectionUri = ConnectorOptions.extractOption(parameters, "connectionUri");
         final String username = ConnectorOptions.extractOption(parameters, "username");

--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
@@ -79,7 +79,7 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
         component.setAfterProducer(statusCodeUpdater(httpResponseStatus, errorResponseCodeMappings, isReturnBody));
     }
 
-    private Processor statusCodeUpdater(Integer responseCode, Map<String, String> errorResponseCodeMappings,
+    private static Processor statusCodeUpdater(Integer responseCode, Map<String, String> errorResponseCodeMappings,
             Boolean isReturnBody) {
         return exchange -> {
             if (exchange.getException() != null) {

--- a/app/connector/box/src/test/java/io/syndesis/connector/box/customizer/BoxDownloadCustomizerTest.java
+++ b/app/connector/box/src/test/java/io/syndesis/connector/box/customizer/BoxDownloadCustomizerTest.java
@@ -62,7 +62,7 @@ public class BoxDownloadCustomizerTest extends CamelTestSupport {
         assertEquals(size, file.getSize());
     }
 
-    private void setBody(Exchange inbound, String content, String encoding) throws Exception {
+    private static void setBody(Exchange inbound, String content, String encoding) throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write(content.getBytes(encoding));
         inbound.getIn().setBody(output);

--- a/app/connector/dropbox/src/main/java/io/syndesis/connector/dropbox/DropBoxVerifierExtension.java
+++ b/app/connector/dropbox/src/main/java/io/syndesis/connector/dropbox/DropBoxVerifierExtension.java
@@ -53,10 +53,10 @@ public class DropBoxVerifierExtension extends DefaultComponentVerifierExtension 
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyCredentials).build();
+                .error(parameters, DropBoxVerifierExtension::verifyCredentials).build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
         String token = ConnectorOptions.extractOption(parameters, "accessToken");
         String clientId = ConnectorOptions.extractOption(parameters, "clientIdentifier");

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailReceiveCustomizer.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailReceiveCustomizer.java
@@ -34,10 +34,10 @@ public class EMailReceiveCustomizer implements ComponentProxyCustomizer, EMailCo
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setBeforeConsumer(this::beforeConsumer);
+        component.setBeforeConsumer(EMailReceiveCustomizer::beforeConsumer);
     }
 
-    private void beforeConsumer(Exchange exchange) throws MessagingException, IOException {
+    private static void beforeConsumer(Exchange exchange) throws MessagingException, IOException {
 
         final Message in = exchange.getIn();
         final EMailMessageModel mail = new EMailMessageModel();
@@ -63,7 +63,7 @@ public class EMailReceiveCustomizer implements ComponentProxyCustomizer, EMailCo
         exchange.getIn().setBody(mail);
     }
 
-    private String getPlainTextFromMultipart(Multipart multipart)  throws MessagingException, IOException {
+    private static String getPlainTextFromMultipart(Multipart multipart)  throws MessagingException, IOException {
         StringBuilder result = new StringBuilder();
         int count = multipart.getCount();
         for (int i = 0; i < count; i++) {
@@ -92,7 +92,7 @@ public class EMailReceiveCustomizer implements ComponentProxyCustomizer, EMailCo
         return result.toString();
     }
 
-    private void textFromMessage(Message camelMessage, EMailMessageModel model) throws MessagingException, IOException {
+    private static void textFromMessage(Message camelMessage, EMailMessageModel model) throws MessagingException, IOException {
         Object content = camelMessage.getBody();
 
         if (content instanceof String) {

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/customizer/EMailSendCustomizer.java
@@ -106,7 +106,7 @@ public class EMailSendCustomizer implements ComponentProxyCustomizer, EMailConst
         setContentType(content, in);
     }
 
-    private boolean isHtml(String content) {
+    private static boolean isHtml(String content) {
         if (ObjectHelper.isEmpty(content)) {
             return false;
         }
@@ -115,7 +115,7 @@ public class EMailSendCustomizer implements ComponentProxyCustomizer, EMailConst
         return htmlMatch.find();
     }
 
-    private void setContentType(Object content, Message in) {
+    private static void setContentType(Object content, Message in) {
         if (content instanceof String) {
 
             if (isHtml(content.toString())) {

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
@@ -75,7 +75,7 @@ public abstract class AbstractEMailVerifier extends DefaultComponentVerifierExte
         }
     }
 
-    private void setJavaMailProperty(MailConfiguration configuration, String key, String value) {
+    private static void setJavaMailProperty(MailConfiguration configuration, String key, String value) {
         configuration.getAdditionalJavaMailProperties().setProperty(key, value);
     }
 
@@ -113,8 +113,7 @@ public abstract class AbstractEMailVerifier extends DefaultComponentVerifierExte
         return setProperties(new MailConfiguration(), new HashMap<>(parameters));
     }
 
-    protected JavaMailSender createJavaMailSender(MailConfiguration configuration) throws NoSuchMethodException, SecurityException, IllegalAccessException,
-        IllegalArgumentException, InvocationTargetException {
+    protected JavaMailSender createJavaMailSender(MailConfiguration configuration) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
             Method method = MailConfiguration.class.getDeclaredMethod("createJavaMailSender");
             method.setAccessible(true);
             return (JavaMailSender) method.invoke(configuration);

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/producer/EMailSendRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/producer/EMailSendRouteTest.java
@@ -106,7 +106,7 @@ public class EMailSendRouteTest extends AbstractEmailServerTest implements Route
         return emailAction;
     }
 
-    private Step createDirectStep() {
+    private static Step createDirectStep() {
         Step directStep = new Step.Builder()
             .stepKind(StepKind.endpoint)
             .action(new ConnectorAction.Builder()

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetadataRetrieval.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetadataRetrieval.java
@@ -81,12 +81,12 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
 
         if (ObjectHelper.isNotEmpty(ConnectorOptions.extractOption(properties, "resourceType"))) {
             return createSyndesisMetadata(actionId, properties, enrichedProperties);
-        } else {
-            return SyndesisMetadata.of(enrichedProperties);
         }
+
+        return SyndesisMetadata.of(enrichedProperties);
     }
 
-    private SyndesisMetadata createSyndesisMetadata(String actionId, Map<String, Object> properties, Map<String, List<PropertyPair>> enrichedProperties) {
+    private static SyndesisMetadata createSyndesisMetadata(String actionId, Map<String, Object> properties, Map<String, List<PropertyPair>> enrichedProperties) {
         String containedResourceTypes = ConnectorOptions.extractOption(properties, "containedResourceTypes");
         String type = ConnectorOptions.extractOption(properties, "resourceType");
 
@@ -169,7 +169,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         }
     }
 
-    private String newPatchSpecification(Integer operationNumber) {
+    private static String newPatchSpecification(Integer operationNumber) {
         final JsonSchemaFactory factory = new JsonSchemaFactory();
         final ObjectSchema patchSchema = factory.objectSchema();
         patchSchema.set$schema("http://json-schema.org/schema#");
@@ -191,7 +191,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         return schema;
     }
 
-    private String newResourceSpecification(String type, String containedResourceTypes) {
+    private static String newResourceSpecification(String type, String containedResourceTypes) {
         String specification;
         String resourcePath = type.toLowerCase(Locale.ENGLISH);
         try {
@@ -208,7 +208,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         return specification;
     }
 
-    String includeResources(String specification, String... resourceTypes) throws IOException {
+    static String includeResources(String specification, String... resourceTypes) throws IOException {
         if (resourceTypes != null && resourceTypes.length != 0) {
             XmlDocument document = MAPPER.readValue(specification, XmlDocument.class);
             includeResources(null, document, resourceTypes);
@@ -218,7 +218,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         return specification;
     }
 
-    private void includeResources(String rootPath, XmlDocument resource, String... resourceTypes) throws IOException {
+    private static void includeResources(String rootPath, XmlDocument resource, String... resourceTypes) throws IOException {
         XmlComplexType resourceElement = (XmlComplexType) resource.getFields().getField().get(0);
         switch (resourceElement.getName()) {
             case "tns:Bundle":
@@ -237,7 +237,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         }
     }
 
-    private void includeResourcesInPath(String rootPath, XmlComplexType resourceElement, String[] resourceTypes, String... path) throws IOException {
+    private static void includeResourcesInPath(String rootPath, XmlComplexType resourceElement, String[] resourceTypes, String... path) throws IOException {
         XmlComplexType element = getElement(resourceElement, 0, path);
         if (element != null) {
             List<XmlField> elements = new ArrayList<>();
@@ -263,7 +263,7 @@ public class FhirMetadataRetrieval extends ComponentMetadataRetrieval {
         }
     }
 
-    XmlComplexType getElement(XmlComplexType field, int depth, String... path) {
+    static XmlComplexType getElement(XmlComplexType field, int depth, String... path) {
         if (path.length == 0) {
             return field;
         }

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirTransactionCustomizer.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/customizer/FhirTransactionCustomizer.java
@@ -103,7 +103,7 @@ public class FhirTransactionCustomizer implements ComponentProxyCustomizer {
         in.setBody(transaction.toString());
     }
 
-    private Document toDocument(Node resourceNode, DocumentBuilderFactory dbf) throws ParserConfigurationException {
+    private static Document toDocument(Node resourceNode, DocumentBuilderFactory dbf) throws ParserConfigurationException {
         Document document = dbf.newDocumentBuilder().newDocument();
         Element elementNS = document.createElementNS("http://hl7.org/fhir", resourceNode.getNodeName());
         elementNS.setPrefix("tns");
@@ -117,7 +117,7 @@ public class FhirTransactionCustomizer implements ComponentProxyCustomizer {
         return document;
     }
 
-    private String toXml(Document document) throws TransformerException {
+    private static String toXml(Document document) throws TransformerException {
         StringWriter buf = new StringWriter();
         Transformer xform = TransformerFactory.newInstance().newTransformer();
         xform.transform(new DOMSource(document), new StreamResult(buf));

--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/verifier/FhirVerifierExtension.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/verifier/FhirVerifierExtension.java
@@ -59,12 +59,12 @@ public class FhirVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-            .error(parameters, this::verifyFhirVersion)
-            .error(parameters, this::verifyConnection)
+            .error(parameters, FhirVerifierExtension::verifyFhirVersion)
+            .error(parameters, FhirVerifierExtension::verifyConnection)
             .build();
     }
 
-    private void verifyFhirVersion(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyFhirVersion(ResultBuilder builder, Map<String, Object> parameters) {
         try {
             final FhirVersionEnum fhirVersionEnum = ConnectorOptions.extractOptionAndMap(
                 parameters, "fhirVersion", FhirVersionEnum::valueOf);
@@ -77,7 +77,7 @@ public class FhirVerifierExtension extends DefaultComponentVerifierExtension {
         }
     }
 
-    private void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
         if (!builder.build().getErrors().isEmpty()) {
             return;
         }

--- a/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirMetadataRetrievalTest.java
+++ b/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirMetadataRetrievalTest.java
@@ -31,8 +31,6 @@ import java.nio.file.Path;
 
 public class FhirMetadataRetrievalTest {
 
-    private FhirMetadataRetrieval fhirMetadataRetrieval = new FhirMetadataRetrieval();
-
     @Test
     public void includeResourcesInBundle() throws Exception {
         Path bundle = FileSystems.getDefault().getPath("target/classes/META-INF/syndesis/schemas/dstu3/bundle.json");
@@ -42,7 +40,7 @@ public class FhirMetadataRetrievalTest {
             inspection = IOUtils.toString(fileIn, StandardCharsets.UTF_8);
         }
 
-        String inspectionWithResources = fhirMetadataRetrieval.includeResources(inspection, "patient", "account");
+        String inspectionWithResources = FhirMetadataRetrieval.includeResources(inspection, "patient", "account");
 
         ObjectMapper mapper = io.atlasmap.v2.Json.mapper();
         XmlDocument xmlDocument = mapper.readValue(inspectionWithResources, XmlDocument.class);
@@ -68,7 +66,7 @@ public class FhirMetadataRetrievalTest {
             inspection = IOUtils.toString(fileIn, StandardCharsets.UTF_8);
         }
 
-        String inspectionWithResources = new FhirMetadataRetrieval().includeResources(inspection, "person", "account");
+        String inspectionWithResources = FhirMetadataRetrieval.includeResources(inspection, "person", "account");
 
         ObjectMapper mapper = io.atlasmap.v2.Json.mapper();
         XmlDocument xmlDocument = mapper.readValue(inspectionWithResources, XmlDocument.class);
@@ -84,7 +82,7 @@ public class FhirMetadataRetrievalTest {
     }
 
     public String getPath(XmlComplexType fields, String... path) {
-        XmlComplexType element = fhirMetadataRetrieval.getElement(fields, 0, path);
+        XmlComplexType element = FhirMetadataRetrieval.getElement(fields, 0, path);
         return element != null ? element.getPath() : null;
     }
 

--- a/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
+++ b/app/connector/ftp/src/main/java/io/syndesis/connector/ftp/FtpVerifierExtension.java
@@ -52,11 +52,11 @@ public class FtpVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyCredentials).build();
+                .error(parameters, FtpVerifierExtension::verifyCredentials).build();
     }
 
     @SuppressWarnings("PMD.NPathComplexity")
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
         final String host = ConnectorOptions.extractOption(parameters, "host");
         final Integer port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt, 21);

--- a/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailReceiveEmailCustomizer.java
+++ b/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailReceiveEmailCustomizer.java
@@ -28,10 +28,10 @@ public class GmailReceiveEmailCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setBeforeConsumer(this::beforeConsumer);
+        component.setBeforeConsumer(GmailReceiveEmailCustomizer::beforeConsumer);
     }
 
-    private void beforeConsumer(Exchange exchange) {
+    private static void beforeConsumer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final GmailMessageModel mail = new GmailMessageModel();

--- a/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailSendEmailCustomizer.java
+++ b/app/connector/gmail/src/main/java/io/syndesis/connector/gmail/GmailSendEmailCustomizer.java
@@ -96,7 +96,7 @@ public class GmailSendEmailCustomizer implements ComponentProxyCustomizer {
         in.setHeader("CamelGoogleMail.userId", userId);
     }
 
-    private com.google.api.services.gmail.model.Message createMessage(String to, String from, String subject,
+    private static com.google.api.services.gmail.model.Message createMessage(String to, String from, String subject,
             String bodyText, String cc, String bcc) throws MessagingException, IOException {
 
         if (ObjectHelper.isEmpty(to)) {
@@ -140,7 +140,7 @@ public class GmailSendEmailCustomizer implements ComponentProxyCustomizer {
         return message;
     }
 
-    private Address[] getAddressesList(String addressString) throws AddressException {
+    private static Address[] getAddressesList(String addressString) throws AddressException {
         List<String> recipientList = Splitter.on(',').splitToList(addressString);
         Address[] recipientAddress = new InternetAddress[recipientList.size()];
         int counter = 0;

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventsCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventsCustomizer.java
@@ -34,11 +34,11 @@ public class GoogleCalendarEventsCustomizer implements ComponentProxyCustomizer 
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setBeforeConsumer(this::beforeConsumer);
+        component.setBeforeConsumer(GoogleCalendarEventsCustomizer::beforeConsumer);
     }
 
     @SuppressWarnings("PMD.NPathComplexity")
-    private void beforeConsumer(Exchange exchange) {
+    private static void beforeConsumer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final Event event = exchange.getIn().getBody(Event.class);

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarGetEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarGetEventCustomizer.java
@@ -40,7 +40,7 @@ public class GoogleCalendarGetEventCustomizer implements ComponentProxyCustomize
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(GoogleCalendarGetEventCustomizer::afterProducer);
     }
 
     private void setApiMethod(Map<String, Object> options) {
@@ -61,7 +61,7 @@ public class GoogleCalendarGetEventCustomizer implements ComponentProxyCustomize
     }
 
     @SuppressWarnings("PMD.NPathComplexity")
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final Event event = exchange.getIn().getBody(Event.class);

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarMetaDataExtension.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarMetaDataExtension.java
@@ -78,7 +78,7 @@ public class GoogleCalendarMetaDataExtension extends AbstractMetaDataExtension {
         }
     }
 
-    private List<String> getScopes(String scopesString) {
+    private static List<String> getScopes(String scopesString) {
        return Splitter.on(',').splitToList(scopesString);
     }
 }

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarSendEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarSendEventCustomizer.java
@@ -51,7 +51,7 @@ public class GoogleCalendarSendEventCustomizer implements ComponentProxyCustomiz
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(GoogleCalendarSendEventCustomizer::afterProducer);
     }
 
     private void setApiMethod(Map<String, Object> options) {
@@ -106,7 +106,7 @@ public class GoogleCalendarSendEventCustomizer implements ComponentProxyCustomiz
     }
 
     @SuppressWarnings("PMD.NPathComplexity")
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final Event event = exchange.getIn().getBody(Event.class);
@@ -151,7 +151,7 @@ public class GoogleCalendarSendEventCustomizer implements ComponentProxyCustomiz
         in.setBody(model);
     }
 
-    private Event createGoogleEvent(String summary, String description, String attendees, String startDate, String startTime, String endDate, String endTime, String location) throws ParseException {
+    private static Event createGoogleEvent(String summary, String description, String attendees, String startDate, String startTime, String endDate, String endTime, String location) throws ParseException {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
         Event event = new Event();
         event.setSummary(summary);

--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarUpdateEventCustomizer.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarUpdateEventCustomizer.java
@@ -52,7 +52,7 @@ public class GoogleCalendarUpdateEventCustomizer implements ComponentProxyCustom
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(GoogleCalendarUpdateEventCustomizer::afterProducer);
     }
 
     private void setApiMethod(Map<String, Object> options) {
@@ -112,7 +112,7 @@ public class GoogleCalendarUpdateEventCustomizer implements ComponentProxyCustom
     }
 
     @SuppressWarnings("PMD.NPathComplexity")
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final Event event = exchange.getIn().getBody(Event.class);
@@ -157,7 +157,7 @@ public class GoogleCalendarUpdateEventCustomizer implements ComponentProxyCustom
         in.setBody(model);
     }
 
-    private Event createGoogleEvent(String summary, String description, String attendees, String startDate, String startTime, String endDate, String endTime, String location) throws ParseException {
+    private static Event createGoogleEvent(String summary, String description, String attendees, String startDate, String startTime, String endDate, String endTime, String location) throws ParseException {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
         Event event = new Event();
         event.setSummary(summary);

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizer.java
@@ -98,7 +98,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         AddChartRequest addChartRequest = new AddChartRequest();
         batchUpdateRequest.getRequests().add(new Request().setAddChart(addChartRequest));
 
-        ChartSpec chartSpec = createChartSpec();
+        ChartSpec chartSpec = createChartSpec(title, subtitle);
         if (model != null) {
             addChartRequest.setChart(createEmbeddedChart(model, chartSpec));
             if (model.getBasicChart() != null) {
@@ -114,7 +114,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
-    private ChartSpec createChartSpec() {
+    private static ChartSpec createChartSpec(String title, String subtitle) {
         ChartSpec chartSpec = new ChartSpec();
         if (ObjectHelper.isNotEmpty(title)) {
             chartSpec.setTitle(title);
@@ -125,7 +125,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         return chartSpec;
     }
 
-    private EmbeddedChart createEmptyChart(ChartSpec chartSpec) {
+    private static EmbeddedChart createEmptyChart(ChartSpec chartSpec) {
         EmbeddedChart embeddedChart = new EmbeddedChart();
         EmbeddedObjectPosition position = new EmbeddedObjectPosition();
         position.setNewSheet(true);
@@ -135,7 +135,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         return embeddedChart;
     }
 
-    private EmbeddedChart createEmbeddedChart(GoogleChart model, ChartSpec chartSpec) {
+    private static EmbeddedChart createEmbeddedChart(GoogleChart model, ChartSpec chartSpec) {
         Integer sourceSheetId = Optional.ofNullable(model.getSourceSheetId())
                                     .orElse(0);
 
@@ -162,7 +162,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         return embeddedChart;
     }
 
-    private void addPieChart(ChartSpec chartSpec, GoogleChart model) {
+    private static void addPieChart(ChartSpec chartSpec, GoogleChart model) {
         Integer sheetId = Optional.ofNullable(model.getSheetId())
                                   .orElse(0);
 
@@ -190,7 +190,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         chartSpec.setPieChart(pieChartSpec);
     }
 
-    private void addBasicChart(ChartSpec chartSpec, GoogleChart model) {
+    private static void addBasicChart(ChartSpec chartSpec, GoogleChart model) {
         Integer sheetId = Optional.ofNullable(model.getSheetId())
                 .orElse(0);
 
@@ -242,7 +242,7 @@ public class GoogleSheetsAddChartCustomizer implements ComponentProxyCustomizer 
         chartSpec.setBasicChart(basicChartSpec);
     }
 
-    private ChartSourceRange getDomainSourceRange(int sourceSheetId, String domainRange) {
+    private static ChartSourceRange getDomainSourceRange(int sourceSheetId, String domainRange) {
         ChartSourceRange domainSourceRange = new ChartSourceRange();
         GridRange domainGridRange = new GridRange();
         domainGridRange.setSheetId(sourceSheetId);

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizer.java
@@ -113,7 +113,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
-    private GridCoordinate getStartCoordinate(PivotTable pivotTable, GooglePivotTable model) {
+    private static GridCoordinate getStartCoordinate(PivotTable pivotTable, GooglePivotTable model) {
         Integer sheetId = Optional.ofNullable(model)
                                     .map(GooglePivotTable::getSheetId)
                                     .orElse(0);
@@ -141,7 +141,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         }
     }
 
-    private void addRowGroups(PivotTable pivotTable, GooglePivotTable model) {
+    private static void addRowGroups(PivotTable pivotTable, GooglePivotTable model) {
         if (ObjectHelper.isEmpty(model.getRowGroups())) {
             return;
         }
@@ -152,7 +152,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         }
     }
 
-    private void addColumnGroups(PivotTable pivotTable, GooglePivotTable model) {
+    private static void addColumnGroups(PivotTable pivotTable, GooglePivotTable model) {
         if (ObjectHelper.isEmpty(model.getColumnGroups())) {
             return;
         }
@@ -163,7 +163,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         }
     }
 
-    private List<PivotGroup> getPivotGroups(List<GooglePivotTable.PivotGroup> model) {
+    private static List<PivotGroup> getPivotGroups(List<GooglePivotTable.PivotGroup> model) {
         List<PivotGroup> groups = new ArrayList<>();
         model.forEach(group -> {
             PivotGroup pivotGroup = new PivotGroup();
@@ -186,7 +186,7 @@ public class GoogleSheetsAddPivotTableCustomizer implements ComponentProxyCustom
         return groups;
     }
 
-    private void addValueGroups(PivotTable pivotTable, GooglePivotTable model) {
+    private static void addValueGroups(PivotTable pivotTable, GooglePivotTable model) {
         List<PivotValue> values = new ArrayList<>();
         model.getValueGroups().forEach(group -> {
             PivotValue pivotValue = new PivotValue();

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizer.java
@@ -45,7 +45,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizer implements ComponentProxyCu
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(GoogleSheetsCreateSpreadsheetCustomizer::afterProducer);
     }
 
     private void setApiMethod(Map<String, Object> options) {
@@ -100,7 +100,7 @@ public class GoogleSheetsCreateSpreadsheetCustomizer implements ComponentProxyCu
         in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "content", spreadsheet);
     }
 
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
         final Message in = exchange.getIn();
         final Spreadsheet spreadsheet = in.getBody(Spreadsheet.class);
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsGetSpreadsheetCustomizer.java
@@ -37,16 +37,16 @@ public class GoogleSheetsGetSpreadsheetCustomizer implements ComponentProxyCusto
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
-        component.setBeforeConsumer(this::beforeConsumer);
+        component.setBeforeConsumer(GoogleSheetsGetSpreadsheetCustomizer::beforeConsumer);
     }
 
-    private void setApiMethod(Map<String, Object> options) {
+    private static void setApiMethod(Map<String, Object> options) {
         options.put("apiName",
                 GoogleSheetsApiCollection.getCollection().getApiName(SheetsSpreadsheetsApiMethod.class).getName());
         options.put("methodName", "get");
     }
 
-    private void beforeConsumer(Exchange exchange) {
+    private static void beforeConsumer(Exchange exchange) {
         final Message in = exchange.getIn();
         final Spreadsheet spreadsheet = exchange.getIn().getBody(Spreadsheet.class);
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsMetadataRetrieval.java
@@ -103,7 +103,7 @@ public final class GoogleSheetsMetadataRetrieval extends ComponentMetadataRetrie
         }
     }
 
-    private void applyMetadata(DataShape.Builder builder, JsonSchema spec) {
+    private static void applyMetadata(DataShape.Builder builder, JsonSchema spec) {
         if (spec.isObjectSchema()) {
             builder.putMetadata("variant", "element");
         }

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizer.java
@@ -51,7 +51,7 @@ public class GoogleSheetsUpdateSpreadsheetCustomizer implements ComponentProxyCu
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setApiMethod(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(GoogleSheetsUpdateSpreadsheetCustomizer::afterProducer);
     }
 
     private void setApiMethod(Map<String, Object> options) {
@@ -114,7 +114,7 @@ public class GoogleSheetsUpdateSpreadsheetCustomizer implements ComponentProxyCu
         in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "batchUpdateSpreadsheetRequest", batchUpdateRequest);
     }
 
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
         final Message in = exchange.getIn();
         final BatchUpdateSpreadsheetResponse batchUpdateResponse = in.getBody(BatchUpdateSpreadsheetResponse.class);
 

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -134,7 +134,7 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
         in.setHeader(GoogleSheetsConstants.PROPERTY_PREFIX + "valueInputOption", valueInputOption);
     }
 
-    private ObjectSchema getItemSchema(JsonSchema spec) {
+    private static ObjectSchema getItemSchema(JsonSchema spec) {
         ObjectSchema itemSpec = null;
         if (spec.isObjectSchema()) {
             itemSpec = (ObjectSchema) spec;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
@@ -334,13 +334,13 @@ public class GoogleSheetsAddPivotTableCustomizerTest extends AbstractGoogleSheet
         Assert.assertNull(pivotTable.getValues().get(0).getSourceColumnOffset());
     }
 
-    private GooglePivotTable.ValueGroup sampleValueGroup() {
+    private static GooglePivotTable.ValueGroup sampleValueGroup() {
         GooglePivotTable.ValueGroup valueGroup = new GooglePivotTable.ValueGroup();
         valueGroup.setSourceColumn("C");
         return valueGroup;
     }
 
-    private void assertSampleValueGroup(PivotTable pivotTable) {
+    private static void assertSampleValueGroup(PivotTable pivotTable) {
         Assert.assertEquals(1, pivotTable.getValues().size());
         Assert.assertEquals("SUM", pivotTable.getValues().get(0).getSummarizeFunction());
         Assert.assertEquals(Integer.valueOf(2), pivotTable.getValues().get(0).getSourceColumnOffset());

--- a/app/connector/http/src/test/java/io/syndesis/connector/http/HttpConnectorVerifierTest.java
+++ b/app/connector/http/src/test/java/io/syndesis/connector/http/HttpConnectorVerifierTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.syndesis.connector.http.util.BasicValidationHandler;
-import io.syndesis.connector.support.verifier.api.ComponentVerifier;
 import io.syndesis.connector.support.verifier.api.Verifier;
 import io.syndesis.connector.support.verifier.api.VerifierResponse;
 import org.apache.camel.CamelContext;
@@ -61,7 +60,7 @@ public class HttpConnectorVerifierTest {
         }
     }
 
-    private HttpProcessor getHttpProcessor() {
+    private static HttpProcessor getHttpProcessor() {
         return new ImmutableHttpProcessor(
             Arrays.asList(
                 new RequestBasicAuth()

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
@@ -61,11 +61,11 @@ public class KafkaVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyCredentials)
+                .error(parameters, KafkaVerifierExtension::verifyCredentials)
                 .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         final String brokers = ConnectorOptions.extractOption(parameters, "brokers");
 
         LOG.debug("Validating Kafka connection to {}", brokers);

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduConnectorVerifierExtension.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduConnectorVerifierExtension.java
@@ -43,11 +43,11 @@ public class KuduConnectorVerifierExtension extends DefaultComponentVerifierExte
     @Override
     public Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyConnection)
+                .error(parameters, KuduConnectorVerifierExtension::verifyConnection)
                 .build();
     }
 
-    private void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
         try {
             KuduClient c = KuduSupport.createConnection(parameters);
             c.getTablesList();

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduCreateTableCustomizer.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduCreateTableCustomizer.java
@@ -40,7 +40,7 @@ public class KuduCreateTableCustomizer implements ComponentProxyCustomizer {
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setOptions(options);
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(KuduCreateTableCustomizer::afterProducer);
     }
 
     private void setOptions(Map<String, Object> options) {
@@ -97,7 +97,7 @@ public class KuduCreateTableCustomizer implements ComponentProxyCustomizer {
         in.setHeader("TableOptions", new CreateTableOptions().setRangePartitionColumns(rangeKeys));
     }
 
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
         final Message in = exchange.getIn();
         final KuduTable table = exchange.getIn().getBody(KuduTable.class);
 
@@ -111,7 +111,7 @@ public class KuduCreateTableCustomizer implements ComponentProxyCustomizer {
         in.setBody(model);
     }
 
-    private Type convertType(String type) {
+    private static Type convertType(String type) {
         switch (type) {
             case "String":
                 return Type.STRING;

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduInsertCustomizer.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduInsertCustomizer.java
@@ -33,16 +33,16 @@ public class KuduInsertCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setOptions(options);
-        component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setBeforeProducer(KuduInsertCustomizer::beforeProducer);
+        component.setAfterProducer(KuduInsertCustomizer::afterProducer);
     }
 
-    private void setOptions(Map<String, Object> options) {
+    private static void setOptions(Map<String, Object> options) {
         options.put("operation", KuduDbOperations.INSERT);
         options.put("type", KuduDbOperations.INSERT);
     }
 
-    private void beforeProducer(Exchange exchange) throws IOException {
+    private static void beforeProducer(Exchange exchange) throws IOException {
         final Message in = exchange.getIn();
         final String body = in.getBody(String.class);
 
@@ -53,7 +53,7 @@ public class KuduInsertCustomizer implements ComponentProxyCustomizer {
         }
     }
 
-    private void afterProducer(Exchange exchange) {
+    private static void afterProducer(Exchange exchange) {
         final Message in = exchange.getIn();
         final String body = in.getBody(String.class);
 

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduMetadataRetrieval.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduMetadataRetrieval.java
@@ -92,7 +92,7 @@ public class KuduMetadataRetrieval extends ComponentMetadataRetrieval {
         return new KuduMetaDataExtension(context);
     }
 
-    private ObjectSchema createSpec(KuduMetaData kuduMetaData) {
+    private static ObjectSchema createSpec(KuduMetaData kuduMetaData) {
         // build the input and output schemas
         ObjectSchema spec = new ObjectSchema();
 

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduScanCustomizer.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/KuduScanCustomizer.java
@@ -39,16 +39,16 @@ public class KuduScanCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
         setOptions(options);
-        component.setBeforeConsumer(this::processBody);
-        component.setAfterProducer(this::processBody);
+        component.setBeforeConsumer(KuduScanCustomizer::processBody);
+        component.setAfterProducer(KuduScanCustomizer::processBody);
     }
 
-    private void setOptions(Map<String, Object> options) {
+    private static void setOptions(Map<String, Object> options) {
         options.put("operation", KuduDbOperations.SCAN);
         options.put("type", KuduDbOperations.SCAN);
     }
 
-    private void processBody(Exchange exchange) throws KuduException, JsonProcessingException {
+    private static void processBody(Exchange exchange) throws KuduException, JsonProcessingException {
         final Message in = exchange.getIn();
         final KuduScanner scanner = in.getBody(KuduScanner.class);
 

--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/verifier/MongoConnectorVerifierExtension.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/verifier/MongoConnectorVerifierExtension.java
@@ -62,11 +62,11 @@ public class MongoConnectorVerifierExtension extends DefaultComponentVerifierExt
     @Override
     public Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-            .error(parameters, this::verifyCredentials)
+            .error(parameters, MongoConnectorVerifierExtension::verifyCredentials)
             .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         MongoConfiguration mongoConf = new MongoConfiguration(cast(parameters));
         MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
         // Avoid retry and long timeout

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
@@ -76,7 +76,7 @@ public class MongoDBConnectorInsertTest extends MongoDBConnectorTestSupport {
         assertThat(result, containsInAnyOrder(docsFound.toArray()));
     }
 
-    private List<Document> formatBatchMessageDocument(int batchNo) {
+    private static List<Document> formatBatchMessageDocument(int batchNo) {
         List<Document> list = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             Document next = new Document();

--- a/app/connector/mqtt/src/main/java/io/syndesis/connector/mqtt/MqttVerifierExtension.java
+++ b/app/connector/mqtt/src/main/java/io/syndesis/connector/mqtt/MqttVerifierExtension.java
@@ -52,11 +52,11 @@ public class MqttVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-            .error(parameters, this::verifyCredentials)
+            .error(parameters, MqttVerifierExtension::verifyCredentials)
             .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         String brokerUrl = ConnectorOptions.extractOption(parameters, "brokerUrl");
         String username = ConnectorOptions.extractOption(parameters, "userName");
         String password = ConnectorOptions.extractOption(parameters, "password");

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadFromCustomizer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/ODataReadFromCustomizer.java
@@ -28,7 +28,7 @@ public class ODataReadFromCustomizer extends AbstractODataCustomizer {
      * options map & makes them available via a getter, hence the need to look
      * at the component rather than the options
      */
-    private boolean shouldSplitResult(ComponentProxyComponent component) {
+    private static boolean shouldSplitResult(ComponentProxyComponent component) {
         if (! (component instanceof ODataComponent)) {
             return false;
         }

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataExtension.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataExtension.java
@@ -60,7 +60,7 @@ public class ODataMetaDataExtension extends AbstractMetaDataExtension implements
         return Optional.of(new DefaultMetaData(null, null, odataMetadata));
     }
 
-    private ODataMetadata buildMetadata(Map<String, Object> parameters) {
+    private static ODataMetadata buildMetadata(Map<String, Object> parameters) {
         ODataMetadata odataMetadata = new ODataMetadata();
 
         String serviceUrl = ConnectorOptions.extractOption(parameters, SERVICE_URI);
@@ -93,7 +93,7 @@ public class ODataMetaDataExtension extends AbstractMetaDataExtension implements
         return odataMetadata;
     }
 
-    private void extractEdmMetadata(ODataMetadata odataMetadata, Edm edm, String resourcePath) {
+    private static void extractEdmMetadata(ODataMetadata odataMetadata, Edm edm, String resourcePath) {
         if (ObjectHelper.isEmpty(resourcePath)) {
             LOG.warn("No method name with which to query OData service.");
             return;
@@ -112,7 +112,7 @@ public class ODataMetaDataExtension extends AbstractMetaDataExtension implements
         odataMetadata.setEntityProperties(properties);
     }
 
-    private void extractEdmNames(ODataMetadata odataMetadata, Edm edm) {
+    private static void extractEdmNames(ODataMetadata odataMetadata, Edm edm) {
         Set<EdmNamed> namedList = new HashSet<>();
         EdmEntityContainer container = edm.getEntityContainer();
         namedList.addAll(container.getEntitySets());
@@ -133,7 +133,7 @@ public class ODataMetaDataExtension extends AbstractMetaDataExtension implements
         odataMetadata.setEntityNames(names);
     }
 
-    private Edm requestEdm(Map<String, Object> parameters, String serviceUrl) {
+    private static Edm requestEdm(Map<String, Object> parameters, String serviceUrl) {
         ODataClient client = ODataClientFactory.getClient();
         HttpClientFactory factory = ODataUtil.newHttpFactory(parameters);
         client.getConfiguration().setHttpClientFactory(factory);

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
@@ -45,7 +45,7 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
     // This is the schema supported by current jackson API for {@link ObjectSchema}
     private static final String JSON_SCHEMA_URI = "http://json-schema.org/draft-03/schema#";
 
-    private JsonSchemaFactory factory = new JsonSchemaFactory();
+    private final JsonSchemaFactory factory = new JsonSchemaFactory();
 
     @Override
     protected MetaDataExtension resolveMetaDataExtension(CamelContext context, Class<? extends MetaDataExtension> metaDataExtensionClass, String componentId, String actionId) {
@@ -88,7 +88,7 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         return SyndesisMetadata.of(enrichedProperties);
     }
 
-    private SyndesisMetadata createSyndesisMetadata(
+    private static SyndesisMetadata createSyndesisMetadata(
                                        Map<String, List<PropertyPair>> enrichedProperties,
                                        DataShape.Builder inDataShapeBuilder,
                                        DataShape.Builder outDataShapeBuilder) {
@@ -96,7 +96,7 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
                                     inDataShapeBuilder.build(), outDataShapeBuilder.build());
     }
 
-    private ObjectSchema createEntitySchema() {
+    private static ObjectSchema createEntitySchema() {
         ObjectSchema entitySchema = new ObjectSchema();
         entitySchema.setTitle("ODATA_ENTITY_PROPERTIES");
         entitySchema.set$schema(JSON_SCHEMA_URI);
@@ -113,12 +113,12 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         }
     }
 
-    private boolean isSplit(Map<String, Object> properties) {
+    private static boolean isSplit(Map<String, Object> properties) {
         Object splitProp = ConnectorOptions.extractOption(properties, SPLIT_RESULT);
         return splitProp != null && Boolean.parseBoolean(splitProp.toString());
     }
 
-    private String serializeSpecification(ContainerTypeSchema schema) {
+    private static String serializeSpecification(ContainerTypeSchema schema) {
         try {
             return Json.writer().writeValueAsString(schema);
         } catch (JsonProcessingException e) {
@@ -126,7 +126,7 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         }
     }
 
-    private void applyEntitySchemaSpecification(ContainerTypeSchema schema, DataShape.Builder dataShapeBuilder) {
+    private static void applyEntitySchemaSpecification(ContainerTypeSchema schema, DataShape.Builder dataShapeBuilder) {
         final String specification = serializeSpecification(schema);
 
         dataShapeBuilder

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/verifier/ODataVerifierExtension.java
@@ -72,10 +72,10 @@ public class ODataVerifierExtension extends DefaultComponentVerifierExtension im
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyConnection).build();
+                .error(parameters, ODataVerifierExtension::verifyConnection).build();
     }
 
-    private void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyConnection(ResultBuilder builder, Map<String, Object> parameters) {
         if (!builder.build().getErrors().isEmpty()) {
             return;
         }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.http.HttpStatus;
@@ -54,7 +53,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration;
-import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
@@ -155,7 +153,7 @@ public class ODataSerializerTest extends AbstractODataTest {
         checkEntity(entity, TEST_ENUM);
     }
 
-    private String fetchReferenceEntity(String uri) throws Exception {
+    private static String fetchReferenceEntity(String uri) throws Exception {
         URI httpURI = URI.create(uri);
         ClientEntity olEntity = null;
         ODataRetrieveResponse<ClientEntity> response = null;
@@ -192,7 +190,7 @@ public class ODataSerializerTest extends AbstractODataTest {
         return outputShape.getSpecification();
     }
 
-    private void validateResultAgainstSchema(JsonNode jsonResultNode, JsonNode schemaNode) throws ProcessingException {
+    private static void validateResultAgainstSchema(JsonNode jsonResultNode, JsonNode schemaNode) throws ProcessingException {
         String schemaURI = "http://json-schema.org/schema#";
         LoadingConfiguration loadingConfiguration = LoadingConfiguration.newBuilder()
                 .preloadSchema(schemaURI, schemaNode)

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataUtilTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataUtilTests.java
@@ -59,7 +59,7 @@ public class ODataUtilTests extends AbstractODataTest {
         }
     }
 
-    private Edm requestEdm(String serviceUri) {
+    private static Edm requestEdm(String serviceUri) {
         ODataClient client = ODataClientFactory.getClient();
         HttpClientFactory factory = ODataUtil.newHttpFactory(new HashMap<>());
         client.getConfiguration().setHttpClientFactory(factory);

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
@@ -62,7 +62,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         }
     }
 
-    private Map<String, JsonSchema> checkShape(DataShape dataShape, Class<? extends ContainerTypeSchema> expectedShapeClass) throws IOException, JsonParseException, JsonMappingException {
+    private static Map<String, JsonSchema> checkShape(DataShape dataShape, Class<? extends ContainerTypeSchema> expectedShapeClass) throws IOException, JsonParseException, JsonMappingException {
         assertNotNull(dataShape);
 
         assertEquals(DataShapeKinds.JSON_SCHEMA, dataShape.getKind());
@@ -82,7 +82,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         return propSchemaMap;
     }
 
-    private void checkTestServerSchemaMap(Map<String, JsonSchema> schemaMap) {
+    private static void checkTestServerSchemaMap(Map<String, JsonSchema> schemaMap) {
         JsonSchema descSchema = schemaMap.get("Description");
         JsonSchema specSchema = schemaMap.get("Specification");
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
@@ -98,7 +98,7 @@ public class ODataCreateTests extends AbstractODataRouteTest {
         return odataAction;
     }
 
-    private Step createDirectStep() {
+    private static Step createDirectStep() {
         Step directStep = new Step.Builder()
             .stepKind(StepKind.endpoint)
             .action(new ConnectorAction.Builder()

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
@@ -99,7 +99,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
         return odataAction;
     }
 
-    private Step createDirectStep() {
+    private static Step createDirectStep() {
         Step directStep = new Step.Builder()
             .stepKind(StepKind.endpoint)
             .action(new ConnectorAction.Builder()

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataReadTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataReadTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import java.util.Map;
-import org.apache.camel.Endpoint;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.direct.DirectEndpoint;
@@ -105,7 +104,7 @@ public class ODataReadTests extends AbstractODataRouteTest {
         return odataAction;
     }
 
-    private Step createDirectStep() {
+    private static Step createDirectStep() {
         Step directStep = new Step.Builder()
             .stepKind(StepKind.endpoint)
             .action(new ConnectorAction.Builder()

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -155,7 +155,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         return odataAction;
     }
 
-    private Step createDirectStep() {
+    private static Step createDirectStep() {
         Step directStep = new Step.Builder()
             .stepKind(StepKind.endpoint)
             .action(new ConnectorAction.Builder()
@@ -168,7 +168,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         return directStep;
     }
 
-    private String getPropertyFromEntity(String keyPredicate, String propertyName) {
+    private static String getPropertyFromEntity(String keyPredicate, String propertyName) {
         ClientEntity resultEntity = defaultTestServer.getData(keyPredicate);
         assertNotNull(resultEntity);
         ClientProperty property = resultEntity.getProperty(propertyName);
@@ -337,7 +337,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
             .hasMessageContaining("No Key Predicate available");
     }
 
-    private String queryProperty(String serviceURI, String resourcePath, String keyPredicate, String property) {
+    private static String queryProperty(String serviceURI, String resourcePath, String keyPredicate, String property) {
         ClientEntity olEntity = null;
         ODataRetrieveResponse<ClientEntity> response = null;
         try {
@@ -359,7 +359,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         }
     }
 
-    private void updateProperty(String serviceURI, String resourcePath, String keyPredicate, String property, String value) throws Exception {
+    private static void updateProperty(String serviceURI, String resourcePath, String keyPredicate, String property, String value) throws Exception {
         URI httpURI = URI.create(serviceURI + FORWARD_SLASH +
                                  resourcePath + OPEN_BRACKET +
                                  QUOTE_MARK + keyPredicate + QUOTE_MARK +

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/FilterExpressionVisitor.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/FilterExpressionVisitor.java
@@ -152,7 +152,7 @@ public class FilterExpressionVisitor implements ExpressionVisitor<Object> {
       }
   }
 
-    private Object evaluateBooleanOperation(BinaryOperatorKind operator, Object left, Object right)
+    private static Object evaluateBooleanOperation(BinaryOperatorKind operator, Object left, Object right)
         throws ODataApplicationException {
 
       // First check that both operands are of type Boolean
@@ -173,7 +173,7 @@ public class FilterExpressionVisitor implements ExpressionVisitor<Object> {
       }
     }
 
-  private Object evaluateComparisonOperation(BinaryOperatorKind operator, Object left, Object right)
+  private static Object evaluateComparisonOperation(BinaryOperatorKind operator, Object left, Object right)
       throws ODataApplicationException {
 
     // All types in our tutorial supports all logical operations, but we have to make sure that the types are equals
@@ -212,7 +212,7 @@ public class FilterExpressionVisitor implements ExpressionVisitor<Object> {
     }
   }
 
-  private Object evaluateArithmeticOperation(BinaryOperatorKind operator, Object left,
+  private static Object evaluateArithmeticOperation(BinaryOperatorKind operator, Object left,
       Object right) throws ODataApplicationException {
 
       // First check if the type of both operands is numerical

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
@@ -159,7 +159,7 @@ public class ODataTestServer extends Server implements ODataConstants {
         initServer(sslContext, userName);
     }
 
-    private int extractPort(String property) {
+    private static int extractPort(String property) {
         String portProperty = System.getProperty(property);
         if (portProperty == null) {
             LOG.warn("Server port option requested but no port specified using property {}. "
@@ -224,13 +224,13 @@ public class ODataTestServer extends Server implements ODataConstants {
         return store;
     }
 
-    private KeyManager[] serverKeyManagers(KeyStore store, final char[] password) throws Exception {
+    private static KeyManager[] serverKeyManagers(KeyStore store, final char[] password) throws Exception {
            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
            keyManagerFactory.init(store, password);
            return keyManagerFactory.getKeyManagers();
        }
 
-    private TrustManager[] serverTrustManagers(KeyStore store) throws Exception {
+    private static TrustManager[] serverTrustManagers(KeyStore store) throws Exception {
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(store);
         return trustManagerFactory.getTrustManagers();

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEntityCollectionProcessor.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEntityCollectionProcessor.java
@@ -130,7 +130,7 @@ public class ProductsEntityCollectionProcessor implements EntityCollectionProces
         response.setHeader(HttpHeader.CONTENT_TYPE, responseFormat.toContentTypeString());
     }
 
-    private EntityCollection applyQueryOptions(UriInfo uriInfo, List<Entity> entityList, EntityCollection returnEntityCollection) throws ODataApplicationException {
+    private static EntityCollection applyQueryOptions(UriInfo uriInfo, List<Entity> entityList, EntityCollection returnEntityCollection) throws ODataApplicationException {
         // handle $skip
         SkipOption skipOption = uriInfo.getSkipOption();
         if (skipOption != null) {
@@ -210,7 +210,7 @@ public class ProductsEntityCollectionProcessor implements EntityCollectionProces
         return returnEntityCollection;
     }
 
-    private void applyOrderby(UriInfo uriInfo, EntityCollection entityCollection) {
+    private static void applyOrderby(UriInfo uriInfo, EntityCollection entityCollection) {
         List<Entity> entityList = entityCollection.getEntities();
 
         OrderByOption orderByOption = uriInfo.getOrderByOption();

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Storage.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/Storage.java
@@ -38,24 +38,18 @@ import org.assertj.core.util.Arrays;
 
 public class Storage implements ODataServerConstants {
 
-    private static Object storageLock = new Object();
-
-    private static Storage storage;
+    private static class Lazy {
+        private static final Storage INSTANCE = new Storage();
+    }
 
     private List<Entity> productList;
 
     public static Storage getInstance() {
-        synchronized(storageLock) {
-            if (storage == null) {
-                storage = new Storage();
-            }
-        }
-
-        return storage;
+        return Lazy.INSTANCE;
     }
 
     public static void dispose() {
-        storage = null;
+        Lazy.INSTANCE.productList.clear();
     }
 
     private Storage() {
@@ -76,7 +70,7 @@ public class Storage implements ODataServerConstants {
     public EntityCollection readEntitySetData(EdmEntitySet edmEntitySet) throws ODataApplicationException {
 
         // actually, this is only required if we have more than one Entity Sets
-        if (edmEntitySet.getName().equals(ProductsEdmProvider.ES_PRODUCTS_NAME)) {
+        if (edmEntitySet.getName().equals(ODataServerConstants.ES_PRODUCTS_NAME)) {
             return getProducts();
         }
 
@@ -88,7 +82,7 @@ public class Storage implements ODataServerConstants {
         EdmEntityType edmEntityType = edmEntitySet.getEntityType();
 
         // actually, this is only required if we have more than one Entity Type
-        if (edmEntityType.getName().equals(ProductsEdmProvider.ET_PRODUCT_NAME)) {
+        if (edmEntityType.getName().equals(ODataServerConstants.ET_PRODUCT_NAME)) {
             return getProduct(edmEntityType, keyParams);
         }
 
@@ -99,7 +93,7 @@ public class Storage implements ODataServerConstants {
         EdmEntityType edmEntityType = edmEntitySet.getEntityType();
 
         // actually, this is only required if we have more than one Entity Type
-        if (edmEntityType.getName().equals(ProductsEdmProvider.ET_PRODUCT_NAME)) {
+        if (edmEntityType.getName().equals(ODataServerConstants.ET_PRODUCT_NAME)) {
             return createProduct(entityToCreate);
         }
 
@@ -116,7 +110,7 @@ public class Storage implements ODataServerConstants {
         EdmEntityType edmEntityType = edmEntitySet.getEntityType();
 
         // actually, this is only required if we have more than one Entity Type
-        if (edmEntityType.getName().equals(ProductsEdmProvider.ET_PRODUCT_NAME)) {
+        if (edmEntityType.getName().equals(ODataServerConstants.ET_PRODUCT_NAME)) {
             updateProduct(edmEntityType, keyParams, updateEntity, httpMethod);
         }
     }
@@ -125,7 +119,7 @@ public class Storage implements ODataServerConstants {
         EdmEntityType edmEntityType = edmEntitySet.getEntityType();
 
         // actually, this is only required if we have more than one Entity Type
-        if (edmEntityType.getName().equals(ProductsEdmProvider.ET_PRODUCT_NAME)) {
+        if (edmEntityType.getName().equals(ODataServerConstants.ET_PRODUCT_NAME)) {
             deleteProduct(edmEntityType, keyParams);
         }
     }
@@ -159,7 +153,7 @@ public class Storage implements ODataServerConstants {
         return requestedEntity;
     }
 
-    private URI createId(String entitySetName, Object id) {
+    private static URI createId(String entitySetName, Object id) {
         try {
             return new URI(entitySetName + OPEN_BRACKET + String.valueOf(id) + CLOSE_BRACKET);
         } catch (URISyntaxException e) {
@@ -248,7 +242,7 @@ public class Storage implements ODataServerConstants {
 
     /* HELPER */
 
-    private boolean isKey(EdmEntityType edmEntityType, String propertyName) {
+    private static boolean isKey(EdmEntityType edmEntityType, String propertyName) {
         List<EdmKeyPropertyRef> keyPropertyRefs = edmEntityType.getKeyPropertyRefs();
         for (EdmKeyPropertyRef propRef : keyPropertyRefs) {
             String keyPropertyName = propRef.getName();
@@ -259,7 +253,7 @@ public class Storage implements ODataServerConstants {
         return false;
     }
 
-    private ComplexValue createSpec(String productType, String detail1, String detail2, int powerType) {
+    private static ComplexValue createSpec(String productType, String detail1, String detail2, int powerType) {
         ComplexValue complexValue = new ComplexValue();
         List<Property> complexValueValue = complexValue.getValue();
         complexValueValue.add(new Property(
@@ -277,7 +271,7 @@ public class Storage implements ODataServerConstants {
         return complexValue;
     }
 
-    private Entity createEntity(int id, String name, String description, String[] serials, ComplexValue spec) {
+    private static Entity createEntity(int id, String name, String description, String[] serials, ComplexValue spec) {
         Entity e = new Entity()
             .addProperty(new Property(
                                   EdmPrimitiveTypeKind.Int32.getFullQualifiedName().toString(),

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetaDataExtension.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetaDataExtension.java
@@ -177,7 +177,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
             .query("sysparm_exclude_reference_link", "true")
             .query("sysparm_fields", "name%2Csys_id")
             .query("sysparm_query", "name=sys_import_set_row")
-            .trasform(HttpMethod.GET, this::findResultNode);
+            .trasform(HttpMethod.GET, ServiceNowMetaDataExtension::findResultNode);
 
         if (response.isPresent()) {
             final JsonNode node = response.get();
@@ -196,7 +196,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
                 .query("sysparm_exclude_reference_link", "true")
                 .query("sysparm_fields", "name%2Csys_name")
                 .queryF("sysparm_query", "super_class=%s", sysId.textValue())
-                .trasform(HttpMethod.GET, this::findResultNode);
+                .trasform(HttpMethod.GET, ServiceNowMetaDataExtension::findResultNode);
 
             if (response.isPresent()) {
                 final ObjectNode root = context.getConfiguration().getOrCreateMapper().createObjectNode();
@@ -234,7 +234,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
             .query("sysparm_exclude_reference_link", "true")
             .query("sysparm_fields", "name%2Csys_id")
             .query("sysparm_query", "name=sys_import_set_row")
-            .trasform(HttpMethod.GET, this::findResultNode);
+            .trasform(HttpMethod.GET, ServiceNowMetaDataExtension::findResultNode);
 
         if (response.isPresent()) {
             final JsonNode node = response.get();
@@ -248,7 +248,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
                 .path("sys_db_object")
                 .query("sysparm_exclude_reference_link", "true")
                 .query("sysparm_fields", "name%2Csys_name%2Csuper_class")
-                .trasform(HttpMethod.GET, this::findResultNode);
+                .trasform(HttpMethod.GET, ServiceNowMetaDataExtension::findResultNode);
 
             if (response.isPresent()) {
                 final ObjectNode root = context.getConfiguration().getOrCreateMapper().createObjectNode();
@@ -342,7 +342,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
     // ********************************
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-    private void loadDictionary(MetaContext context, String name, ObjectNode root) throws Exception {
+    private static void loadDictionary(MetaContext context, String name, ObjectNode root) throws Exception {
         String offset = "0";
 
         while (true) {
@@ -371,7 +371,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
     }
 
     @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
-    private void processDictionaryNode(MetaContext context, ObjectNode root, JsonNode node) {
+    private static void processDictionaryNode(MetaContext context, ObjectNode root, JsonNode node) {
         if (node.hasNonNull("element")) {
             final String id = node.get("element").asText();
 
@@ -490,7 +490,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
      * Determine the hierarchy of a table by inspecting the super_class attribute.
      */
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-    private List<String> getObjectHierarchy(MetaContext context) throws Exception {
+    private static List<String> getObjectHierarchy(MetaContext context) throws Exception {
         List<String> hierarchy = new ArrayList<>();
         String query = String.format("name=%s", context.getObjectName());
 
@@ -504,7 +504,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
                 .query("sysparm_exclude_reference_link", "true")
                 .query("sysparm_fields", "name%2Csuper_class")
                 .query("sysparm_query", query)
-                .trasform(HttpMethod.GET, this::findResultNode);
+                .trasform(HttpMethod.GET, ServiceNowMetaDataExtension::findResultNode);
 
             if (response.isPresent()) {
                 final JsonNode node = response.get();
@@ -525,7 +525,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
         return hierarchy;
     }
 
-    private void processResult(JsonNode node, Consumer<JsonNode> consumer) {
+    private static void processResult(JsonNode node, Consumer<JsonNode> consumer) {
         if (node.isArray()) {
             Iterator<JsonNode> it = node.elements();
             while (it.hasNext()) {
@@ -536,7 +536,7 @@ final class ServiceNowMetaDataExtension extends AbstractMetaDataExtension {
         }
     }
 
-    private Optional<JsonNode> findResultNode(Response response) {
+    private static Optional<JsonNode> findResultNode(Response response) {
         if (ObjectHelper.isNotEmpty(response.getHeaderString(HttpHeaders.CONTENT_TYPE))) {
             JsonNode root = response.readEntity(JsonNode.class);
             if (root != null) {

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/ServiceNowMetadataRetrieval.java
@@ -81,14 +81,14 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
             }
 
             return super.fetch(context, componentId, actionId, props);
-        } else {
-            Map<String, Object> props = new HashMap<>(properties);
-            props.put("objectType", ServiceNowConstants.RESOURCE_TABLE);
-            props.put("objectName", table);
-            props.put("metaType", "definition");
-
-            return super.fetch(context, componentId, actionId, props);
         }
+
+        Map<String, Object> props = new HashMap<>(properties);
+        props.put("objectType", ServiceNowConstants.RESOURCE_TABLE);
+        props.put("objectName", table);
+        props.put("metaType", "definition");
+
+        return super.fetch(context, componentId, actionId, props);
     }
 
     @Override
@@ -111,7 +111,7 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
         return SyndesisMetadata.EMPTY;
     }
 
-    private SyndesisMetadata adaptTableDefinitionMetadata(String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
+    private static SyndesisMetadata adaptTableDefinitionMetadata(String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
         try {
             final Object table = ConnectorOptions.extractOption(properties, "table");
             final ObjectNode schema = (ObjectNode) metadata.getPayload();
@@ -140,7 +140,7 @@ public final class ServiceNowMetadataRetrieval extends ComponentMetadataRetrieva
         return SyndesisMetadata.EMPTY;
     }
 
-    private SyndesisMetadata adaptTableListMetadata(MetaDataExtension.MetaData metadata) {
+    private static SyndesisMetadata adaptTableListMetadata(MetaDataExtension.MetaData metadata) {
         try {
             final JsonNode payload = metadata.getPayload(JsonNode.class);
             final List<PropertyPair> tables = new ArrayList<>();

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/customizers/ServiceNowImportSetCustomizer.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/customizers/ServiceNowImportSetCustomizer.java
@@ -26,7 +26,7 @@ import org.apache.camel.component.servicenow.model.ImportSetResult;
 public class ServiceNowImportSetCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> properties) {
-        component.setBeforeProducer(this::beforeProducer);
+        component.setBeforeProducer(ServiceNowImportSetCustomizer::beforeProducer);
     }
 
     //
@@ -35,7 +35,7 @@ public class ServiceNowImportSetCustomizer implements ComponentProxyCustomizer {
     //
     // https://github.com/syndesisio/syndesis/issues/2819
     //
-    private void beforeProducer(final Exchange exchange) {
+    private static void beforeProducer(final Exchange exchange) {
         exchange.getIn().setHeader(ServiceNowConstants.RESOURCE, ServiceNowConstants.RESOURCE_IMPORT);
         exchange.getIn().setHeader(ServiceNowConstants.ACTION, ServiceNowConstants.ACTION_CREATE);
         exchange.getIn().setHeader(ServiceNowConstants.RETRIEVE_TARGET_RECORD, false);

--- a/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/customizers/ServiceNowTableGetCustomizer.java
+++ b/app/connector/servicenow/src/main/java/io/syndesis/connector/servicenow/customizers/ServiceNowTableGetCustomizer.java
@@ -57,7 +57,7 @@ public class ServiceNowTableGetCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> properties) {
         component.setBeforeProducer(this::beforeProducer);
-        component.setAfterProducer(this::afterProducer);
+        component.setAfterProducer(ServiceNowTableGetCustomizer::afterProducer);
     }
 
     //
@@ -92,7 +92,7 @@ public class ServiceNowTableGetCustomizer implements ComponentProxyCustomizer {
         }
     }
 
-    private void afterProducer(final Exchange exchange) {
+    private static void afterProducer(final Exchange exchange) {
         final Message message = exchange.getIn();
         final Object body = message.getBody();
 

--- a/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
+++ b/app/connector/sftp/src/main/java/io/syndesis/connector/sftp/SftpVerifierExtension.java
@@ -56,10 +56,10 @@ public class SftpVerifierExtension extends DefaultComponentVerifierExtension {
     @Override
     protected Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-                .error(parameters, this::verifyCredentials).build();
+                .error(parameters, SftpVerifierExtension::verifyCredentials).build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
 
         final String host = ConnectorOptions.extractOption(parameters, "host");
         final Integer port = ConnectorOptions.extractOptionAndMap(parameters, "port", Integer::parseInt, 22);

--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackChannelCustomizer.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackChannelCustomizer.java
@@ -26,11 +26,11 @@ public class SlackChannelCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setBeforeProducer(this::beforeProducer);
+        component.setBeforeProducer(SlackChannelCustomizer::beforeProducer);
         sanitizeUserOrChannel(options);
     }
 
-    private void sanitizeUserOrChannel(Map<String, Object> options) {
+    private static void sanitizeUserOrChannel(Map<String, Object> options) {
         String username = ConnectorOptions.extractOption(options, "receiver");
         String channel = ConnectorOptions.popOption(options, "channel");
 
@@ -49,7 +49,7 @@ public class SlackChannelCustomizer implements ComponentProxyCustomizer {
         }
     }
 
-    private void beforeProducer(Exchange exchange) {
+    private static void beforeProducer(Exchange exchange) {
 
         final Message in = exchange.getIn();
         final SlackPlainMessage message = in.getBody(SlackPlainMessage.class);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorMetaDataExtension.java
@@ -67,7 +67,7 @@ public class SqlConnectorMetaDataExtension extends AbstractMetaDataExtension {
     // Helpers
     // *********************************
 
-    private SqlStatementMetaData parseStatement(SqlStatementParser parser) throws SQLException {
+    private static SqlStatementMetaData parseStatement(SqlStatementParser parser) throws SQLException {
         return parser.parse();
     }
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlConnectorVerifierExtension.java
@@ -110,11 +110,11 @@ public class SqlConnectorVerifierExtension extends DefaultComponentVerifierExten
     @Override
     public Result verifyConnectivity(Map<String, Object> parameters) {
         return ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY)
-            .error(parameters, this::verifyCredentials)
+            .error(parameters, SqlConnectorVerifierExtension::verifyCredentials)
             .build();
     }
 
-    private void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
+    private static void verifyCredentials(ResultBuilder builder, Map<String, Object> parameters) {
         try ( Connection connection = SqlSupport.createConnection(parameters)) {
             if (connection == null) {
                 throw new SQLException("No Connection");

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
@@ -229,7 +229,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
      * @param procedureMap
      * @return list of property pairs containing the stored procedure names
      */
-    private List<PropertyPair> obtainToProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
+    private static List<PropertyPair> obtainToProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
         final List<PropertyPair> ppList = new ArrayList<>();
         for (final String storedProcedureName : procedureMap.keySet()) {
             final PropertyPair pp = new PropertyPair(storedProcedureName, storedProcedureName);
@@ -244,7 +244,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
      * @param procedureMap
      * @return list of property pairs containing the stored procedure names
      */
-    private List<PropertyPair> obtainFromProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
+    private static List<PropertyPair> obtainFromProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
         final List<PropertyPair> ppList = new ArrayList<>();
         for (final StoredProcedureMetadata storedProcedure : procedureMap.values() ) {
             if (! containsInputParams(storedProcedure)) {
@@ -260,7 +260,7 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
      * @param storedProcedure
      * @return boolean - true if input params present, false if no input params.
      */
-    private boolean containsInputParams(StoredProcedureMetadata storedProcedure) {
+    private static boolean containsInputParams(StoredProcedureMetadata storedProcedure) {
         if (storedProcedure.getColumnList() != null && !storedProcedure.getColumnList().isEmpty()) {
             for (final StoredProcedureColumn column : storedProcedure.getColumnList()) {
                 if (column.getMode().equals(ColumnMode.IN) || column.getMode().equals(ColumnMode.INOUT)) {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbAdapter.java
@@ -38,7 +38,7 @@ public class DbAdapter {
         return this.db;
     }
 
-    private Db getDb(Connection conn) throws SQLException {
+    private static Db getDb(Connection conn) throws SQLException {
         DbEnum dbEnum =  DbEnum.fromName(conn.getMetaData().getDatabaseProductName());
         switch (dbEnum) {
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartStoredConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartStoredConnectorCustomizer.java
@@ -25,10 +25,10 @@ import org.apache.camel.Exchange;
 public final class SqlStartStoredConnectorCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setAfterProducer(this::doAfterProducer);
+        component.setAfterProducer(SqlStartStoredConnectorCustomizer::doAfterProducer);
     }
 
-    private void doAfterProducer(Exchange exchange) {
+    private static void doAfterProducer(Exchange exchange) {
         @SuppressWarnings("unchecked")
         final Map<String, Object> body = exchange.getIn().getBody(Map.class);
         final String jsonBean = JSONBeanUtil.toJSONBean(body);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStoredConnectorCustomizer.java
@@ -26,11 +26,11 @@ import org.apache.camel.Exchange;
 public final class SqlStoredConnectorCustomizer implements ComponentProxyCustomizer {
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setBeforeProducer(this::doBeforeProducer);
-        component.setAfterProducer(this::doAfterProducer);
+        component.setBeforeProducer(SqlStoredConnectorCustomizer::doBeforeProducer);
+        component.setAfterProducer(SqlStoredConnectorCustomizer::doAfterProducer);
     }
 
-    private void doBeforeProducer(Exchange exchange) {
+    private static void doBeforeProducer(Exchange exchange) {
         final String body = exchange.getIn().getBody(String.class);
         if (body != null) {
             final Properties properties = JSONBeanUtil.parsePropertiesFromJSONBean(body);
@@ -38,7 +38,7 @@ public final class SqlStoredConnectorCustomizer implements ComponentProxyCustomi
         }
     }
 
-    private void doAfterProducer(Exchange exchange) {
+    private static void doAfterProducer(Exchange exchange) {
         @SuppressWarnings("unchecked")
         final Map<String, Object> body = exchange.getIn().getBody(Map.class);
         final String jsonBean = JSONBeanUtil.toJSONBean(body);

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadata.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadata.java
@@ -59,12 +59,6 @@ public final class SyndesisMetadata {
     // Helpers
     // *********************
 
-    public static SyndesisMetadata of(Map<String, List<PropertyPair>> properties) {
-        ObjectHelper.notNull(properties, "Properties");
-
-        return new SyndesisMetadata(properties, null, null);
-    }
-
     public static SyndesisMetadata inOnly(DataShape dataShape) {
         ObjectHelper.notNull(dataShape, "DataShape");
 
@@ -75,6 +69,12 @@ public final class SyndesisMetadata {
         ObjectHelper.notNull(dataShape, "DataShape");
 
         return new SyndesisMetadata(Collections.emptyMap(), null, dataShape);
+    }
+
+    public static SyndesisMetadata of(Map<String, List<PropertyPair>> properties) {
+        ObjectHelper.notNull(properties, "Properties");
+
+        return new SyndesisMetadata(properties, null, null);
     }
 
     public static SyndesisMetadata of(DataShape dataShape) {

--- a/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/TwitterCustomizer.java
+++ b/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/TwitterCustomizer.java
@@ -27,12 +27,12 @@ public class TwitterCustomizer implements ComponentProxyCustomizer {
 
     @Override
     public void customize(ComponentProxyComponent component, Map<String, Object> options) {
-        component.setAfterProducer(this::doAfterProducer);
+        component.setAfterProducer(TwitterCustomizer::doAfterProducer);
     }
 
-	private void doAfterProducer(Exchange exchange) {
+    private static void doAfterProducer(Exchange exchange) {
         if (exchange.getException() != null) {
-        	throw SyndesisConnectorException.wrap(TwitterErrorCategory.TWITTER_CONNECTOR_ERROR, exchange.getException());
+            throw SyndesisConnectorException.wrap(TwitterErrorCategory.TWITTER_CONNECTOR_ERROR, exchange.getException());
         }
     }
 }

--- a/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
+++ b/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookConnectorCustomizer.java
@@ -80,10 +80,10 @@ public class WebhookConnectorCustomizer implements ComponentProxyCustomizer, Cam
         component.setBeforeConsumer(Pipeline.newInstance(camelContext, beforeConsumers));
 
         // Unconditionally we remove output in 7.1 release
-        component.setAfterConsumer(this::removeOutput);
+        component.setAfterConsumer(WebhookConnectorCustomizer::removeOutput);
     }
 
-    private void removeOutput(final Exchange exchange) {
+    private static void removeOutput(final Exchange exchange) {
         exchange.getOut().setBody("");
         exchange.getOut().removeHeaders("*");
 

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzer.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzer.java
@@ -82,7 +82,7 @@ class DefaultBinaryExtensionAnalyzer implements BinaryExtensionAnalyzer {
         return allowedIconPaths.get(path);
     }
 
-    private Extension doGetExtension(InputStream binaryExtension) throws IOException {
+    private static Extension doGetExtension(InputStream binaryExtension) throws IOException {
         Optional<InputStream> entry = readPath(binaryExtension, MANIFEST_LOCATION);
         if (!entry.isPresent()) {
             throw new IllegalArgumentException("Cannot find manifest file (" + MANIFEST_LOCATION + ") inside JAR");
@@ -97,7 +97,7 @@ class DefaultBinaryExtensionAnalyzer implements BinaryExtensionAnalyzer {
     }
 
     @SuppressWarnings("PMD.EmptyCatchBlock")
-    private Optional<InputStream> readPath(InputStream binaryExtension, String path) {
+    private static Optional<InputStream> readPath(InputStream binaryExtension, String path) {
         JarInputStream jar;
         try {
             jar = new JarInputStream(binaryExtension);

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
@@ -32,7 +32,7 @@ class DefaultExtensionConverter implements ExtensionConverter {
      *
      * Version of the public model is assumed to be latest ({@link ExtensionConverter#getCurrentSchemaVersion()}).
      */
-    private ObjectNode convertInternalToPublicModel(ObjectNode tree) {
+    private static ObjectNode convertInternalToPublicModel(ObjectNode tree) {
         return tree;
     }
 
@@ -41,7 +41,7 @@ class DefaultExtensionConverter implements ExtensionConverter {
      *
      * Version of the public model is assumed to be latest ({@link ExtensionConverter#getCurrentSchemaVersion()}).
      */
-    private ObjectNode convertPublicToInternalModel(ObjectNode tree) {
+    private static ObjectNode convertPublicToInternalModel(ObjectNode tree) {
         return tree;
     }
 
@@ -50,7 +50,7 @@ class DefaultExtensionConverter implements ExtensionConverter {
      *
      * Normally public versions are backward compatible, so this method is likely to remain empty.
      */
-    private ObjectNode convertToLatestSchemaVersion(ObjectNode tree, String sourceVersion) {
+    private static ObjectNode convertToLatestSchemaVersion(ObjectNode tree, String sourceVersion) {
         if ("v0".equals(sourceVersion)) {
             // Custom transformations here
             return tree;
@@ -72,7 +72,7 @@ class DefaultExtensionConverter implements ExtensionConverter {
         return updateToLatestVersion(publicTree);
     }
 
-    private ObjectNode updateToLatestVersion(ObjectNode tree) {
+    private static ObjectNode updateToLatestVersion(ObjectNode tree) {
         Optional<String> treeVersion = getSchemaVersion(tree);
         if (treeVersion.isPresent() && !ExtensionConverter.getCurrentSchemaVersion().equals(treeVersion.get())) {
             ObjectNode converted = convertToLatestSchemaVersion(tree, treeVersion.get());
@@ -84,23 +84,23 @@ class DefaultExtensionConverter implements ExtensionConverter {
         return tree;
     }
 
-    private Optional<String> getSchemaVersion(ObjectNode tree) {
+    private static Optional<String> getSchemaVersion(ObjectNode tree) {
         return Optional.ofNullable(tree)
                 .flatMap(t -> Optional.ofNullable(t.get(SCHEMA_VERSION_FIELD)))
                 .flatMap(t -> Optional.ofNullable(t.textValue()));
     }
 
-    private Extension unmarshal(JsonNode node) throws IOException {
+    private static Extension unmarshal(JsonNode node) throws IOException {
         byte[] bytes = Json.writer().writeValueAsBytes(node);
         return Json.reader().forType(Extension.class).readValue(bytes);
     }
 
-    private ObjectNode marshal(Extension extension) throws IOException {
+    private static ObjectNode marshal(Extension extension) throws IOException {
         byte[] bytes = Json.writer().writeValueAsBytes(extension);
         return Json.reader().forType(ObjectNode.class).readValue(bytes);
     }
 
-    private ObjectNode toObjectNode(JsonNode tree) {
+    private static ObjectNode toObjectNode(JsonNode tree) {
         if (!(tree instanceof ObjectNode)) {
             throw new IllegalArgumentException("The JSON document is not an object: " + tree);
         }

--- a/app/integration/api/src/test/java/io/syndesis/integration/api/IntegrationResourceManagerTest.java
+++ b/app/integration/api/src/test/java/io/syndesis/integration/api/IntegrationResourceManagerTest.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.ResourceBundle;
 
 import io.syndesis.common.model.action.Action;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -186,7 +185,7 @@ public class IntegrationResourceManagerTest {
     }
 
 
-    private Integration newIntegration(Step... steps) {
+    private static Integration newIntegration(Step... steps) {
         return new Integration.Builder()
             .id("test-integration")
             .name("Test Integration")
@@ -197,7 +196,7 @@ public class IntegrationResourceManagerTest {
             .build();
     }
 
-    private Connector getHttpConnector() {
+    private static Connector getHttpConnector() {
         return new Connector.Builder()
             .id("http")
             .putProperty(
@@ -233,7 +232,7 @@ public class IntegrationResourceManagerTest {
 
     }
 
-    private ConnectorAction getHttpPostAction() {
+    private static ConnectorAction getHttpPostAction() {
 
         return new ConnectorAction.Builder()
             .id("http-post-action")
@@ -244,7 +243,7 @@ public class IntegrationResourceManagerTest {
             .build();
     }
 
-    private ConnectorAction getHttpGetAction() {
+    private static ConnectorAction getHttpGetAction() {
         return new ConnectorAction.Builder()
             .id("http-get-action")
             .descriptor(new ConnectorDescriptor.Builder()
@@ -255,7 +254,7 @@ public class IntegrationResourceManagerTest {
             .build();
     }
 
-    private Action getPeriodicTimerAction() {
+    private static Action getPeriodicTimerAction() {
         return new ConnectorAction.Builder()
             .id("periodic-timer-action")
             .descriptor(new ConnectorDescriptor.Builder()
@@ -265,7 +264,7 @@ public class IntegrationResourceManagerTest {
             .build();
     }
 
-    private Connector getTimerConnector() {
+    private static Connector getTimerConnector() {
         return new Connector.Builder()
             .id("timer")
             .putProperty(
@@ -278,8 +277,7 @@ public class IntegrationResourceManagerTest {
             .build();
     }
 
-
-    private IntegrationResourceManager createResourceManager() {
+    private static IntegrationResourceManager createResourceManager() {
         return new IntegrationResourceManager() {
             @Override
             public Optional<Connector> loadConnector(String id) {

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
@@ -399,13 +399,13 @@ public class ComponentProxyComponent extends DefaultComponent {
         return endpointOptions;
     }
 
-    private <T> void doAddOptions(Map<String, T> destination, Map<String, T> options) {
+    private static <T> void doAddOptions(Map<String, T> destination, Map<String, T> options) {
         options.forEach(
             (k, v) -> doAddOption(destination, k, v)
         );
     }
 
-    private <T> void doAddOption(Map<String, T> options, String name, T value) {
+    private static <T> void doAddOption(Map<String, T> options, String name, T value) {
         LOGGER.trace("Adding option: {}={}", name, value);
         T val = options.put(name, value);
         if (val != null) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
@@ -347,7 +347,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
             .setHeader(IntegrationLoggingConstants.STEP_ID, constant(stepId));
     }
 
-    private String getStepId(String stepId) {
+    private static String getStepId(String stepId) {
         return String.format("step:%s", stepId);
     }
 
@@ -374,9 +374,9 @@ public class IntegrationRouteBuilder extends RouteBuilder {
                 flow.getId().ifPresent(route::setId);
 
                 return route;
-            } else {
-                throw new IllegalArgumentException("Unsupported scheduler type: " + scheduler.getType());
             }
+
+            throw new IllegalArgumentException("Unsupported scheduler type: " + scheduler.getType());
         }
 
         return null;
@@ -422,7 +422,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         throw new IllegalStateException("Unsupported step kind: " + step.getStepKind());
     }
 
-    private Object mandatoryLoadResource(CamelContext context, String resource) {
+    private static Object mandatoryLoadResource(CamelContext context, String resource) {
         Object instance = null;
 
         if (resource.startsWith("classpath:")) {
@@ -445,7 +445,7 @@ public class IntegrationRouteBuilder extends RouteBuilder {
         return instance;
     }
 
-    private RoutesDefinition mandatoryConvertToRoutesDefinition(String resource, Object instance)  {
+    private static RoutesDefinition mandatoryConvertToRoutesDefinition(String resource, Object instance)  {
         final RoutesDefinition definitions;
 
         if (instance instanceof RoutesDefinition) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
@@ -78,7 +78,7 @@ public class ChoiceStepHandler implements IntegrationStepHandler {
         return Optional.of(route);
     }
 
-    private Predicate getPredicate(String conditionExpression, CamelContext context) {
+    private static Predicate getPredicate(String conditionExpression, CamelContext context) {
         return new JsonSimplePredicate(conditionExpression, context);
     }
 
@@ -94,11 +94,11 @@ public class ChoiceStepHandler implements IntegrationStepHandler {
      * @param flowId
      * @return
      */
-    private String getEndpointUri(String routingScheme, String flowId) {
+    private static String getEndpointUri(String routingScheme, String flowId) {
         return routingScheme + ":" + flowId;
     }
 
-    private List<FlowOption> extractFlows(String flowMappings) {
+    private static List<FlowOption> extractFlows(String flowMappings) {
         try {
             if (flowMappings == null || flowMappings.isEmpty()) {
                 return Collections.emptyList();

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
@@ -153,7 +153,7 @@ public class ConnectorStepHandler implements IntegrationStepHandler, Integration
     // Helpers
     // *************************
 
-    private ComponentProxyComponent resolveComponent(String componentId, String componentScheme, CamelContext context, Connector connector, ConnectorDescriptor descriptor) {
+    private static ComponentProxyComponent resolveComponent(String componentId, String componentScheme, CamelContext context, Connector connector, ConnectorDescriptor descriptor) {
         ComponentProxyFactory factory = ComponentProxyComponent::new;
 
         if (descriptor.getConnectorFactory().isPresent()) {
@@ -165,7 +165,7 @@ public class ConnectorStepHandler implements IntegrationStepHandler, Integration
         return factory.newInstance(componentId, componentScheme);
     }
 
-    private Optional<ComponentProxyFactory> resolveComponentProxyFactory(CamelContext context, Optional<String> componentProxyFactory) {
+    private static Optional<ComponentProxyFactory> resolveComponentProxyFactory(CamelContext context, Optional<String> componentProxyFactory) {
         ComponentProxyFactory factory = null;
 
         if (componentProxyFactory.isPresent()) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
@@ -76,7 +76,7 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
      * @param dataSources
      * @return
      */
-    private void addJsonTypeSourceProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
+    private static void addJsonTypeSourceProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
         List<Map<String, Object>> sourceDocuments = dataSources.stream()
                                             .filter(s -> "SOURCE".equals(s.get("dataSourceType")))
                                             .collect(Collectors.toList());
@@ -99,7 +99,7 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
      * @param dataSources
      * @return
      */
-    private void addJsonTypeTargetProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
+    private static void addJsonTypeTargetProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
         boolean isJsonTypeTarget = dataSources.stream()
                 .anyMatch(s -> ATLASMAP_JSON_DATA_SOURCE.equals(s.get("jsonType")) && "TARGET".equals(s.get("dataSourceType")));
 
@@ -114,7 +114,7 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
      * @return
      */
     @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> getAtlasmapDataSources(Map<String, String> configuredProperties) {
+    private static List<Map<String, Object>> getAtlasmapDataSources(Map<String, String> configuredProperties) {
         List<Map<String, Object>> sources = new ArrayList<>();
 
         try {
@@ -164,7 +164,7 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
          * Convert list typed message body to Json array String representation.
          * @param message
          */
-        private void convertMessageJsonTypeBody(Exchange exchange, Message message) {
+        private static void convertMessageJsonTypeBody(Exchange exchange, Message message) {
             if (message != null && message.getBody() instanceof List) {
                 List<?> jsonBeans = message.getBody(List.class);
                 message.setBody(JsonUtils.jsonBeansToArray(jsonBeans));

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/RuleFilterStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/RuleFilterStepHandler.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.runtime.handlers;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -55,7 +56,7 @@ public class RuleFilterStepHandler extends AbstractFilterStepHandler {
     // Helpers
     // *******************************
 
-    private List<FilterRule> extractRules(String rulesString) {
+    private static List<FilterRule> extractRules(String rulesString) {
         try {
             if (rulesString == null || rulesString.isEmpty()) {
                 return null;
@@ -66,10 +67,9 @@ public class RuleFilterStepHandler extends AbstractFilterStepHandler {
         }
     }
 
-    @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
-    private FilterPredicate getPredicate(String predicate) {
+    private static FilterPredicate getPredicate(String predicate) {
         if (predicate != null) {
-            return FilterPredicate.valueOf(predicate.toUpperCase());
+            return FilterPredicate.valueOf(predicate.toUpperCase(Locale.US));
         }
         return FilterPredicate.OR;
     }

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/TemplateStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/TemplateStepHandler.java
@@ -154,7 +154,7 @@ public class TemplateStepHandler implements IntegrationStepHandler, StringConsta
          * will be stored AS the body of the exchange which is then inserted
          * into a mustache map keyed with "body".
          */
-        private void refactorKeys(Map<String, Object> map) {
+        private static void refactorKeys(Map<String, Object> map) {
             ArrayList<String> keys = new ArrayList<String>(map.keySet());
             keys.stream().forEach(key -> {
                 Object value = map.remove(key);
@@ -175,7 +175,7 @@ public class TemplateStepHandler implements IntegrationStepHandler, StringConsta
 
             try {
                 // Map the json body to a Map
-                Map<String, Object> map = (Map<String, Object>) MAPPER.readValue(body.toString(), HashMap.class);
+                Map<String, Object> map = MAPPER.readValue(body.toString(), HashMap.class);
 
                 // Refactor the keys of the map to remove any "body." notation since this
                 // is no longer required during actual exchange processing

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/BodyLogger.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/BodyLogger.java
@@ -61,7 +61,7 @@ public interface BodyLogger {
                                  .evaluate(exchange, String.class);
         }
 
-        private String convertToString(Exchange exchange, Object o) {
+        private static String convertToString(Exchange exchange, Object o) {
             CamelContext camelContext = Optional.ofNullable(exchange.getContext())
                                                 .orElseGet(DefaultCamelContext::new);
 

--- a/app/meta/src/main/java/io/syndesis/connector/meta/EndpointMetricsFilter.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/EndpointMetricsFilter.java
@@ -71,11 +71,11 @@ public class EndpointMetricsFilter implements ContainerRequestFilter, ContainerR
         }
     }
 
-    private String getMethod(ContainerRequestContext requestContext) {
+    private static String getMethod(ContainerRequestContext requestContext) {
         return requestContext.getRequest().getMethod();
     }
 
-    private String getStatus(ContainerResponseContext responseContext) {
+    private static String getStatus(ContainerResponseContext responseContext) {
         return Integer.toString(responseContext.getStatus());
     }
 

--- a/app/meta/src/main/java/io/syndesis/connector/meta/v1/DriverUploadEndpoint.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/v1/DriverUploadEndpoint.java
@@ -78,7 +78,7 @@ public class DriverUploadEndpoint {
         return isDeleted;
     }
 
-    private void storeFile(String location, MultipartFormDataInput dataInput) {
+    private static void storeFile(String location, MultipartFormDataInput dataInput) {
         // Store the artifact into /deployments/ext
         try (InputStream is = getBinaryArtifact(dataInput)) {
             final File file = new File(location);
@@ -90,7 +90,7 @@ public class DriverUploadEndpoint {
         }
     }
 
-    private String getFileName(MultipartFormDataInput input) {
+    private static String getFileName(MultipartFormDataInput input) {
         if (input == null || input.getParts() == null || input.getParts().isEmpty()) {
             throw new IllegalArgumentException("Multipart request is empty");
         }
@@ -105,7 +105,7 @@ public class DriverUploadEndpoint {
         }
     }
 
-    private InputStream getBinaryArtifact(MultipartFormDataInput input) {
+    private static InputStream getBinaryArtifact(MultipartFormDataInput input) {
         if (input == null || input.getParts() == null || input.getParts().isEmpty()) {
             throw new IllegalArgumentException("Multipart request is empty");
         }

--- a/app/meta/src/main/java/io/syndesis/connector/meta/v1/VerifierEndpoint.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/v1/VerifierEndpoint.java
@@ -90,7 +90,7 @@ public class VerifierEndpoint {
         return answer;
     }
 
-    private List<VerifierResponse> filterExceptions(List<VerifierResponse> responses) {
+    private static List<VerifierResponse> filterExceptions(List<VerifierResponse> responses) {
         for (VerifierResponse response : responses) {
             List<VerifierResponse.Error> errors = response.getErrors();
             if (errors != null) {
@@ -113,7 +113,7 @@ public class VerifierEndpoint {
         return responses;
     }
 
-    private VerifierResponse createUnsupportedResponse(String connectorId) {
+    private static VerifierResponse createUnsupportedResponse(String connectorId) {
         return new VerifierResponse.Builder(Verifier.Status.UNSUPPORTED, Verifier.Scope.PARAMETERS)
             .error("unknown-connector", String.format("No connector for ID %s registered", connectorId))
             .build();

--- a/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
+++ b/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
@@ -117,7 +117,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         }
     }
 
-    private URLClassLoader createClassLoader(File jar) throws MalformedURLException {
+    private static URLClassLoader createClassLoader(File jar) throws MalformedURLException {
         return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
             @Override
             public URLClassLoader run() {
@@ -130,7 +130,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         });
     }
 
-    private void addConnectorMeta(ObjectNode root, ClassLoader classLoader) {
+    private static void addConnectorMeta(ObjectNode root, ClassLoader classLoader) {
         ObjectNode node = new ObjectNode(JsonNodeFactory.instance);
         addOptionalNode(classLoader, node, "meta", "camel-connector.json");
         addOptionalSchemaAsString(classLoader, node, "schema", "camel-connector-schema.json");
@@ -214,7 +214,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
 
     // TODO: Should return an ObjectNode, but because of
     // Camels' JSonSchemaHelper being very picky on the format, we use it as plain string directly
-    private String loadComponentJSonSchema(ClassLoader classLoader, String scheme, String javaType) {
+    private static String loadComponentJSonSchema(ClassLoader classLoader, String scheme, String javaType) {
         int pos = javaType.lastIndexOf('.');
         String path = javaType.substring(0, pos);
         path = path.replace('.', '/');
@@ -233,7 +233,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         mapper.writerWithDefaultPrettyPrinter().writeValue(new File(target), root);
     }
 
-    private void addOptionalSchemaAsString(ClassLoader cl, ObjectNode node, String key, String path) {
+    private static void addOptionalSchemaAsString(ClassLoader cl, ObjectNode node, String key, String path) {
         // We can't use real JSON here as
         // https://github.com/apache/camel/blob/master/camel-core/src/main/java/org/apache/camel/runtimecatalog/JSonSchemaHelper.java#L44-L123
         // can parse proper JSON. We need to do it as an opaque sting
@@ -243,14 +243,14 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         }
     }
 
-    private void addOptionalNode(ClassLoader cl, ObjectNode node, String key, String path) {
+    private static void addOptionalNode(ClassLoader cl, ObjectNode node, String key, String path) {
         JsonNode result = getJson(cl, path);
         if (result != null) {
             node.set(key, result);
         }
     }
 
-    private void addGav(ObjectNode node, Artifact artifact) {
+    private static void addGav(ObjectNode node, Artifact artifact) {
         TextNode gavNode = new TextNode(
             String.format("%s:%s:%s",
                           artifact.getGroupId(),
@@ -259,7 +259,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         node.set("gav", gavNode);
     }
 
-    private JsonNode getJson(ClassLoader classLoader, String path) {
+    private static JsonNode getJson(ClassLoader classLoader, String path) {
         try {
             InputStream is = classLoader.getResourceAsStream(path);
             if (is == null) {
@@ -271,7 +271,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
         }
     }
 
-    private String getOpaqueJsonString(ClassLoader classLoader, String path) {
+    private static String getOpaqueJsonString(ClassLoader classLoader, String path) {
         try {
             InputStream is = classLoader.getResourceAsStream(path);
             if (is == null) {

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/endpoint/EndpointController.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/endpoint/EndpointController.java
@@ -158,7 +158,7 @@ public class EndpointController implements BackendController {
         }
     }
 
-    private Optional<IntegrationEndpoint> expectedEndpoint(IntegrationDeployment integrationDeployment, Optional<String> host) {
+    private static Optional<IntegrationEndpoint> expectedEndpoint(IntegrationDeployment integrationDeployment, Optional<String> host) {
         if (!host.isPresent()) {
             return Optional.empty();
         }
@@ -174,21 +174,21 @@ public class EndpointController implements BackendController {
                     .build());
     }
 
-    private Optional<String> serverBasePath(Integration integration) {
+    private static Optional<String> serverBasePath(Integration integration) {
         return allSteps(integration)
             .findFirst()
             .flatMap(Step::getAction)
             .flatMap(action -> action.getMetadata("serverBasePath"));
     }
 
-    private Optional<String> contextPath(Integration integration) {
+    private static Optional<String> contextPath(Integration integration) {
         return allSteps(integration)
             .findFirst()
             .flatMap(step -> step.getAction().flatMap(action -> action.propertyTaggedWith(step.getConfiguredProperties(), "context-path")));
     }
 
     @SafeVarargs
-    private final String join(Optional<String>... paths) {
+    private static final String join(Optional<String>... paths) {
         StringBuilder res = new StringBuilder();
         for (Optional<String> path : paths) {
             if (path.isPresent()) {

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/BaseHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/BaseHandler.java
@@ -87,11 +87,11 @@ public class BaseHandler {
         }
     }
 
-    private String getLabel(Integration integration) {
+    private static String getLabel(Integration integration) {
         return String.format("Integration [%s]", Names.sanitize(integration.getName()));
     }
 
-    private String getLabel(IntegrationDeployment integrationDeployment) {
+    private static String getLabel(IntegrationDeployment integrationDeployment) {
         return String.format("Integration [%s]", Names.sanitize(integrationDeployment.getSpec().getName()));
     }
 

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/BaseIntegrationController.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/BaseIntegrationController.java
@@ -198,7 +198,7 @@ public abstract class BaseIntegrationController implements BackendController {
         }
     }
 
-    private String getLabel(IntegrationDeployment integrationDeployment) {
+    private static String getLabel(IntegrationDeployment integrationDeployment) {
         return "Integration " + integrationDeployment.getIntegrationId().orElse("[none]");
     }
 
@@ -272,13 +272,13 @@ public abstract class BaseIntegrationController implements BackendController {
         );
     }
 
-    private String getIntegrationMarkerKey(IntegrationDeployment integrationDeployment) {
+    private static String getIntegrationMarkerKey(IntegrationDeployment integrationDeployment) {
         return integrationDeployment.getTargetState() +
                ":" +
                integrationDeployment.getId().orElseThrow(() -> new IllegalArgumentException("No id set in integration " + integrationDeployment));
     }
 
-    private boolean stale(StateChangeHandler handler, IntegrationDeployment integrationDeployment) {
+    private static boolean stale(StateChangeHandler handler, IntegrationDeployment integrationDeployment) {
         if (integrationDeployment == null || handler == null) {
             return true;
         }

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/camelk/customizer/OpenApiCustomizer.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/camelk/customizer/OpenApiCustomizer.java
@@ -111,7 +111,7 @@ public class OpenApiCustomizer implements CamelKIntegrationCustomizer {
     }
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-    private ResourceSpec generateOpenAPIResource(OpenApi openApi) throws Exception {
+    private static ResourceSpec generateOpenAPIResource(OpenApi openApi) throws Exception {
         final byte[] openApiBytes = openApi.getDocument();
 //        final String content = configuration.getCamelk().isCompression() ? CamelKSupport.compress(openApiBytes) : new String(openApiBytes, UTF_8);
 

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/validation/extension/NoDuplicateExtensionValidator.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/validation/extension/NoDuplicateExtensionValidator.java
@@ -59,7 +59,7 @@ public class NoDuplicateExtensionValidator implements ConstraintValidator<NoDupl
         return true;
     }
 
-    private boolean isValid(final ExtensionWithDomain value) {
+    private static boolean isValid(final ExtensionWithDomain value) {
         Extension target = value.getTarget();
         if (target.getExtensionId() == null) {
             return true;

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/validation/NoDuplicateValidatorTest.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/validation/NoDuplicateValidatorTest.java
@@ -129,7 +129,7 @@ public class NoDuplicateValidatorTest implements StringConstants {
 
     }
 
-    private Connector newSqlConnector() {
+    private static Connector newSqlConnector() {
         ConnectorAction action1 = new ConnectorAction.Builder()
             .id(SQL_CONNECTOR_ACTION_ID)
             .actionType("connector")
@@ -146,7 +146,7 @@ public class NoDuplicateValidatorTest implements StringConstants {
            .build();
     }
 
-    private Connection newSqlConnection(Connector connector) {
+    private static Connection newSqlConnection(Connector connector) {
         assertNotNull(connector);
 
         Map<String, String> configuredProperties = new HashMap<>();
@@ -167,7 +167,7 @@ public class NoDuplicateValidatorTest implements StringConstants {
             .build();
     }
 
-    private Step newSqlStep(Connection connection) {
+    private static Step newSqlStep(Connection connection) {
         ConnectorAction action = new ConnectorAction.Builder()
             .actionType("connector")
             .id(SQL_CONNECTOR_ACTION_ID)
@@ -183,7 +183,7 @@ public class NoDuplicateValidatorTest implements StringConstants {
             .build();
     }
 
-    private Integration newSqlIntegration(String id, Connection connection) {
+    private static Integration newSqlIntegration(String id, Connection connection) {
         return new Integration.Builder()
             .id(id)
             .name(id)

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/ApiDocumentationEndpoint.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/ApiDocumentationEndpoint.java
@@ -67,7 +67,7 @@ public class ApiDocumentationEndpoint {
         return Response.ok(resource("/static/swagger." + type), mediaTypeFor(type)).build();
     }
 
-    private MediaType mediaTypeFor(final String type) {
+    private static MediaType mediaTypeFor(final String type) {
         if ("json".equals(type)) {
             return MediaType.APPLICATION_JSON_TYPE;
         }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionActivator.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionActivator.java
@@ -133,7 +133,7 @@ public class ExtensionActivator {
         }
     }
 
-    private Connector migrateOldConnectorData(Connector existingConnector, Connector newConnector) {
+    private static Connector migrateOldConnectorData(Connector existingConnector, Connector newConnector) {
         Map<String, String> propValues = new TreeMap<>(existingConnector.getConfiguredProperties());
         propValues.keySet().retainAll(newConnector.getProperties().keySet());
 
@@ -163,7 +163,7 @@ public class ExtensionActivator {
         return Optional.ofNullable(dataManager.fetch(Connector.class, getConnectorIdForExtension(extension)));
     }
 
-    private Connector toConnector(Extension extension) {
+    private static Connector toConnector(Extension extension) {
         List<ConnectorAction> connectorActions = extension.getActions(ConnectorAction.class);
 
         return new Connector.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
@@ -281,7 +281,7 @@ public class ExtensionHandler extends BaseHandler implements Lister<Extension>, 
 
     @Nonnull
     @SuppressWarnings("PMD.CyclomaticComplexity")
-    private InputStream getBinaryArtifact(MultipartFormDataInput input) {
+    private static InputStream getBinaryArtifact(MultipartFormDataInput input) {
         if (input == null || input.getParts() == null || input.getParts().isEmpty()) {
             throw new IllegalArgumentException("Multipart request is empty");
         }
@@ -329,12 +329,12 @@ public class ExtensionHandler extends BaseHandler implements Lister<Extension>, 
             .collect(Collectors.toSet());
         return getDataManager().fetchAll(IntegrationDeployment.class).getItems().stream()
             .filter(integrationDeployment -> isIntegrationActiveAndUsingExtension(integrationDeployment, deletedIntegrationIds, extension))
-            .map(this::toIntegrationResourceIdentifier)
+            .map(ExtensionHandler::toIntegrationResourceIdentifier)
             .distinct()
             .collect(Collectors.toSet());
     }
 
-    private ResourceIdentifier toIntegrationResourceIdentifier(IntegrationDeployment integrationDeployment) {
+    private static ResourceIdentifier toIntegrationResourceIdentifier(IntegrationDeployment integrationDeployment) {
         return new ResourceIdentifier.Builder()
             .id(integrationDeployment.getIntegrationId())
             .kind(Kind.Integration)

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
@@ -266,7 +266,7 @@ public class PublicApiHandler {
         return Response.ok(output).build();
     }
 
-    private void validateParam(String name, String param) {
+    private static void validateParam(String name, String param) {
         if (param == null || param.isEmpty()) {
             throw new ClientErrorException("Missing parameter " + name, Response.Status.BAD_REQUEST);
         }
@@ -453,7 +453,7 @@ public class PublicApiHandler {
         return resource;
     }
 
-    private Map<String, Map<String, String>> getParams(InputStream paramFile) throws IOException {
+    private static Map<String, Map<String, String>> getParams(InputStream paramFile) throws IOException {
         Properties properties = new Properties();
         properties.load(paramFile);
 
@@ -479,7 +479,7 @@ public class PublicApiHandler {
         return result;
     }
 
-    private <T> List<T> getResourcesOfType(List<WithResourceId> resources, Class<T> type) {
+    private static <T> List<T> getResourcesOfType(List<WithResourceId> resources, Class<T> type) {
         return resources.stream()
             .filter(type::isInstance)
             .map(type::cast)

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelper.java
@@ -147,7 +147,7 @@ class IntegrationOverviewHelper {
         return builder.build();
     }
 
-    private boolean computeDraft(final Integration current, final Integration deployed) {
+    private static boolean computeDraft(final Integration current, final Integration deployed) {
         final List<Flow> currentFlows = current.getFlows();
         final List<Flow> deployedFlows = deployed.getFlows();
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -605,7 +605,7 @@ public class IntegrationSupportHandler {
                 .collect(Collectors.toSet());
     }
 
-    private String getNextAvailableName(String name, Set<String> names) {
+    private static String getNextAvailableName(String name, Set<String> names) {
         String newName = null;
         for (int i = 1; newName == null; i++) {
             final String candidate = name + IMPORTED_SUFFIX + i;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -237,7 +237,7 @@ class AggregateMetadataHandler implements StepMetadataHandler {
      * @return
      * @throws IOException
      */
-    private String adaptUnifiedJsonBodySpecToSingleElement(String specification) throws IOException {
+    private static String adaptUnifiedJsonBodySpecToSingleElement(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);
         if (schema.isObjectSchema()) {
             JsonSchema bodySchema = schema.asObjectSchema().getProperties().get("body");
@@ -262,7 +262,7 @@ class AggregateMetadataHandler implements StepMetadataHandler {
      * @return
      * @throws IOException
      */
-    private String adaptUnifiedJsonBodySpecToCollection(String specification) throws IOException {
+    private static String adaptUnifiedJsonBodySpecToCollection(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);
         if (schema.isObjectSchema()) {
             JsonSchema bodySchema = schema.asObjectSchema().getProperties().get("body");

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -167,7 +167,7 @@ class SplitMetadataHandler implements StepMetadataHandler {
      * @return
      * @throws IOException
      */
-    private String extractUnifiedJsonBodySpec(String specification) throws IOException {
+    private static String extractUnifiedJsonBodySpec(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);
         if (schema.isObjectSchema()) {
             JsonSchema bodySchema = schema.asObjectSchema().getProperties().get("body");

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
@@ -53,7 +53,7 @@ public class MixedTest {
         assertEquals("{\"label\": \"label\", \"value\": \"value\"}", serialize(create(val)), true);
     }
 
-    private Mixed create(final Object... parts) {
+    private static Mixed create(final Object... parts) {
         return new Mixed(parts) {
             // test object
         };

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -579,7 +579,7 @@ public class AggregateMetadataHandlerTest {
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(DataShapeMetaData.VARIANT));
     }
 
-    private DataShape dummyShape(DataShapeKinds kind) {
+    private static DataShape dummyShape(DataShapeKinds kind) {
         return new DataShape.Builder()
                 .kind(kind)
                 .description("dummyShape")
@@ -588,7 +588,7 @@ public class AggregateMetadataHandlerTest {
                 .build();
     }
 
-    private String getSpecification(String path) throws IOException {
+    private static String getSpecification(String path) throws IOException {
         return IOUtils.toString(new ClassPathResource(path, AggregateMetadataHandlerTest.class).getInputStream(), StandardCharsets.UTF_8);
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
@@ -133,7 +133,7 @@ public class ChoiceMetadataHandlerTest {
         Assert.assertEquals(metadata, enrichedMetadata);
     }
 
-    private DataShape testShape(String name) {
+    private static DataShape testShape(String name) {
         return new DataShape.Builder()
                 .kind(DataShapeKinds.JSON_INSTANCE)
                 .description(name)

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
@@ -410,7 +410,7 @@ public class SplitMetadataHandlerTest {
         Assert.assertEquals("dummy", enrichedMetadata.outputShape().getVariants().get(0).getMetadata().get(DataShapeMetaData.VARIANT));
     }
 
-    private DataShape dummyShape(DataShapeKinds kind) {
+    private static DataShape dummyShape(DataShapeKinds kind) {
         return new DataShape.Builder()
                 .kind(kind)
                 .specification("{}")
@@ -419,7 +419,7 @@ public class SplitMetadataHandlerTest {
                 .build();
     }
 
-    private String getSpecification(String path) throws IOException {
+    private static String getSpecification(String path) throws IOException {
         return IOUtils.toString(new ClassPathResource(path, SplitMetadataHandlerTest.class).getInputStream(), StandardCharsets.UTF_8);
     }
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/StepActionHandlerTest.java
@@ -527,7 +527,7 @@ public class StepActionHandlerTest {
         assertThat(enriched.get(2).getAction().orElseThrow(AssertionError::new).getDescriptor().getOutputDataShape()).contains(StepMetadataHelper.ANY_SHAPE);
     }
 
-    private DataShape dummyShape() {
+    private static DataShape dummyShape() {
         return new DataShape.Builder()
                 .kind(DataShapeKinds.JAVA)
                 .specification("{}")

--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -182,12 +182,12 @@ public class SqlFileStore {
         }
     }
 
-    private void doWriteStandard(Handle h, String path, InputStream file) {
+    private static void doWriteStandard(Handle h, String path, InputStream file) {
         doDelete(h, path);
         h.insert("INSERT INTO filestore(path, data) values (?,?)", path, file);
     }
 
-    private void doWritePostgres(Handle h, String path, InputStream file) {
+    private static void doWritePostgres(Handle h, String path, InputStream file) {
         doDelete(h, path);
         try {
             LargeObjectManager lobj = getPostgresConnection(h.getConnection()).getLargeObjectAPI();
@@ -203,7 +203,7 @@ public class SqlFileStore {
         }
     }
 
-    private void doWriteDerby(Handle h, String path, InputStream file) {
+    private static void doWriteDerby(Handle h, String path, InputStream file) {
         doDelete(h, path);
         try {
             Blob blob = h.getConnection().createBlob();
@@ -217,7 +217,7 @@ public class SqlFileStore {
         }
     }
 
-    private InputStream doReadStandard(Handle h, String path) {
+    private static InputStream doReadStandard(Handle h, String path) {
         List<Map<String, Object>> res = h.select("SELECT data FROM filestore WHERE path=?", path);
 
         Optional<Blob> blob = res.stream()
@@ -304,18 +304,18 @@ public class SqlFileStore {
         }
     }
 
-    private boolean doDelete(Handle h, String path) {
+    private static boolean doDelete(Handle h, String path) {
         return h.update("DELETE FROM filestore WHERE path=?", path) > 0;
     }
 
-    private PGConnection getPostgresConnection(Connection conn) throws SQLException {
+    private static PGConnection getPostgresConnection(Connection conn) throws SQLException {
         if (conn instanceof PGConnection) {
             return PGConnection.class.cast(conn);
         }
         return conn.unwrap(PGConnection.class);
     }
 
-    private String newRandomTempFilePath() {
+    private static String newRandomTempFilePath() {
         SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.ROOT);
         return "/tmp/" + fmt.format(new Date()) + "_" + UUID.randomUUID();
     }
@@ -348,7 +348,7 @@ public class SqlFileStore {
      */
     static class HandleCloserInputStream extends FilterInputStream {
 
-        private Handle handle;
+        private final Handle handle;
 
         HandleCloserInputStream(Handle handle, InputStream in) {
             super(in);

--- a/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
+++ b/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
@@ -60,7 +60,7 @@ public class JsonInstanceInspectorTest {
         assertThat(paths).isEqualTo(JsonInstanceInspector.COLLECTION_PATHS);
     }
 
-    private String getJsonInstance() {
+    private static String getJsonInstance() {
         return "{" +
                     "\"id\": \"" + UUID.randomUUID().toString() + "\"," +
                     "\"firstName\": \"Foo\"," +
@@ -93,19 +93,19 @@ public class JsonInstanceInspectorTest {
                 "}";
     }
 
-    private String getJsonArrayInstance() {
+    private static String getJsonArrayInstance() {
         return "[" + getJsonInstance() + "]";
     }
 
-    private void assertProperties(List<String> paths) {
+    private static void assertProperties(List<String> paths) {
         assertProperties(paths, null);
     }
 
-    private void assertArrayProperties(List<String> paths) {
+    private static void assertArrayProperties(List<String> paths) {
         assertProperties(paths, "[]");
     }
 
-    private void assertProperties(List<String> paths, String context) {
+    private static void assertProperties(List<String> paths, String context) {
         List<String> expectedPaths = Arrays.asList("id", "isAlive",
                 "firstName", "lastName", "address.city", "address.state",
                 "phoneNumbers[].type", "phoneNumbers.size()", "phoneNumbers[].number",

--- a/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonSchemaInspectorTest.java
+++ b/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonSchemaInspectorTest.java
@@ -87,19 +87,19 @@ public class JsonSchemaInspectorTest {
         assertThat(paths).containsAll(Arrays.asList("Id", "PhoneNumbers.size()", "PhoneNumbers[].Name", "PhoneNumbers[].Number"));
     }
 
-    private InputStream getPetstoreUnifiedSchema(String schemaPath) {
+    private static InputStream getPetstoreUnifiedSchema(String schemaPath) {
         return JsonSchemaInspectorTest.class.getResourceAsStream(schemaPath);
     }
 
-    private InputStream getSalesForceContactSchema() {
+    private static InputStream getSalesForceContactSchema() {
         return JsonSchemaInspectorTest.class.getResourceAsStream("/salesforce.Contact.jsonschema");
     }
 
-    private String getSalesForceContactArraySchema() throws IOException {
+    private static String getSalesForceContactArraySchema() throws IOException {
         return "{\"type\":\"array\",\"$schema\":\"" + JSON_SCHEMA_ORG_SCHEMA + "\",\"items\":" + IOStreams.readText(getSalesForceContactSchema()) + "}";
     }
 
-    private String getSchemaWithNestedArray() {
+    private static String getSchemaWithNestedArray() {
         return "{" +
                     "\"type\":\"object\"," +
                 "\"$schema\":\"" + JSON_SCHEMA_ORG_SCHEMA + "\", " +
@@ -119,15 +119,15 @@ public class JsonSchemaInspectorTest {
                 "}";
     }
 
-    private void assertSalesforceContactProperties(List<String> paths) {
+    private static void assertSalesforceContactProperties(List<String> paths) {
         assertSalesforceContactProperties(paths, null);
     }
 
-    private void assertSalesforceContactArrayProperties(List<String> paths) {
+    private static void assertSalesforceContactArrayProperties(List<String> paths) {
         assertSalesforceContactProperties(paths, "[]");
     }
 
-    private void assertSalesforceContactProperties(List<String> paths, String context) {
+    private static void assertSalesforceContactProperties(List<String> paths, String context) {
         List<String> expectedPaths = Arrays.asList("Id",
                 "IsDeleted", "MasterRecordId", "AccountId", "LastName",
                 "FirstName", "OtherAddress.latitude", "MailingAddress.city");
@@ -137,7 +137,7 @@ public class JsonSchemaInspectorTest {
                                                     .collect(Collectors.toList()));
     }
 
-    private void assertPetstoreProperties(List<String> paths) {
+    private static void assertPetstoreProperties(List<String> paths) {
         List<String> expectedParameters = Collections.singletonList("version");
         List<String> expectedBodyPaths = Arrays.asList("id", "name", "category.id", "category.name", "photoUrls.size()",
                 "tags[].id", "tags[].name", "tags.size()", "status");

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/SqlJsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/SqlJsonDB.java
@@ -391,7 +391,7 @@ public class SqlJsonDB implements JsonDB, WithGlobalTransaction {
         return key;
     }
 
-    class BatchManager {
+    static class BatchManager {
 
         private final Handle dbi;
         private long batchSize;
@@ -510,7 +510,7 @@ public class SqlJsonDB implements JsonDB, WithGlobalTransaction {
     }
 
 
-    private int deleteJsonRecords(Handle dbi, String baseDBPath, String like) {
+    private static int deleteJsonRecords(Handle dbi, String baseDBPath, String like) {
 
         ArrayList<String> expressions = new ArrayList<>();
         ArrayList<String> queryParams = new ArrayList<>();
@@ -541,7 +541,7 @@ public class SqlJsonDB implements JsonDB, WithGlobalTransaction {
         return  params;
     }
 
-    private int countJsonRecords(Handle dbi, String like) {
+    private static int countJsonRecords(Handle dbi, String like) {
         Integer result = dbi.createQuery("SELECT COUNT(*) from jsondb where path LIKE ?")
             .bind(0, like)
             .map(IntegerColumnMapper.PRIMITIVE).first();

--- a/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonRecordSupportTest.java
+++ b/app/server/jsondb/src/test/java/io/syndesis/server/jsondb/impl/JsonRecordSupportTest.java
@@ -72,7 +72,7 @@ public class JsonRecordSupportTest {
         }
     }
 
-    private String rtrim(String value, String suffix) {
+    private static String rtrim(String value, String suffix) {
         return value.replaceAll("("+Pattern.quote(suffix)+")+$", "");
     }
 }

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/PodLogMonitor.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/PodLogMonitor.java
@@ -248,7 +248,7 @@ class PodLogMonitor implements Consumer<InputStream> {
         }
     }
 
-    private void processLogLineStep(Map<String, Object> json, InflightData inflightData, String step, String id) throws IOException {
+    private static void processLogLineStep(Map<String, Object> json, InflightData inflightData, String step, String id) throws IOException {
         ActivityStep as = inflightData.getStep(step, id);
         String message = (String) json.remove("message");
         if (message != null) {

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -212,7 +212,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         return new UserBuilder().withNewMetadata().withName(username).and().build();
     }
 
-    private int nullSafe(Integer nr) {
+    private static int nullSafe(Integer nr) {
         return nr != null ? nr : 0;
     }
 

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/DataStoreConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/DataStoreConfiguration.java
@@ -75,13 +75,13 @@ public class DataStoreConfiguration {
         return jsondb;
     }
 
-    private void addIndex(List<Index> indexes, Kind kind, IndexedProperty indexedProperty) {
+    private static void addIndex(List<Index> indexes, Kind kind, IndexedProperty indexedProperty) {
         if (indexedProperty != null) {
             indexes.add(new Index("/" + kind.getModelName() + "s", indexedProperty.value()));
         }
     }
 
-    private void addIndex(List<Index> indexes, Kind kind, UniqueProperty p) {
+    private static void addIndex(List<Index> indexes, Kind kind, UniqueProperty p) {
         if (p != null) {
             indexes.add(new Index("/" + kind.getModelName() + "s", p.value()));
         }

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/EndpointMetricsFilter.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/EndpointMetricsFilter.java
@@ -73,11 +73,11 @@ public class EndpointMetricsFilter implements ContainerRequestFilter, ContainerR
         }
     }
 
-    private String getMethod(ContainerRequestContext requestContext) {
+    private static String getMethod(ContainerRequestContext requestContext) {
         return requestContext.getRequest().getMethod();
     }
 
-    private String getStatus(ContainerResponseContext responseContext) {
+    private static String getStatus(ContainerResponseContext responseContext) {
         return Integer.toString(responseContext.getStatus());
     }
 

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SecurityConfiguration.java
@@ -95,7 +95,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return f;
     }
 
-    private AuthenticationProvider authenticationProvider() {
+    private static AuthenticationProvider authenticationProvider() {
         PreAuthenticatedAuthenticationProvider authProvider = new PreAuthenticatedAuthenticationProvider();
         authProvider.setPreAuthenticatedUserDetailsService(new PreAuthenticatedGrantedAuthoritiesUserDetailsService());
         return authProvider;

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCsrfRepository.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/SyndesisCsrfRepository.java
@@ -55,7 +55,7 @@ public class SyndesisCsrfRepository implements CsrfTokenRepository {
         return token.map(val -> new DefaultCsrfToken(XSRF_HEADER_NAME, XSRF_HEADER_NAME, val)).orElse(null);
     }
 
-    private Optional<String> extractToken(HttpServletRequest request) {
+    private static Optional<String> extractToken(HttpServletRequest request) {
         String token = request.getHeader(XSRF_HEADER_NAME);
         return Optional.ofNullable(token);
     }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
@@ -269,7 +269,7 @@ public abstract class BaseITCase {
         return processResponse(expectedStatus, response);
     }
 
-    private <T> ResponseEntity<T> processResponse(HttpStatus expectedStatus, ResponseEntity<T> response) {
+    private static <T> ResponseEntity<T> processResponse(HttpStatus expectedStatus, ResponseEntity<T> response) {
         if( expectedStatus!=null ) {
             if( !response.getStatusCode().equals(expectedStatus) ) {
                 LOG.warn("Got unexpected status code: {}, body: {}", response.getStatusCode(), response.getBody());
@@ -279,7 +279,7 @@ public abstract class BaseITCase {
         return response;
     }
 
-    private void prepareHeaders(Object body, HttpHeaders headers, String token) {
+    private static void prepareHeaders(Object body, HttpHeaders headers, String token) {
         if( body!=null && !headers.containsKey(HttpHeaders.CONTENT_TYPE) ) {
             headers.set(HttpHeaders.CONTENT_TYPE, "application/json");
         }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/ConnectorsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/ConnectorsITCase.java
@@ -238,7 +238,7 @@ public class ConnectorsITCase extends BaseITCase {
         assertThat(dataManager.fetch(Connection.class, "test-connection")).isNull();
     }
 
-    private HttpHeaders multipartHeaders() {
+    private static HttpHeaders multipartHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         return headers;

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/EventsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/EventsITCase.java
@@ -15,31 +15,38 @@
  */
 package io.syndesis.server.runtime;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.launchdarkly.eventsource.EventHandler;
-import com.launchdarkly.eventsource.EventSource;
-import com.launchdarkly.eventsource.MessageEvent;
-import io.syndesis.common.model.ChangeEvent;
-import io.syndesis.common.model.EventMessage;
-import io.syndesis.common.model.integration.Integration;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.WebSocket;
-import okhttp3.WebSocketListener;
-import org.junit.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static io.syndesis.server.runtime.Recordings.*;
+import io.syndesis.common.model.ChangeEvent;
+import io.syndesis.common.model.EventMessage;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.server.runtime.Recordings.Invocation;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.launchdarkly.eventsource.EventHandler;
+import com.launchdarkly.eventsource.EventSource;
+import com.launchdarkly.eventsource.MessageEvent;
+
+import static io.syndesis.server.runtime.Recordings.recordedInvocations;
+import static io.syndesis.server.runtime.Recordings.recorder;
+import static io.syndesis.server.runtime.Recordings.resetRecorderLatch;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 
 /**
  * Used to test the SimpleEventBus
@@ -95,7 +102,7 @@ public class EventsITCase extends BaseITCase {
     }
 
 
-    private void reorderEventSourceInvocations(List<Invocation> invocations) {
+    private static void reorderEventSourceInvocations(List<Invocation> invocations) {
         // The EventSource is using a thread pool to emmit events.. so we get non-deterministic results.
         // lets reorder stuff so that the onOpen is the first event.
         for (int i = 1; i < invocations.size(); i++) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/ExtensionsITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/ExtensionsITCase.java
@@ -18,7 +18,6 @@ package io.syndesis.server.runtime;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -355,7 +354,7 @@ public class ExtensionsITCase extends BaseITCase {
 
     // ===========================================================
 
-    private byte[] extensionData(final int prg) throws IOException {
+    private static byte[] extensionData(final int prg) throws IOException {
         try (ByteArrayOutputStream data = new ByteArrayOutputStream();
             JarOutputStream jar = new JarOutputStream(data)) {
 
@@ -380,13 +379,13 @@ public class ExtensionsITCase extends BaseITCase {
         }
     }
 
-    private MultiValueMap<String, Object> multipartBody(final byte[] data) {
+    private static MultiValueMap<String, Object> multipartBody(final byte[] data) {
         final LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
         multipartData.add("file", new InputStreamResource(new ByteArrayInputStream(data)));
         return multipartData;
     }
 
-    private HttpHeaders multipartHeaders() {
+    private static HttpHeaders multipartHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         return headers;

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/SimpleEventBusTest.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/SimpleEventBusTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class SimpleEventBusTest {
 
-    private SimpleEventBus createEventBus() {
+    private static SimpleEventBus createEventBus() {
         return new SimpleEventBus();
     }
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/ConnectorTemplateITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/ConnectorTemplateITCase.java
@@ -54,7 +54,7 @@ public class ConnectorTemplateITCase extends BaseITCase {
         private static final ConfigurationProperty PROPERTY_1 = new ConfigurationProperty.Builder().displayName("Property 1").build();
 
         @Bean("connector-template")
-        public static final ConnectorGenerator testGenerator() {
+        public ConnectorGenerator testGenerator() {
             return new ConnectorGenerator(new Connector.Builder()
                 .addTags("from-connector")
                 .build()) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomConnectorITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomConnectorITCase.java
@@ -80,7 +80,7 @@ public class CustomConnectorITCase extends BaseITCase {
         private static final ConfigurationProperty PROPERTY_1 = new ConfigurationProperty.Builder().displayName("Property 1").build();
 
         @Bean(TEMPLATE_ID)
-        public static ConnectorGenerator testGenerator() {
+        public ConnectorGenerator testGenerator() {
             return new ConnectorGenerator(new Connector.Builder()
                 .addTags("from-connector")
                 .build()) {
@@ -217,14 +217,21 @@ public class CustomConnectorITCase extends BaseITCase {
         assertThat(responseForNonCustomConnector.getBody().getActionsSummary()).isNotPresent();
     }
 
-    private MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon) {
+    private static ConnectorTemplate createConnectorTemplate(final String id, final String name) {
+        return new ConnectorTemplate.Builder()//
+            .id(id)//
+            .name(name)//
+            .build();
+    }
+
+    private static MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon) {
         final LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
         multipartData.add("connectorSettings", connectorSettings);
         multipartData.add("icon", new InputStreamResource(icon));
         return multipartData;
     }
 
-    private MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon,
+    private static MultiValueMap<String, Object> multipartBody(final ConnectorSettings connectorSettings, final InputStream icon,
         final InputStream specification) {
         final MultiValueMap<String, Object> multipartData = multipartBody(connectorSettings, icon);
         multipartData.add("specification", new InputStreamResource(specification));
@@ -232,16 +239,9 @@ public class CustomConnectorITCase extends BaseITCase {
         return multipartData;
     }
 
-    private HttpHeaders multipartHeaders() {
+    private static HttpHeaders multipartHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         return headers;
-    }
-
-    private static ConnectorTemplate createConnectorTemplate(final String id, final String name) {
-        return new ConnectorTemplate.Builder()//
-            .id(id)//
-            .name(name)//
-            .build();
     }
 }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
@@ -114,7 +114,7 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
             JSONCompareMode.LENIENT);
     }
 
-    private MultiValueMap<String, Object> multipartBodyForInfo(final ConnectorSettings connectorSettings, final InputStream is)
+    private static MultiValueMap<String, Object> multipartBodyForInfo(final ConnectorSettings connectorSettings, final InputStream is)
         throws IOException {
         final LinkedMultiValueMap<String, Object> multipartData = new LinkedMultiValueMap<>();
         multipartData.add("connectorSettings", connectorSettings);
@@ -122,7 +122,7 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
         return multipartData;
     }
 
-    private HttpHeaders multipartHeaders() {
+    private static HttpHeaders multipartHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         return headers;

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
@@ -70,7 +70,7 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
 
     final Validator validator = mock(Validator.class);
 
-    private Connector newSqlConnector() {
+    private static Connector newSqlConnector() {
         ConnectorAction action1 = new ConnectorAction.Builder()
             .id(SQL_CONNECTOR_ACTION_ID)
             .actionType("connector")
@@ -87,7 +87,7 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
            .build();
     }
 
-    private Connection newSqlConnection(Connector connector) {
+    private static Connection newSqlConnection(Connector connector) {
         assertNotNull(connector);
 
         Map<String, String> configuredProperties = new HashMap<>();
@@ -108,7 +108,7 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
             .build();
     }
 
-    private Step newSqlStep(Connection connection) {
+    private static Step newSqlStep(Connection connection) {
         ConnectorAction action = new ConnectorAction.Builder()
             .actionType("connector")
             .id(SQL_CONNECTOR_ACTION_ID)
@@ -124,7 +124,7 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
             .build();
     }
 
-    private Integration newSqlIntegration(String id, Connection connection) {
+    private static Integration newSqlIntegration(String id, Connection connection) {
         return new Integration.Builder()
             .id(id)
             .name(id)
@@ -134,7 +134,7 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
             .build();
     }
 
-    private IntegrationDeployment newIntegrationDeployment(String id, int version, Integration integration, boolean published) {
+    private static IntegrationDeployment newIntegrationDeployment(String id, int version, Integration integration, boolean published) {
         Map<String, String> stepsDone = new HashMap<>();
         stepsDone.put("buildv1", "ip:port/syndesis/buildName");
         stepsDone.put("deploy", "2");

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
@@ -109,7 +109,7 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
         verifyRecordInDb(runner, "Meet Joanna from Red Hat");
     }
 
-    private String contact(String firstName, String company) {
+    private static String contact(String firstName, String company) {
         return String.format("{\"first_name\":\"%s\",\"company\":\"%s\"}", firstName, company);
     }
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
@@ -141,7 +141,7 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
         verifyRecordsInDb(runner, 0, "New hire for ${first_name} from ${company}");
     }
 
-    private String getWebhookPayload() {
+    private static String getWebhookPayload() {
         return "{\"first_name\":\"${first_name}\",\"company\":\"${company}\",\"mail\":\"${email}\"}";
     }
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
@@ -110,7 +110,7 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
         verifyRecordsInDb(runner, 0);
     }
 
-    private String contacts(String company, String ... firstNames) {
+    private static String contacts(String company, String ... firstNames) {
         StringJoiner joiner = new StringJoiner(",", "[", "]");
 
         Stream.of(firstNames)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
@@ -120,7 +120,7 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
         verifyRecordsInDb(runner, 0);
     }
 
-    private String contact(String firstName, String company) {
+    private static String contact(String firstName, String company) {
         return String.format("{\"first_name\":\"%s\",\"company\":\"%s\"}", firstName, company);
     }
 

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/project/CamelKProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/project/CamelKProjectBuilder.java
@@ -198,7 +198,7 @@ public class CamelKProjectBuilder extends AbstractMavenProjectBuilder<CamelKProj
         );
     }
 
-    private void extractSources(io.syndesis.server.controller.integration.camelk.crd.Integration integrationCR, Path projectPath) throws IOException {
+    private static void extractSources(io.syndesis.server.controller.integration.camelk.crd.Integration integrationCR, Path projectPath) throws IOException {
         for (SourceSpec sourceSpec : integrationCR.getSpec().getSources()) {
             DataSpec sourceData = sourceSpec.getDataSpec();
             if (sourceData != null &&
@@ -210,7 +210,7 @@ public class CamelKProjectBuilder extends AbstractMavenProjectBuilder<CamelKProj
         }
     }
 
-    private void extractResources(io.syndesis.server.controller.integration.camelk.crd.Integration integrationCR, Path projectPath) throws IOException {
+    private static void extractResources(io.syndesis.server.controller.integration.camelk.crd.Integration integrationCR, Path projectPath) throws IOException {
         for (ResourceSpec resourceSpec : integrationCR.getSpec().getResources()) {
             DataSpec resourceData = resourceSpec.getDataSpec();
             if (resourceData != null &&

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
@@ -95,11 +95,11 @@ public class IntegrationExportSource implements IntegrationSource {
         return openApis;
     }
 
-    private JsonNode readModel(Path exportDirectory) throws IOException {
+    private static JsonNode readModel(Path exportDirectory) throws IOException {
         return Json.reader().readTree(Files.newInputStream(exportDirectory.resolve("model.json")));
     }
 
-    private JsonNode readModelFromZip(InputStream export) {
+    private static JsonNode readModelFromZip(InputStream export) {
         try (ZipInputStream zis = new ZipInputStream(export)) {
             while (true) {
                 ZipEntry entry = zis.getNextEntry();


### PR DESCRIPTION
In accordance with the open/closed principle and designing code around reducing access and mutating state of objects static methods should have a preference over instance methods. They in general can be easier on the JIT compiler to inline, and thus gives us a bit better performance.