### PR TITLE
fix(release): perform remote staging

### DIFF
--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -618,16 +618,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-deploy</id>
-                <phase />
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -354,8 +354,7 @@ release_staging_repo() {
 
     echo "==== Releasing Sonatype staging repo"
     cd $topdir/app
-    # We do not wish to publish ui-react module on Maven Central, so we exclude it from reactor
-    ./mvnw ${maven_opts} -pl \!:ui-react -Prelease nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
+    ./mvnw ${maven_opts} -N -Prelease nexus-staging:release -DstagingDescription="Releasing $(readopt --release-version)"
 }
 
 git_commit_files() {


### PR DESCRIPTION
After quite some deliberations, trials and errors I think I understand
what the issue is with staging and releasing artifacts to Maven central
using nexus-staging plugin.

Disabling the nexus-staging plugin from ui-react module ends up not
uploading the artifacts to the staging repository when performing the
`deploy` goal via `nexus-staging:deploy`. This is because the upload to
the staging repository is deferred till the last module, and since the
ui-react is the last module in the reactor and the nexus-staging plugin
execution is skipped there the upload doesn not happen.

Then when we try to release the artifacts from the staging repository
using `nexus-staging:release` there is no staging repository and the
invocation again fails on the last module, which was `meta` and
previously `ui-react`.

This tries to fix the staging/releasing artifacts to Maven Central by
executing the `nexus-staging:deploy` in the ui-react module even though
the ui-react module has no artifacts to stage -- just to have it perform
the upload to the staging repository.

Also when performing `nexus-staging:release` we do not need to run it
over every module, we can run it only for the syndesis-parent.

[skip ci]