### PR TITLE
fix(connector/rest-swagger): support multiple values for query parame…

### DIFF
--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RequestPayloadConverterTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RequestPayloadConverterTest.java
@@ -15,6 +15,8 @@
  */
 package io.syndesis.connector.rest.swagger;
 
+import java.util.List;
+
 import io.syndesis.common.model.DataShapeKinds;
 
 import org.apache.camel.Exchange;
@@ -36,6 +38,21 @@ public class RequestPayloadConverterTest {
         converter.process(createExhangeWithBody(null, "{}"));
         converter.process(createExhangeWithBody("application/xml", "<xml/>"));
         converter.process(createExhangeWithBody("application/json", "{}"));
+    }
+
+    @Test
+    public void shouldConvertArrays() {
+        final RequestPayloadConverter converter = new RequestPayloadConverter(DataShapeKinds.JSON_SCHEMA);
+
+        final Exchange exchange = createExhangeWithBody("application/json",
+            "{\"parameters\":{\"param\": [\"1\", \"2\", \"3\"]}}");
+
+        converter.process(exchange);
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        final Class<List<String>> listType = (Class) List.class;
+
+        assertThat(exchange.getIn().getHeader("param")).isInstanceOfSatisfying(listType, l -> assertThat(l).containsExactly("1", "2", "3"));
     }
 
     @Test

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RestSwaggerConnectorIntegrationTest.java
@@ -181,6 +181,23 @@ public class RestSwaggerConnectorIntegrationTest {
     }
 
     @Test
+    public void shouldPassArrayQueryParameters() {
+        final String doggieArray = "[" + DOGGIE + "]";
+
+        wiremock.givenThat(get("/v2/pet/findByStatus?status=available&status=pending")
+            .willReturn(ok(doggieArray)
+                .withHeader("Content-Type", "application/json")));
+
+        assertThat(context.createProducerTemplate().requestBody("direct:findPetsByStatus",
+            "{\"parameters\":{\"status\":[\"available\",\"pending\"]}}", String.class))
+                .isEqualTo(doggieArray);
+
+        wiremock.verify(getRequestedFor(urlEqualTo("/v2/pet/findByStatus?status=available&status=pending"))
+            .withHeader("Accept", equalTo("application/json"))
+            .withRequestBody(WireMock.equalTo("")));
+    }
+
+    @Test
     public void shouldPassAuthenticationParameterHeader() throws Exception {
         wiremock.givenThat(get("/v2/user/logout")
             .withHeader("apiKey", equalTo("supersecret"))


### PR DESCRIPTION
…ters

This adds support for setting multiple values for query parameters in
the custom API client connectors.

For example query parameters that are of array type and for which
multiple values are given now appear multiple times as query parameter
each time with one of the values.

For example:

    /v2/pet/findByStatus?status=available&status=pending

For `status` having a values `available` and `pending`.

Ref https://issues.jboss.org/browse/ENTESB-12139