### PR TITLE
fix(release): build the UI

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -140,6 +140,7 @@
     <module>server</module>
     <module>s2i</module>
     <module>meta</module>
+    <module>ui-react</module>
   </modules>
 
   <profiles>
@@ -298,7 +299,6 @@
       </activation>
 
       <modules>
-        <module>ui-react</module>
         <module>../doc</module>
         <module>test</module>
       </modules>


### PR DESCRIPTION
Seems that the change in #6942 prevents the UI from being built as it's build with `-DstagingDescription` and the `deploy` Maven goal. This reinstates the `ui-react` module in that case.