### PR TITLE
user doc: Add downstream prereq for eval version or sample data installed

### DIFF
--- a/doc/assemblies/tutorials/as_amq2api-intro.adoc
+++ b/doc/assemblies/tutorials/as_amq2api-intro.adoc
@@ -30,6 +30,12 @@ ifeval::["{location}" == "downstream"]
 * You must be logged in to {prodname}.
 If you are not already logged in, see 
 link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.] 
+
+* You are working in a {prodname} evaluation environment that is running 
+on OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname} 
+environment that is running in an OpenShift Container Platform project in which 
+an administrator added the {prodname} sample data, which provides the *To Do* 
+app for confirming that the integration works as expected. 
 endif::[]
 
 To implement the AMQ to REST API sample integration, the main steps are:

--- a/doc/assemblies/tutorials/as_sf2db-intro.adoc
+++ b/doc/assemblies/tutorials/as_sf2db-intro.adoc
@@ -35,6 +35,11 @@ ifeval::["{location}" == "downstream"]
 * You must be logged in to your {prodname} environment. 
 If you are not already logged in, see 
 link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
+* You are working in a {prodname} evaluation environment that is running on 
+OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname} 
+environment that is running in an OpenShift Container Platform project in 
+which an administrator added the {prodname} sample data, which provides the 
+*PostgresDB* connection. 
 endif::[]
 
 To implement, deploy, and test this sample integration, the main steps are:


### PR DESCRIPTION
Evaluation versions of Fuse Online continue to provide the To Do app and the PostgresDB connection. But by default, installations of Fuse Online do not include these features. I added a prereguisite to the tutorials for the Salesforce to DB sample integration and for the AMQ to REST API sample integration, to say that you must be running an evaluation version of Fuse Online or you must be running a Fuse Online environment to which the sample data was added. This prerequisite is conditionalized to appear only downstream. Although the prerequisite is obviously in the upstream source, if and when the doc is published on the community web site, this prerequisite will not appear. Luis and Martin Stepanek reviewed/approved this update. 