### PR TITLE
fix(install): platform and binary name

### DIFF
--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OPERATOR_GO_PACKAGE="github.com/syndesisio/syndesis/install/operator"
-OPERATOR_BINARY=$HOME/.syndesis/bin/syndesis
+OPERATOR_BINARY=$HOME/.syndesis/bin/syndesis-operator
 
 operatorsdk_is_available() {
     set +e
@@ -82,7 +82,7 @@ download_operator_binary() {
 
     case "$OSTYPE" in
         darwin*)  pattern="mac-64" ;;
-        linux*)   pattern="linux-64" ;;
+        linux*)   pattern="linux-amd64" ;;
         *)        pattern="unknown" ;;
     esac
 


### PR DESCRIPTION
We renamed the operator binary from `operator` to `syndesis` to
`syndesis-operator` (I think that was how the lineage went). The current
binary is named `syndesis-operator`, so we need to use that name as it's
the filename that will be created when we untar the release from GitHub.

The linux platform tar archive has `linux-amd64` in it, we need the to
reflect that.