### PR TITLE
fix: maintain selection in create view wizard TEIIDTOOLS-681

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
@@ -6,12 +6,12 @@ export interface IConnectionSchemaListItemProps {
   icon?: string;
   connectionName: string;
   connectionDescription: string;
+  haveSelectedSource: boolean;
 }
 
 export const ConnectionSchemaListItem: React.FunctionComponent<
   IConnectionSchemaListItemProps
 > = props => {
-
   return (
     <>
       <ListViewItem
@@ -20,31 +20,23 @@ export const ConnectionSchemaListItem: React.FunctionComponent<
         )}-list-item`}
         heading={props.connectionName}
         description={
-          props.connectionDescription
-            ? props.connectionDescription
-            : ''
+          props.connectionDescription ? props.connectionDescription : ''
         }
         hideCloseIcon={true}
         leftContent={
           props.icon ? (
             <div className="blank-slate-pf-icon">
-              <img
-                src={props.icon}
-                alt={props.connectionName}
-                width={46}
-              />
+              <img src={props.icon} alt={props.connectionName} width={46} />
             </div>
           ) : (
-              <ListViewIcon name={'database'} />
-            )
+            <ListViewIcon name={'database'} />
+          )
         }
+        initExpanded={props.haveSelectedSource}
         stacked={false}
       >
-        {props.children ? (
-          <ListView>{props.children}</ListView>
-        ) : null}
+        {props.children ? <ListView>{props.children}</ListView> : null}
       </ListViewItem>
     </>
   );
-
-}
+};

--- a/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
@@ -66,18 +66,21 @@ const connectionItems = [
     key="connectionListItem1"
     connectionName={connectionName1}
     connectionDescription={connectionDescription1}
+    haveSelectedSource={false}
   />,
   <ConnectionSchemaListItem
     key="connectionListItem2"
     connectionName={connectionName2}
     connectionDescription={connectionDescription2}
     children={conn2NodeItems}
+    haveSelectedSource={false}
   />,
   <ConnectionSchemaListItem
     key="connectionListItem3"
     connectionName={connectionName3}
     connectionDescription={connectionDescription3}
     children={conn3NodeItems}
+    haveSelectedSource={false}
   />,
 ];
 

--- a/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaListItem.stories.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 
 import { ConnectionSchemaListItem } from '../../../src';
 
-const stories = storiesOf(
-  'Data/Views/ConnectionSchemaListItem',
-  module
-);
+const stories = storiesOf('Data/Views/ConnectionSchemaListItem', module);
 
 const connectionName = 'Connection_1';
 const connectionDescription = 'Connection_1 description';
@@ -15,5 +12,6 @@ stories.add('sample connection schema item', () => (
   <ConnectionSchemaListItem
     connectionName={connectionName}
     connectionDescription={connectionDescription}
+    haveSelectedSource={false}
   />
 ));

--- a/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
@@ -1,4 +1,4 @@
-import { Virtualization } from '@syndesis/models';
+import { SchemaNodeInfo, Virtualization } from '@syndesis/models';
 import { Breadcrumb } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -17,6 +17,50 @@ export interface IViewCreateAppRouteState {
 export const ViewCreateApp: React.FunctionComponent = () => {
   const { t } = useTranslation(['data', 'shared']);
   const { state } = useRouteData<null, IViewCreateAppRouteState>();
+
+  const [selectedSchemaNodes, setSelectedSchemaNodes] = React.useState<
+    SchemaNodeInfo[]
+  >([]);
+  const [selectedNodesCount, setSelectedNodesCount] = React.useState(0);
+
+  const handleNodeSelected = async (
+    connName: string,
+    name: string,
+    teiidName: string,
+    nodePath: string[]
+  ) => {
+    const srcInfo = {
+      connectionName: connName,
+      name,
+      nodePath,
+      teiidName,
+    } as SchemaNodeInfo;
+
+    const currentNodes = selectedSchemaNodes;
+    currentNodes.push(srcInfo);
+    setSelectedSchemaNodes(currentNodes);
+    setSelectedNodesCount(currentNodes.length);
+  };
+
+  const handleNodeDeselected = async (
+    connectionName: string,
+    teiidName: string
+  ) => {
+    const tempArray = selectedSchemaNodes;
+    const index = getIndex(teiidName, tempArray, 'teiidName');
+    tempArray.splice(index, 1);
+    setSelectedSchemaNodes(tempArray);
+    setSelectedNodesCount(tempArray.length);
+  };
+
+  const getIndex = (value: string, arr: SchemaNodeInfo[], prop: string) => {
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i][prop] === value) {
+        return i;
+      }
+    }
+    return -1; // to handle the case where the value doesn't exist
+  };
 
   return (
     <WithClosedNavigation>
@@ -51,7 +95,14 @@ export const ViewCreateApp: React.FunctionComponent = () => {
               .selectSources
           }
           exact={true}
-          component={SelectSourcesPage}
+          render={() => (
+            <SelectSourcesPage
+              selectedSchemaNodes={selectedSchemaNodes}
+              selectedNodesCount={selectedNodesCount}
+              handleNodeSelected={handleNodeSelected}
+              handleNodeDeselected={handleNodeDeselected}
+            />
+          )}
         />
         {/* step 2 */}
         <Route

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -19,47 +19,24 @@ export interface ISelectSourcesRouteState {
   virtualization: Virtualization;
 }
 
-export const SelectSourcesPage: React.FunctionComponent = () => {
+export interface ISelectSourcesPageProps {
+  handleNodeSelected: (
+    connectionName: string,
+    name: string,
+    teiidName: string,
+    nodePath: string[]
+  ) => void;
+  handleNodeDeselected: (connectionName: string, teiidName: string) => void;
+  selectedSchemaNodes: SchemaNodeInfo[];
+  selectedNodesCount: number;
+}
 
-  const { state } = useRouteData<
-    null,
-    ISelectSourcesRouteState
-  >();
-  const [selectedSchemaNodes, setSelectedSchemaNodes] = React.useState<SchemaNodeInfo[]>([]);
-  const [selectedNodesCount, setSelectedNodesCount] = React.useState(0);
+export const SelectSourcesPage: React.FunctionComponent<
+  ISelectSourcesPageProps
+> = props => {
+  const { state } = useRouteData<null, ISelectSourcesRouteState>();
 
-  const handleNodeSelected = async (connName: string, name: string, teiidName: string, nodePath: string[]) => {
-    const srcInfo = {
-      connectionName: connName,
-      name,
-      nodePath,
-      teiidName,
-     } as SchemaNodeInfo;
-
-    const currentNodes = selectedSchemaNodes;
-    currentNodes.push(srcInfo);
-    setSelectedSchemaNodes(currentNodes);
-    setSelectedNodesCount(currentNodes.length);
-  }
-
-  const handleNodeDeselected = async (connectionName: string, teiidName: string) => {
-    const tempArray = selectedSchemaNodes;
-    const index = getIndex(teiidName, tempArray, 'teiidName');
-    tempArray.splice(index, 1);
-    setSelectedSchemaNodes(tempArray);
-    setSelectedNodesCount(tempArray.length);
-  }
-
-  const getIndex = (value: string, arr: SchemaNodeInfo[], prop: string) => {
-    for (let i = 0; i < arr.length; i++) {
-      if (arr[i][prop] === value) {
-        return i;
-      }
-    }
-    return -1; // to handle the case where the value doesn't exist
-  }
-
-  const schemaNodeInfo: SchemaNodeInfo[] = selectedSchemaNodes;
+  const schemaNodeInfo: SchemaNodeInfo[] = props.selectedSchemaNodes;
   const virtualization = state.virtualization;
 
   return (
@@ -67,23 +44,21 @@ export const SelectSourcesPage: React.FunctionComponent = () => {
       header={<ViewCreateSteps step={1} />}
       content={
         <ConnectionSchemaContent
-          onNodeSelected={handleNodeSelected}
-          onNodeDeselected={handleNodeDeselected}
+          onNodeSelected={props.handleNodeSelected}
+          onNodeDeselected={props.handleNodeDeselected}
+          selectedSchemaNodes={props.selectedSchemaNodes}
         />
       }
       cancelHref={resolvers.data.virtualizations.views.root({
         virtualization,
       })}
-      nextHref={resolvers.data.virtualizations.views.createView.selectName(
-        {
-          schemaNodeInfo,
-          virtualization,
-        }
-      )}
-      isNextDisabled={selectedNodesCount>1}
+      nextHref={resolvers.data.virtualizations.views.createView.selectName({
+        schemaNodeInfo,
+        virtualization,
+      })}
+      isNextDisabled={props.selectedNodesCount > 1}
       isNextLoading={false}
       isLastStep={false}
     />
   );
-
-}
+};

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
@@ -36,6 +36,7 @@ export interface IConnectionSchemaContentProps {
     nodePath: string[]
   ) => void;
   onNodeDeselected: (connectionName: string, teiidName: string) => void;
+  selectedSchemaNodes: SchemaNodeInfo[];
 }
 
 export const ConnectionSchemaContent: React.FunctionComponent<
@@ -89,6 +90,11 @@ export const ConnectionSchemaContent: React.FunctionComponent<
                 key={index}
                 connectionName={cName}
                 connectionDescription={''}
+                haveSelectedSource={
+                  props.selectedSchemaNodes[0]
+                    ? props.selectedSchemaNodes[0].connectionName === cName
+                    : false
+                }
                 // tslint:disable-next-line: no-shadowed-variable
                 children={srcInfos.map((info, index) => (
                   <SchemaNodeListItem
@@ -97,7 +103,12 @@ export const ConnectionSchemaContent: React.FunctionComponent<
                     teiidName={info.teiidName}
                     connectionName={info.connectionName}
                     nodePath={info.nodePath}
-                    selected={false}
+                    selected={
+                      props.selectedSchemaNodes[0]
+                        ? props.selectedSchemaNodes[0].teiidName ===
+                          info.teiidName
+                        : false
+                    }
                     onSelectionChanged={handleSourceSelectionChange}
                   />
                 ))}


### PR DESCRIPTION
- Jira Issue https://issues.jboss.org/browse/TEIIDTOOLS-681

- With this PR here is the behavior of Create View Wizard:
when the user expands and selects connection and table on page 1 move to page 2 then decided to come back on page 1.
  -- connection selection is maintained.
  -- list with selected connection is maintained in an expanded state.

- Lifted selected nodes state up in ViewCreateApp component.

- Added haveSelectedSource props in ConnectionSchemaListItem to control the list expansion.

- Assumption: 
  --"teiidName" info for a connection is always present and unique.
  --"connectionName" is always unique.

 