### PR TITLE
fix: maintain list item selections on back/next TEIIDTOOLS-679

### DIFF
--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
@@ -31,13 +31,10 @@ export interface IDvConnectionCardProps {
 export const DvConnectionCard: React.FunctionComponent<
   IDvConnectionCardProps
 > = props => {
-  const [isSelected, setIsSelected] = React.useState(props.selected);
-
   const doToggleSelected = (connName: string) => (event: any) => {
     // User can only select active connections that are not loading
     if (props.dvStatus === ConnectionStatus.ACTIVE && props.loading === false) {
-      setIsSelected(!isSelected);
-      props.onSelectionChanged(connName, !isSelected);
+      props.onSelectionChanged(connName, !props.selected);
     }
   };
 
@@ -50,10 +47,7 @@ export const DvConnectionCard: React.FunctionComponent<
       onClick={doToggleSelected(props.name)}
     >
       <CardHeader>
-        {props.loading ? (
-          <Spinner loading={true} inline={true} />
-        ) : ( <></> )
-        }
+        {props.loading ? <Spinner loading={true} inline={true} /> : <></>}
         <Label
           className="dv-connection-card__status"
           type={

--- a/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
@@ -21,7 +21,6 @@ export const ViewCreateApp: React.FunctionComponent = () => {
   const [selectedSchemaNodes, setSelectedSchemaNodes] = React.useState<
     SchemaNodeInfo[]
   >([]);
-  const [selectedNodesCount, setSelectedNodesCount] = React.useState(0);
 
   const handleNodeSelected = async (
     connName: string,
@@ -36,21 +35,19 @@ export const ViewCreateApp: React.FunctionComponent = () => {
       teiidName,
     } as SchemaNodeInfo;
 
-    const currentNodes = selectedSchemaNodes;
+    const currentNodes = selectedSchemaNodes.slice();
     currentNodes.push(srcInfo);
     setSelectedSchemaNodes(currentNodes);
-    setSelectedNodesCount(currentNodes.length);
   };
 
   const handleNodeDeselected = async (
     connectionName: string,
     teiidName: string
   ) => {
-    const tempArray = selectedSchemaNodes;
+    const tempArray = selectedSchemaNodes.slice();
     const index = getIndex(teiidName, tempArray, 'teiidName');
     tempArray.splice(index, 1);
     setSelectedSchemaNodes(tempArray);
-    setSelectedNodesCount(tempArray.length);
   };
 
   const getIndex = (value: string, arr: SchemaNodeInfo[], prop: string) => {
@@ -98,7 +95,6 @@ export const ViewCreateApp: React.FunctionComponent = () => {
           render={() => (
             <SelectSourcesPage
               selectedSchemaNodes={selectedSchemaNodes}
-              selectedNodesCount={selectedNodesCount}
               handleNodeSelected={handleNodeSelected}
               handleNodeDeselected={handleNodeDeselected}
             />

--- a/app/ui-react/syndesis/src/modules/data/ViewsImportApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewsImportApp.tsx
@@ -30,29 +30,25 @@ export const ViewsImportApp: React.FunctionComponent = () => {
   };
 
   const [selectedViews, setSelectedViews] = React.useState<ViewInfo[]>([]);
-  const [hasSelectedViews, setHasSelectedViews] = React.useState(false);
 
   const handleAddView = async (view: ViewInfo) => {
-    const currentViews = selectedViews;
+    const currentViews = selectedViews.slice();
     currentViews.push(view);
     setSelectedViews(currentViews);
-    setHasSelectedViews(currentViews.length > 0);
   };
 
   const handleRemoveView = async (viewName: string) => {
-    const currentViews = selectedViews;
+    const currentViews = selectedViews.slice();
     const index = currentViews.findIndex(view => view.viewName === viewName);
 
     if (index !== -1) {
       currentViews.splice(index, 1);
     }
     setSelectedViews(currentViews);
-    setHasSelectedViews(currentViews.length > 0);
   };
 
   const clearViewSelection = () => {
     setSelectedViews([]);
-    setHasSelectedViews(false);
   };
 
   return (
@@ -107,7 +103,6 @@ export const ViewsImportApp: React.FunctionComponent = () => {
           render={() => (
             <SelectViewsPage
               selectedViews={selectedViews}
-              hasSelectedViews={hasSelectedViews}
               handleAddView={handleAddView}
               handleRemoveView={handleRemoveView}
             />

--- a/app/ui-react/syndesis/src/modules/data/ViewsImportApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewsImportApp.tsx
@@ -1,4 +1,4 @@
-import { Virtualization } from '@syndesis/models';
+import { ViewInfo, Virtualization } from '@syndesis/models';
 import { Breadcrumb } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -17,6 +17,43 @@ export interface IViewsImportAppRouteState {
 export const ViewsImportApp: React.FunctionComponent = () => {
   const { t } = useTranslation(['data', 'shared']);
   const { state } = useRouteData<null, IViewsImportAppRouteState>();
+
+  const [selectedConnection, setSelectedConnection] = React.useState('');
+
+  const handleConnectionSelectionChanged = async (
+    name: string,
+    selected: boolean
+  ) => {
+    const selConn = selected ? name : '';
+    setSelectedConnection(selConn);
+    clearViewSelection();
+  };
+
+  const [selectedViews, setSelectedViews] = React.useState<ViewInfo[]>([]);
+  const [hasSelectedViews, setHasSelectedViews] = React.useState(false);
+
+  const handleAddView = async (view: ViewInfo) => {
+    const currentViews = selectedViews;
+    currentViews.push(view);
+    setSelectedViews(currentViews);
+    setHasSelectedViews(currentViews.length > 0);
+  };
+
+  const handleRemoveView = async (viewName: string) => {
+    const currentViews = selectedViews;
+    const index = currentViews.findIndex(view => view.viewName === viewName);
+
+    if (index !== -1) {
+      currentViews.splice(index, 1);
+    }
+    setSelectedViews(currentViews);
+    setHasSelectedViews(currentViews.length > 0);
+  };
+
+  const clearViewSelection = () => {
+    setSelectedViews([]);
+    setHasSelectedViews(false);
+  };
 
   return (
     <WithClosedNavigation>
@@ -51,7 +88,14 @@ export const ViewsImportApp: React.FunctionComponent = () => {
               .selectConnection
           }
           exact={true}
-          component={SelectConnectionPage}
+          render={() => (
+            <SelectConnectionPage
+              selectedConnection={selectedConnection}
+              handleConnectionSelectionChanged={
+                handleConnectionSelectionChanged
+              }
+            />
+          )}
         />
         {/* step 2 */}
         <Route
@@ -60,7 +104,14 @@ export const ViewsImportApp: React.FunctionComponent = () => {
               .selectViews
           }
           exact={true}
-          component={SelectViewsPage}
+          render={() => (
+            <SelectViewsPage
+              selectedViews={selectedViews}
+              hasSelectedViews={hasSelectedViews}
+              handleAddView={handleAddView}
+              handleRemoveView={handleRemoveView}
+            />
+          )}
         />
       </Switch>
     </WithClosedNavigation>

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -28,7 +28,7 @@ export interface ISelectSourcesPageProps {
   ) => void;
   handleNodeDeselected: (connectionName: string, teiidName: string) => void;
   selectedSchemaNodes: SchemaNodeInfo[];
-  selectedNodesCount: number;
+  // selectedNodesCount: number;
 }
 
 export const SelectSourcesPage: React.FunctionComponent<
@@ -56,7 +56,7 @@ export const SelectSourcesPage: React.FunctionComponent<
         schemaNodeInfo,
         virtualization,
       })}
-      isNextDisabled={props.selectedNodesCount > 1}
+      isNextDisabled={props.selectedSchemaNodes.length > 1}
       isNextLoading={false}
       isLastStep={false}
     />

--- a/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectConnectionPage.tsx
@@ -20,22 +20,20 @@ export interface ISelectConnectionRouteState {
   virtualization: Virtualization;
 }
 
-export const SelectConnectionPage: React.FunctionComponent = () => {
+export interface ISelectConnectionPageProps {
+  selectedConnection: string;
+  handleConnectionSelectionChanged: (name: string, selected: boolean) => void;
+}
+
+export const SelectConnectionPage: React.FunctionComponent<
+  ISelectConnectionPageProps
+> = props => {
   const { state } = useRouteData<
     ISelectConnectionRouteParams,
     ISelectConnectionRouteState
   >();
-  const [selectedConnection, setSelectedConnection] = React.useState('');
 
-  const handleConnectionSelectionChanged = async (
-    name: string,
-    selected: boolean
-  ) => {
-    const selConn = selected ? name : '';
-    setSelectedConnection(selConn);
-  };
-
-  const connectionId = selectedConnection;
+  const connectionId = props.selectedConnection;
   const virtualization = state.virtualization;
   const {
     resource: connectionStatuses,
@@ -56,7 +54,8 @@ export const SelectConnectionPage: React.FunctionComponent = () => {
           }
           loading={!hasConnectionStatuses}
           dvSourceStatuses={connectionStatuses}
-          onConnectionSelectionChanged={handleConnectionSelectionChanged}
+          onConnectionSelectionChanged={props.handleConnectionSelectionChanged}
+          selectedConnection={props.selectedConnection}
         />
       }
       cancelHref={resolvers.data.virtualizations.views.root({
@@ -66,7 +65,7 @@ export const SelectConnectionPage: React.FunctionComponent = () => {
         connectionId,
         virtualization,
       })}
-      isNextDisabled={selectedConnection.length < 1}
+      isNextDisabled={props.selectedConnection.length < 1}
       isNextLoading={false}
       isLastStep={false}
     />

--- a/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
@@ -35,7 +35,6 @@ export interface ISelectViewsRouteState {
 
 export interface ISelectViewsPageProps {
   selectedViews: ViewInfo[];
-  hasSelectedViews: boolean;
   handleAddView: (view: ViewInfo) => void;
   handleRemoveView: (viewName: string) => void;
 }
@@ -126,7 +125,7 @@ export const SelectViewsPage: React.FunctionComponent<
         { virtualization }
       )}
       onCreateViews={handleCreateViews}
-      isNextDisabled={!props.hasSelectedViews}
+      isNextDisabled={props.selectedViews.length < 1}
       isNextLoading={saveInProgress}
       isLastStep={true}
     />

--- a/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
@@ -33,14 +33,21 @@ export interface ISelectViewsRouteState {
   connectionId: string;
 }
 
-export const SelectViewsPage: React.FunctionComponent = () => {
+export interface ISelectViewsPageProps {
+  selectedViews: ViewInfo[];
+  hasSelectedViews: boolean;
+  handleAddView: (view: ViewInfo) => void;
+  handleRemoveView: (viewName: string) => void;
+}
+
+export const SelectViewsPage: React.FunctionComponent<
+  ISelectViewsPageProps
+> = props => {
   const { params, state, history } = useRouteData<
     ISelectViewsRouteParams,
     ISelectViewsRouteState
   >();
   const [saveInProgress, setSaveInProgress] = React.useState(false);
-  const [selectedViews, setSelectedViews] = React.useState<ViewInfo[]>([]);
-  const [hasSelectedViews, setHasSelectedViews] = React.useState(false);
   const { pushNotification } = useContext(UIContext);
   const { t } = useTranslation(['data']);
   const { importSource } = useVirtualizationHelpers();
@@ -55,24 +62,6 @@ export const SelectViewsPage: React.FunctionComponent = () => {
     return viewNames;
   };
 
-  const handleAddView = async (view: ViewInfo) => {
-    const currentViews = selectedViews;
-    currentViews.push(view);
-    setSelectedViews(currentViews);
-    setHasSelectedViews(currentViews.length > 0);
-  };
-
-  const handleRemoveView = async (viewName: string) => {
-    const currentViews = selectedViews;
-    const index = currentViews.findIndex(view => view.viewName === viewName);
-
-    if (index !== -1) {
-      currentViews.splice(index, 1);
-    }
-    setSelectedViews(currentViews);
-    setHasSelectedViews(currentViews.length > 0);
-  };
-
   const setInProgress = async (isWorking: boolean) => {
     setSaveInProgress(isWorking);
   };
@@ -84,8 +73,10 @@ export const SelectViewsPage: React.FunctionComponent = () => {
 
   const handleCreateViews = async () => {
     setInProgress(true);
-    const viewNames = selectedViews.map(selectedView => selectedView.viewName);
-    const connName = selectedViews[0].connectionName;
+    const viewNames = props.selectedViews.map(
+      selectedView => selectedView.viewName
+    );
+    const connName = props.selectedViews[0].connectionName;
     const importSources: ImportSources = {
       tables: viewNames,
     };
@@ -123,8 +114,9 @@ export const SelectViewsPage: React.FunctionComponent = () => {
         <ViewInfosContent
           connectionName={state.connectionId}
           existingViewNames={getExistingViewNames(viewDefinitionDescriptors)}
-          onViewSelected={handleAddView}
-          onViewDeselected={handleRemoveView}
+          onViewSelected={props.handleAddView}
+          onViewDeselected={props.handleRemoveView}
+          selectedViews={props.selectedViews}
         />
       }
       cancelHref={resolvers.data.virtualizations.views.root({
@@ -134,7 +126,7 @@ export const SelectViewsPage: React.FunctionComponent = () => {
         { virtualization }
       )}
       onCreateViews={handleCreateViews}
-      isNextDisabled={!hasSelectedViews}
+      isNextDisabled={!props.hasSelectedViews}
       isNextLoading={saveInProgress}
       isLastStep={true}
     />

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
@@ -6,7 +6,10 @@ import {
 } from '@syndesis/ui';
 import * as React from 'react';
 import { EntityIcon } from '../../../shared';
-import { getDvConnectionStatus, isDvConnectionLoading } from './VirtualizationUtils';
+import {
+  getDvConnectionStatus,
+  isDvConnectionLoading,
+} from './VirtualizationUtils';
 
 export interface IDvConnectionsProps {
   connections: Connection[];
@@ -17,17 +20,10 @@ export interface IDvConnectionsProps {
 export const DvConnections: React.FunctionComponent<
   IDvConnectionsProps
 > = props => {
-  const [selectedConnection, setSelectedConnection] = React.useState(
-    props.initialSelection
-  );
-
   const handleConnSourceSelectionChanged = (
     name: string,
     isSelected: boolean
   ) => {
-    const newSelection = isSelected ? name : '';
-    setSelectedConnection(newSelection);
-
     props.onConnectionSelectionChanged(name, isSelected);
   };
 
@@ -41,7 +37,7 @@ export const DvConnections: React.FunctionComponent<
             dvStatus={getDvConnectionStatus(c)}
             icon={<EntityIcon entity={c} alt={c.name} width={46} />}
             loading={isDvConnectionLoading(c)}
-            selected={selectedConnection === c.name}
+            selected={props.initialSelection === c.name}
             onSelectionChanged={handleConnSourceSelectionChanged}
           />
         </DvConnectionsGridCell>

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
@@ -42,6 +42,7 @@ export interface IDvConnectionsWithToolbarProps {
   loading: boolean;
   dvSourceStatuses: VirtualizationSourceStatus[];
   onConnectionSelectionChanged: (name: string, selected: boolean) => void;
+  selectedConnection: string;
   children?: any;
 }
 
@@ -49,7 +50,6 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
   IDvConnectionsWithToolbarProps
 > = props => {
   const { t } = useTranslation(['data', 'shared']);
-  const [selectedConnection, setSelectedConnection] = React.useState('');
 
   function getFilteredAndSortedConnections(
     connections: Connection[],
@@ -89,7 +89,6 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
     selected: boolean
   ) => {
     props.onConnectionSelectionChanged(name, selected);
-    setSelectedConnection(selected ? name : '');
   };
 
   const {
@@ -107,7 +106,7 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
         const filteredAndSortedConnections = getFilteredAndSortedConnections(
           connectionsData.connectionsForDisplay,
           props.dvSourceStatuses,
-          selectedConnection,
+          props.selectedConnection,
           helpers.activeFilters,
           helpers.currentSortType,
           helpers.isSortAscending
@@ -153,7 +152,7 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
                 {filteredAndSortedConnections.length > 0 && (
                   <DvConnections
                     connections={filteredAndSortedConnections}
-                    initialSelection={selectedConnection}
+                    initialSelection={props.selectedConnection}
                     onConnectionSelectionChanged={
                       handleConnectionSelectionChanged
                     }

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
@@ -54,11 +54,16 @@ function getFilteredAndSortedViewInfos(
   return filteredAndSorted;
 }
 
+const getSelectedViewName = (selectedViews: ViewInfo[]): string[] => {
+  return selectedViews.map(view => view.viewName);
+};
+
 export interface IViewInfosContentProps {
   connectionName: string;
   existingViewNames: string[];
   onViewSelected: (view: ViewInfo) => void;
   onViewDeselected: (viewName: string) => void;
+  selectedViews: ViewInfo[];
 }
 
 const filterByName = {
@@ -84,7 +89,7 @@ export const ViewInfosContent: React.FunctionComponent<
   const { t } = useTranslation(['data', 'shared']);
 
   let displayedViews: ViewInfo[] = [];
-  const selectedViewNames: string[] = [];
+  const selectedViewNames: string[] = getSelectedViewName(props.selectedViews);
 
   const handleViewSelectionChange = async (name: string, selected: boolean) => {
     if (selected) {


### PR DESCRIPTION
- Jira Issue https://issues.jboss.org/browse/TEIIDTOOLS-679

- With this PR here is the behavior of Import Datasource Wizard
When the user selects some source on page 1 and moves to page 2 and selects few connections their
  --If the user moves back to page 1, the selected source will be maintained selected there.
  --If the user does not change selection on page 1 and move back to page 2 then the connections selected there will be maintained.
  --If the user changes the selection on page 1 then connection selected on page 2 will be reset

- Lifted the selected source state and selected connection state form SelectConnectionPage and SelecViewPage respectively to ViewsImportApp.
