### PR TITLE
chore(install): remove `--nodev` from `syndesis install`

### DIFF
--- a/doc/sdh/cli/cmd_install.adoc
+++ b/doc/sdh/cli/cmd_install.adoc
@@ -13,42 +13,42 @@ features specific to these local development environments.
 
 [source,indent=0,subs="verbatim,quotes"]
 ----
--s  --setup               Install CRDs clusterwide. Use --grant if you want a specific user to be
-                          able to install Syndesis. You have to run this option once as
-                          cluster admin.
--u  --grant <user>        Add permissions for the given user so that user can install
-                          the operator in her projects. Must be run as cluster admin.
-    --cluster             Add the permission for all projects in the cluster
-                          (only when used together with --grant)
--p  --project             Install into this project. Delete this project
-                          if it already exists. By default, install into the current project
-                          (without deleting)
-    --operator-only       Only install the operator but no resource
-    --route               Route to use. If not given, the route is trying to be detected
-                          from the currently connected cluster.
-    --console             The URL to the OpenShift console
-    --tag <tag>           Syndesis version/tag to install. If not given, then the latest
-                          version from master is installed
-    --dev                 Prepare for development of Syndesis so that S2I builds of
-                          Syndesis images are picked up properly (implies --watch)
-    --force               Override an existing "Syndesis" if present
--r  --route <route>       Use the given route.
-                          By default "syndesis-<project_name>.apps-crc.testing" is used.
--w  --watch               Wait until cluster is up
-    --local               install from local Git repo when using. By default the
-                          resource descriptor is downloaded from GitHub remotely.
--o  --open                Open Syndesis in browser when installation is ready (implies --watch)
--y  --yes                 Assume 'yes' automatically when asking for deleting
-                          a given project.
-    --memory-server <mem> Memory limit to set for syndesis-server. Specify as "800Mi"
-    --memory-meta <mem>   Memory limit to set for syndesis-meta. Specify as "512Mi"
-    --test-support        Allow test support endpoint for syndesis-server
-    --datavirt            Install Data Virtualizations
-    --maven-mirror        Install Maven Mirror to be used with --maven-mirror when building to speed up builds.
-
-You have to run `--setup --grant <user>` as a cluster-admin before you can
-install Fuse Online as a user.
+Options for install:
+-s  --setup                   Install CRDs clusterwide. Use --grant if you want a specific user to be
+                              able to install Syndesis. You have to run this option once as cluster admin.
+-u  --grant <user>            Add permissions for the given user so that user can install the operator
+                              in her projects. Must be run as cluster admin.
+    --cluster                 Add the permission for all projects in the cluster
+                              (only when used together with --grant)
+-p  --project                 Install into this project. Delete this project
+                              if it already exists. By default, install into the current project (without deleting)
+    --operator-only           Only install the operator but no resource
+                              connected cluster.
+    --tag <tag>               Syndesis version/tag to install. If not given, then the latest
+                              version from master is installed
+    --force                   Override an existing "Syndesis" if present
+-w  --watch                   Wait until cluster is up
+    --local                   install from local Git repo when using. By default the resource descriptor is
+                              downloaded from GitHub remotely.
+-f  --force-binary-download   By default if the binary cli is present in the expected path, it will
+                              be used. With this option enabled, the binary will be removed and downloaded,
+                              ensuring it is the latest version
+-o  --open                    Open Syndesis in browser when installation is ready (implies --watch)
+-y  --yes                     Assume 'yes' automatically when asking for deleting
+                              a given project.
+    --memory-server <mem>     Memory limit to set for syndesis-server. Specify as "800Mi"
+    --memory-meta <mem>       Memory limit to set for syndesis-meta. Specify as "512Mi"
+    --test-support            Allow test support endpoint for syndesis-server
+    --camel-k <version>       Install camel-k operator version <version>
+                              (version is optional)
+    --camel-k-options "opts"  Options used when installing the camel-k operator.
+                              Use quotes and start with a space before appending the options.
+    --datavirt                Install Data Virtualizations.
+    --maven-mirror            Install Maven Mirror to be used with --maven-mirror when building.
+    --man                     Open HTML documentation in the Syndesis Developer Handbook
 ----
+
+You have to run `--setup --grant <user>` as a cluster-admin before you can install Fuse Online as a user.
 
 The deployment happens to the currently connected OpenShift cluster.
 So it's mandatory that you have logged into the cluster with `oc login` before.

--- a/tools/bin/commands/install
+++ b/tools/bin/commands/install
@@ -37,7 +37,6 @@ install::usage() {
                               Use quotes and start with a space before appending the options.
     --datavirt                Install Data Virtualizations.
     --maven-mirror            Install Maven Mirror to be used with --maven-mirror when building.
-    --nodev                   Do not set the devSupport flag in CR (deploys all images)
 EOT
 }
 
@@ -130,17 +129,12 @@ install::run() {
         exit 0
     else
         echo "Deploying syndesis app."
-        if [ $(hasflag --nodev) ] ; then
-            result=$($OPERATOR_BINARY install app)
-        else
-            result=$($OPERATOR_BINARY install app --dev)
-            echo "To complete the installation please go ahead and run local dev builds for syndesis-server syndesis-ui syndesis-meta syndesis-s2i."
-        fi
+        result=$($OPERATOR_BINARY install app)
         check_error "$result"
     fi
 
     echo "Install finished."
-    if [ $(hasflag --watch -w) ] || [ $(hasflag --dev) ] || [ $(hasflag --open -o) ]; then
+    if [ $(hasflag --watch -w) ] || [ $(hasflag --open -o) ]; then
         wait_for_deployments 1 syndesis-server syndesis-ui syndesis-meta
     fi
 


### PR DESCRIPTION
This removes the `--nodev` option from `syndesis install`, development workflows are supported via `syndesis minishift` or `syndesis crc`. For installing to arbitrary cluster one needs to perform `syndesis install` followed by editing of the Syndesis custom resource to enable the dev mode or use the `syndesis-operator` binary with `--dev` option.

Updates the documentation.