### PR TITLE
TEIIDTOOLS-829 Adds details tab to virtualization page

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/index.tsx
+++ b/app/ui-react/syndesis/src/modules/data/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router';
 import {
   VirtualizationCreatePage,
+  VirtualizationDetailsPage,
   VirtualizationImportPage,
   VirtualizationsPage,
   VirtualizationSqlClientPage,
@@ -64,6 +65,11 @@ export class DataModule extends React.Component {
             path={routes.virtualizations.virtualization.sqlClient}
             exact={true}
             component={VirtualizationSqlClientPage}
+          />
+          <Route
+            path={routes.virtualizations.virtualization.details}
+            exact={true}
+            component={VirtualizationDetailsPage}
           />
         </Switch>
       </>

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -31,6 +31,7 @@
   "deleteViewSuccess": "View \"{{name}}\" was deleted.",
   "deleteVirtualizationFailed": "Delete virtualization \"{{name}}\" failed. Details: {{details}}",
   "descriptionPlaceholder": "Enter a description...",
+  "details": "Details",
   "editDataVirtualizationTip": "Edit the data virtualization",
   "emptyStateInfoMessage": "There are no virtualizations available. Click the button below to create one.",
   "emptyStateTitle": "$t(createDataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -31,6 +31,7 @@
   "deleteViewSuccess": "Visualizza \"{{name}}\" è stato eliminato.",
   "deleteVirtualizationFailed": "Elimina virtualizzazione \"{{name}}\" non riuscita. Dettagli: {{details}}",
   "descriptionPlaceholder": "Inserisci una descrizione ...",
+  "details": "Dettagli",
   "editDataVirtualizationTip": "Modifica la virtualizzazione dei dati",
   "emptyStateInfoMessage": "TNon ci sono virtualizzazioni disponibili. Fai clic sul pulsante in basso per crearne uno.",
   "emptyStateTitle": "$t(createDataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationDetailsPage.tsx
@@ -1,0 +1,49 @@
+import { useVirtualization } from '@syndesis/api';
+import { PageSection } from '@syndesis/ui';
+import { useRouteData } from '@syndesis/utils';
+import * as React from 'react';
+import resolvers from '../../resolvers';
+import {
+  IVirtualizationEditorPageRouteParams,
+  IVirtualizationEditorPageRouteState,
+  VirtualizationEditorPage,
+} from './VirtualizationEditorPage';
+
+/**
+ * A page that displays virtualization publish state and history.
+ */
+export const VirtualizationDetailsPage: React.FunctionComponent = () => {
+  /**
+   * Hook to obtain route params and history.
+   */
+  const { params, state, history } = useRouteData<
+    IVirtualizationEditorPageRouteParams,
+    IVirtualizationEditorPageRouteState
+  >();
+
+  /**
+   * Hook to obtain the virtualization being edited. Also does polling to get virtualization descriptor updates.
+   */
+  const { model: virtualization } = useVirtualization(params.virtualizationId);
+
+  /**
+   * Callback for when a virtualization is successfully deleted. This will route to the virtualization
+   * list page.
+   */
+  const deleteCallback = React.useCallback(() => {
+    history.push(resolvers.data.virtualizations.list().pathname);
+  }, [history]);
+
+  return (
+    <VirtualizationEditorPage
+      onDeleteSuccess={deleteCallback}
+      routeParams={params}
+      routeState={state}
+      virtualization={virtualization}
+    >
+      <PageSection>
+        <React.Fragment>Details display coming soon...</React.Fragment>
+      </PageSection>
+    </VirtualizationEditorPage>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -155,7 +155,7 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
             helpers.isSortAscending
           );
           return (
-            <PageSection variant={'light'} noPadding={true}>
+            <PageSection>
               <WithLoader
                 error={error !== false}
                 loading={!hasData}
@@ -197,9 +197,7 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
                         const doDelete = async (
                           virtId: string
                         ): Promise<void> => {
-                          await deleteVirtualization(
-                            virtId
-                          ).catch((e: any) => {
+                          await deleteVirtualization(virtId).catch((e: any) => {
                             pushNotification(
                               t('deleteVirtualizationFailed', {
                                 details: e.errorMessage || e.message || e,
@@ -225,43 +223,44 @@ export const VirtualizationsPage: React.FunctionComponent = () => {
                             throw e;
                           }
 
-                          await publishVirtualization(
-                            virtId
-                          ).catch((e: any) => {
-                            pushNotification(
-                              t('publishVirtualizationFailed', {
-                                details: e.errorMessage || e.message || error,
-                                name: virtId,
-                              }),
-                              'error'
-                            );
-                            throw e;
-                          });
-                        };
-                        const doUnpublish = async (
-                          virtId: string
-                        ): Promise<void> => {
-                          await unpublishVirtualization(
-                            virtId
-                          ).catch((e: any) => {
-                            if (e.name === 'AlreadyUnpublished') {
+                          await publishVirtualization(virtId).catch(
+                            (e: any) => {
                               pushNotification(
-                                t('unpublishedVirtualization', {
-                                  name: virtId,
-                                }),
-                                'info'
-                              );
-                            } else {
-                              pushNotification(
-                                t('unpublishVirtualizationFailed', {
+                                t('publishVirtualizationFailed', {
                                   details: e.errorMessage || e.message || error,
                                   name: virtId,
                                 }),
                                 'error'
                               );
+                              throw e;
                             }
-                            throw e;
-                          });
+                          );
+                        };
+                        const doUnpublish = async (
+                          virtId: string
+                        ): Promise<void> => {
+                          await unpublishVirtualization(virtId).catch(
+                            (e: any) => {
+                              if (e.name === 'AlreadyUnpublished') {
+                                pushNotification(
+                                  t('unpublishedVirtualization', {
+                                    name: virtId,
+                                  }),
+                                  'info'
+                                );
+                              } else {
+                                pushNotification(
+                                  t('unpublishVirtualizationFailed', {
+                                    details:
+                                      e.errorMessage || e.message || error,
+                                    name: virtId,
+                                  }),
+                                  'error'
+                                );
+                              }
+                              throw e;
+                            }
+                          );
                         };
                         const isProgressWithLink = isPublishStep(
                           publishingDetails

--- a/app/ui-react/syndesis/src/modules/data/pages/index.ts
+++ b/app/ui-react/syndesis/src/modules/data/pages/index.ts
@@ -1,5 +1,6 @@
 export * from './VirtualizationCreatePage';
 export * from './VirtualizationEditorPage';
+export * from './VirtualizationDetailsPage';
 export * from './VirtualizationImportPage';
 export * from './VirtualizationsPage';
 export * from './VirtualizationSqlClientPage';

--- a/app/ui-react/syndesis/src/modules/data/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/data/resolvers.ts
@@ -67,7 +67,7 @@ export default {
             },
             state: {
               virtualization,
-              viewDefinition
+              viewDefinition,
             },
           })
         ),
@@ -105,6 +105,17 @@ export default {
         ),
       },
     },
+    details: makeResolver<{ virtualization: Virtualization }>(
+      routes.virtualizations.virtualization.details,
+      ({ virtualization }) => ({
+        params: {
+          virtualizationId: virtualization.name,
+        },
+        state: {
+          virtualization,
+        },
+      })
+    ),
     sqlClient: makeResolver<{ virtualization: Virtualization }>(
       routes.virtualizations.virtualization.sqlClient,
       ({ virtualization }) => ({

--- a/app/ui-react/syndesis/src/modules/data/routes.ts
+++ b/app/ui-react/syndesis/src/modules/data/routes.ts
@@ -7,6 +7,7 @@ export default include('/data', {
     import: 'import',
     list: '',
     virtualization: include(':virtualizationId', {
+      details: 'details',
       root: '',
       sqlClient: 'sqlClient',
       views: include('views', {

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationNavBar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationNavBar.tsx
@@ -18,7 +18,8 @@ export interface IVirtualizationNavBarProps {
  * A component that displays a nav bar with 4 items:
  *
  * 1. a link to the page that displays a list of Views
- * 2. a link to the page that displays the SQL Query editor
+ * 2. a link to the page that displays the virtualization state and history
+ * 3. a link to the page that displays the SQL Query editor
  *
  */
 export const VirtualizationNavBar: React.FunctionComponent<
@@ -33,6 +34,12 @@ export const VirtualizationNavBar: React.FunctionComponent<
         <TabBarItem
           label={t('views')}
           to={resolvers.virtualizations.views.root({
+            virtualization,
+          })}
+        />
+        <TabBarItem
+          label={t('details')}
+          to={resolvers.virtualizations.details({
             virtualization,
           })}
         />


### PR DESCRIPTION
Adds the details tab to the virtualization page.  Content is 'coming soon...' for now, will be updated in subsequent PRs
- Add VirtualizationDetailsPage
- Add the new page to the VirtualizationNavBar
- update routes and resolvers to include details
- also include fix for TEIIDTOOLS-836 - modify PageSection on VirtualizationPages so that content margins agree with other pages.