### PR TITLE
fix(TEIIDTOOLS-846) - Add a page for virtualization metrics

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvCacheHitMetric.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvCacheHitMetric.css
@@ -1,0 +1,13 @@
+.dv-cache-hit-metric__content {
+  align-items: center;
+}
+
+.dv-cache-hit-metric__datetime {
+  font-size: small;
+}
+
+.dv-cache-hit-metric__percentage {
+  font-size: large;
+  font-weight: 600;
+}
+

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvCacheHitMetric.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvCacheHitMetric.tsx
@@ -1,0 +1,85 @@
+import {
+  Card,
+  CardBody,
+  CardHead,
+  CardHeader,
+  Popover,
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Spinner } from 'patternfly-react';
+import * as React from 'react';
+import './DvCacheHitMetric.css';
+import './DvMetricsContainer.css';
+
+/**
+ * @property {string} a11yInfoCloseButton - the localized accessibility text for the info popover close button
+ * @property {string} a11yInfoPopover - the localized accessibility text for the info popover
+ * @property {string} i18nDatetime - the localized text representing the time of the metric was taken
+ * @property {string} i18nInfoMessage - the localized text of the message shown in the info popover
+ * @property {string} i18nNoData - the localized text displayed when there is no metric data
+ * @property {string} i18nTitle - the localize title of this metric
+ * @property {boolean} loading - `true` when a backend call to fetch this metric is ongoing
+ * @property {string} percentage - the text representing the cache hit ratio
+ */
+export interface IDvCacheHitMetricProps {
+  a11yInfoCloseButton: string;
+  a11yInfoPopover: string;
+  i18nDatetime: string;
+  i18nInfoMessage: string;
+  i18nNoData: string;
+  i18nTitle: string;
+  loading: boolean;
+  percentage: string;
+}
+
+/**
+ * A component showing the cache hit ratio metric.
+ * @param props the properties that configure this component
+ */
+export const DvCacheHitMetric: React.FunctionComponent<
+  IDvCacheHitMetricProps
+> = props => {
+  return (
+    <Card isHoverable={true}>
+      <CardHead>
+        <CardHeader className={'dv-metrics-container__cardTitle'}>
+          {props.i18nTitle}
+          &nbsp;&nbsp;
+          <Popover
+            aria-label={props.a11yInfoPopover}
+            bodyContent={<div>{props.i18nInfoMessage}</div>}
+            closeBtnAriaLabel={props.a11yInfoCloseButton}
+          >
+            <InfoCircleIcon color={'blue'} />
+          </Popover>
+        </CardHeader>
+      </CardHead>
+      <CardBody>
+        {props.loading ? (
+          <Spinner loading={true} inline={false} />
+        ) : props.percentage &&
+          props.percentage.length > 0 &&
+          props.i18nDatetime &&
+          props.i18nDatetime.length > 0 ? (
+          <Split className={'dv-cache-hit-metric__content'} gutter={'lg'}>
+            <SplitItem className={'dv-cache-hit-metric__percentage'}>
+              {props.percentage}
+            </SplitItem>
+            <SplitItem className={'dv-cache-hit-metric__datetime'}>
+              {props.i18nDatetime}
+            </SplitItem>
+          </Split>
+        ) : (
+          <TextContent>
+            <Text component={TextVariants.small}>{props.i18nNoData}</Text>
+          </TextContent>
+        )}
+      </CardBody>
+    </Card>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvClientSessionMetric.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvClientSessionMetric.css
@@ -1,0 +1,12 @@
+.dv-client-session-metric__connectionCount {
+  font-size: large;
+  font-weight: 600;
+}
+
+.dv-client-session-metric__connectionMessage {
+  font-size: small;
+}
+
+.dv-client-session-metric__content {
+  align-items: center;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvClientSessionMetric.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvClientSessionMetric.tsx
@@ -1,0 +1,81 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardBody,
+  CardHead,
+  CardHeader,
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { Spinner } from 'patternfly-react';
+import * as React from 'react';
+import './DvClientSessionMetric.css';
+import './DvMetricsContainer.css';
+
+/**
+ * @property {number} connectionCount - a count of the current number of connections
+ * @property {string} i18nConnectionMessage - the localized text identifying the connections performing queries
+ * @property {string} i18nNoData - the localized text displayed when there is no metric data
+ * @property {string} i18nTitle - the localize title of this metric
+ * @property {string} i18nViewAllAction - the localized text for the view all connections action
+ * @property {boolean} loading - `true` when a backend call to fetch this metric is ongoing
+ * @property {() => void} onViewAll - a callback for when the view all action is clicked
+ */
+export interface IDvClientSessionMetricProps {
+  connectionCount: number;
+  i18nConnectionMessage: string;
+  i18nNoData: string;
+  i18nTitle: string;
+  i18nViewAllAction: string;
+  loading: boolean;
+  onViewAll: () => void;
+}
+
+/**
+ * A component showing the client session metric.
+ * @param props the properties that configure this component
+ */
+export const DvClientSessionMetric: React.FunctionComponent<
+  IDvClientSessionMetricProps
+> = props => {
+  return (
+    <Card isHoverable={true}>
+      <CardHead>
+        <CardActions>
+          <Button onClick={props.onViewAll} variant={'link'}>
+            {props.i18nViewAllAction}
+          </Button>
+        </CardActions>
+        <CardHeader className={'dv-metrics-container__cardTitle'}>
+          {props.i18nTitle}
+        </CardHeader>
+      </CardHead>
+      <CardBody>
+        {props.loading ? (
+          <Spinner loading={true} inline={false} />
+        ) : props.connectionCount &&
+          props.i18nConnectionMessage &&
+          props.i18nConnectionMessage.length > 0 ? (
+          <Split className={'dv-client-session-metric__content'} gutter={'lg'}>
+            <SplitItem className={'dv-client-session-metric__connectionCount'}>
+              {props.connectionCount}
+            </SplitItem>
+            <SplitItem
+              className={'dv-client-session-metric__connectionMessage'}
+            >
+              {props.i18nConnectionMessage}
+            </SplitItem>
+          </Split>
+        ) : (
+          <TextContent>
+            <Text component={TextVariants.small}>{props.i18nNoData}</Text>
+          </TextContent>
+        )}
+      </CardBody>
+    </Card>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvMetricsContainer.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvMetricsContainer.css
@@ -1,0 +1,3 @@
+.dv-metrics-container__cardTitle {
+  font-weight: bold !important;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvMetricsContainer.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvMetricsContainer.tsx
@@ -1,0 +1,73 @@
+import {
+  Flex,
+  FlexItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import * as React from 'react';
+import { DvCacheHitMetric, IDvCacheHitMetricProps } from './DvCacheHitMetric';
+import {
+  DvClientSessionMetric,
+  IDvClientSessionMetricProps,
+} from './DvClientSessionMetric';
+import { DvRequestMetric, IDvRequestMetricProps } from './DvRequestMetric';
+import { DvUptimeMetric, IDvUptimeMetricProps } from './DvUptimeMetric';
+
+/**
+ * A component container for DV metrics.
+ * @property {IDvCacheHitMetricProps} cacheHitProps - if set, the cache hit ratio metric is shown
+ * @property {IDvClientSessionMetricProps} clientSessionProps - if set, the clien session metric component is shown
+ * @property {string} i18nNoData - the localized text used when no metric components are used
+ * @property {IDvRequestMetricProps} requestProps - if set, the request metric component is shown
+ * @property {IDvUptimeMetricProps} uptimeProps - if set, the uptime metric component is shown
+ */
+export interface IDvMetricsContainer {
+  cacheHitProps?: IDvCacheHitMetricProps;
+  clientSessionProps?: IDvClientSessionMetricProps;
+  i18nNoData: string;
+  requestProps?: IDvRequestMetricProps;
+  uptimeProps?: IDvUptimeMetricProps;
+}
+
+export const DvMetricsContainer: React.FunctionComponent<
+  IDvMetricsContainer
+> = props => {
+  if (
+    props.cacheHitProps ||
+    props.clientSessionProps ||
+    props.requestProps ||
+    props.uptimeProps
+  ) {
+    return (
+      <Flex>
+        {props.clientSessionProps && (
+          <FlexItem className={'pf-m-flex-1'}>
+            <DvClientSessionMetric {...props.clientSessionProps} />
+          </FlexItem>
+        )}
+        {props.requestProps && (
+          <FlexItem className={'pf-m-flex-1'}>
+            <DvRequestMetric {...props.requestProps} />
+          </FlexItem>
+        )}
+        {props.cacheHitProps && (
+          <FlexItem className={'pf-m-flex-1'}>
+            <DvCacheHitMetric {...props.cacheHitProps} />
+          </FlexItem>
+        )}
+        {props.uptimeProps && (
+          <FlexItem className={'pf-m-flex-1'}>
+            <DvUptimeMetric {...props.uptimeProps} />
+          </FlexItem>
+        )}
+      </Flex>
+    );
+  }
+
+  return (
+    <TextContent>
+      <Text component={TextVariants.small}>{props.i18nNoData}</Text>
+    </TextContent>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvRequestMetric.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvRequestMetric.css
@@ -1,0 +1,13 @@
+.dv-request-metric__content {
+  align-items: center;
+}
+
+.dv-request-metric__count {
+  font-size: large;
+  font-weight: 600;
+  width: 50%;
+}
+
+.dv-request-metric__countIcon {
+  font-size: small;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvRequestMetric.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvRequestMetric.tsx
@@ -1,0 +1,101 @@
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { ErrorCircleOIcon, OkIcon } from '@patternfly/react-icons';
+import { Spinner } from 'patternfly-react';
+import * as React from 'react';
+import './DvMetricsContainer.css';
+import './DvRequestMetric.css';
+
+/**
+ * @property {string} a11yShowFailed - the localized accessibility text for the failed request icon
+ * @property {string} a11yShowSucceeded - the localized accessibility text for the succeeded request icon
+ * @property {number} failedCount - the number of failed requests
+ * @property {string} i18nNoData - the localized text displayed when there is no metric data
+ * @property {string} i18nTitle - the localize title of this metric
+ * @property {boolean} loading - `true` when a backend call to fetch this metric is ongoing
+ * @property {number} successCount - the number of successful requests
+ * @property {() => void} onShowFailed - a callback for when the failed request icon is clicked
+ * @property {() => void} onShowSucceeded - a callback for when the succeeded request icon is clicked
+ */
+export interface IDvRequestMetricProps {
+  a11yShowFailed: string;
+  a11yShowSucceeded: string;
+  failedCount: number;
+  i18nNoData: string;
+  i18nTitle: string;
+  loading: boolean;
+  successCount: number;
+  onShowFailed: () => void;
+  onShowSucceeded: () => void;
+}
+
+/**
+ * A component showing the request metric.
+ * @param props the properties that configure this component
+ */
+export const DvRequestMetric: React.FunctionComponent<
+  IDvRequestMetricProps
+> = props => {
+  return (
+    <Card isHoverable={true}>
+      <CardHeader className={'dv-metrics-container__cardTitle'}>
+        {props.i18nTitle}
+      </CardHeader>
+      <CardBody>
+        {props.loading ? (
+          <Spinner loading={true} inline={false} />
+        ) : props.failedCount && props.successCount ? (
+          <Stack>
+            <StackItem>
+              <Split className={'dv-request-metric__content'} gutter={'lg'}>
+                <SplitItem className={'dv-request-metric__count'}>
+                  {props.successCount}
+                </SplitItem>
+                <SplitItem className={'dv-request-metric__countIcon'}>
+                  <Button
+                    variant="plain"
+                    aria-label={props.a11yShowSucceeded}
+                    onClick={props.onShowSucceeded}
+                  >
+                    <OkIcon color={'green'} />
+                  </Button>
+                </SplitItem>
+              </Split>
+            </StackItem>
+            <StackItem>
+              <Split className={'dv-request-metric__content'} gutter={'lg'}>
+                <SplitItem className={'dv-request-metric__count'}>
+                  {props.failedCount}
+                </SplitItem>
+                <SplitItem className={'dv-request-metric__countIcon'}>
+                  <Button
+                    variant="plain"
+                    aria-label={props.a11yShowFailed}
+                    onClick={props.onShowFailed}
+                  >
+                    <ErrorCircleOIcon color={'red'} />
+                  </Button>
+                </SplitItem>
+              </Split>
+            </StackItem>
+          </Stack>
+        ) : (
+          <TextContent>
+            <Text component={TextVariants.small}>{props.i18nNoData}</Text>
+          </TextContent>
+        )}
+      </CardBody>
+    </Card>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvUptimeMetric.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvUptimeMetric.css
@@ -1,0 +1,8 @@
+.dv-uptime-metric__sinceMessage {
+  font-size: small;
+}
+
+.dv-uptime-metric__uptimeMessage {
+  font-size: large;
+  font-weight: 600;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvUptimeMetric.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/DvUptimeMetric.tsx
@@ -1,0 +1,66 @@
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { Spinner } from 'patternfly-react';
+import * as React from 'react';
+import './DvMetricsContainer.css';
+import './DvUptimeMetric.css';
+
+/**
+ * @property {string} i18nNoData - the localized text displayed when there is no metric data
+ * @property {string} i18nSinceMessage - the localized text of the date the uptime started
+ * @property {string} i18nTitle - the localize title of this metric
+ * @property {string} i18nUptime - the localize text representing the total uptime
+ * @property {boolean} loading - `true` when a backend call to fetch this metric is ongoing
+ */
+export interface IDvUptimeMetricProps {
+  i18nNoData: string;
+  i18nSinceMessage: string;
+  i18nTitle: string;
+  i18nUptime: string;
+  loading: boolean;
+}
+
+/**
+ * A component showing the uptime metric.
+ * @param props the properties that configure this component
+ */
+export const DvUptimeMetric: React.FunctionComponent<
+  IDvUptimeMetricProps
+> = props => {
+  return (
+    <Card isHoverable={true}>
+      <CardHeader className={'dv-metrics-container__cardTitle'}>
+        {props.i18nTitle}
+      </CardHeader>
+      <CardBody>
+        {props.loading ? (
+          <Spinner loading={true} inline={false} />
+        ) : props.i18nSinceMessage &&
+          props.i18nSinceMessage.length > 0 &&
+          props.i18nUptime &&
+          props.i18nUptime.length > 0 ? (
+          <Stack className={'dv-uptime-metric__content'} gutter={'sm'}>
+            <StackItem className={'dv-uptime-metric__sinceMessage'}>
+              {props.i18nSinceMessage}
+            </StackItem>
+            <StackItem className={'dv-uptime-metric__uptimeMessage'}>
+              {props.i18nUptime}
+            </StackItem>
+          </Stack>
+        ) : (
+          <TextContent>
+            <Text component={TextVariants.small}>{props.i18nNoData}</Text>
+          </TextContent>
+        )}
+      </CardBody>
+    </Card>
+  );
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/index.ts
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Metrics/index.ts
@@ -1,0 +1,5 @@
+export * from './DvCacheHitMetric';
+export * from './DvClientSessionMetric';
+export * from './DvMetricsContainer';
+export * from './DvRequestMetric';
+export * from './DvUptimeMetric';

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/index.ts
@@ -1,3 +1,4 @@
+export * from './Metrics';
 export * from './Views';
 export * from './ViewEditor';
 export * from './PublishStatusWithProgress';

--- a/app/ui-react/syndesis/src/modules/data/index.tsx
+++ b/app/ui-react/syndesis/src/modules/data/index.tsx
@@ -4,6 +4,7 @@ import {
   VirtualizationCreatePage,
   VirtualizationDetailsPage,
   VirtualizationImportPage,
+  VirtualizationMetricsPage,
   VirtualizationsPage,
   VirtualizationSqlClientPage,
   VirtualizationViewsPage,
@@ -70,6 +71,11 @@ export class DataModule extends React.Component {
             path={routes.virtualizations.virtualization.details}
             exact={true}
             component={VirtualizationDetailsPage}
+          />
+          <Route
+            path={routes.virtualizations.virtualization.metrics}
+            exact={true}
+            component={VirtualizationMetricsPage}
           />
         </Switch>
       </>

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -60,6 +60,7 @@
   "importVirtualizationSuccess": "Successfully imported \"{{fileName}}\".",
   "importVirtualizationTip": "Import a data virtualization",
   "importVirtualizationZipInvalid": "Zip file is invalid (dv.json not found).",
+  "Metrics": "Metrics",
   "preview": {
     "hidePreview": "Hide Preview",
     "loadingQueryResults": "Loading query results...",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -60,6 +60,7 @@
   "importVirtualizationSuccess": "\"{{fileName}}\" importato con successo.",
   "importVirtualizationTip": "Importa una virtualizzazione dei dati",
   "importVirtualizationZipInvalid": "Il file zip non è valido (dv.json non trovato).",
+  "Metrics": "Metrica",
   "preview": {
     "hidePreview": "Nascondi Anteprima",
     "loadingQueryResults": "Caricamento dei risultati della query...",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationMetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationMetricsPage.tsx
@@ -1,0 +1,78 @@
+import { useVirtualization } from '@syndesis/api';
+import { DvMetricsContainer, PageSection } from '@syndesis/ui';
+import { useRouteData } from '@syndesis/utils';
+import * as React from 'react';
+import {
+  IVirtualizationEditorPageRouteParams,
+  IVirtualizationEditorPageRouteState,
+  VirtualizationEditorPage,
+} from './VirtualizationEditorPage';
+
+/**
+ * A page that displays virtualization publish state and history.
+ */
+export const VirtualizationMetricsPage: React.FunctionComponent = () => {
+  /**
+   * Hook to obtain route params and history.
+   */
+  const { params, state } = useRouteData<
+    IVirtualizationEditorPageRouteParams,
+    IVirtualizationEditorPageRouteState
+  >();
+
+  /**
+   * Hook to obtain the virtualization being edited. Also does polling to get virtualization descriptor updates.
+   */
+  const { model: virtualization } = useVirtualization(params.virtualizationId);
+
+  return (
+    <VirtualizationEditorPage
+      routeParams={params}
+      routeState={state}
+      virtualization={virtualization}
+    >
+      <PageSection>
+        <DvMetricsContainer
+          cacheHitProps={{
+            a11yInfoCloseButton: 'Close info popover',
+            a11yInfoPopover: 'Info popover',
+            i18nDatetime: 'Nov 18, 11:40:00 pm',
+            i18nInfoMessage: 'Cache hit ratios information message goes here.',
+            i18nNoData: 'No data available',
+            i18nTitle: 'Cache hit ratios',
+            loading: false,
+            percentage: '35%',
+          }}
+          clientSessionProps={{
+            connectionCount: 8,
+            i18nConnectionMessage: 'Connections are issuing queries',
+            i18nNoData: 'No data available',
+            i18nTitle: 'Client sessions',
+            i18nViewAllAction: 'View all',
+            loading: false,
+            onViewAll: () => alert('Implement View all'),
+          }}
+          i18nNoData={'No metrics data available'}
+          requestProps={{
+            a11yShowFailed: 'Show Failed Requests',
+            a11yShowSucceeded: 'Show Succeeded Requests',
+            failedCount: 129,
+            i18nNoData: 'No data available',
+            i18nTitle: 'Total requests',
+            loading: false,
+            onShowFailed: () => alert('Implement Show Failed'),
+            onShowSucceeded: () => alert('Implement Show Succeeded'),
+            successCount: 17000,
+          }}
+          uptimeProps={{
+            i18nNoData: 'No data available',
+            i18nSinceMessage: 'Since Oct 11, 11:47:14 pm',
+            i18nTitle: 'Uptime',
+            i18nUptime: '1 day 3 hours 9 minutes',
+            loading: false,
+          }}
+        />
+      </PageSection>
+    </VirtualizationEditorPage>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/data/pages/index.ts
+++ b/app/ui-react/syndesis/src/modules/data/pages/index.ts
@@ -2,6 +2,7 @@ export * from './VirtualizationCreatePage';
 export * from './VirtualizationEditorPage';
 export * from './VirtualizationDetailsPage';
 export * from './VirtualizationImportPage';
+export * from './VirtualizationMetricsPage';
 export * from './VirtualizationsPage';
 export * from './VirtualizationSqlClientPage';
 export * from './VirtualizationViewsPage';

--- a/app/ui-react/syndesis/src/modules/data/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/data/resolvers.ts
@@ -116,6 +116,17 @@ export default {
         },
       })
     ),
+    metrics: makeResolver<{ virtualization: Virtualization }>(
+      routes.virtualizations.virtualization.metrics,
+      ({ virtualization }) => ({
+        params: {
+          virtualizationId: virtualization.name,
+        },
+        state: {
+          virtualization,
+        },
+      })
+    ),
     sqlClient: makeResolver<{ virtualization: Virtualization }>(
       routes.virtualizations.virtualization.sqlClient,
       ({ virtualization }) => ({

--- a/app/ui-react/syndesis/src/modules/data/routes.ts
+++ b/app/ui-react/syndesis/src/modules/data/routes.ts
@@ -8,6 +8,7 @@ export default include('/data', {
     list: '',
     virtualization: include(':virtualizationId', {
       details: 'details',
+      metrics: 'metrics',
       root: '',
       sqlClient: 'sqlClient',
       views: include('views', {

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationNavBar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationNavBar.tsx
@@ -38,14 +38,20 @@ export const VirtualizationNavBar: React.FunctionComponent<
           })}
         />
         <TabBarItem
+          label={t('sqlClient')}
+          to={resolvers.virtualizations.sqlClient({
+            virtualization,
+          })}
+        />
+        <TabBarItem
           label={t('details')}
           to={resolvers.virtualizations.details({
             virtualization,
           })}
         />
         <TabBarItem
-          label={t('sqlClient')}
-          to={resolvers.virtualizations.sqlClient({
+          label={t('Metrics')}
+          to={resolvers.virtualizations.metrics({
             virtualization,
           })}
         />


### PR DESCRIPTION
- see [TEIIDTOOLS-846](https://issues.jboss.org/browse/TEIIDTOOLS-846)
- added new virtualization editor page for metrics
- created `DvMetricsContainer` as a container for individual metric components
- added metric components for cache hit ratio, client sessions, requests, and uptime
- i18n of metric components was not done as it is still unclear which metric components will be needed