### PR TITLE
fix: Flaky integration test on nightly CI

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -56,8 +56,9 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
     private HttpServer httpTestServer;
 
     /**
-     * Integration periodically retrieves all contacts from the database and maps the entries (first_name, last_name, company) to a spreadsheet on a Google Sheets account.
-     * The integration uses a split step to pass entries one by one to the Google Sheets API.
+     * Integration periodically retrieves all contacts (ordered by first_name) from the database and maps the
+     * entries (first_name, last_name, company) to a Http endpoint.
+     * The integration uses a split step to pass entries one by one to the Http endpoint.
      */
     @ClassRule
     public static SyndesisIntegrationRuntimeContainer integrationContainer = new SyndesisIntegrationRuntimeContainer.Builder()
@@ -74,12 +75,12 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
     public void testDBToHttp(@CitrusResource TestRunner runner) {
         runner.sql(builder -> builder.dataSource(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company) values ('Joe','Jackson','Red Hat')",
-                                "insert into contact (first_name, last_name, company) values ('Joanne','Jackson','Red Hat')")));
+                                          "insert into contact (first_name, last_name, company) values ('Joanne','Jackson','Red Hat')")));
 
         runner.http(builder -> builder.server(httpTestServer)
                 .receive()
                 .put()
-                .payload("{\"contact\":\"Joe Jackson Red Hat\"}"));
+                .payload("{\"contact\":\"Joanne Jackson Red Hat\"}"));
 
         runner.http(builder -> builder.server(httpTestServer)
                 .send()
@@ -88,7 +89,7 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.http(builder -> builder.server(httpTestServer)
                 .receive()
                 .put()
-                .payload("{\"contact\":\"Joanne Jackson Red Hat\"}"));
+                .payload("{\"contact\":\"Joe Jackson Red Hat\"}"));
 
         runner.http(builder -> builder.server(httpTestServer)
                 .send()

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/sql/DBToHttp-export/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/sql/DBToHttp-export/model.json
@@ -1080,7 +1080,7 @@
                     "type": "SQL_PARAM_IN"
                   },
                   "outputDataShape": {
-                    "description": "Result of SQL [select * from contact]",
+                    "description": "Result of SQL [select * from contact order by first_name]",
                     "kind": "json-schema",
                     "metadata": {
                       "variant": "collection"
@@ -1095,13 +1095,13 @@
                       "name": "SQL statement",
                       "properties": {
                         "query": {
-                          "defaultValue": "select * from contact",
+                          "defaultValue": "select * from contact order by first_name",
                           "deprecated": false,
                           "displayName": "SQL statement",
                           "enum": [
                             {
                               "label": "query",
-                              "value": "select * from contact"
+                              "value": "select * from contact order by first_name"
                             }
                           ],
                           "group": "common",
@@ -1138,7 +1138,7 @@
                 ]
               },
               "configuredProperties": {
-                "query": "select * from contact",
+                "query": "select * from contact order by first_name",
                 "schedulerExpression": "60000"
               },
               "connection": {
@@ -1472,7 +1472,7 @@
                     "type": "SQL_PARAM_IN"
                   },
                   "outputDataShape": {
-                    "description": "Result of SQL [select * from contact]",
+                    "description": "Result of SQL [select * from contact order by first_name]",
                     "kind": "json-schema",
                     "metadata": {
                       "variant": "element"
@@ -1482,7 +1482,7 @@
                     "type": "SQL_PARAM_OUT",
                     "variants": [
                       {
-                        "description": "Result of SQL [select * from contact]",
+                        "description": "Result of SQL [select * from contact order by first_name]",
                         "kind": "json-schema",
                         "metadata": {
                           "variant": "collection"


### PR DESCRIPTION
DBToHttp_IT has had flaky behavior on CI builds. The order of contact entries has not been deterministic so the Http server validation sometimes failed. Now order entries by first name.