### PR TITLE
feat: add semantics for actions with 'Pipe' pattern

### DIFF
--- a/app/ui-react/packages/api/src/WithConnection.tsx
+++ b/app/ui-react/packages/api/src/WithConnection.tsx
@@ -1,13 +1,19 @@
 import { Action, ConnectionOverview } from '@syndesis/models';
 import * as React from 'react';
 import { IFetchState } from './Fetch';
-import { getActionsWithFrom, getActionsWithTo } from './helpers';
+import {
+  getActionsWithFrom,
+  getActionsWithPipe,
+  getActionsWithTo,
+} from './helpers';
 import { SyndesisFetch } from './SyndesisFetch';
 
 export interface IConnectionOverviewExtended extends ConnectionOverview {
   readonly actionsWithFrom: Action[];
+  readonly actionsWithPipe: Action[];
   readonly actionsWithTo: Action[];
 }
+
 
 export interface IWithConnectionProps {
   id: string;
@@ -31,6 +37,9 @@ export class WithConnection extends React.Component<IWithConnectionProps> {
             data: {
               ...response.data,
               actionsWithFrom: getActionsWithFrom(
+                response.data.connector ? response.data.connector.actions : []
+              ),
+              actionsWithPipe: getActionsWithPipe(
                 response.data.connector ? response.data.connector.actions : []
               ),
               actionsWithTo: getActionsWithTo(

--- a/app/ui-react/packages/api/src/helpers/connectionFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/connectionFunctions.ts
@@ -19,6 +19,10 @@ export function getActionsWithTo(actions: Action[] = []) {
   return actions.filter(a => a.pattern === 'To');
 }
 
+export function getActionsWithPipe(actions: Action[] = []) {
+  return actions.filter(a => a.pattern === 'Pipe');
+}
+
 export function getConnectionMetadataValue(
   connection: Connection,
   key: string

--- a/app/ui-react/packages/api/src/useConnection.tsx
+++ b/app/ui-react/packages/api/src/useConnection.tsx
@@ -1,6 +1,7 @@
 import { IConnectionOverview } from '@syndesis/models';
 import {
   getActionsWithFrom,
+  getActionsWithPipe,
   getActionsWithTo,
   isConfigRequired,
   isDerived,
@@ -19,6 +20,7 @@ export const transformConnectionResponse = (
   return {
     ...connection,
     actionsWithFrom: getActionsWithFrom(connector ? connector.actions : []),
+    actionsWithPipe: getActionsWithPipe(connector ? connector.actions : []),
     actionsWithTo: getActionsWithTo(connector ? connector.actions : []),
     connector,
     derived: isDerived(connection),

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -60,64 +60,75 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                   loaderChildren={<PageLoader />}
                   errorChildren={<ApiError error={errorMessage!} />}
                 >
-                  {() => (
-                    <>
-                      <PageTitle title={'Choose an action'} />
-                      <IntegrationEditorLayout
-                        title={'Choose an action'}
-                        description={
-                          'Choose an action for the selected connection.'
-                        }
-                        toolbar={this.props.getBreadcrumb(
-                          'Choose an action',
-                          params,
-                          state
-                        )}
-                        sidebar={this.props.sidebar({
-                          activeIndex: positionAsNumber,
-                          activeStep: {
-                            ...toUIStep(state.connection),
-                          },
-                          steps: toUIStepCollection(
-                            getSteps(state.integration, params.flowId)
-                          ),
-                        })}
-                        content={
-                          <IntegrationEditorChooseAction>
-                            {(positionAsNumber > 0
-                              ? data.actionsWithTo
-                              : data.actionsWithFrom
-                            )
-                              .sort((a, b) => a.name.localeCompare(b.name))
-                              .map((a, idx) => (
-                                <IntegrationEditorActionsListItem
-                                  key={idx}
-                                  integrationName={a.name}
-                                  integrationDescription={
-                                    a.description || 'No description available.'
-                                  }
-                                  actions={
-                                    <ButtonLink
-                                      data-testid={
-                                        'select-action-page-select-button'
-                                      }
-                                      href={this.props.selectHref(
-                                        a.id!,
-                                        params,
-                                        state
-                                      )}
-                                    >
-                                      Select
-                                    </ButtonLink>
-                                  }
-                                />
-                              ))}
-                          </IntegrationEditorChooseAction>
-                        }
-                        cancelHref={this.props.cancelHref(params, state)}
-                      />
-                    </>
-                  )}
+                  {() => {
+                    const steps = toUIStepCollection(
+                      getSteps(state.integration, params.flowId)
+                    );
+                    // if we're looking at the 1st step, only show
+                    // actions with 'From'.  If we're looking at the
+                    // last step, only show actions with 'To'.
+                    // Otherwise, show actions with 'To' and 'Pipe'.
+                    const actions =
+                      positionAsNumber > 0
+                        ? positionAsNumber === steps.length
+                          ? data.actionsWithTo
+                          : [...data.actionsWithTo, ...data.actionsWithPipe]
+                        : data.actionsWithFrom;
+                    return (
+                      <>
+                        <PageTitle title={'Choose an action'} />
+                        <IntegrationEditorLayout
+                          title={'Choose an action'}
+                          description={
+                            'Choose an action for the selected connection.'
+                          }
+                          toolbar={this.props.getBreadcrumb(
+                            'Choose an action',
+                            params,
+                            state
+                          )}
+                          sidebar={this.props.sidebar({
+                            activeIndex: positionAsNumber,
+                            activeStep: {
+                              ...toUIStep(state.connection),
+                            },
+                            steps,
+                          })}
+                          content={
+                            <IntegrationEditorChooseAction>
+                              {actions
+                                .sort((a, b) => a.name.localeCompare(b.name))
+                                .map((a, idx) => (
+                                  <IntegrationEditorActionsListItem
+                                    key={idx}
+                                    integrationName={a.name}
+                                    integrationDescription={
+                                      a.description ||
+                                      'No description available.'
+                                    }
+                                    actions={
+                                      <ButtonLink
+                                        data-testid={
+                                          'select-action-page-select-button'
+                                        }
+                                        href={this.props.selectHref(
+                                          a.id!,
+                                          params,
+                                          state
+                                        )}
+                                      >
+                                        Select
+                                      </ButtonLink>
+                                    }
+                                  />
+                                ))}
+                            </IntegrationEditorChooseAction>
+                          }
+                          cancelHref={this.props.cancelHref(params, state)}
+                        />
+                      </>
+                    );
+                  }}
                 </WithLoader>
               )}
             </WithConnection>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -436,7 +436,7 @@ export function filterStepsByPosition(
     if ((step.connection || (step as Connection)).connector) {
       return (step.connection || (step as Connection)).connector!.actions.some(
         (action: ConnectorAction) => {
-          return action.pattern === 'To';
+          return action.pattern === 'To' || action.pattern === 'Pipe';
         }
       );
     }


### PR DESCRIPTION
fixes #6978

With this you can see the request/response action from AMQ:

![image](https://user-images.githubusercontent.com/351660/67311454-9f52fd80-f4cd-11e9-9cbe-9e4cf7782111.png)

@squakez FYI