### PR TITLE
fix(ENTESB-12310): Fix spelling of API provider flow descriptions

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/OpenApiGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/swagger/OpenApiGenerator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -101,7 +102,7 @@ public class OpenApiGenerator implements APIGenerator {
                 final Oas20Operation operation = operationEntry.getValue();
 
                 String operationName = operation.summary;
-                final String operationDescription = operationEntry.getKey() + " " + pathEntry.getPath();
+                final String operationDescription = operationEntry.getKey().toUpperCase(Locale.US) + " " + pathEntry.getPath();
 
                 final String operationId = requireUniqueOperationId(operation.operationId, alreadyUsedOperationIds);
                 alreadyUsedOperationIds.add(operationId);

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/OpenApiGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/swagger/OpenApiGeneratorTest.java
@@ -17,6 +17,7 @@ package io.syndesis.server.api.generator.swagger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import io.syndesis.common.model.action.ConnectorAction;
@@ -82,9 +83,15 @@ public class OpenApiGeneratorTest {
 
         final List<Flow> flows = apiIntegration.getIntegration().getFlows();
 
-        assertThat(flows).filteredOn(operationIdEquals("operation-1")).first().hasFieldOrPropertyWithValue("name", "Receiving GET request on /hi");
-        assertThat(flows).filteredOn(operationIdEquals("operation-2")).first().hasFieldOrPropertyWithValue("name", "post operation");
-        assertThat(flows).filteredOn(operationIdEquals("operation-3")).first().hasFieldOrPropertyWithValue("name", "Receiving PUT request on /hi");
+        assertThat(flows).filteredOn(operationIdEquals("operation-1")).first()
+            .hasFieldOrPropertyWithValue("description", Optional.of("GET /hi"))
+            .hasFieldOrPropertyWithValue("name", "Receiving GET request on /hi");
+        assertThat(flows).filteredOn(operationIdEquals("operation-2")).first()
+            .hasFieldOrPropertyWithValue("description", Optional.of("POST /hi"))
+            .hasFieldOrPropertyWithValue("name", "post operation");
+        assertThat(flows).filteredOn(operationIdEquals("operation-3")).first()
+            .hasFieldOrPropertyWithValue("description", Optional.of("PUT /hi"))
+            .hasFieldOrPropertyWithValue("name", "Receiving PUT request on /hi");
     }
 
     private static Connection dummyConnection() {


### PR DESCRIPTION
Use uppercase Http method names in flow description as this is displayed in UI to show the different flows in an OpenAPI operation.

Fixes ENTESB-12310