### PR TITLE
refactor: remove hamcrest dependency

### DIFF
--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -194,11 +194,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>test</scope>

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/EMailUtil.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/EMailUtil.java
@@ -31,7 +31,11 @@ import org.apache.camel.util.jsse.TrustManagersParameters;
 import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.util.KeyStoreHelper;
 
-public class EMailUtil implements EMailConstants {
+public final class EMailUtil implements EMailConstants {
+
+    private EMailUtil() {
+        // utility class
+    }
 
     private static boolean isSecure(String protocol) {
         if (ObjectHelper.isEmpty(protocol)) {

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadWithTLSRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadWithTLSRouteTest.java
@@ -15,11 +15,9 @@
  */
 package io.syndesis.connector.email.consumer;
 
-import static org.junit.Assume.assumeThat;
 import java.util.Map;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +26,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -41,6 +40,8 @@ import io.syndesis.connector.email.component.EMailComponentFactory;
 import io.syndesis.connector.email.customizer.EMailReceiveCustomizer;
 import io.syndesis.connector.email.model.EMailMessageModel;
 import io.syndesis.connector.support.util.PropertyBuilder;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -94,7 +95,7 @@ public class EMailReadWithTLSRouteTest extends AbstractEmailTest implements Rout
      */
     @Test
     public void testImapEMailRouteWithStartTLS() throws Exception {
-        assumeThat(HOSTNAME, CoreMatchers.is(CoreMatchers.not(NO_HOST)));
+        assumeThat(HOSTNAME).isNotEqualTo(NO_HOST);
 
         Protocol protocol = Protocol.IMAP;
 

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
@@ -15,20 +15,20 @@
  */
 package io.syndesis.connector.email.verifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.hamcrest.CoreMatchers;
+
 import org.junit.Test;
 import io.syndesis.connector.email.AbstractEmailServerTest;
 import io.syndesis.connector.email.verifier.receive.ReceiveEMailVerifier;
 import io.syndesis.connector.email.verifier.send.SendEMailVerifier;
 import io.syndesis.connector.support.verifier.api.Verifier;
 import io.syndesis.connector.support.verifier.api.VerifierResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class EMailVerifierTest extends AbstractEmailServerTest {
 
@@ -99,7 +99,7 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         long stopTime = System.currentTimeMillis();
 
         // Time should be roughly equal to the timeout set
-        assertTrue((stopTime - startTime) <= (timeout + 1000L)); // extra second for processing time
+        assertThat(stopTime - startTime).isLessThanOrEqualTo(timeout + 1000L); // extra second for processing time
 
         assertThat(responses).hasSize(2);
         assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
@@ -138,7 +138,7 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         long stopTime = System.currentTimeMillis();
 
         // Time should be roughly equal to the timeout set
-        assertTrue((stopTime - startTime) <= (timeout + 5000L)); // pop3 connect is quite slow so few extra seconds for processing time
+        assertThat(stopTime - startTime).isLessThanOrEqualTo(timeout + 5000L); // pop3 connect is quite slow so few extra seconds for processing time
 
         assertThat(responses).hasSize(2);
         assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
@@ -177,7 +177,7 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         long stopTime = System.currentTimeMillis();
 
         // Time should be roughly equal to the timeout set
-        assertTrue((stopTime - startTime) <= (timeout + 3000L)); // pop3 connect is quite slow so few extra seconds for processing time
+        assertThat(stopTime - startTime).isLessThanOrEqualTo(timeout + 3000L); // pop3 connect is quite slow so few extra seconds for processing time
 
         assertThat(responses).hasSize(2);
         assertThat(responses).anyMatch(response -> response.getScope() == Verifier.Scope.CONNECTIVITY);
@@ -313,7 +313,7 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
      */
     @Test
     public void testVerifyWithStartTLSServer() throws Exception {
-        assumeThat(TLS_HOSTNAME, CoreMatchers.is(CoreMatchers.not(NO_HOST)));
+        assumeThat(TLS_HOSTNAME).isNotEqualTo(NO_HOST);
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(PROTOCOL, Protocol.IMAP.id());

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -326,11 +326,6 @@
       <artifactId>jetty-servlet</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/app/dv/pom.xml
+++ b/app/dv/pom.xml
@@ -248,7 +248,6 @@
     <version.com.fasterxml.jackson.databind>2.9.9.3</version.com.fasterxml.jackson.databind>
     <version.io.fabric8.openshift-client>3.0.3</version.io.fabric8.openshift-client>
     <version.io.fabric8.kubernetes-api>3.0.8</version.io.fabric8.kubernetes-api>
-    <version.org.hamcrest>1.3</version.org.hamcrest> <!-- tesing only -->
     <!--arquillian.version>1.4.0.Final</arquillian.version-->
 
     <!-- DO NOT CHANGE VERSION PROPETY NAMES, THESE ARE USED IN CODE At s2i -->
@@ -738,12 +737,6 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <scope>test</scope>
-        <version>${version.org.hamcrest}</version>
-      </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spring-jaeger-web-starter</artifactId>

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/ServiceVdbGeneratorTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/ServiceVdbGeneratorTest.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.dv.server.endpoint;
 
-import static org.hamcrest.core.Is.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -45,6 +44,8 @@ import org.teiid.metadata.Schema;
 import org.teiid.metadata.Table;
 import org.teiid.query.metadata.SystemMetadata;
 import org.teiid.query.parser.QueryParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.syndesis.dv.KException;
 
@@ -421,7 +422,7 @@ public class ServiceVdbGeneratorTest {
 
         List<org.teiid.adminapi.Model> models = serviceVdb.getModels();
 
-        assertThat(models.size(), is(2));
+        assertThat(models).hasSize(2);
         ModelMetaData viewModel = serviceVdb.getModel("servicevdb");
         assertNotNull(viewModel);
         assertEquals("CREATE VIEW orderInfoView (ID, orderDate, name) OPTIONS (ANNOTATION 'test view description text') AS \n" +
@@ -451,7 +452,7 @@ public class ServiceVdbGeneratorTest {
 
         List<org.teiid.adminapi.Model> models = serviceVdb.getModels();
 
-        assertThat(models.size(), is(3));
+        assertThat(models).hasSize(3);
         ModelMetaData viewModel = serviceVdb.getModel("servicevdb");
         assertNotNull(viewModel);
         assertEquals("CREATE VIEW orderInfoView (ID, orderDate, customerName) OPTIONS (ANNOTATION 'test view description text') AS \n" +

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1045,6 +1045,13 @@
               <condition>javax.crypto.Cipher.getMaxAllowedKeyLength("AES")
                 > 128</condition>
             </evaluateBeanshell>
+            <bannedDependencies>
+              <excludes>
+                <exclude>org.hamcrest:*</exclude>
+              </excludes>
+              <message>Prefer using AssertJ for assertions</message>
+              <searchTransitive>false</searchTransitive>
+            </bannedDependencies>
           </rules>
         </configuration>
       </plugin>

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -139,8 +139,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
@@ -18,13 +18,14 @@ package io.syndesis.test.itest.ftp;
 
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.container.IteratingConditionExpression;
+import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.apache.commons.net.ftp.FTPCmd;
 import org.apache.ftpserver.DataConnectionConfiguration;
 import org.apache.ftpserver.DataConnectionConfigurationFactory;
-import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.context.annotation.Bean;
@@ -71,7 +72,12 @@ public class FtpSplitToDB_IT extends FtpTestSupport {
         runner.repeatOnError()
                 .startsWith(1)
                 .autoSleep(1000L)
-                .until(Matchers.greaterThan(10))
+                .until(new IteratingConditionExpression() {
+                    @Override
+                    public boolean evaluate(int index, TestContext context) {
+                        return index > 10;
+                    }
+                })
                 .actions(runner.query(builder -> builder.dataSource(sampleDb)
                         .statement("select count(*) as found_records from todo")
                         .validate("found_records", String.valueOf(3))));

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
@@ -18,13 +18,14 @@ package io.syndesis.test.itest.ftp;
 
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.container.IteratingConditionExpression;
+import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.apache.commons.net.ftp.FTPCmd;
 import org.apache.ftpserver.DataConnectionConfiguration;
 import org.apache.ftpserver.DataConnectionConfigurationFactory;
-import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.context.annotation.Bean;
@@ -71,7 +72,12 @@ public class FtpToDB_IT extends FtpTestSupport {
         runner.repeatOnError()
                 .startsWith(1)
                 .autoSleep(1000L)
-                .until(Matchers.greaterThan(10))
+                .until(new IteratingConditionExpression() {
+                    @Override
+                    public boolean evaluate(int index, TestContext context) {
+                        return index > 10;
+                    }
+                })
                 .actions(runner.query(builder -> builder.dataSource(sampleDb)
                         .statement("select count(*) as found_records from todo")
                         .validate("found_records", String.valueOf(3))));


### PR DESCRIPTION
This removes the use and forbids the Hamcrest dependency using the
enforcer plugin.

The reasoning behind that is that Hamcrest encourages poorly defined
assertions that fail with unhelpful messages whereas AssertJ encourages
verbose assertions that fail with more helpful messages.