### PR TITLE
fix(release): dist attachment and POM signature

### DIFF
--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -51,6 +51,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
+              <attach>false</attach>
               <tarLongFileMode>posix</tarLongFileMode>
               <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
               <descriptors>
@@ -596,15 +597,6 @@
             <executions>
               <execution>
                 <id>basepom.default</id>
-                <phase />
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
                 <phase />
               </execution>
             </executions>


### PR DESCRIPTION
We do not wish to publish the `ui-react-x.y.z-dist.tar.gz` artefact to
Maven central, so we need to disable the attachment of artifact from the
Maven reactor. Being that the ui-react module is the last module in the
reactor and that staging of artefacts will happen on the last module
there is no way to escape staging of the POM file of the ui-react. So
for the staged repository to be released we can't skip the signing of
the POM file.

So this will in fact publish the ui-react module to Maven central, but
hopefully only of the POM.

[ci skip]