### PR TITLE
chore: upgrade basepom to 30 (from 29)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.basepom</groupId>
     <artifactId>basepom-oss</artifactId>
-    <version>29</version>
+    <version>30</version>
   </parent>
 
   <groupId>io.syndesis</groupId>
@@ -90,6 +90,10 @@
 
     <!-- Plugin versions -->
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <!-- FIXME: update to 6.19 when released we're seeing:
+      https://github.com/pmd/pmd/issues/1969
+    -->
+    <dep.pmd.version>6.17.0</dep.pmd.version>
 
     <!-- Maven versions -->
     <maven-archetype-packaging.version>2.0</maven-archetype-packaging.version>
@@ -100,7 +104,6 @@
     <maven-common-artifact-filters.version>1.4</maven-common-artifact-filters.version>
     <maven-shared-utils.version>3.1.0</maven-shared-utils.version>
     <maven-download.version>1.3.0</maven-download.version>
-
 
     <!-- UI dependencies -->
     <iltorb-version>2.4.1</iltorb-version>
@@ -1958,7 +1961,12 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>${dep.plugin.spotbugs.version}</version>
+        <!-- we were using ${dep.plugin.spotbugs.version} and this broke
+          as the plugin version differed from the spotbug-annotations
+          version, keep in mind when upgrading the plugin also to set
+          this version
+        --> 
+        <version>3.1.12</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION
One snag in upgrading was the false positive PMD issue, so the PMD plugin was manually downgraded.