### PR TITLE
fix(TEIIDTOOLS-827) - Cut/Paste URL of virtualization views page or SQL client page does not work

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationDetailsHeader.tsx
@@ -42,7 +42,7 @@ export const VirtualizationDetailsHeader: React.FunctionComponent<
               {props.virtualizationName}
             </SplitItem>
             <SplitItem>
-              {props.publishedState && props.i18nPublishState ? (
+              {!props.isWorking ? (
                 <PublishStatusWithProgress
                   isProgressWithLink={props.isProgressWithLink}
                   i18nPublishState={props.i18nPublishState}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -1,6 +1,19 @@
 {
   "activeConnectionsEmptyStateInfo": "There are no active connections available. Click Create Connection for new connection.",
   "activeConnectionsEmptyStateTitle": "No Active Connections",
+  "buildStatus": {
+    "BUILDING": "Building",
+    "CANCELLED": "Cancelled",
+    "CONFIGURING": "Configuring",
+    "DELETE_SUBMITTED": "Delete Submitted",
+    "DELETE_REQUEUE": "Delete Requeue",
+    "DELETE_DONE": "Delete Done",
+    "DEPLOYING": "Deploying",
+    "FAILED": "Failed",
+    "NOTFOUND": "Not Found",
+    "RUNNING": "Running",
+    "SUBMITTED": "Submitted"
+  },
   "createDataVirtualization": "Create $t(shared:DataVirtualization)",
   "createDataVirtualizationTip": "Create a data virtualization",
   "createDataVirtualizationTitle": "Create New $t(shared:DataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -1,6 +1,19 @@
 {
   "activeConnectionsEmptyStateInfo": "Non ci sono connessioni attive disponibili. Fai clic su Crea connessione per una nuova connessione.",
   "activeConnectionsEmptyStateTitle": "Nessuna Connessione Attiva",
+  "buildStatus": {
+    "BUILDING": "Costruzione",
+    "CANCELLED": "Annullato",
+    "CONFIGURING": "Configurazione",
+    "DELETE_SUBMITTED": "Elimina Inviato",
+    "DELETE_REQUEUE": "Elimina la Coda",
+    "DELETE_DONE": "Elimina Fatto",
+    "DEPLOYING": "Distribuzione",
+    "FAILED": "Mancato",
+    "NOTFOUND": "Non Trovato",
+    "RUNNING": "In Esecuzione",
+    "SUBMITTED": "Inserito"
+  },
   "createDataVirtualization": "Crea $t(shared:DataVirtualization)",
   "createDataVirtualizationTip": "Creare una virtualizzazione dei dati",
   "createDataVirtualizationTitle": "Crea Nuova $t(shared:DataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
@@ -49,6 +49,7 @@ export const VirtualizationSqlClientPage: React.FunctionComponent = () => {
   return (
     <VirtualizationEditorPage
       onDeleteSuccess={deleteCallback}
+      routeParams={params}
       routeState={state}
       virtualization={virtualization}
     >

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -161,6 +161,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
   return (
     <VirtualizationEditorPage
       onDeleteSuccess={deleteCallback}
+      routeParams={params}
       routeState={state}
       virtualization={virtualization}
     >

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -356,25 +356,18 @@ export function getPublishingDetails(
   const publishStepDetails: VirtualizationPublishingDetails = {
     state: virtualization.publishedState,
     stepNumber: 0,
-    stepText: '',
-    stepTotal: 4,
+    stepText: i18n.t('data:buildStatus.' + virtualization.publishedState),
+    stepTotal: 3,
   };
   switch (virtualization.publishedState) {
     case 'CONFIGURING':
       publishStepDetails.stepNumber = 1;
-      publishStepDetails.stepText = 'Configuring';
       break;
     case 'BUILDING':
       publishStepDetails.stepNumber = 2;
-      publishStepDetails.stepText = 'Building';
       break;
     case 'DEPLOYING':
       publishStepDetails.stepNumber = 3;
-      publishStepDetails.stepText = 'Deploying';
-      break;
-    case 'RUNNING':
-      publishStepDetails.stepNumber = 4;
-      publishStepDetails.stepText = 'Published';
       break;
     default:
       break;


### PR DESCRIPTION
- see [TEIIDTOOLS-827](https://issues.jboss.org/browse/TEIIDTOOLS-827)
- added route params to `VirtualizationEditorPage` so that virtualization name is immediately available to page
- reworked code that referenced `state.virtualization` since that is not available during cut/paste
- description initializes to the actual description when clicking from page to page. It was previously always initializing to `Draft`
- changed build status total steps from 4 to 3
- i18n'd the build status values