### PR TITLE
fix(#7214): spring cannot choose the correct constructor

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/support/SupportUtil.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/support/SupportUtil.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.DumperOptions;
@@ -87,6 +88,7 @@ public class SupportUtil {
         this.log = log;
     }
 
+    @Autowired
     public SupportUtil(NamespacedOpenShiftClient client, IntegrationHandler integrationHandler, IntegrationSupportHandler integrationSupportHandler) {
         this.client = Objects.requireNonNull(client, "client");
         this.integrationHandler = integrationHandler;


### PR DESCRIPTION
* Without the Autowired annotation, spring appears unable to choose which
  constructor to use.