### PR TITLE
fix for Community install is broken #7157

### DIFF
--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -81,7 +81,7 @@ download_operator_binary() {
     fi
 
     case "$OSTYPE" in
-        darwin*)  pattern="mac-64" ;;
+        darwin*)  pattern="darwin" ;;
         linux*)   pattern="linux-amd64" ;;
         *)        pattern="unknown" ;;
     esac


### PR DESCRIPTION
The operator download fails for Mac as the OS calls itself 'darwin' and not 'mac-64'. 