### PR TITLE
chore: fix the alignment of the dashboard cards

### DIFF
--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.css
@@ -29,3 +29,7 @@
   --pf-c-card__body--FontSize: var(--pf-global--icon--FontSize--lg);
   font-weight: var(--pf-global--FontWeight--light);
 }
+
+.dashboard__integrations-grid-item > .pf-c-card {
+  height: 100%;
+}

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
@@ -78,13 +78,27 @@ export class Dashboard extends React.PureComponent<IIntegrationsPageProps> {
               ) : (
                 <>
                   <Grid gutter={'lg'}>
-                    <GridItem xl={7} xlRowSpan={12}>
+                    <GridItem
+                      className={'dashboard__integrations-grid-item'}
+                      xl={7}
+                      xlRowSpan={12}
+                    >
                       {this.props.topIntegrations}
                     </GridItem>
-                    <GridItem lg={6} xl={5} xlRowSpan={6}>
+                    <GridItem
+                      className={'dashboard__integrations-grid-item'}
+                      lg={6}
+                      xl={5}
+                      xlRowSpan={6}
+                    >
                       {this.props.integrationBoard}
                     </GridItem>
-                    <GridItem lg={6} xl={5} xlRowSpan={6}>
+                    <GridItem
+                      className={'dashboard__integrations-grid-item'}
+                      lg={6}
+                      xl={5}
+                      xlRowSpan={6}
+                    >
                       {this.props.integrationUpdates}
                     </GridItem>
                   </Grid>


### PR DESCRIPTION
This was bugging me yesterday.  Basically this PR makes the dashboard cards align better, so instead of:

![image](https://user-images.githubusercontent.com/351660/69741228-b1494100-1108-11ea-8cee-571fb1caa680.png)

it looks like:

![image](https://user-images.githubusercontent.com/351660/69741267-c0c88a00-1108-11ea-8b27-03bdd263bf2d.png)
