### PR TITLE
fix(ENTESB-12218): Fix request body extraction for OpenAPI 3.x

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/DataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/DataShapeGenerator.java
@@ -22,8 +22,8 @@ import java.util.function.Predicate;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import io.apicurio.datamodels.openapi.models.OasOperation;
-import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasResponse;
+import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 
@@ -45,20 +45,25 @@ public interface DataShapeGenerator<T extends OasDocument, O extends OasOperatio
     DataShape createShapeFromResponse(ObjectNode json, T openApiDoc, O operation);
 
     /**
-     * Find parameter that is specified to live in the body.
-     * @param operation holding some parameters.
-     * @return the body parameter.
+     * Find schema that is specified to define the body if any.
+     * @param operation maybe holding a body schema.
+     * @return the body schema.
      */
-    default Optional<OasParameter> findBodyParameter(final OasOperation operation) {
-        if (operation.parameters == null) {
-            return Optional.empty();
+    default Optional<NameAndSchema> findBodySchema(final O operation) {
+        return Optional.empty();
+    }
+
+    /**
+     * Combination of schema and name for request body.
+     */
+    class NameAndSchema {
+        protected final String name;
+        protected final OasSchema schema;
+
+        public NameAndSchema(String name, OasSchema schema) {
+            this.name = name;
+            this.schema = schema;
         }
-
-        final List<OasParameter> operationParameters = operation.parameters;
-
-        return operationParameters.stream()
-            .filter(p -> "body".equals(p.in) && p.schema != null)
-            .findFirst();
     }
 
     /**

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedJsonDataShapeSupport.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedJsonDataShapeSupport.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import io.apicurio.datamodels.openapi.models.OasOperation;
-import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
@@ -40,17 +39,15 @@ public abstract class UnifiedJsonDataShapeSupport<T extends OasDocument, O exten
 
     private static final List<String> PROPERTIES_TO_REMOVE_ON_MERGE = Arrays.asList("$schema", "title");
 
-    protected ObjectNode createJsonSchemaForBodyOf(final ObjectNode json, final OasOperation operation) {
-        final Optional<OasParameter> maybeRequestBody = findBodyParameter(operation);
+    protected ObjectNode createJsonSchemaForBodyOf(final ObjectNode json, final O operation) {
+        final Optional<NameAndSchema> maybeRequestBody = findBodySchema(operation);
 
         if (!maybeRequestBody.isPresent()) {
             return null;
         }
 
-        final OasParameter requestBody = maybeRequestBody.get();
-
-        final OasSchema requestSchema = (OasSchema) requestBody.schema;
-        final String name = Optional.ofNullable(requestBody.getName()).orElse(requestBody.description);
+        final OasSchema requestSchema = maybeRequestBody.get().schema;
+        final String name = maybeRequestBody.get().name;
 
         return createSchemaFromModel(json, name, requestSchema);
     }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedXmlDataShapeSupport.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedXmlDataShapeSupport.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import io.apicurio.datamodels.openapi.models.OasOperation;
-import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasResponse;
 import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.apicurio.datamodels.openapi.models.OasXML;
@@ -169,15 +168,13 @@ public abstract class UnifiedXmlDataShapeSupport<T extends OasDocument, O extend
 
     private Element createRequestBodySchema(final T openApiDoc, final O operation,
                                               final Map<String, SchemaPrefixAndElement> moreSchemas) {
-        final Optional<OasParameter> bodyParameter = findBodyParameter(operation);
+        final Optional<NameAndSchema> maybeBodySchema = findBodySchema(operation);
 
-        if (!bodyParameter.isPresent()) {
+        if (!maybeBodySchema.isPresent()) {
             return null;
         }
 
-        final OasParameter body = bodyParameter.get();
-
-        final OasSchema bodySchema = (OasSchema) body.schema;
+        final OasSchema bodySchema = maybeBodySchema.get().schema;
 
         final OasSchema bodySchemaToUse;
         if (OasModelHelper.isReferenceType(bodySchema)) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ModelHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ModelHelper.java
@@ -17,9 +17,11 @@ package io.syndesis.server.api.generator.openapi.v2;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.apicurio.datamodels.openapi.models.OasOperation;
+import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasPathItem;
 import io.apicurio.datamodels.openapi.models.OasPaths;
 import io.apicurio.datamodels.openapi.models.OasSchema;
@@ -111,5 +113,22 @@ final class Oas20ModelHelper {
      */
     static Map<String, Oas20Operation> getOperationMap(OasPathItem pathItem) {
         return OasModelHelper.getOperationMap(pathItem, Oas20Operation.class);
+    }
+
+    /**
+     * Find parameter that is defined to live in body.
+     * @param operation
+     * @return
+     */
+    static Optional<OasParameter> findBodyParameter(Oas20Operation operation) {
+        if (operation.parameters == null) {
+            return Optional.empty();
+        }
+
+        final List<OasParameter> operationParameters = operation.parameters;
+
+        return operationParameters.stream()
+            .filter(p -> "body".equals(p.in) && p.schema != null)
+            .findFirst();
     }
 }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/UnifiedJsonDataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/UnifiedJsonDataShapeGenerator.java
@@ -23,7 +23,9 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasPathItem;
+import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Items;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Operation;
@@ -39,6 +41,7 @@ import io.syndesis.server.api.generator.openapi.util.JsonSchemaHelper;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 import org.apache.commons.lang3.StringUtils;
 
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
@@ -70,6 +73,19 @@ class UnifiedJsonDataShapeGenerator extends UnifiedJsonDataShapeSupport<Oas20Doc
         final ObjectNode bodySchema = createSchemaFromModel(json, description, responseSchema);
 
         return unifiedJsonSchema("Response", "API response payload", bodySchema, null);
+    }
+
+    @Override
+    public Optional<NameAndSchema> findBodySchema(Oas20Operation operation) {
+        Optional<OasParameter> maybeBody = Oas20ModelHelper.findBodyParameter(operation);
+
+        if (maybeBody.isPresent()) {
+            OasParameter body = maybeBody.get();
+            String name = ofNullable(body.getName()).orElse(body.description);
+            return Optional.of(new NameAndSchema(name, (OasSchema) body.schema));
+        }
+
+        return empty();
     }
 
     private static void addEnumsTo(final ObjectNode parameterParameter, final Oas20Parameter parameter) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGenerator.java
@@ -17,9 +17,11 @@ package io.syndesis.server.api.generator.openapi.v2;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.models.OasPathItem;
 import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
@@ -37,6 +39,7 @@ import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 import io.syndesis.server.api.generator.openapi.util.XmlSchemaHelper;
 import org.dom4j.Element;
 
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
@@ -69,6 +72,19 @@ class UnifiedXmlDataShapeGenerator extends UnifiedXmlDataShapeSupport<Oas20Docum
     @Override
     protected Oas20Schema getSchema(Oas20Response response) {
         return response.schema;
+    }
+
+    @Override
+    public Optional<NameAndSchema> findBodySchema(Oas20Operation operation) {
+        Optional<OasParameter> maybeBody = Oas20ModelHelper.findBodyParameter(operation);
+
+        if (maybeBody.isPresent()) {
+            OasParameter body = maybeBody.get();
+            String name = ofNullable(body.getName()).orElse(body.description);
+            return Optional.of(new NameAndSchema(name, (OasSchema) body.schema));
+        }
+
+        return empty();
     }
 
     @Override

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/UnifiedJsonDataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/UnifiedJsonDataShapeGenerator.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.openapi.models.OasPathItem;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+import io.apicurio.datamodels.openapi.v3.models.Oas30MediaType;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Parameter;
 import io.apicurio.datamodels.openapi.v3.models.Oas30ParameterDefinition;
@@ -38,6 +39,7 @@ import io.syndesis.server.api.generator.openapi.util.JsonSchemaHelper;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 import org.apache.commons.lang3.StringUtils;
 
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
@@ -69,6 +71,21 @@ class UnifiedJsonDataShapeGenerator extends UnifiedJsonDataShapeSupport<Oas30Doc
         final ObjectNode bodySchema = createSchemaFromModel(json, description, responseSchema);
 
         return unifiedJsonSchema("Response", "API response payload", bodySchema, null);
+    }
+
+    @Override
+    public Optional<NameAndSchema> findBodySchema(Oas30Operation operation) {
+        if (operation.requestBody == null) {
+            return empty();
+        }
+
+        Oas30MediaType body = Oas30ModelHelper.getMediaType(operation.requestBody, APPLICATION_JSON);
+        if (body != null) {
+            String name = ofNullable(body.getName()).orElse(operation.requestBody.description);
+            return Optional.of(new NameAndSchema(name, body.schema));
+        }
+
+        return empty();
     }
 
     private static void addEnumsTo(final ObjectNode parameterParameter, final Oas30Schema schema) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/UnifiedXmlDataShapeGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/UnifiedXmlDataShapeGenerator.java
@@ -18,12 +18,14 @@ package io.syndesis.server.api.generator.openapi.v3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import io.apicurio.datamodels.openapi.models.OasPathItem;
 import io.apicurio.datamodels.openapi.models.OasSchema;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+import io.apicurio.datamodels.openapi.v3.models.Oas30MediaType;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Parameter;
 import io.apicurio.datamodels.openapi.v3.models.Oas30ParameterDefinition;
@@ -36,6 +38,7 @@ import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 import io.syndesis.server.api.generator.openapi.util.XmlSchemaHelper;
 import org.dom4j.Element;
 
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
@@ -68,6 +71,21 @@ class UnifiedXmlDataShapeGenerator extends UnifiedXmlDataShapeSupport<Oas30Docum
     @Override
     protected OasSchema getSchema(Oas30Response response) {
         return Oas30ModelHelper.getSchema(response, APPLICATION_XML);
+    }
+
+    @Override
+    public Optional<NameAndSchema> findBodySchema(Oas30Operation operation) {
+        if (operation.requestBody == null) {
+            return empty();
+        }
+
+        Oas30MediaType body = Oas30ModelHelper.getMediaType(operation.requestBody, APPLICATION_XML);
+        if (body != null) {
+            String name = ofNullable(body.getName()).orElse(operation.requestBody.description);
+            return Optional.of(new NameAndSchema(name, body.schema));
+        }
+
+        return empty();
     }
 
     @Override

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGeneratorShapeValidityTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGeneratorShapeValidityTest.java
@@ -32,13 +32,12 @@ import java.util.stream.StreamSupport;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
-import io.apicurio.datamodels.openapi.models.OasParameter;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Operation;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.json.JsonUtils;
-import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
+import io.syndesis.server.api.generator.openapi.DataShapeGenerator;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -218,9 +217,9 @@ public class UnifiedXmlDataShapeGeneratorShapeValidityTest {
 
             openApiDoc.paths.getPathItems()
                 .forEach(pathItem -> {
-                    OasModelHelper.getOperationMap(pathItem).forEach((path, operation) -> {
-                        final Optional<OasParameter> bodyParameter = generator.findBodyParameter(operation);
-                        if (!bodyParameter.isPresent()) {
+                    Oas20ModelHelper.getOperationMap(pathItem).forEach((path, operation) -> {
+                        final Optional<DataShapeGenerator.NameAndSchema> bodySchema = generator.findBodySchema(operation);
+                        if (!bodySchema.isPresent()) {
                             // by default we resort to JSON for payloads without
                             // body, i.e.
                             // only parameters


### PR DESCRIPTION
Parameter defined as "in body" has been replaced by requestBody element in OpenAPI 3.x so we need to add specific logic to extract body schemas when working on OpenAPI 3.x