### PR TITLE
refactor: cleanup kudu connector tests

### DIFF
--- a/app/connector/kudu/src/test/java/io/syndesis/connector/kudu/KuduScanCustomizerTest.java
+++ b/app/connector/kudu/src/test/java/io/syndesis/connector/kudu/KuduScanCustomizerTest.java
@@ -16,33 +16,35 @@
 
 package io.syndesis.connector.kudu;
 
-import io.syndesis.connector.kudu.common.KuduSupport;
-import org.apache.camel.Exchange;
-import org.apache.camel.impl.DefaultExchange;
-import org.apache.kudu.ColumnSchema;
-import org.apache.kudu.client.KuduClient;
-import org.apache.kudu.client.KuduScanner;
-import org.apache.kudu.client.KuduTable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import io.syndesis.connector.kudu.common.KuduSupport;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultExchange;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduTable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+
 public class KuduScanCustomizerTest extends AbstractKuduCustomizerTestSupport {
-    private KuduScanCustomizer customizer;
-    private KuduClient connection;
     private static final String HOST = "quickstart.cloudera";
     private static final String PORT = "7051";
+    private KuduClient connection;
+    private KuduScanCustomizer customizer;
 
     @Before
     public void setupCustomizer() {
-        this.customizer = new KuduScanCustomizer();
-        Map<String, Object> options = new HashMap<>();
+        customizer = new KuduScanCustomizer();
+        final Map<String, Object> options = new HashMap<>();
         options.put("host", HOST);
         options.put("port", PORT);
 
@@ -50,34 +52,30 @@ public class KuduScanCustomizerTest extends AbstractKuduCustomizerTestSupport {
     }
 
     @After
-    public void shutDown() {
-        try {
-            connection.shutdown();
-        } catch (Exception e) {
-
-        }
+    public void shutDown() throws KuduException {
+        connection.shutdown();
     }
 
     @Ignore
     public void testBeforeConsumer() throws Exception {
-        Map<String, Object> options = new HashMap<>();
+        final Map<String, Object> options = new HashMap<>();
 
         customizer.customize(getComponent(), options);
 
-        KuduTable table = connection.openTable("impala::default.syndesis_todo");
+        final KuduTable table = connection.openTable("impala::default.syndesis_todo");
 
-        List<String> projectColumns = new ArrayList<>(1);
-        Iterator<ColumnSchema> columns = table.getSchema().getColumns().iterator();
+        final List<String> projectColumns = new ArrayList<>(1);
+        final Iterator<ColumnSchema> columns = table.getSchema().getColumns().iterator();
 
         while (columns.hasNext()) {
             projectColumns.add(columns.next().getName());
         }
 
-        KuduScanner scanner = connection.newScannerBuilder(table)
-                .setProjectedColumnNames(projectColumns)
-                .build();
+        final KuduScanner scanner = connection.newScannerBuilder(table)
+            .setProjectedColumnNames(projectColumns)
+            .build();
 
-        Exchange inbound = new DefaultExchange(createCamelContext());
+        final Exchange inbound = new DefaultExchange(createCamelContext());
         inbound.getIn().setBody(scanner);
         getComponent().getBeforeConsumer().process(inbound);
     }


### PR DESCRIPTION
This cleans up the kudu connector tests by making sure resources are
disposed using try-with-resources and proper exception handling is
performed.