### PR TITLE
user doc: State that raw version of task-api.json is required

### DIFF
--- a/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
+++ b/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
@@ -16,10 +16,11 @@ process integration data according to the requirements for that operation.
 operations that you want the integration to perform. 
 +
 To experiment,
-link:{syndesis-quickstart-url}/api-provider/task-api.json[download the `task-api.json` file], 
+link:{syndesis-quickstart-url}/api-provider/task-api.json[download the raw version of the `task-api.json` file], 
 which is an OpenAPI document for an API provider quickstart. You can
 upload this file when {prodname} prompts you to provide an OpenAPI
-document. 
+document. Alternatively, you can specify the URL for the raw `task-api.json` file, 
+which is https://raw.githubusercontent.com/syndesisio/syndesis-quickstarts/1.8/api-provider/task-api.json[].
 * You have a plan for the flow for each OpenAPI operation. 
 * You created a connection for each application or service that you want
 to add to an operation's flow. 


### PR DESCRIPTION
Kurt approved this update to the doc for creating an api provider integration. The update states that you must download the raw version of the file, or specify the URL for the raw version. 