### PR TITLE
refactor: remove needless else

### DIFF
--- a/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetaDataExtension.java
+++ b/app/connector/fhir/src/main/java/io/syndesis/connector/fhir/FhirMetaDataExtension.java
@@ -48,9 +48,9 @@ public class FhirMetaDataExtension extends AbstractMetaDataExtension {
     public static Set<String> getResources(FhirVersionEnum fhirVersion) {
         if (FhirVersionEnum.DSTU3.equals(fhirVersion)) {
             return toSet(org.hl7.fhir.dstu3.model.ResourceType.values());
-        } else {
-            throw new IllegalArgumentException(fhirVersion + " is not among supported FHIR versions: DSTU3");
         }
+
+        throw new IllegalArgumentException(fhirVersion + " is not among supported FHIR versions: DSTU3");
     }
 
     @SuppressWarnings({"PMD.UseVarargs"})

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
@@ -75,10 +75,9 @@ public class AggregateStepHandler implements IntegrationStepHandler {
                 // When filter match indicator is not present aggregate all.
                 if (exchange.getProperty(Exchange.FILTER_MATCHED, true, Boolean.class)) {
                     return super.getValue(exchange);
-                } else {
-                    return null;
                 }
 
+                return null;
             }
         }),
         latest(UseLatestAggregationStrategy::new),

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
@@ -62,10 +62,9 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
 
             if (shouldTrackDoneEvent(definition)) {
                 return new TrackDoneEventProcessor(target, stepId);
-            } else {
-                return new TrackStartEventProcessor(target, stepId);
             }
 
+            return new TrackStartEventProcessor(target, stepId);
         }
 
         return target;

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
@@ -124,9 +124,9 @@ public final class JsonSimplePredicate implements Predicate {
                             // we do not need to dump on the logs so log it at trace level.
                             LOG.trace("Try to match array item out of bounds ", e);
                             return false;
-                        } else {
-                            throw e;
                         }
+
+                        throw e;
                     }
                 } else if (json.isObject()) {
                     payload.setBody(mapper.convertValue(json, Map.class));


### PR DESCRIPTION
`if` blocks that contain a `return` or a `throw` do not need to use the `else` block for the _otherwise_ case. This increases complexity and makes the code harder to read.