### PR TITLE
refactor: remove `throws Exception` from ComponentProxyComponent

### DIFF
--- a/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnector.java
+++ b/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQConnector.java
@@ -99,9 +99,8 @@ class ActiveMQConnector extends ComponentProxyComponent {
         this.clientCertificate = clientCertificate;
     }
 
-    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @Override
-    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
         SjmsComponent component = lookupComponent();
 
         if (component == null) {

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQConnectionTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQConnectionTest.java
@@ -67,7 +67,7 @@ public class ActiveMQConnectionTest extends ConnectorTestSupport {
     // **************************
 
     @Test
-    public void connectionTest() throws Exception {
+    public void connectionTest() {
         final String message = UUID.randomUUID().toString();
         final SjmsComponent sjms1 = context.getComponent("sjms-sjms-0-0", SjmsComponent.class);
         final SjmsComponent sjms2 = context.getComponent("sjms-sjms-0-1", SjmsComponent.class);

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSharedConnectionTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSharedConnectionTest.java
@@ -56,7 +56,7 @@ public class ActiveMQSharedConnectionTest extends ActiveMQConnectorTestSupport {
     // **************************
 
     @Test
-    public void sharedConnectionTest() throws Exception {
+    public void sharedConnectionTest() {
         final String message = UUID.randomUUID().toString();
         final SjmsComponent sjms1 = context.getComponent("sjms-sjms-0-0", SjmsComponent.class);
         final SjmsComponent sjms2 = context.getComponent("sjms-sjms-0-1", SjmsComponent.class);

--- a/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSubscribeConnectorTest.java
+++ b/app/connector/activemq/src/test/java/io/syndesis/connector/activemq/ActiveMQSubscribeConnectorTest.java
@@ -50,7 +50,7 @@ public class ActiveMQSubscribeConnectorTest extends ActiveMQConnectorTestSupport
     // **************************
 
     @Test
-    public void subscribeTest() throws Exception {
+    public void subscribeTest() throws InterruptedException {
         final String message = UUID.randomUUID().toString();
 
         MockEndpoint mock = getMockEndpoint("mock:result");

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnector.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnector.java
@@ -112,9 +112,8 @@ class AMQPConnector extends ComponentProxyComponent {
         return new AMQPVerifierExtension(getComponentId(), getCamelContext());
     }
 
-    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @Override
-    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
 
         AMQPComponent delegate = lookupComponent();
 

--- a/app/connector/box/src/main/java/io/syndesis/connector/box/BoxConnector.java
+++ b/app/connector/box/src/main/java/io/syndesis/connector/box/BoxConnector.java
@@ -38,7 +38,7 @@ public class BoxConnector extends ComponentProxyComponent {
     }
 
     @Override
-    protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) throws Exception {
+    protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) {
         super.configureDelegateComponent(definition, component, options);
 
         if (component instanceof BoxComponent) {
@@ -53,7 +53,7 @@ public class BoxConnector extends ComponentProxyComponent {
     }
 
     @Override
-    protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
+    protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) {
         Map<String, String> endpointOptions = super.buildEndpointOptions(remaining, options);
         Stream.of("parentFolderId", "fileId").forEach(key -> {
                 ConnectorOptions.extractOptionAndConsume(options, key, (String value) -> endpointOptions.put(key, value));

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
@@ -190,7 +190,7 @@ public final class EMailComponent extends ComponentProxyComponent implements EMa
     }
 
     @Override
-    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
         String protocol = getProtocol();
         if (protocol == null) {
             throw new IllegalStateException("No protocol specified for email component");
@@ -230,7 +230,7 @@ public final class EMailComponent extends ComponentProxyComponent implements EMa
     }
 
     @Override
-    protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
+    protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) {
         Endpoint endpoint = super.createDelegateEndpoint(getDefinition(), scheme, options);
 
         Protocol protocol = Protocol.getValueOf(getProtocol());

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnector.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnector.java
@@ -16,6 +16,8 @@
 
 package io.syndesis.connector.sheets;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,10 +41,14 @@ public class GoogleSheetsConnector extends ComponentProxyComponent {
         super(componentId, componentScheme);
     }
 
-    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @Override
-    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
-        final GoogleSheetsClientFactory clientFactory = GoogleSheetsConnectorHelper.createClientFactory(rootUrl, serverCertificate, validateCertificates);
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
+        final GoogleSheetsClientFactory clientFactory;
+        try {
+            clientFactory = GoogleSheetsConnectorHelper.createClientFactory(rootUrl, serverCertificate, validateCertificates);
+        } catch (GeneralSecurityException | IOException e) {
+            throw new IllegalStateException("Unable to create Google Sheets client factory", e);
+        }
 
         switch (getComponentScheme()) {
             case "google-sheets-stream": {

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -66,10 +66,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-catalog</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-http4</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorFactories.java
+++ b/app/connector/http/src/main/java/io/syndesis/connector/http/HttpConnectorFactories.java
@@ -18,16 +18,15 @@ package io.syndesis.connector.http;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.camel.Component;
-import org.apache.camel.Endpoint;
-import org.apache.camel.catalog.DefaultCamelCatalog;
-import org.apache.camel.util.ObjectHelper;
-import org.apache.camel.util.StringHelper;
-import org.apache.commons.lang3.StringUtils;
-
 import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyFactory;
+
+import org.apache.camel.Component;
+import org.apache.camel.Endpoint;
+import org.apache.camel.util.ObjectHelper;
+import org.apache.camel.util.StringHelper;
+import org.apache.commons.lang3.StringUtils;
 
 public final class HttpConnectorFactories {
     private HttpConnectorFactories() {
@@ -42,8 +41,7 @@ public final class HttpConnectorFactories {
         public ComponentProxyComponent newInstance(String componentId, String componentScheme) {
             return new ComponentProxyComponent(componentId, componentScheme) {
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+                protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
                     // As we don't have any specific component setting, we do
                     // not need
                     // to create a delegated component
@@ -51,19 +49,15 @@ public final class HttpConnectorFactories {
                 }
 
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
+                protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) {
                     options.put("httpUri", computeHttpUri("http", options));
 
                     return super.buildEndpointOptions(remaining, options);
                 }
 
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
-                    // Build the delegate uri using the catalog
-                    DefaultCamelCatalog catalog = new DefaultCamelCatalog(false);
-                    String uri = catalog.asEndpointUri(scheme, options, false);
+                protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) {
+                    final String uri = createEndpointUriFor(scheme, options);
                     final String uriFinal = uri + "&httpClient.redirectsEnabled=true";
                     return getCamelContext().getEndpoint(uriFinal);
                 }
@@ -80,8 +74,7 @@ public final class HttpConnectorFactories {
         public ComponentProxyComponent newInstance(String componentId, String componentScheme) {
             return new ComponentProxyComponent(componentId, componentScheme) {
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+                protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
                     // As we don't have any specific component setting, we do
                     // not need
                     // to create a delegated component (till we add support for
@@ -90,19 +83,15 @@ public final class HttpConnectorFactories {
                 }
 
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
+                protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) {
                     options.put("httpUri", computeHttpUri("https", options));
 
                     return super.buildEndpointOptions(remaining, options);
                 }
 
                 @Override
-                @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-                protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
-                    // Build the delegate uri using the catalog
-                    DefaultCamelCatalog catalog = new DefaultCamelCatalog(false);
-                    String uri = catalog.asEndpointUri(scheme, options, false);
+                protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) {
+                    final String uri = createEndpointUriFor(scheme, options);
                     final String uriFinal = uri + "&httpClient.redirectsEnabled=true";
                     return getCamelContext().getEndpoint(uriFinal);
                 }
@@ -114,7 +103,6 @@ public final class HttpConnectorFactories {
     // Helpers
     // *******************************
 
-    @SuppressWarnings("PMD.UseStringBufferForStringAppends")
     public static String computeHttpUri(String scheme, Map<String, Object> options) {
         String baseUrl = (String)options.remove("baseUrl");
 
@@ -133,11 +121,7 @@ public final class HttpConnectorFactories {
 
         String path = (String)options.remove("path");
         if (StringUtils.isNotEmpty(path)) {
-            if (path.charAt(0) != '/') {
-                path = "/" + path;
-            }
-
-            return StringUtils.removeEnd(baseUrl, "/") + path;
+            return StringUtils.removeEnd(baseUrl, "/") + "/" + StringUtils.removeStart(path, "/");
         } else {
             return baseUrl;
         }

--- a/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
+++ b/app/connector/irc/src/main/java/io/syndesis/connector/irc/IrcConnector.java
@@ -25,7 +25,7 @@ public class IrcConnector extends ComponentProxyComponent {
     }
 
     @Override
-    protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) throws Exception {
+    protected Map<String, String> buildEndpointOptions(String remaining, Map<String, Object> options) {
         Map<String, String> endpointOptions = super.buildEndpointOptions(remaining, options);
         String channels = ConnectorOptions.extractOption(options, "channels");
         if (channels != null) {

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -116,7 +116,6 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         this.queryParams = queryParams;
     }
 
-    @SuppressWarnings("PMD")
     public boolean isFilterAlreadySeen() {
         return filterAlreadySeen ;
     }
@@ -190,10 +189,8 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
             .build();
     }
 
-    @SuppressWarnings("PMD")
     @Override
-    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
-        Olingo4Component component = new Olingo4Component(getCamelContext());
+    protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
         Olingo4AppEndpointConfiguration configuration = new Olingo4AppEndpointConfiguration();
 
         Map<String, String> httpHeaders = new HashMap<>();
@@ -250,29 +247,27 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
             configuration.setFilterAlreadySeen(isFilterAlreadySeen());
         }
 
+        Olingo4Component component = new Olingo4Component(getCamelContext());
         component.setConfiguration(configuration);
         return Optional.of(component);
     }
 
-    @SuppressWarnings("PMD")
     private void configureResourcePath(Olingo4AppEndpointConfiguration configuration, Map<String, Object> options) {
         //
         // keyPredicate is not supported properly in 2.21.0 but is handled
         // in 2.24.0 by setting it directly on the configuration. Can modify
         // this when component dependencies are upgraded.
         //
-        String resourcePath = ConnectorOptions.extractOption(options, RESOURCE_PATH);
+        StringBuilder resourcePath = new StringBuilder(ConnectorOptions.extractOption(options, RESOURCE_PATH));
         if (getKeyPredicate() != null) {
-            resourcePath = resourcePath + ODataUtil.formatKeyPredicate(getKeyPredicate(), true);
+            resourcePath.append(ODataUtil.formatKeyPredicate(getKeyPredicate(), true));
         }
 
-        configuration.setResourcePath(resourcePath);
+        configuration.setResourcePath(resourcePath.toString());
     }
 
     @Override
-    protected Endpoint createDelegateEndpoint(
-                                              ComponentDefinition definition, String scheme, Map<String, String> options)
-                                              throws Exception {
+    protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) {
 
         Endpoint endpoint = super.createDelegateEndpoint(definition, scheme, options);
 

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/json/ClientPrimitiveValueSerializer.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/customizer/json/ClientPrimitiveValueSerializer.java
@@ -43,7 +43,6 @@ public class ClientPrimitiveValueSerializer
         return ClientPrimitiveValue.class;
     }
 
-    @SuppressWarnings("PMD.MissingBreakInSwitch")
     @Override
     public void serialize(ClientPrimitiveValue value, JsonGenerator generator, SerializerProvider provider) throws IOException {
         try {
@@ -64,11 +63,11 @@ public class ClientPrimitiveValueSerializer
                 case Int64:
                     generator.writeNumber(value.toCastValue(Integer.class));
                     break;
-                case String:
                 default:
                     generator.writeString(value.toString());
+                    break;
             }
-        } catch (EdmPrimitiveTypeException e) {
+        } catch (EdmPrimitiveTypeException ignored) {
             generator.writeString(value.toString());
         }
     }

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrieval.java
@@ -53,7 +53,6 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         return new ODataMetaDataExtension(context);
     }
 
-    @SuppressWarnings({"PMD"})
     @Override
     protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
         ODataMetadata odataMetadata = (ODataMetadata) metadata.getPayload();
@@ -75,9 +74,9 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
             case READ:
                 if (actionId.endsWith(FROM)) {
                     return genReadFromDataShape(odataMetadata, properties, enrichedProperties);
-                } else {
-                    return genReadToShape(odataMetadata, enrichedProperties);
                 }
+
+                return genReadToShape(odataMetadata, enrichedProperties);
             case CREATE:
                 return genCreateDataShape(odataMetadata, enrichedProperties);
             case DELETE:
@@ -141,7 +140,6 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
         }
     }
 
-    @SuppressWarnings("PMD")
     private void schemaFor(PropertyMetadata propertyMetadata, ObjectSchema parentSchema) {
         JsonSchema schema;
 
@@ -168,6 +166,7 @@ public class ODataMetaDataRetrieval extends ComponentMetadataRetrieval implement
                 break;
             default:
                 schema = factory.anySchema();
+                break;
         }
 
         if (propertyMetadata.isArray()) {

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetadata.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/meta/ODataMetadata.java
@@ -19,8 +19,11 @@ import java.util.HashSet;
 import java.util.Set;
 import io.syndesis.connector.odata.ODataConstants;
 
-@SuppressWarnings("PMD")
 public class ODataMetadata implements ODataConstants {
+
+    private Set<String> entityNames;
+
+    private Set<PropertyMetadata> entityProperties;
 
     public static class PropertyMetadata {
 
@@ -85,10 +88,6 @@ public class ODataMetadata implements ODataConstants {
             this.chilldProperties = childProperties;
         }
     }
-
-    private Set<String> entityNames;
-
-    private Set<PropertyMetadata> entityProperties;
 
     public boolean hasEntityProperties() {
         return entityProperties != null && ! entityProperties.isEmpty();

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -201,9 +201,10 @@ public abstract class AbstractODataTest implements ODataConstants {
     }
 
     protected String testData(String fileName, Class<?> tgtClass) throws IOException {
-        InputStream in = tgtClass.getResourceAsStream(fileName);
-        String expected = streamToString(in);
-        return expected;
+        try (InputStream in = tgtClass.getResourceAsStream(fileName)) {
+            String expected = streamToString(in);
+            return expected;
+        }
     }
 
     protected String testData(String fileName) throws IOException {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -384,13 +384,10 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
         request.addHeader(HttpHeader.ODATA_VERSION, ODataServiceVersion.V40.toString());
         request.addHeader(HttpHeader.ODATA_MAX_VERSION, ODataServiceVersion.V40.toString());
 
-        CloseableHttpClient client = HttpClients.createMinimal();
-        try {
-            CloseableHttpResponse response = client.execute(request);
+        try (CloseableHttpClient client = HttpClients.createMinimal();
+            CloseableHttpResponse response = client.execute(request)) {
             StatusLine statusLine = response.getStatusLine();
             assertEquals(HttpStatus.SC_NO_CONTENT, statusLine.getStatusCode());
-        } finally {
-            client.close();
         }
     }
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/FilterExpressionVisitor.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/FilterExpressionVisitor.java
@@ -42,262 +42,278 @@ public class FilterExpressionVisitor implements ExpressionVisitor<Object> {
 
     private final Entity currentEntity;
 
-  public FilterExpressionVisitor(Entity currentEntity) {
-    this.currentEntity = currentEntity;
+    public FilterExpressionVisitor(Entity currentEntity) {
+        this.currentEntity = currentEntity;
     }
 
-  @Override
-  public Object visitMember(final Member member) throws ExpressionVisitException, ODataApplicationException {
-    // To keeps things simple, this tutorial allows only primitive properties.
-    // We have faith that the java type of Edm.Int32 is Integer
+    @Override
+    public Object visitMember(final Member member) throws ExpressionVisitException, ODataApplicationException {
+        // To keeps things simple, this tutorial allows only primitive
+        // properties.
+        // We have faith that the java type of Edm.Int32 is Integer
 
-    final List<UriResource> uriResourceParts = member.getResourcePath().getUriResourceParts();
+        final List<UriResource> uriResourceParts = member.getResourcePath().getUriResourceParts();
 
-    // Make sure that the resource path of the property contains only a single segment and a primitive property
-    // has been addressed. We can be sure, that the property exists because the UriParser checks if the
-    // property has been defined in service metadata document.
+        // Make sure that the resource path of the property contains only a
+        // single segment and a primitive property
+        // has been addressed. We can be sure, that the property exists because
+        // the UriParser checks if the
+        // property has been defined in service metadata document.
 
-    if(uriResourceParts.size() == 1 && uriResourceParts.get(0) instanceof UriResourcePrimitiveProperty) {
-      UriResourcePrimitiveProperty uriResourceProperty = (UriResourcePrimitiveProperty) uriResourceParts.get(0);
-      return currentEntity.getProperty(uriResourceProperty.getProperty().getName()).getValue();
-    } else {
-      // The OData specification allows in addition complex properties and navigation properties
-      // with a target cardinality 0..1 or 1.
-      // This means any combination can occur e.g. Supplier/Address/City
-      //  -> Navigation properties  Supplier
-      //  -> Complex Property       Address
-      //  -> Primitive Property     City
-      // For such cases the resource path returns a list of UriResourceParts
-      throw new ODataApplicationException("Only primitive properties are implemented in filter expressions",
-          HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-    }
-  }
+        if (uriResourceParts.size() == 1 && uriResourceParts.get(0) instanceof UriResourcePrimitiveProperty) {
+            UriResourcePrimitiveProperty uriResourceProperty = (UriResourcePrimitiveProperty) uriResourceParts.get(0);
+            return currentEntity.getProperty(uriResourceProperty.getProperty().getName()).getValue();
+        }
 
-  @Override
-  public Object visitLiteral(Literal literal) throws ExpressionVisitException, ODataApplicationException {
-    // To keep this tutorial simple, our filter expression visitor supports only Edm.Int32 and Edm.String
-    // In real world scenarios it can be difficult to guess the type of an literal.
-    // We can be sure, that the literal is a valid OData literal because the URI Parser checks
-    // the lexicographical structure
-
-    // String literals start and end with an single quotation mark
-    String literalAsString = literal.getText();
-    if(literal.getType() instanceof EdmString) {
-      String stringLiteral = "";
-      if(literal.getText().length() > 2) {
-        stringLiteral = literalAsString.substring(1, literalAsString.length() - 1);
-      }
-
-      return stringLiteral;
-    } else {
-      // Try to convert the literal into an Java Integer
-      try {
-        return Integer.parseInt(literalAsString);
-      } catch(NumberFormatException e) {
-        throw new ODataApplicationException("Only Edm.Int32 and Edm.String literals are implemented",
+        // The OData specification allows in addition complex properties and
+        // navigation properties
+        // with a target cardinality 0..1 or 1.
+        // This means any combination can occur e.g. Supplier/Address/City
+        // -> Navigation properties Supplier
+        // -> Complex Property Address
+        // -> Primitive Property City
+        // For such cases the resource path returns a list of UriResourceParts
+        throw new ODataApplicationException("Only primitive properties are implemented in filter expressions",
             HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-      }
-    }
-  }
-
-  @Override
-  public Object visitUnaryOperator(UnaryOperatorKind operator, Object operand)
-      throws ExpressionVisitException, ODataApplicationException {
-    // OData allows two different unary operators. We have to take care, that the type of the operand fits to
-    // operand
-
-    if(operator == UnaryOperatorKind.NOT && operand instanceof Boolean) {
-      // 1.) boolean negation
-      return !(Boolean) operand;
-    } else if(operator == UnaryOperatorKind.MINUS && operand instanceof Integer){
-      // 2.) arithmetic minus
-      return -(Integer) operand;
     }
 
-    // Operation not processed, throw an exception
-    throw new ODataApplicationException("Invalid type for unary operator",
-        HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
-  }
+    @Override
+    public Object visitLiteral(Literal literal) throws ExpressionVisitException, ODataApplicationException {
+        // To keep this tutorial simple, our filter expression visitor supports
+        // only Edm.Int32 and Edm.String
+        // In real world scenarios it can be difficult to guess the type of an
+        // literal.
+        // We can be sure, that the literal is a valid OData literal because the
+        // URI Parser checks
+        // the lexicographical structure
+
+        // String literals start and end with an single quotation mark
+        String literalAsString = literal.getText();
+        if (literal.getType() instanceof EdmString) {
+            String stringLiteral = "";
+            if (literal.getText().length() > 2) {
+                stringLiteral = literalAsString.substring(1, literalAsString.length() - 1);
+            }
+
+            return stringLiteral;
+        }
+
+        // Try to convert the literal into an Java Integer
+        try {
+            return Integer.parseInt(literalAsString);
+        } catch (NumberFormatException e) {
+            throw new ODataApplicationException("Only Edm.Int32 and Edm.String literals are implemented",
+                HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH, e);
+        }
+    }
+
+    @Override
+    public Object visitUnaryOperator(UnaryOperatorKind operator, Object operand)
+        throws ExpressionVisitException, ODataApplicationException {
+        // OData allows two different unary operators. We have to take care,
+        // that the type of the operand fits to
+        // operand
+
+        if (operator == UnaryOperatorKind.NOT && operand instanceof Boolean) {
+            // 1.) boolean negation
+            return !(Boolean) operand;
+        } else if (operator == UnaryOperatorKind.MINUS && operand instanceof Integer) {
+            // 2.) arithmetic minus
+            return -(Integer) operand;
+        }
+
+        // Operation not processed, throw an exception
+        throw new ODataApplicationException("Invalid type for unary operator",
+            HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
+    }
 
     @Override
     public Object visitBinaryOperator(BinaryOperatorKind operator, Object left, Object right)
         throws ExpressionVisitException, ODataApplicationException {
 
-      // Binary Operators are split up in three different kinds. Up to the kind of the operator it can be applied
-      // to different types
-      //   - Arithmetic operations like add, minus, modulo, etc. are allowed on numeric types like Edm.Int32
-      //   - Logical operations are allowed on numeric types and also Edm.String
-      //   - Boolean operations like and, or are allowed on Edm.Boolean
-      // A detailed explanation can be found in OData Version 4.0 Part 2: URL Conventions
+        // Binary Operators are split up in three different kinds. Up to the
+        // kind of the operator it can be applied
+        // to different types
+        // - Arithmetic operations like add, minus, modulo, etc. are allowed on
+        // numeric types like Edm.Int32
+        // - Logical operations are allowed on numeric types and also Edm.String
+        // - Boolean operations like and, or are allowed on Edm.Boolean
+        // A detailed explanation can be found in OData Version 4.0 Part 2: URL
+        // Conventions
 
-    if (operator == BinaryOperatorKind.ADD
-        || operator == BinaryOperatorKind.MOD
-        || operator == BinaryOperatorKind.MUL
-        || operator == BinaryOperatorKind.DIV
-        || operator == BinaryOperatorKind.SUB) {
-      return evaluateArithmeticOperation(operator, left, right);
-    } else if (operator == BinaryOperatorKind.EQ
-        || operator == BinaryOperatorKind.NE
-        || operator == BinaryOperatorKind.GE
-        || operator == BinaryOperatorKind.GT
-        || operator == BinaryOperatorKind.LE
-        || operator == BinaryOperatorKind.LT) {
-      return evaluateComparisonOperation(operator, left, right);
-    } else if (operator == BinaryOperatorKind.AND
-        || operator == BinaryOperatorKind.OR) {
-      return evaluateBooleanOperation(operator, left, right);
-      } else {
-        throw new ODataApplicationException("Binary operation " + operator.name() + " is not implemented",
-          HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-      }
-  }
+        if (operator == BinaryOperatorKind.ADD
+            || operator == BinaryOperatorKind.MOD
+            || operator == BinaryOperatorKind.MUL
+            || operator == BinaryOperatorKind.DIV
+            || operator == BinaryOperatorKind.SUB) {
+            return evaluateArithmeticOperation(operator, left, right);
+        } else if (operator == BinaryOperatorKind.EQ
+            || operator == BinaryOperatorKind.NE
+            || operator == BinaryOperatorKind.GE
+            || operator == BinaryOperatorKind.GT
+            || operator == BinaryOperatorKind.LE
+            || operator == BinaryOperatorKind.LT) {
+            return evaluateComparisonOperation(operator, left, right);
+        } else if (operator == BinaryOperatorKind.AND
+            || operator == BinaryOperatorKind.OR) {
+            return evaluateBooleanOperation(operator, left, right);
+        } else {
+            throw new ODataApplicationException("Binary operation " + operator.name() + " is not implemented",
+                HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
+        }
+    }
 
     private static Object evaluateBooleanOperation(BinaryOperatorKind operator, Object left, Object right)
         throws ODataApplicationException {
 
-      // First check that both operands are of type Boolean
-      if(left instanceof Boolean && right instanceof Boolean) {
-        Boolean valueLeft = (Boolean) left;
-        Boolean valueRight = (Boolean) right;
+        // First check that both operands are of type Boolean
+        if (left instanceof Boolean && right instanceof Boolean) {
+            Boolean valueLeft = (Boolean) left;
+            Boolean valueRight = (Boolean) right;
 
-        // Than calculate the result value
-        if(operator == BinaryOperatorKind.AND) {
-          return valueLeft && valueRight;
-        } else {
-          // OR
-          return valueLeft || valueRight;
+            // Than calculate the result value
+            if (operator == BinaryOperatorKind.AND) {
+                return valueLeft && valueRight;
+            }
+
+            // OR
+            return valueLeft || valueRight;
         }
-      } else {
+
         throw new ODataApplicationException("Boolean operations needs two numeric operands",
-          HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
-      }
+            HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
     }
 
-  private static Object evaluateComparisonOperation(BinaryOperatorKind operator, Object left, Object right)
-      throws ODataApplicationException {
+    private static Object evaluateComparisonOperation(BinaryOperatorKind operator, Object left, Object right)
+        throws ODataApplicationException {
 
-    // All types in our tutorial supports all logical operations, but we have to make sure that the types are equals
-    if(left.getClass().equals(right.getClass()) && left instanceof Comparable) {
-      // Luckily all used types String, Boolean and also Integer support the interface Comparable
-      int result;
-      if(left instanceof Integer) {
-        result = ((Comparable<Integer>) (Integer)left).compareTo((Integer) right);
-      } else if(left instanceof String) {
-        result = ((Comparable<String>) (String)left).compareTo((String) right);
-      } else if(left instanceof Boolean) {
-        result = ((Comparable<Boolean>) (Boolean)left).compareTo((Boolean) right);
-      } else {
-        throw new ODataApplicationException("Class " + left.getClass().getCanonicalName() + " not expected",
-            HttpStatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), Locale.ENGLISH);
-      }
+        // All types in our tutorial supports all logical operations, but we
+        // have to make sure that the types are equals
+        if (left.getClass().equals(right.getClass()) && left instanceof Comparable) {
+            // Luckily all used types String, Boolean and also Integer support
+            // the interface Comparable
+            int result;
+            if (left instanceof Integer) {
+                result = ((Comparable<Integer>) (Integer) left).compareTo((Integer) right);
+            } else if (left instanceof String) {
+                result = ((Comparable<String>) (String) left).compareTo((String) right);
+            } else if (left instanceof Boolean) {
+                result = ((Comparable<Boolean>) (Boolean) left).compareTo((Boolean) right);
+            } else {
+                throw new ODataApplicationException("Class " + left.getClass().getCanonicalName() + " not expected",
+                    HttpStatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), Locale.ENGLISH);
+            }
 
-      if (operator == BinaryOperatorKind.EQ) {
-        return result == 0;
-      } else if (operator == BinaryOperatorKind.NE) {
-        return result != 0;
-      } else if (operator == BinaryOperatorKind.GE) {
-        return result >= 0;
-      } else if (operator == BinaryOperatorKind.GT) {
-        return result > 0;
-      } else if (operator == BinaryOperatorKind.LE) {
-        return result <= 0;
-      } else {
-        // BinaryOperatorKind.LT
-        return result < 0;
-      }
+            if (operator == BinaryOperatorKind.EQ) {
+                return result == 0;
+            } else if (operator == BinaryOperatorKind.NE) {
+                return result != 0;
+            } else if (operator == BinaryOperatorKind.GE) {
+                return result >= 0;
+            } else if (operator == BinaryOperatorKind.GT) {
+                return result > 0;
+            } else if (operator == BinaryOperatorKind.LE) {
+                return result <= 0;
+            } else {
+                // BinaryOperatorKind.LT
+                return result < 0;
+            }
 
-    } else {
-      throw new ODataApplicationException("Comparision needs two equal types",
-          HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
-    }
-  }
-
-  private static Object evaluateArithmeticOperation(BinaryOperatorKind operator, Object left,
-      Object right) throws ODataApplicationException {
-
-      // First check if the type of both operands is numerical
-      if(left instanceof Integer && right instanceof Integer) {
-        Integer valueLeft = (Integer) left;
-        Integer valueRight = (Integer) right;
-
-        // Than calculate the result value
-        if(operator == BinaryOperatorKind.ADD) {
-          return valueLeft + valueRight;
-        } else if(operator == BinaryOperatorKind.SUB) {
-          return valueLeft - valueRight;
-        } else if(operator == BinaryOperatorKind.MUL) {
-          return valueLeft * valueRight;
-        } else if(operator == BinaryOperatorKind.DIV) {
-          return valueLeft / valueRight;
-        } else {
-          // BinaryOperatorKind,MOD
-          return valueLeft % valueRight;
         }
-      } else {
+
+        throw new ODataApplicationException("Comparision needs two equal types",
+            HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
+    }
+
+    private static Object evaluateArithmeticOperation(BinaryOperatorKind operator, Object left,
+        Object right) throws ODataApplicationException {
+
+        // First check if the type of both operands is numerical
+        if (left instanceof Integer && right instanceof Integer) {
+            Integer valueLeft = (Integer) left;
+            Integer valueRight = (Integer) right;
+
+            // Than calculate the result value
+            if (operator == BinaryOperatorKind.ADD) {
+                return valueLeft + valueRight;
+            } else if (operator == BinaryOperatorKind.SUB) {
+                return valueLeft - valueRight;
+            } else if (operator == BinaryOperatorKind.MUL) {
+                return valueLeft * valueRight;
+            } else if (operator == BinaryOperatorKind.DIV) {
+                return valueLeft / valueRight;
+            } else {
+                // BinaryOperatorKind,MOD
+                return valueLeft % valueRight;
+            }
+        }
+
         throw new ODataApplicationException("Arithmetic operations needs two numeric operands",
             HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
-      }
-  }
+    }
 
-  @Override
+    @Override
     public Object visitMethodCall(MethodKind methodCall, List<Object> parameters)
         throws ExpressionVisitException, ODataApplicationException {
 
-    // To keep this tutorial small and simple, we implement only one method call
-    if(methodCall == MethodKind.CONTAINS) {
-      // "Contains" gets two parameters, both have to be of type String
-      // e.g. /Products?$filter=contains(Description, '1024 MB')
-      //
-      // First the method visistMember is called, which returns the current String value of the property.
-      // After that the method visitLiteral is called with the string literal '1024 MB',
-      // which returns a String
-      //
-      // Both String values are passed to visitMethodCall.
-      if(parameters.get(0) instanceof String && parameters.get(1) instanceof String) {
-        String valueParam1 = (String) parameters.get(0);
-        String valueParam2 = (String) parameters.get(1);
+        // To keep this tutorial small and simple, we implement only one method
+        // call
+        if (methodCall == MethodKind.CONTAINS) {
+            // "Contains" gets two parameters, both have to be of type String
+            // e.g. /Products?$filter=contains(Description, '1024 MB')
+            //
+            // First the method visistMember is called, which returns the
+            // current String value of the property.
+            // After that the method visitLiteral is called with the string
+            // literal '1024 MB',
+            // which returns a String
+            //
+            // Both String values are passed to visitMethodCall.
+            if (parameters.get(0) instanceof String && parameters.get(1) instanceof String) {
+                String valueParam1 = (String) parameters.get(0);
+                String valueParam2 = (String) parameters.get(1);
 
-        return valueParam1.contains(valueParam2);
-      } else {
-        throw new ODataApplicationException("Contains needs two parametes of type Edm.String",
-            HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
-      }
-    } else {
-      throw new ODataApplicationException("Method call " + methodCall + " not implemented",
-          HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-    }
+                return valueParam1.contains(valueParam2);
+            }
+
+            throw new ODataApplicationException("Contains needs two parametes of type Edm.String",
+                HttpStatusCode.BAD_REQUEST.getStatusCode(), Locale.ENGLISH);
+        }
+
+        throw new ODataApplicationException("Method call " + methodCall + " not implemented",
+            HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
     }
 
     @Override
     public Object visitTypeLiteral(EdmType type) throws ExpressionVisitException, ODataApplicationException {
-      throw new ODataApplicationException("Type literals are not implemented",
-        HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
+        throw new ODataApplicationException("Type literals are not implemented",
+            HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
     }
 
-     @Override
-      public Object visitAlias(String aliasName) throws ExpressionVisitException, ODataApplicationException {
-       throw new ODataApplicationException("Aliases are not implemented",
-         HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-     }
+    @Override
+    public Object visitAlias(String aliasName) throws ExpressionVisitException, ODataApplicationException {
+        throw new ODataApplicationException("Aliases are not implemented",
+            HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
+    }
 
-      @Override
-      public Object visitEnum(EdmEnumType type, List<String> enumValues)
-          throws ExpressionVisitException, ODataApplicationException {
+    @Override
+    public Object visitEnum(EdmEnumType type, List<String> enumValues)
+        throws ExpressionVisitException, ODataApplicationException {
         throw new ODataApplicationException("Enums are not implemented",
-          HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-      }
+            HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
+    }
 
-      @Override
-      public Object visitLambdaExpression(String lambdaFunction, String lambdaVariable, Expression expression)
-          throws ExpressionVisitException, ODataApplicationException {
+    @Override
+    public Object visitLambdaExpression(String lambdaFunction, String lambdaVariable, Expression expression)
+        throws ExpressionVisitException, ODataApplicationException {
         throw new ODataApplicationException("Lamdba expressions are not implemented",
-          HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-      }
+            HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
+    }
 
-      @Override
-      public Object visitLambdaReference(String variableName)
-          throws ExpressionVisitException, ODataApplicationException {
+    @Override
+    public Object visitLambdaReference(String variableName)
+        throws ExpressionVisitException, ODataApplicationException {
         throw new ODataApplicationException("Lamdba references are not implemented",
             HttpStatusCode.NOT_IMPLEMENTED.getStatusCode(), Locale.ENGLISH);
-      }
+    }
 }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
@@ -170,10 +170,8 @@ public class ODataTestServer extends Server implements ODataConstants {
 
         try {
             return Integer.parseInt(portProperty);
-        } catch (NumberFormatException ex) {
-            LOG.error("Cannot format the port from the property {}. "
-                                    + "Falling back to default of finding next random port",
-                                      property);
+        } catch (NumberFormatException e) {
+            LOG.error("Cannot format the port from the property {}. Falling back to default of finding next random port", property, e);
             return 0;
         }
     }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEntityCollectionProcessor.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ProductsEntityCollectionProcessor.java
@@ -195,7 +195,7 @@ public class ProductsEntityCollectionProcessor implements EntityCollectionProces
 
                 } catch (ExpressionVisitException e) {
                   throw new ODataApplicationException("Exception in filter evaluation",
-                      HttpStatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), Locale.ENGLISH);
+                      HttpStatusCode.INTERNAL_SERVER_ERROR.getStatusCode(), Locale.ENGLISH, e);
                 }
         }
 

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnectorFactory.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceStreamingConnectorFactory.java
@@ -37,8 +37,7 @@ public class SalesforceStreamingConnectorFactory implements ComponentProxyFactor
         }
 
         @Override
-        @SuppressWarnings("PMD.SignatureDeclareThrowsException")
-        protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) throws Exception {
+        protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme, Map<String, String> options) {
             final String sObjectName = options.get(SalesforceEndpointConfig.SOBJECT_NAME);
             final String query = "SELECT Id FROM " + sObjectName;
             final String topicName = SalesforceUtil.topicNameFor(options);

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomComponentTest.java
@@ -57,7 +57,7 @@ public class ComponentProxyWithCustomComponentTest {
 
         ComponentProxyComponent component = new ComponentProxyComponent("my-sql-proxy", "sql") {
             @Override
-            protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+            protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
                 return Optional.of(new SqlComponent());
             }
         };
@@ -78,7 +78,7 @@ public class ComponentProxyWithCustomComponentTest {
 
         ComponentProxyComponent component = new ComponentProxyComponent("my-sql-proxy", "sql") {
             @Override
-            protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) throws Exception {
+            protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) {
                 assertThat(component).isInstanceOf(SqlComponent.class);
                 assertThat(options).containsKey("dataSource");
                 assertThat(options).hasEntrySatisfying("dataSource", new Condition<Object>() {
@@ -110,13 +110,13 @@ public class ComponentProxyWithCustomComponentTest {
 
         ComponentProxyComponent component = new ComponentProxyComponent("my-sql-proxy", "sql") {
             @Override
-            protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) throws Exception {
+            protected Optional<Component> createDelegateComponent(ComponentDefinition definition, Map<String, Object> options) {
                 componentRef.set(new SqlComponent());
 
                 return Optional.of(componentRef.get());
             }
             @Override
-            protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) throws Exception {
+            protected void configureDelegateComponent(ComponentDefinition definition, Component component, Map<String, Object> options) {
                 assertThat(component).isSameAs(componentRef.get());
                 assertThat(component).isInstanceOf(SqlComponent.class);
                 assertThat(options).containsKey("dataSource");

--- a/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
+++ b/app/integration/component-proxy/src/test/java/io/syndesis/integration/component/proxy/ComponentProxyWithCustomEndpointTest.java
@@ -48,7 +48,7 @@ public class ComponentProxyWithCustomEndpointTest {
 
         ComponentProxyComponent component = new ComponentProxyComponent("my-ftp-proxy", "ftp") {
             @Override
-            protected void configureDelegateEndpoint(ComponentDefinition definition, Endpoint endpoint, Map<String, Object> options) throws Exception {
+            protected void configureDelegateEndpoint(ComponentDefinition definition, Endpoint endpoint, Map<String, Object> options) {
                 assertThat(endpoint).isNotNull();
                 assertThat(endpoint).isInstanceOf(FtpEndpoint.class);
 


### PR DESCRIPTION
Should go without saying, this code should never have been written with `throws Exception`, there's no good reason to do it like that.

Also refactors the endpoint URI creation to reduce duplicate code and handle exceptions properly.

Removes some of the horrids in the OData connector code.