### PR TITLE
fix: warnings in Maven POM

### DIFF
--- a/app/common/pom.xml
+++ b/app/common/pom.xml
@@ -27,7 +27,6 @@
 
   <groupId>io.syndesis.common</groupId>
   <artifactId>common-parent</artifactId>
-  <version>1.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Common</name>

--- a/app/connector/mqtt/pom.xml
+++ b/app/connector/mqtt/pom.xml
@@ -88,7 +88,6 @@
       <plugin>
         <groupId>io.syndesis.connector</groupId>
         <artifactId>connector-support-maven-plugin</artifactId>
-        <version>${project.version}</version>
         <executions>
           <execution>
             <id>inspections</id>

--- a/app/connector/pom.xml
+++ b/app/connector/pom.xml
@@ -26,7 +26,6 @@
 
   <groupId>io.syndesis.connector</groupId>
   <artifactId>connector-parent</artifactId>
-  <version>1.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Connector</name>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -212,6 +212,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8.2</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -27,7 +27,6 @@
 
   <groupId>io.syndesis.server</groupId>
   <artifactId>server-parent</artifactId>
-  <version>1.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Server</name>


### PR DESCRIPTION
This removes unneeded declarations of module versions when the version is inherited from the parent Maven module and declares the missing version for the maven-deploy-plugin plugin in the extension BOM.