### PR TITLE
fix(TEIIDTOOLS-853) - Disable delete action in virtualization details kebab if running or in-progress

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationActions.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationActions.tsx
@@ -107,7 +107,7 @@ export const VirtualizationActions: React.FunctionComponent<
                   className={'virtualization-actions__menuItem'}
                   component={'button'}
                   data-testid={`virtualization-actions-${toValidHtmlId(item.id)}`}
-                  isDisabled={item.isDisabled}
+                  isDisabled={item.disabled}
                   key={index}
                 >
                   <Link to={item.href}>{item.i18nLabel}</Link>
@@ -117,7 +117,7 @@ export const VirtualizationActions: React.FunctionComponent<
                   className={'virtualization-actions__menuItem'}
                   component={'button'}
                   data-testid={`virtualization-actions-${toValidHtmlId(item.id)}`}
-                  isDisabled={item.isDisabled}
+                  isDisabled={item.disabled}
                   key={index}
                   onClick={item.onClick}
                 >


### PR DESCRIPTION
- see [TEIIDTOOLS-853](https://issues.jboss.org/browse/TEIIDTOOLS-853)
- fixes a bug in `VirtualizationActions` that prevented the kebab menu item from being disabled
- reworked `VirtualizationActionContainer` to only construct actions that are actually being used (removed default actions)
- added logic in `VirtualizationActionContainer` to disable delete action when virtualization is published or being published