### PR TITLE
fix(connector/mongodb): flaky test cases fix

### DIFF
--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorCappedCollectionConsumerTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorCappedCollectionConsumerTest.java
@@ -17,13 +17,14 @@ package io.syndesis.connector.mongo;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.mongodb.client.model.CreateCollectionOptions;
 import io.syndesis.common.model.integration.Step;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,19 +34,15 @@ import org.slf4j.LoggerFactory;
 public class MongoDBConnectorCappedCollectionConsumerTest extends MongoDBConnectorTestSupport {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBConnectorCappedCollectionConsumerTest.class);
-    private static int globalId = 1;
-
-    // **************************
-    // Set up
-    // **************************
+    private static int globalId = 0;
 
     // JUnit will execute this method after the @BeforeClass of the superclass
     @BeforeClass
     public static void doCollectionSetup() {
         // The feature only works with capped collections!
         CreateCollectionOptions opts = new CreateCollectionOptions().capped(true).sizeInBytes(1024 * 1024);
-        database.createCollection("test", opts);
-        LOG.debug("Created a capped collection named test");
+        database.createCollection(COLLECTION, opts);
+        LOG.debug("Created a capped collection named {}", COLLECTION);
     }
 
     @Override
@@ -54,39 +51,39 @@ public class MongoDBConnectorCappedCollectionConsumerTest extends MongoDBConnect
             "id");
     }
 
-    // **************************
-    // Tests
-    // **************************
-
     @Test
     public void mongoTest() throws Exception {
         // When
+        String unique = UUID.randomUUID().toString();
+        int id = globalId++;
         MockEndpoint mock = getMockEndpoint("mock:result");
+        // We just retain last message
+        mock.setRetainLast(1);
         mock.expectedMessageCount(1);
         mock.expectedMessagesMatches((Exchange e) -> {
             try {
                 @SuppressWarnings("unchecked")
                 List<String> doc = e.getMessage().getBody(List.class);
                 JsonNode jsonNode = MAPPER.readTree(doc.get(0));
-                int id = jsonNode.get("id").asInt();
-                String value = jsonNode.get("someKey").asText();
-                return id <= globalId && "someValue".equals(value);
+                Assertions.assertThat(jsonNode.get("unique").asText()).isEqualTo(unique);
+                Assertions.assertThat(jsonNode.get("id").asInt()).isEqualTo(id);
+                return true;
             } catch (IOException ex) {
                 return false;
             }
         });
         // Given
         Document doc = new Document();
-        doc.append("id", globalId++);
-        doc.append("someKey", "someValue");
+        doc.append("id", id);
+        doc.append("unique", unique);
         collection.insertOne(doc);
         // Then
-        MockEndpoint.assertIsSatisfied(5, TimeUnit.SECONDS, mock);
+        mock.assertIsSatisfied();
     }
 
     @Test
     public void repeatMongoTest() throws Exception {
-        // As we are tracking _id, any new insert should trigger the new document only
+        // As we are tracking id, any new insert should trigger the new document only
         mongoTest();
     }
 

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorTestSupport.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorTestSupport.java
@@ -123,7 +123,7 @@ public abstract class MongoDBConnectorTestSupport extends ConnectorTestSupport {
 
     protected List<Step> fromMongoTailToMock(String mock, String connector, String db, String collection,
                                          String tailTrackIncreasingField) {
-        return this.fromMongoTailToMock(mock, connector, db, collection, tailTrackIncreasingField, null, null, null, null, null);
+        return this.fromMongoTailToMock(mock, connector, db, collection, tailTrackIncreasingField, true, null, null, null, null);
     }
 
     protected List<Step> fromMongoTailToMock(String mock, String connector, String db, String collection,


### PR DESCRIPTION
* Provided persistent tracking in repeating consumer tailing unit test
* Setting mock retain policy to check last message in other consumer unit tests

Fix #7115