### PR TITLE
More refactorings and stricter errorprone

### DIFF
--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedCamelOperationTest.java
@@ -17,7 +17,6 @@ package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
 
-import org.apache.camel.FailedToCreateRouteException;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorNotSupportedSyndesisOperationTest.java
@@ -17,9 +17,6 @@ package io.syndesis.connector.mongo;
 
 import io.syndesis.common.model.integration.Step;
 
-import org.apache.camel.CamelExecutionException;
-import org.apache.camel.FailedToCreateRouteException;
-import org.apache.camel.component.mongodb3.CamelMongoDbException;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -480,7 +480,6 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
      *
      * @throws Exception
      */
-    @SuppressWarnings( "unchecked" )
     @Test
     public void testReferenceODataRouteAlreadySeenWithKeyPredicate() throws Exception {
         String resourcePath = "Airports";

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/TrustAllTrustManager.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/TrustAllTrustManager.java
@@ -18,24 +18,24 @@ package io.syndesis.connector.support.util;
 import java.net.Socket;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;
 
 /**
- * TrustManager that trusts all certificates.
- * Use only for AMQ connections to SSL Brokers, when no Broker certificate provided.
- * @author dhirajsb
+ * TrustManager that trusts all certificates. Use only for AMQ connections to
+ * SSL Brokers, when no Broker certificate provided.
  */
-public class TrustAllTrustManager extends X509ExtendedTrustManager {
+class TrustAllTrustManager extends X509ExtendedTrustManager {
     private static final X509Certificate[] NONE = new X509Certificate[0];
 
     @Override
-    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
         // no-op
     }
 
     @Override
-    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
         // no-op
     }
 
@@ -45,17 +45,17 @@ public class TrustAllTrustManager extends X509ExtendedTrustManager {
     }
 
     @Override
-    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
-        // no-op
-    }
-
-    @Override
-    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-        // no-op
-    }
-
-    @Override
     public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        // no-op
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
+        // no-op
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
         // no-op
     }
 

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
@@ -134,7 +134,7 @@ public class GenerateMetadataMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "RESOURCE_AND_SPECIFICATION")
     @SuppressWarnings("PMD.ImmutableField")
-    private InspectionMode inspectionMode = InspectionMode.RESOURCE_AND_SPECIFICATION;
+    private InspectionMode inspectionMode;
 
     /**
      * Partial Extension JSON descriptor to augment

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationResourceManager.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationResourceManager.java
@@ -92,14 +92,6 @@ public interface IntegrationResourceManager {
      */
     String decrypt(String encrypted);
 
-    /**
-     * Collect dependencies.
-     */
-    default Collection<Dependency> collectDependencies(Integration integration) {
-        return collectDependencies(integration.getFlows().stream().flatMap(flow -> flow.getSteps().stream()).collect(Collectors.toList()), true);
-    }
-
-
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     @SuppressWarnings("PMD.ExcessiveMethodLength")
     default Integration sanitize(Integration integration) {
@@ -223,9 +215,10 @@ public interface IntegrationResourceManager {
         return name == null ? null : Names.sanitize(name);
     }
 
-    /**
-     * Collect dependencies.
-     */
+    default Collection<Dependency> collectDependencies(Integration integration) {
+        return collectDependencies(integration.getFlows().stream().flatMap(flow -> flow.getSteps().stream()).collect(Collectors.toList()), true);
+    }
+
     default Collection<Dependency> collectDependencies(Collection<? extends Step> steps, boolean resolveExtensionTags) {
         final List<Dependency> dependencies = new ArrayList<>();
 

--- a/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/IntegrationRuntimeAutoConfiguration.java
+++ b/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/IntegrationRuntimeAutoConfiguration.java
@@ -50,9 +50,10 @@ public class IntegrationRuntimeAutoConfiguration {
     private IntegrationRuntimeConfiguration configuration;
 
     @Autowired(required = false)
+    @SuppressWarnings("FieldCanBeFinal")
     private List<ActivityTrackingPolicyFactory> activityTrackingPolicyFactories = Collections.emptyList();
 
-    @SuppressWarnings("PMD.ImmutableField")
+    @SuppressWarnings({"PMD.ImmutableField", "FieldCanBeFinal"})
     @Autowired(required = false)
     private List<IntegrationStepHandler> integrationStepHandlers = Collections.emptyList();
 

--- a/app/meta/src/main/java/io/syndesis/connector/meta/Application.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/Application.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.connector.meta;
 
-
 import javax.servlet.Filter;
 
 import io.syndesis.connector.support.verifier.api.MetadataRetrieval;
@@ -34,11 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.web.filter.CommonsRequestLoggingFilter;
 
-/**
- * @author roland
- * @since 20/03/2017
- */
-@SuppressWarnings("PMD.UseUtilityClass")
+@SuppressWarnings("PrivateConstructorForUtilityClass")
 @SpringBootApplication
 public class Application {
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -133,6 +133,8 @@
     <micrometer.version>1.2.0</micrometer.version>
     <teiid.version>12.2.1</teiid.version>
     <aws-java-sdk-core.version>1.11.269</aws-java-sdk-core.version>
+
+    <javac.werror>-Werror</javac.werror>
   </properties>
 
   <modules>
@@ -559,12 +561,27 @@
                 <arg>-Xlint:-deprecation</arg>
                 <arg>-Xlint:-processing</arg>
                 <arg>-Xlint:-serial</arg>
-                <arg>-Werror</arg>
+                <arg>${javac.werror}</arg>
                 <arg>-XepDisableWarningsInGeneratedCode</arg>
                 <arg>-XepExcludedPaths:.*/generated-sources/.*</arg>
+                <arg>-Xep:ConstantField:WARN</arg>
+                <arg>-Xep:ExpectedExceptionRefactoring:WARN</arg>
+                <arg>-Xep:FieldCanBeFinal:WARN</arg>
+                <arg>-Xep:LambdaFunctionalInterface:WARN</arg>
+                <arg>-Xep:MethodCanBeStatic:WARN</arg>
+                <arg>-XepOpt:MethodCanBeStatic:FindingPerSite</arg>
+                <arg>-Xep:PackageLocation:WARN</arg>
+                <arg>-Xep:PrivateConstructorForUtilityClass:WARN</arg>
+                <arg>-Xep:RemoveUnusedImports:WARN</arg>
+                <arg>-Xep:SwitchDefault:WARN</arg>
+                <arg>-Xep:TestExceptionRefactoring:WARN</arg>
+                <arg>-Xep:ThrowsUncheckedException:WARN</arg>
+                <arg>-Xep:TryFailRefactoring:WARN</arg>
+                <arg>-Xep:UnnecessaryStaticImport:WARN</arg>
+                <arg>-Xep:WildcardImport:WARN</arg>
                 <arg>-implicit:none</arg>
-                <!-- temporary disable until https://github.com/google/error-prone/issues/780 is resolved -->
-                <arg>-Xep:ParameterName:OFF</arg>
+                <arg>${errorprone.autofix.arg1}</arg>
+                <arg>${errorprone.autofix.arg2}</arg>
               </compilerArgs>
             </configuration>
             <dependencies>
@@ -588,28 +605,14 @@
 
     <profile>
       <id>autofix</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <compilerArgs>
-                <!-- partialy duplicated from above, no way to combine.self not helping here -->
-                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                <arg>-XepExcludedPaths:.*/generated-sources/.*</arg>
-                <!-- temporary disable until https://github.com/google/error-prone/issues/780 is resolved -->
-                <arg>-Xep:ParameterName:OFF</arg>
-                <!-- configuration to patch in fixes -->
-                <arg>-XepPatchChecks:BadImport,DeadException,DefaultCharset,MissingOverride,UnnecessaryParentheses,UnusedVariable,UnusedMethod</arg>
-                <arg>-XepPatchLocation:IN_PLACE</arg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <!-- -Werror is given to javac it never reaches the GENERATE task, and fails in COMPILATION, and refactorings are applied in GENERATE task, so they would be skipped -->
+        <javac.werror></javac.werror>
+        <errorprone.autofix.arg1>-XepPatchChecks:BadImport,DeadException,DefaultCharset,MissingOverride,UnnecessaryParentheses,UnusedVariable,UnusedMethod,FieldCanBeFinal,MethodCanBeStatic,ClassCanBeStatic,RemoveUnusedImports,ThrowsUncheckedException</errorprone.autofix.arg1>
+        <errorprone.autofix.arg2>-XepPatchLocation:IN_PLACE</errorprone.autofix.arg2>
+      </properties>
     </profile>
+
   </profiles>
 
   <build>

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/util/IconGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/util/IconGeneratorTest.java
@@ -15,11 +15,6 @@
  */
 package io.syndesis.server.api.generator.util;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,23 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class IconGeneratorTest {
 
     private static final String PREFIX = "data:image/svg+xml,%3Csvg";
-
-    @Test
-    @Ignore("Generates test.html for visual inspection")
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    public void generateTestHtml() throws IOException {
-        try (PrintStream out = new PrintStream(new FileOutputStream("test.html"))) {
-            out.println("<html><body>");
-
-            for (int letter = 'A'; letter <= 'Z'; letter++) {
-                final String letterString = String.valueOf((char) letter);
-                final String icon = IconGenerator.generate("swagger-connector-template", letterString);
-
-                out.println("<br/>");
-                out.println("<img src=\"" + icon + "\" /> (" + icon.length() + ")");
-            }
-        }
-    }
 
     @Test
     public void shouldGenerateIcon() {

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/salesforce/SalesforceConfiguration.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/salesforce/SalesforceConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.social.salesforce.connect.SalesforceConnectionFactory
 
 @Configuration
 @ConditionalOnClass(SalesforceConnectionFactory.class)
+@SuppressWarnings("PrivateConstructorForUtilityClass") // Spring auto configuration
 public class SalesforceConfiguration {
 
     protected static final class SalesforceApplicator extends OAuth2Applicator {

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialsIntegrationTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialsIntegrationTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
+
 import org.junit.runners.Parameterized.Parameters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -59,8 +59,7 @@ import static org.mockito.Mockito.when;
 @Configuration
 public class CredentialsIntegrationTest {
 
-    @Parameter(0)
-    public static String PROVIDER;
+    public String provider;
 
     @ClassRule
     public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
@@ -107,9 +106,13 @@ public class CredentialsIntegrationTest {
         }
     }
 
+    public CredentialsIntegrationTest(final String provider) {
+        this.provider = provider;
+    }
+
     @Test
     public void shouldSupportResourceProviders() {
-        assertThat(credentialProviderLocator.providerWithId(PROVIDER)).isNotNull();
+        assertThat(credentialProviderLocator.providerWithId(provider)).isNotNull();
     }
 
     @Parameters(name = "provider={0}")

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
@@ -64,7 +64,7 @@ public final class IntegrationDeploymentHandler extends BaseHandler {
     private final UserConfigurationProperties properties;
 
     public static class TargetStateRequest {
-        private IntegrationDeploymentState targetState;
+        private final IntegrationDeploymentState targetState;
 
         @JsonCreator
         public TargetStateRequest(@JsonProperty("targetState") IntegrationDeploymentState targetState) {


### PR DESCRIPTION
Contains:

refactor: remove unused imports (e116d41)

refactor: warning suppression tuning (97d9c9c)

This removes unnecessary @SuppressWarnings and adds additional ones that
are needed to pass the stricter checks.

refactor: test cleanup (0ca4cb7)

refactor: field can be final (4a71242)

refactor: group overridden methods (15bd8be)

refactor: field could be final (4130261)

In this case since Plexus will initialize the field with the default
value when the Mojo is configured there's no need to initialize the
field at construction, that would be cleaner, but it would mark the
field for could be made final check.

chore: stricter errorprone checks (ac71470)

This adds additional errorprone checks by changing their severity from
suggestion to warning. And makes sure that the autofix profile can
perform fixes and that the autofix inherits the configuration from the
default profile.

cc @syndesisio/backend 