### PR TITLE
fix: selection allowed for source of active status even for loading

### DIFF
--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
@@ -47,12 +47,8 @@ export const DvConnectionCard: React.FunctionComponent<
       onClick={doToggleSelected(props.name)}
     >
       <CardHeader>
-        {props.loading ? (
-          props.dvStatus !== ConnectionStatus.ACTIVE ? (
-            <Spinner loading={true} inline={true} />
-          ) : (
-            <></>
-          )
+        {props.loading && props.dvStatus !== ConnectionStatus.ACTIVE ? (
+          <Spinner loading={true} inline={true} />
         ) : (
           <></>
         )}

--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionCard.tsx
@@ -33,7 +33,7 @@ export const DvConnectionCard: React.FunctionComponent<
 > = props => {
   const doToggleSelected = (connName: string) => (event: any) => {
     // User can only select active connections that are not loading
-    if (props.dvStatus === ConnectionStatus.ACTIVE && props.loading === false) {
+    if (props.dvStatus === ConnectionStatus.ACTIVE) {
       props.onSelectionChanged(connName, !props.selected);
     }
   };
@@ -47,7 +47,15 @@ export const DvConnectionCard: React.FunctionComponent<
       onClick={doToggleSelected(props.name)}
     >
       <CardHeader>
-        {props.loading ? <Spinner loading={true} inline={true} /> : <></>}
+        {props.loading ? (
+          props.dvStatus !== ConnectionStatus.ACTIVE ? (
+            <Spinner loading={true} inline={true} />
+          ) : (
+            <></>
+          )
+        ) : (
+          <></>
+        )}
         <Label
           className="dv-connection-card__status"
           type={

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -28,7 +28,6 @@ export interface ISelectSourcesPageProps {
   ) => void;
   handleNodeDeselected: (connectionName: string, teiidName: string) => void;
   selectedSchemaNodes: SchemaNodeInfo[];
-  // selectedNodesCount: number;
 }
 
 export const SelectSourcesPage: React.FunctionComponent<


### PR DESCRIPTION
- Jira Issue https://issues.jboss.org/browse/TEIIDTOOLS-820

- with this PR here is the behaviour in Import Datasource wizard
  -- Allowed selection of any ACTIVE connection, even if loading.
  --Removed spinner for ACTIVE connections that are 'loading' (refreshing)