### PR TITLE
refactor(mongodb): database directory and output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ hs_err_pid*
 *.eclipse-pmd
 .factorypath
 .sts4-cache/
+.cache
+.extracted
 
 # System Files
 .DS_Store

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/meta/DataShapeConnectorTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/meta/DataShapeConnectorTest.java
@@ -42,7 +42,6 @@ public class DataShapeConnectorTest {
     @Test
     public void verifyMetadataFilter() throws IOException {
         DataShape criteriaParams = MongoDBMetadataRetrieval.criteria("{test: \":#someText\", xyz.moreTest: /:#more/}");
-        System.out.println("!!!!!!!!!! "+criteriaParams.getSpecification());
         JsonNode json = OBJECT_MAPPER.readTree(criteriaParams.getSpecification());
         Assertions.assertThat(criteriaParams.getKind()).isEqualTo(DataShapeKinds.JSON_SCHEMA);
         Assertions.assertThat(json.get("properties").get("someText")).isNotNull();

--- a/app/connector/mongodb/src/test/resources/logback-test.xml
+++ b/app/connector/mongodb/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+    <file>target/tests.log</file>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
This creates the database in a temporary directory instead of $HOME
making the tests repeatable and allow them to run concurrently and in
environments where $HOME is not writable (CI).

Redirects the output to `target/test.log` to speed up the build and keep
the output separate from the console output of the build.