### PR TITLE
fix(release): exclude ui-react module from nexus

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -354,7 +354,8 @@ release_staging_repo() {
 
     echo "==== Releasing Sonatype staging repo"
     cd $topdir/app
-    ./mvnw ${maven_opts} -Prelease nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
+    # We do not wish to publish ui-react module on Maven Central, so we exclude it from reactor
+    ./mvnw ${maven_opts} -pl \!:ui-react -Prelease nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
 }
 
 git_commit_files() {


### PR DESCRIPTION
When we run `mvn nexus-staging:release` we do not wish to include the ui-react module. We don't wish to publish ui-react artefacts to Maven central and we don't have any configuration for the nexus-staging plugin to work with in the ui-react module.