### PR TITLE
user doc: Update release number to 7.5 in UI links to downstream doc

### DIFF
--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -83,7 +83,7 @@
       },
       "project": {
         "name": "Syndesis",
-        "version": "7.4"
+        "version": "7.5"
       },
       "error": {
         "title": "Something is wrong",


### PR DESCRIPTION
Now that the Fuse 7.5 user doc has been published on the Red Hat customer portal, the staging site can link to the 7.5 Fuse Online documents. 

Stan already updated the 1.8 branch to have the 7.5 version number. So no need to backport this update. This just makes the links in the staging site display the latest doc. 

