### PR TITLE
feat: add a create OpenAPI 3.x option to the API provider wizard

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/DndFileChooser.css
+++ b/app/ui-react/packages/ui/src/Shared/DndFileChooser.css
@@ -12,6 +12,11 @@
   cursor: default;
 }
 
+.dnd-file-chooser[disabled] .dnd-file-chooser__helpText,
+.dnd-file-chooser[disabled]:hover .dnd-file-chooser__helpText {
+  color: lightgray
+}
+
 .dnd-file-chooser:hover {
   border-color: #39a5dc; /* color-pf-blue-300 */
   background: #fafafa; /* color-pf-black-100 */

--- a/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
@@ -17,6 +17,7 @@ import { Container } from '../Layout';
 import './OpenApiReviewActions.css';
 
 export interface IApiProviderReviewActionsProps {
+  actions?: React.ReactNode;
   apiProviderDescription?: string;
   apiProviderName?: string;
   errorMessages?: string[];
@@ -148,6 +149,12 @@ export class OpenApiReviewActions extends React.Component<
                   : null}
               </Container>
             </TextContent>
+          )}
+          {this.props.actions && (
+            <>
+              <br />
+              {this.props.actions}
+            </>
           )}
         </CardBody>
       </Card>

--- a/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.css
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.css
@@ -7,3 +7,7 @@
 .open-api-select-method__dnd-container {
   margin: 20px 0;
 }
+
+.open-api-select-method__url-container {
+  margin: 20px 0;
+}

--- a/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
@@ -50,6 +50,7 @@ export interface IOpenApiSelectMethodState {
    */
   method?: Method;
   specification?: string;
+  url?: string;
   /**
    * Used to handle D&D upload success/fail messages
    */
@@ -76,6 +77,7 @@ export class OpenApiSelectMethod extends React.Component<
       disableDropzone: false,
       method: 'file',
       specification: '',
+      url: '',
       valid: false,
     };
 
@@ -84,6 +86,7 @@ export class OpenApiSelectMethod extends React.Component<
     this.onSelectMethod = this.onSelectMethod.bind(this);
     this.onUploadAccepted = this.onUploadAccepted.bind(this);
     this.onUploadRejected = this.onUploadRejected.bind(this);
+    this.handleClickNext = this.handleClickNext.bind(this);
   }
 
   /**
@@ -118,7 +121,7 @@ export class OpenApiSelectMethod extends React.Component<
    * @param e
    */
   public onAddUrlSpecification(e: React.FormEvent<HTMLInputElement>) {
-    this.setState({ specification: e.currentTarget.value });
+    this.setState({ url: e.currentTarget.value });
 
     if (
       this.state.method === 'url' &&
@@ -183,6 +186,14 @@ export class OpenApiSelectMethod extends React.Component<
     );
   }
 
+  public handleClickNext() {
+    if (this.state.method === 'url') {
+      this.props.onNext(this.state.method, this.state.url);
+    } else {
+      this.props.onNext(this.state.method, this.state.specification);
+    }
+  }
+
   public render() {
     return (
       <Card className={'open-api-review-actions'}>
@@ -239,7 +250,8 @@ export class OpenApiSelectMethod extends React.Component<
                         <FormControl
                           type={'text'}
                           disabled={this.state.method !== 'url'}
-                          value={this.state.specification}
+                          value={this.state.url}
+
                           onChange={this.onAddUrlSpecification}
                         />
                         <br />
@@ -277,9 +289,7 @@ export class OpenApiSelectMethod extends React.Component<
               <ButtonLink
                 disabled={!this.state.valid}
                 as={'primary'}
-                onClick={() =>
-                  this.props.onNext(this.state.method, this.state.specification)
-                }
+                onClick={this.handleClickNext}
               >
                 {this.props.i18nBtnNext}
               </ButtonLink>

--- a/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
@@ -13,7 +13,7 @@ import { ButtonLink } from '../Layout';
 import { DndFileChooser } from './DndFileChooser';
 import './OpenApiSelectMethod.css';
 
-export type Method = 'file' | 'url' | 'scratch';
+export type Method = 'file' | 'url' | 'scratch2x' | 'scratch3x';
 
 export interface IOpenApiSelectMethodProps {
   allowFromScratch?: boolean;
@@ -27,7 +27,9 @@ export interface IOpenApiSelectMethodProps {
   i18nInstructions: string;
   i18nMethodFromFile: string;
   i18nMethodFromUrl: string;
-  i18nMethodFromScratch: string;
+  // These aren't needed if allowFromScratch is false
+  i18nMethodFromScratch2x?: string;
+  i18nMethodFromScratch3x?: string;
   i18nNoFileSelectedMessage: string;
   i18nSelectedFileLabel: string;
   i18nUploadFailedMessage?: string;
@@ -139,7 +141,7 @@ export class OpenApiSelectMethod extends React.Component<
       specification: '',
       uploadFailedMessage: '',
       uploadSuccessMessage: '',
-      valid: newMethod === 'scratch',
+      valid: newMethod === 'scratch2x' || newMethod === 'scratch3x',
     });
   }
 
@@ -198,32 +200,34 @@ export class OpenApiSelectMethod extends React.Component<
                       readOnly={true}
                     >
                       <div>{this.props.i18nMethodFromFile}</div>
-                      {this.state.method === 'file' && (
-                        <div className="open-api-select-method__dnd-container">
-                          <DndFileChooser
-                            allowMultiple={false}
-                            disableDropzone={this.props.disableDropzone}
-                            fileExtensions={this.props.fileExtensions}
-                            i18nHelpMessage={this.props.i18nHelpMessage}
-                            i18nInstructions={this.props.i18nInstructions}
-                            i18nNoFileSelectedMessage={
-                              this.props.i18nNoFileSelectedMessage
-                            }
-                            i18nSelectedFileLabel={
-                              this.props.i18nSelectedFileLabel
-                            }
-                            i18nUploadFailedMessage={
-                              this.state.uploadFailedMessage
-                            }
-                            i18nUploadSuccessMessage={
-                              this.state.uploadSuccessMessage
-                            }
-                            onUploadAccepted={this.onUploadAccepted}
-                            onUploadRejected={this.onUploadRejected}
-                          />
-                        </div>
-                      )}
+                      <div className="open-api-select-method__dnd-container">
+                        <DndFileChooser
+                          allowMultiple={false}
+                          disableDropzone={
+                            this.props.disableDropzone ||
+                            this.state.method !== 'file'
+                          }
+                          fileExtensions={this.props.fileExtensions}
+                          i18nHelpMessage={this.props.i18nHelpMessage}
+                          i18nInstructions={this.props.i18nInstructions}
+                          i18nNoFileSelectedMessage={
+                            this.props.i18nNoFileSelectedMessage
+                          }
+                          i18nSelectedFileLabel={
+                            this.props.i18nSelectedFileLabel
+                          }
+                          i18nUploadFailedMessage={
+                            this.state.uploadFailedMessage
+                          }
+                          i18nUploadSuccessMessage={
+                            this.state.uploadSuccessMessage
+                          }
+                          onUploadAccepted={this.onUploadAccepted}
+                          onUploadRejected={this.onUploadRejected}
+                        />
+                      </div>
                     </Radio>
+
                     <Radio
                       id={'method-url'}
                       name={'method'}
@@ -231,30 +235,40 @@ export class OpenApiSelectMethod extends React.Component<
                       readOnly={true}
                     >
                       <div>{this.props.i18nMethodFromUrl}</div>
-                      {this.state.method === 'url' && (
-                        <div>
-                          <FormControl
-                            type={'text'}
-                            disabled={false}
-                            value={this.state.specification}
-                            onChange={this.onAddUrlSpecification}
-                          />
-                          <br />
-                          <span className={'url-note'}>
-                            {this.props.i18nUrlNote}
-                          </span>
-                        </div>
-                      )}
+                      <div className={'open-api-select-method__url-container'}>
+                        <FormControl
+                          type={'text'}
+                          disabled={this.state.method !== 'url'}
+                          value={this.state.specification}
+                          onChange={this.onAddUrlSpecification}
+                        />
+                        <br />
+                        <span className={'url-note'}>
+                          {this.props.i18nUrlNote}
+                        </span>
+                      </div>
                     </Radio>
+
                     {this.props.allowFromScratch && (
-                      <Radio
-                        id={'method-scratch'}
-                        name={'method'}
-                        onClick={() => this.onSelectMethod('scratch')}
-                        readOnly={true}
-                      >
-                        <div>{this.props.i18nMethodFromScratch}</div>
-                      </Radio>
+                      <>
+                        <Radio
+                          id={'method-scratch-3x'}
+                          name={'method'}
+                          onClick={() => this.onSelectMethod('scratch3x')}
+                          readOnly={true}
+                        >
+                          <div>{this.props.i18nMethodFromScratch3x}</div>
+                        </Radio>
+
+                        <Radio
+                          id={'method-scratch-2x'}
+                          name={'method'}
+                          onClick={() => this.onSelectMethod('scratch2x')}
+                          readOnly={true}
+                        >
+                          <div>{this.props.i18nMethodFromScratch2x}</div>
+                        </Radio>
+                      </>
                     )}
                   </div>
                 </FormGroup>

--- a/app/ui-react/packages/ui/stories/Integration/Editor/ApiProvider.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Integration/Editor/ApiProvider.stories.tsx
@@ -20,7 +20,8 @@ stories
     <OpenApiSelectMethod
       i18nBtnNext={'Next'}
       i18nMethodFromFile={'Upload an OpenAPI file'}
-      i18nMethodFromScratch={'Create from scratch'}
+      i18nMethodFromScratch2x={'Create a new OpenAPI 2.x document'}
+      i18nMethodFromScratch3x={'Create a new OpenAPI 3.x document'}
       i18nMethodFromUrl={'Use a URL'}
       i18nUrlNote={
         '* Note: After uploading this document, Syndesis does not automatically obtain any updates to it.'

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
@@ -37,7 +37,6 @@
       "dndNoFileSelectedLabel": "No file selected",
       "dndSelectedFileLabel": "Selected file:",
       "methodFromFile": "Upload an OpenAPI file",
-      "methodFromScratch": "Create from scratch",
       "methodFromUrl": "Use a URL",
       "title": "Upload OpenAPI Document",
       "urlNote": "* Note: After uploading this document, updates to it are not automatically obtained."

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
@@ -106,33 +106,35 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                                   )
                                 : undefined
                             }
+                            actions={
+                              <div>
+                                <ButtonLink href={resolvers.create.upload()}>
+                                  {t('Back')}
+                                </ButtonLink>
+                                &nbsp;&nbsp;&nbsp;
+                                <ButtonLink
+                                  href={resolvers.create.specification({
+                                    specification: apiSummary!
+                                      .configuredProperties!.specification,
+                                  })}
+                                >
+                                  {t(
+                                    'apiClientConnectors:create:review:btnReviewEdit'
+                                  )}
+                                </ButtonLink>
+                                &nbsp;
+                                <ButtonLink
+                                  as={'primary'}
+                                  disabled={apiSummary!.errors}
+                                  href={resolvers.create.security({
+                                    specification: apiSummary!,
+                                  })}
+                                >
+                                  {t('Next')}
+                                </ButtonLink>
+                              </div>
+                            }
                           />
-                          <div>
-                            <ButtonLink href={resolvers.create.upload()}>
-                              {t('Back')}
-                            </ButtonLink>
-                            &nbsp;&nbsp;&nbsp;
-                            <ButtonLink
-                              href={resolvers.create.specification({
-                                specification: apiSummary!.configuredProperties!
-                                  .specification,
-                              })}
-                            >
-                              {t(
-                                'apiClientConnectors:create:review:btnReviewEdit'
-                              )}
-                            </ButtonLink>
-                            &nbsp;
-                            <ButtonLink
-                              as={'primary'}
-                              disabled={apiSummary!.errors}
-                              href={resolvers.create.security({
-                                specification: apiSummary!,
-                              })}
-                            >
-                              {t('Next')}
-                            </ButtonLink>
-                          </div>
                         </>
                       )}
                     </WithLoader>

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
@@ -58,9 +58,6 @@ export const SelectMethodPage: React.FunctionComponent = () => {
                   i18nMethodFromFile={t(
                     'apiClientConnectors:create:selectMethod:methodFromFile'
                   )}
-                  i18nMethodFromScratch={t(
-                    'apiClientConnectors:create:selectMethod:methodFromScratch'
-                  )}
                   i18nMethodFromUrl={t(
                     'apiClientConnectors:create:selectMethod:methodFromUrl'
                   )}

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -175,7 +175,7 @@ export class IntegrationEditorStepAdder extends React.Component<
                   <React.Fragment key={idx}>
                     <IntegrationEditorStepsListItem
                       children={children}
-                      stepName={(s.action && s.action.name) || s.name!}
+                      stepName={`${idx + 1}. ${(s.action && s.action.name) || s.name!}`}
                       stepDescription={
                         (s.action! && s.action!.description) || ''
                       }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
@@ -145,28 +145,30 @@ export const ReviewActionsPage: React.FunctionComponent<
                               )
                             : undefined
                         }
+                        actions={
+                          <div>
+                            <ButtonLink
+                              href={editHref(params, {
+                                ...state,
+                                specification: apiSummary!.configuredProperties!
+                                  .specification,
+                              })}
+                            >
+                              {t(
+                                'integrations:apiProvider:reviewActions:btnReviewEdit'
+                              )}
+                            </ButtonLink>
+                            <ButtonLink
+                              onClick={onNext}
+                              disabled={nextDisabled || apiSummary!.errors}
+                              as={'primary'}
+                              style={{ marginLeft: '10px' }}
+                            >
+                              {t('shared:Next')}
+                            </ButtonLink>
+                          </div>
+                        }
                       />
-                      <div>
-                        <ButtonLink
-                          href={editHref(params, {
-                            ...state,
-                            specification: apiSummary!.configuredProperties!
-                              .specification,
-                          })}
-                        >
-                          {t(
-                            'integrations:apiProvider:reviewActions:btnReviewEdit'
-                          )}
-                        </ButtonLink>
-                        <ButtonLink
-                          onClick={onNext}
-                          disabled={nextDisabled || apiSummary!.errors}
-                          as={'primary'}
-                          style={{ marginLeft: '10px' }}
-                        >
-                          {t('shared:Next')}
-                        </ButtonLink>
-                      </div>
                     </>
                   )}
                 </WithLoader>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/SelectMethodPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/SelectMethodPage.tsx
@@ -16,15 +16,32 @@ import {
   IPageWithEditorBreadcrumb,
 } from '../interfaces';
 
-export const EMPTY_SPEC = `{
+export const EMPTY_API_20: string = `
+{
   "swagger": "2.0",
   "info": {
     "title": "Untitled API",
     "description": "",
     "version": "0.0.0"
   },
-  "paths": {}
+  "paths": {
+  },
+  "consumes": [ "application/json" ],
+  "produces": [ "application/json" ]
 }`;
+
+export const EMPTY_API_30: string = `
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Untitled API",
+    "description": "",
+    "version": "0.0.0"
+  },
+  "paths": {
+  }
+}
+`;
 
 export interface ISelectMethodPageProps extends IPageWithEditorBreadcrumb {
   cancelHref: (
@@ -66,9 +83,14 @@ export class SelectMethodPage extends React.Component<ISelectMethodPageProps> {
                       this.props.getReviewHref(specification, params, state)
                     );
                     break;
-                  case 'scratch':
+                  case 'scratch3x':
                     history.push(
-                      this.props.getEditorHref(EMPTY_SPEC, params, state)
+                      this.props.getEditorHref(EMPTY_API_30, params, state)
+                    );
+                    break;
+                  case 'scratch2x':
+                    history.push(
+                      this.props.getEditorHref(EMPTY_API_20, params, state)
                     );
                     break;
                   default:
@@ -120,8 +142,11 @@ export class SelectMethodPage extends React.Component<ISelectMethodPageProps> {
                           i18nMethodFromFile={t(
                             'integrations:apiProvider:selectMethod:methodFromFile'
                           )}
-                          i18nMethodFromScratch={t(
-                            'integrations:apiProvider:selectMethod:methodFromScratch'
+                          i18nMethodFromScratch2x={t(
+                            'integrations:apiProvider:selectMethod:methodFromScratch2x'
+                          )}
+                          i18nMethodFromScratch3x={t(
+                            'integrations:apiProvider:selectMethod:methodFromScratch3x'
                           )}
                           i18nMethodFromUrl={t(
                             'integrations:apiProvider:selectMethod:methodFromUrl'

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -137,7 +137,7 @@
   "apiProvider": {
     "editSpecification": {
       "title": "Provide API Definition",
-      "description": "An OpenAPI 2.0 document that defines the REST API operations is required."
+      "description": "An OpenAPI document that defines the REST API operations is required."
     },
     "reviewActions": {
       "btnReviewEdit": "Review/Edit",
@@ -165,7 +165,8 @@
       "dndNoFileSelectedLabel": "No file selected",
       "dndSelectedFileLabel": "Selected file:",
       "methodFromFile": "Upload an OpenAPI file",
-      "methodFromScratch": "Create",
+      "methodFromScratch2x": "Create a new OpenAPI 2.x document",
+      "methodFromScratch3x": "Create a new OpenAPI 3.x document",
       "methodFromUrl": "Use a URL",
       "title": "Start integration with an API call",
       "urlNote": "* Note: After uploading this document, updates to it are not automatically obtained."
@@ -202,7 +203,7 @@
     "template-upload-helper-text-size-type": "Max: 1 file (up to 1MB)",
     "template-editor-placeholder": "Drop a file, paste text, or start typing.",
     "template-editor-drag-enter": "Drop file here to upload.",
-    "template-validation-errors": "Vaidation errors",
+    "template-validation-errors": "Validation errors",
     "template-file-upload-dnd": "Drag and drop your template file here.",
     "template-upload-invalid-file": "'{{0}}' is not a valid file. Only text files can be uploaded.",
     "template-url-upload": "Use a URL",


### PR DESCRIPTION
related to [ENTESB-12218](https://issues.jboss.org/browse/ENTESB-12218)
fixes #7195 
fixes #6457

Also fixes a couple typos and improves the create method component so it disables the file upload/URL input field instead of hiding them so the page layout stays consistent.

![image](https://user-images.githubusercontent.com/351660/69353880-34702000-0c4d-11ea-998c-e795a23dd08a.png)
