### PR TITLE
fix(connector/mongodb): embedded mongo refactory

### DIFF
--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -157,10 +157,15 @@
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Analyzer is requiring to explicit this dependency -->
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.process</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Used at test time for tcp free port utility-->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorCountTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorCountTest.java
@@ -22,7 +22,14 @@ import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 
-public class MongoDBConnectorCountTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorCountTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "countCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorFindAllTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorFindAllTest.java
@@ -27,7 +27,14 @@ import org.junit.Test;
 
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
-public class MongoDBConnectorFindAllTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorFindAllTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "findAllCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorInsertTest.java
@@ -26,7 +26,14 @@ import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 
-public class MongoDBConnectorInsertTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorInsertTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "insertCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorMissingDatabaseOptionsTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorMissingDatabaseOptionsTest.java
@@ -23,7 +23,14 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MongoDBConnectorMissingDatabaseOptionsTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorMissingDatabaseOptionsTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "missingDBCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     @Before

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorProducerTestSupport.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorProducerTestSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.mongo;
+
+import com.mongodb.client.MongoCollection;
+import io.syndesis.connector.mongo.embedded.EmbedMongoConfiguration;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class MongoDBConnectorProducerTestSupport extends MongoDBConnectorTestSupport{
+
+    protected MongoCollection<Document> collection;
+
+    public abstract String getCollectionName();
+
+    @Before
+    public void before(){
+        collection = EmbedMongoConfiguration.DATABASE.getCollection(getCollectionName());
+    }
+
+    @After
+    public void after(){
+        collection.drop();
+    }
+
+}

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorRemoveTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorRemoveTest.java
@@ -24,7 +24,14 @@ import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 
-public class MongoDBConnectorRemoveTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorRemoveTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "removeCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorSaveTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorSaveTest.java
@@ -25,7 +25,14 @@ import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 
-public class MongoDBConnectorSaveTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorSaveTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "upsertCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorTestSupport.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorTestSupport.java
@@ -19,87 +19,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.distribution.Version;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.integration.Step;
+import io.syndesis.connector.mongo.embedded.EmbedMongoConfiguration;
 import io.syndesis.connector.support.test.ConnectorTestSupport;
-import org.bson.Document;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 public abstract class MongoDBConnectorTestSupport extends ConnectorTestSupport {
 
     protected static final ObjectMapper MAPPER = new ObjectMapper();
-    protected final static String HOST = "localhost";
-    protected final static int PORT = 27017;
-    protected final static String USER = "test-user";
-    protected final static String PASSWORD = "test-pwd";
     protected final static String DATABASE = "test";
     protected final static String COLLECTION = "test";
-    protected static final String ADMIN_DB = "admin";
-    // Client connections
-    protected static MongoClient mongoClient;
-    protected static MongoDatabase database;
-    protected static MongoCollection<Document> collection;
-    private static MongodExecutable mongodExecutable;
-
-    @AfterClass
-    public static void tearDownMongo() {
-        mongodExecutable.stop();
-        mongoClient.close();
-    }
-
-    @BeforeClass
-    public static void startUpMongo() throws Exception {
-        IMongodConfig mongodConfig = new MongodConfigBuilder()
-            .version(Version.V3_6_5)
-            .net(new Net(HOST, PORT, false))
-            .build();
-        mongodExecutable = MongodStarter.getDefaultInstance().prepare(mongodConfig);
-        mongodExecutable.start();
-        initClient();
-    }
-
-    protected static void initClient() {
-        mongoClient = new MongoClient(HOST);
-        createAuthorizationUser();
-        database = mongoClient.getDatabase(DATABASE);
-        collection = database.getCollection(COLLECTION);
-    }
-
-    private static void createAuthorizationUser() {
-        MongoDatabase admin = mongoClient.getDatabase("admin");
-        MongoCollection<Document> usersCollection = admin.getCollection("system.users");
-        usersCollection.insertOne(Document.parse("" + "{\n"
-            + "    \"_id\": \"admin.test-user\",\n"
-            // + " \"userId\": Binary(\"rT2IgiexSzisOOsmjGXZEQ==\", 4),\n"
-            + "    \"user\": \"test-user\",\n"
-            + "    \"db\": \"admin\",\n"
-            + "    \"credentials\": {\n"
-            + "        \"SCRAM-SHA-1\": {\n"
-            + "            \"iterationCount\": 10000,\n"
-            + "            \"salt\": \"gmmPAoNdvFSWCV6PGnNcAw==\",\n"
-            + "            \"storedKey\": \"qE9u1Ax7Y40hisNHL2b8/LAvG7s=\",\n"
-            + "            \"serverKey\": \"RefeJcxClt9JbOP/VnrQ7YeQh6w=\"\n"
-            + "        }\n"
-            + "    },\n"
-            + "    \"roles\": [\n"
-            + "        {\n"
-            + "            \"role\": \"readWrite\",\n"
-            + "            \"db\": \"test\"\n"
-            + "        }\n"
-            + "    ]\n"
-            + "}"
-            + ""));
-    }
 
     protected List<Step> fromDirectToMongo(String directStart, String connector, String db, String collection) {
         return fromDirectToMongo(directStart, connector, db, collection, null, null);
@@ -109,10 +38,10 @@ public abstract class MongoDBConnectorTestSupport extends ConnectorTestSupport {
         return Arrays.asList(
             newSimpleEndpointStep("direct", builder -> builder.putConfiguredProperty("name", directStart)),
             newEndpointStep("mongodb3", connector, nop(Connection.Builder.class), builder -> {
-                builder.putConfiguredProperty("host", String.format("%s:%s", HOST, PORT));
-                builder.putConfiguredProperty("user", USER);
-                builder.putConfiguredProperty("password", PASSWORD);
-                builder.putConfiguredProperty("adminDB", ADMIN_DB);
+                builder.putConfiguredProperty("host", String.format("%s:%s", EmbedMongoConfiguration.HOST, EmbedMongoConfiguration.PORT));
+                builder.putConfiguredProperty("user", EmbedMongoConfiguration.USER);
+                builder.putConfiguredProperty("password", EmbedMongoConfiguration.PASSWORD);
+                builder.putConfiguredProperty("adminDB", EmbedMongoConfiguration.ADMIN_DB);
                 builder.putConfiguredProperty("database", db);
                 builder.putConfiguredProperty("collection", collection);
                 if (filter != null) {
@@ -133,10 +62,10 @@ public abstract class MongoDBConnectorTestSupport extends ConnectorTestSupport {
                                          String tailTrackIncreasingField, Boolean persistentTailTracking, String persistentId,
                                          String tailTrackDb, String tailTrackCollection, String tailTrackField) {
         return Arrays.asList(newEndpointStep("mongodb3", connector, nop(Connection.Builder.class), builder -> {
-            builder.putConfiguredProperty("host", String.format("%s:%s", HOST, PORT));
-            builder.putConfiguredProperty("user", USER);
-            builder.putConfiguredProperty("password", PASSWORD);
-            builder.putConfiguredProperty("adminDB", ADMIN_DB);
+            builder.putConfiguredProperty("host", String.format("%s:%s", EmbedMongoConfiguration.HOST, EmbedMongoConfiguration.PORT));
+            builder.putConfiguredProperty("user", EmbedMongoConfiguration.USER);
+            builder.putConfiguredProperty("password", EmbedMongoConfiguration.PASSWORD);
+            builder.putConfiguredProperty("adminDB", EmbedMongoConfiguration.ADMIN_DB);
             builder.putConfiguredProperty("database", db);
             builder.putConfiguredProperty("collection", collection);
             builder.putConfiguredProperty("tailTrackIncreasingField", tailTrackIncreasingField);
@@ -160,10 +89,10 @@ public abstract class MongoDBConnectorTestSupport extends ConnectorTestSupport {
 
     protected List<Step> fromMongoChangeStreamToMock(String mock, String connector, String db, String collection) {
         return Arrays.asList(newEndpointStep("mongodb3", connector, nop(Connection.Builder.class), builder -> {
-            builder.putConfiguredProperty("host", String.format("%s:%s", HOST, PORT));
-            builder.putConfiguredProperty("user", USER);
-            builder.putConfiguredProperty("password", PASSWORD);
-            builder.putConfiguredProperty("adminDB", ADMIN_DB);
+            builder.putConfiguredProperty("host", String.format("%s:%s", EmbedMongoConfiguration.HOST, EmbedMongoConfiguration.PORT));
+            builder.putConfiguredProperty("user", EmbedMongoConfiguration.USER);
+            builder.putConfiguredProperty("password", EmbedMongoConfiguration.PASSWORD);
+            builder.putConfiguredProperty("adminDB", EmbedMongoConfiguration.ADMIN_DB);
             builder.putConfiguredProperty("database", db);
             builder.putConfiguredProperty("collection", collection);
         }), newSimpleEndpointStep("mock", builder -> builder.putConfiguredProperty("name", mock)));

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorUpdateTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/MongoDBConnectorUpdateTest.java
@@ -24,7 +24,14 @@ import org.assertj.core.api.Assertions;
 import org.bson.Document;
 import org.junit.Test;
 
-public class MongoDBConnectorUpdateTest extends MongoDBConnectorTestSupport {
+public class MongoDBConnectorUpdateTest extends MongoDBConnectorProducerTestSupport {
+
+    private final static String COLLECTION = "updateCollection";
+
+    @Override
+    public String getCollectionName() {
+        return COLLECTION;
+    }
 
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/embedded/EmbedMongoConfiguration.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/embedded/EmbedMongoConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.mongo.embedded;
+
+import java.io.IOException;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.Storage;
+import org.bson.Document;
+
+import static de.flapdoodle.embed.mongo.distribution.Version.Main.V3_6;
+import static de.flapdoodle.embed.process.runtime.Network.localhostIsIPv6;
+import static org.springframework.util.SocketUtils.findAvailableTcpPort;
+
+public class EmbedMongoConfiguration {
+
+    public final static int PORT = findAvailableTcpPort();
+
+    public final static String HOST = "localhost";
+    public final static String USER = "test-user";
+    public final static String PASSWORD = "test-pwd";
+    public final static String ADMIN_DB = "admin";
+    // Client connections
+    @SuppressWarnings("ConstantField")
+    public static MongoClient CLIENT;
+    @SuppressWarnings("ConstantField")
+    public static MongoDatabase DATABASE;
+
+    private EmbedMongoConfiguration(){}
+
+    static {
+        try {
+            IMongodConfig mongodConfig = new MongodConfigBuilder()
+                    .version(V3_6)
+                    .net(new Net(PORT, localhostIsIPv6()))
+                    .replication(new Storage(null, "replicationName", 5000))
+                    .build();
+            MongodExecutable mongodExecutable = MongodStarter.getDefaultInstance().prepare(mongodConfig);
+            mongodExecutable.start();
+            // init replica set
+            CLIENT = new MongoClient(HOST, PORT);
+            CLIENT.getDatabase("admin").runCommand(new Document("replSetInitiate", new Document()));
+            createAuthorizationUser();
+            DATABASE = CLIENT.getDatabase("test");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void createAuthorizationUser() {
+        MongoDatabase admin = CLIENT.getDatabase("admin");
+        MongoCollection<Document> usersCollection = admin.getCollection("system.users");
+        usersCollection.insertOne(Document.parse("" + "{\n"
+            + "    \"_id\": \"admin.test-user\",\n"
+            // + " \"userId\": Binary(\"rT2IgiexSzisOOsmjGXZEQ==\", 4),\n"
+            + "    \"user\": \"test-user\",\n"
+            + "    \"db\": \"admin\",\n"
+            + "    \"credentials\": {\n"
+            + "        \"SCRAM-SHA-1\": {\n"
+            + "            \"iterationCount\": 10000,\n"
+            + "            \"salt\": \"gmmPAoNdvFSWCV6PGnNcAw==\",\n"
+            + "            \"storedKey\": \"qE9u1Ax7Y40hisNHL2b8/LAvG7s=\",\n"
+            + "            \"serverKey\": \"RefeJcxClt9JbOP/VnrQ7YeQh6w=\"\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"roles\": [\n"
+            + "        {\n"
+            + "            \"role\": \"readWrite\",\n"
+            + "            \"db\": \"test\"\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}"
+            + ""));
+    }
+}

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/meta/MongoDBMetadataTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/meta/MongoDBMetadataTest.java
@@ -28,6 +28,7 @@ import com.mongodb.client.model.ValidationOptions;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.connector.mongo.MongoDBConnectorTestSupport;
+import io.syndesis.connector.mongo.embedded.EmbedMongoConfiguration;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
 import org.assertj.core.api.Assertions;
 import org.bson.Document;
@@ -38,6 +39,7 @@ public class MongoDBMetadataTest extends MongoDBConnectorTestSupport {
     private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final static String CONNECTOR_ID = "io.syndesis.connector:connector-mongodb-find";
     private final static String SCHEME = "mongodb3";
+    private final static String COLLECTION = "metadataCollection";
 
     @Override
     protected List<Step> createSteps() {
@@ -51,10 +53,10 @@ public class MongoDBMetadataTest extends MongoDBConnectorTestSupport {
         Map<String, Object> properties = new HashMap<>();
         properties.put("database", DATABASE);
         properties.put("collection", collection);
-        properties.put("host", String.format("%s:%s", HOST, PORT));
-        properties.put("user", USER);
-        properties.put("password", PASSWORD);
-        properties.put("adminDB", ADMIN_DB);
+        properties.put("host", String.format("%s:%s", EmbedMongoConfiguration.HOST, EmbedMongoConfiguration.PORT));
+        properties.put("user", EmbedMongoConfiguration.USER);
+        properties.put("password", EmbedMongoConfiguration.PASSWORD);
+        properties.put("adminDB", EmbedMongoConfiguration.ADMIN_DB);
         // When
         Document jsonSchema = Document.parse("{ \n"
             + "      bsonType: \"object\", \n"
@@ -80,7 +82,7 @@ public class MongoDBMetadataTest extends MongoDBConnectorTestSupport {
             + "            description: \"can be only M or F\" } \n"
             + "      }}");
         ValidationOptions collOptions = new ValidationOptions().validator(Filters.eq("$jsonSchema",jsonSchema));
-        mongoClient.getDatabase(DATABASE).createCollection(collection,
+        EmbedMongoConfiguration.CLIENT.getDatabase(DATABASE).createCollection(collection,
             new CreateCollectionOptions().validationOptions(collOptions));
         // Then
         MongoDBMetadataRetrieval metaBridge = new MongoDBMetadataRetrieval();
@@ -109,12 +111,12 @@ public class MongoDBMetadataTest extends MongoDBConnectorTestSupport {
         Map<String, Object> properties = new HashMap<>();
         properties.put("database", DATABASE);
         properties.put("collection", collection);
-        properties.put("host", String.format("%s:%s", HOST, PORT));
-        properties.put("user", USER);
-        properties.put("password", PASSWORD);
-        properties.put("adminDB", ADMIN_DB);
+        properties.put("host", String.format("%s:%s", EmbedMongoConfiguration.HOST, EmbedMongoConfiguration.PORT));
+        properties.put("user", EmbedMongoConfiguration.USER);
+        properties.put("password", EmbedMongoConfiguration.PASSWORD);
+        properties.put("adminDB", EmbedMongoConfiguration.ADMIN_DB);
         // When
-        mongoClient.getDatabase(DATABASE).createCollection(collection);
+        EmbedMongoConfiguration.CLIENT.getDatabase(DATABASE).createCollection(collection);
         // Then
         MongoDBMetadataRetrieval metaBridge = new MongoDBMetadataRetrieval();
         SyndesisMetadata metadata = metaBridge.fetch(

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.connector.mongo.MongoDBConnectorTestSupport;
+import io.syndesis.connector.mongo.embedded.EmbedMongoConfiguration;
 import io.syndesis.connector.support.verifier.api.Verifier;
 import io.syndesis.connector.support.verifier.api.VerifierResponse;
 import org.assertj.core.api.Assertions;
@@ -30,6 +31,7 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
 
     private final static String CONNECTOR_ID = "io.syndesis.connector:connector-mongodb-find";
     private final static MongoDBVerifier VERIFIER = new MongoDBVerifier();
+    private final static String COLLECTION = "verifierCollection";
 
     @Override
     protected List<Step> createSteps() {
@@ -40,10 +42,10 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionOK() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
-        params.put("password", PASSWORD);
-        params.put("database", ADMIN_DB);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
+        params.put("database", EmbedMongoConfiguration.ADMIN_DB);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,
             CONNECTOR_ID, params);
@@ -57,9 +59,9 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionFallbackAdmin() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
-        params.put("password", PASSWORD);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
         params.put("database", DATABASE);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,
@@ -74,11 +76,11 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionFullParamsOK() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
-        params.put("password", PASSWORD);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
         params.put("database", DATABASE);
-        params.put("adminDB", ADMIN_DB);
+        params.put("adminDB", EmbedMongoConfiguration.ADMIN_DB);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,
             CONNECTOR_ID, params);
@@ -93,8 +95,8 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
         //When
         Map<String, Object> params = new HashMap<>();
         params.put("host", "notReachableHost");
-        params.put("user", USER);
-        params.put("password", PASSWORD);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
         params.put("database", DATABASE);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,
@@ -108,8 +110,8 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionMissingParams() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
         params.put("database", DATABASE);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,
@@ -123,8 +125,8 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionNotAuthenticated() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
         params.put("password", "wrongPassword");
         params.put("database", DATABASE);
         //Given
@@ -139,9 +141,9 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
     public void verifyConnectionAdminDBKO() {
         //When
         Map<String, Object> params = new HashMap<>();
-        params.put("host", HOST + ":" + PORT);
-        params.put("user", USER);
-        params.put("password", PASSWORD);
+        params.put("host", EmbedMongoConfiguration.HOST + ":" + EmbedMongoConfiguration.PORT);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
         params.put("adminDB", "someAdminDB");
         params.put("database", DATABASE);
         //Given
@@ -157,8 +159,8 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
         //When
         Map<String, Object> params = new HashMap<>();
         params.put("host", "localhost:12343");
-        params.put("user", USER);
-        params.put("password", PASSWORD);
+        params.put("user", EmbedMongoConfiguration.USER);
+        params.put("password", EmbedMongoConfiguration.PASSWORD);
         params.put("database", DATABASE);
         //Given
         List<VerifierResponse> response = VERIFIER.verify(this.context,


### PR DESCRIPTION
* Starting a unique static server instead of one for each testcase
* Reduced time to execute all testcases by half due to the above

`EmbedMongoConfiguration` will startup a unique server (with replicaset). Each unit test class will use its own collection to reduce resource consumption and limit possibility of test collisions.

Fixes #7164