### PR TITLE
Run configuration tests using a test file

### DIFF
--- a/install/operator/build/conf/config-test.yaml
+++ b/install/operator/build/conf/config-test.yaml
@@ -1,0 +1,78 @@
+ProductName: syndesis
+AllowLocalHost: false
+Productized: false
+DevSupport: false
+Scheduled: true
+Syndesis:
+    ImageStreamNamespace: ""
+    Addons:
+        Jaeger:
+            Enabled: false
+            SamplerType: "const"
+            SamplerParam: "0"
+        Ops:
+            Enabled: false
+        Todo:
+            Enabled: false
+        Knative:
+            Enabled: false
+        DV:
+            Enabled: false
+            Image: "docker.io/teiid/syndesis-dv:latest"
+            Resources:
+                Memory: "1024Mi"
+        CamelK:
+            Enabled: false
+            Image: "fabric8/s2i-java:3.0-java8"
+            CamelVersion: "2.21.0.fuse-760011"
+            CamelKRuntime: "0.3.4.fuse-740008"
+    Components:
+        Oauth:
+            Image: "quay.io/openshift/origin-oauth-proxy:v4.0.0"
+        UI:
+            Image: "docker.io/syndesis/syndesis-ui:latest"
+        S2I:
+            Image: "docker.io/syndesis/syndesis-s2i:latest"
+        Prometheus:
+            Rules: ""
+            Image: "docker.io/prom/prometheus:v2.1.0"
+            Resources:
+                Memory: "512Mi"
+                VolumeCapacity: "1Gi"
+        Upgrade:
+            Image: "docker.io/syndesis/syndesis-upgrade:latest"
+            Resources:
+                VolumeCapacity: "1Gi"
+        Meta:
+            Image: "docker.io/syndesis/syndesis-meta:latest"
+            Resources:
+                Memory: "512Mi"
+                VolumeCapacity: "1Gi"
+        Database:
+            Name: "syndesis"
+            User: "syndesis"
+            URL: "postgresql://syndesis-db:5432/syndesis?sslmode=disable"
+            ImageStreamNamespace: "openshift"
+            Image: "postgresql:9.6"
+            Exporter:
+                Image: "docker.io/wrouesnel/postgres_exporter:v0.4.7"
+            Resources:
+                Memory: "255Mi"
+                VolumeCapacity: "1Gi"
+        Server:
+            Image: "docker.io/syndesis/syndesis-server:latest"
+            ControllersIntegrationEnabled: true
+            Resources:
+                Memory: "800Mi"
+            Features:
+                IntegrationLimit: 0
+                IntegrationStateCheckInterval: 60
+                DemoData: false
+                DeployIntegrations: true
+                TestSupport: false
+                OpenShiftMaster: "https://localhost:8443"
+                ManagementUrlFor3scale: ""
+                MavenRepositories:
+                    central: "https://repo.maven.apache.org/maven2/"
+                    repo-02-redhat-ga: "https://maven.repository.redhat.com/ga/"
+                    repo-03-jboss-ea: "https://repository.jboss.org/nexus/content/groups/ea/"

--- a/install/operator/go.mod
+++ b/install/operator/go.mod
@@ -7,6 +7,7 @@ module github.com/syndesisio/syndesis/install/operator
 // replace github.com/chirino/hawtgo => /Users/chirino/sandbox/hawtgo
 
 require (
+	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/chirino/hawtgo v0.0.1
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.4

--- a/install/operator/pkg/syndesis/configuration/configuration_test.go
+++ b/install/operator/pkg/syndesis/configuration/configuration_test.go
@@ -41,7 +41,7 @@ func Test_loadFromFile(t *testing.T) {
 	}{
 		{
 			name:    "When loading the from file, a valid configuration should be loaded",
-			args:    args{file: "../../../build/conf/config.yaml"},
+			args:    args{file: "../../../build/conf/config-test.yaml"},
 			want:    getConfigLiteral(),
 			wantErr: false,
 		},


### PR DESCRIPTION
Fixes: https://github.com/syndesisio/syndesis/issues/7232

When building, the default values from the configuration file `conf/config.yaml` are changed to better fit the build, and test fails. It is better to have a test configuration file for the tests.