### PR TITLE
fix(TEIIDTOOLS-858, 863, and 864) - Changes to virtualization versions table layout and story

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Details/VirtualizationDetailHistoryTable.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Details/VirtualizationDetailHistoryTable.tsx
@@ -3,13 +3,10 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
-  PageSection,
-  Stack,
-  StackItem,
   Title,
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, OkIcon } from '@patternfly/react-icons';
-import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { classNames, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { Spinner } from 'patternfly-react';
 import * as React from 'react';
 
@@ -21,10 +18,17 @@ export interface IVirtualizationHistoryItem {
 }
 
 export interface IVirtualizationDetailHistoryTableProps {
+  /**
+   * Accessibility message for the table column for the kebab menu.
+   */
+  a11yActionMenuColumn: string;
   historyItems: IVirtualizationHistoryItem[];
   i18nEmptyVersionsTitle: string;
   i18nEmptyVersionsMsg: string;
   isModified: boolean;
+  /**
+   * i18n column headers in this order: version, published time, published indicator, kebab menu
+   */
   tableHeaders: string[];
 }
 
@@ -40,9 +44,25 @@ const getPublishIcon = (publishState: string) => {
 };
 
 const getColumns = (headers: string[]) => {
-  return headers.map(header => ({
-    title: header,
-  }));
+  const cols = [
+    {
+      columnTransforms: [classNames('pf-m-fit-content')], // column sized to heading and data
+      title: headers[0],
+    },
+    {
+      columnTransforms: [classNames('pf-m-fit-content')],
+      title: headers[1],
+    },
+    {
+      columnTransforms: [classNames('pf-m-width-max')], // column sized to take up remaining space
+      title: headers[2],
+    },
+    {
+      columnTransforms: [classNames('pf-m-fit-content')],
+      title: headers[3],
+    },
+  ];
+  return cols;
 };
 
 const getRows = (
@@ -99,22 +119,17 @@ export const VirtualizationDetailHistoryTable: React.FunctionComponent<
   IVirtualizationDetailHistoryTableProps
 > = props => {
   return (
-    <PageSection>
-      <Stack>
-        <StackItem>
-          <Table
-            cells={getColumns(props.tableHeaders)}
-            rows={getRows(
-              props.historyItems,
-              props.i18nEmptyVersionsTitle,
-              props.i18nEmptyVersionsMsg
-            )}
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
-        </StackItem>
-      </Stack>
-    </PageSection>
+    <Table
+      aria-label={props.a11yActionMenuColumn}
+      cells={getColumns(props.tableHeaders)}
+      rows={getRows(
+        props.historyItems,
+        props.i18nEmptyVersionsTitle,
+        props.i18nEmptyVersionsMsg
+      )}
+    >
+      <TableHeader />
+      <TableBody />
+    </Table>
   );
 };

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationDetailHistoryTable.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationDetailHistoryTable.stories.tsx
@@ -1,4 +1,4 @@
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import {
@@ -8,9 +8,9 @@ import {
 
 const colHeaders = ['History', 'Published Time', 'Published', ''];
 
-const version1Actions = <React.Fragment>Version1 Actions</React.Fragment>;
-const version2Actions = <React.Fragment>Version2 Actions</React.Fragment>;
-const version3Actions = <React.Fragment>Version3 Actions</React.Fragment>;
+const version1Actions = <div>Version1 Actions</div>;
+const version2Actions = <div>Version2 Actions</div>;
+const version3Actions = <div>Version3 Actions</div>;
 
 const version3Item: IVirtualizationHistoryItem = {
   actions: version3Actions,
@@ -37,6 +37,7 @@ const emptyVersionsMsg = 'There is no version history for this virtualization.';
 storiesOf('Data/Virtualizations/VirtualizationDetailHistoryTable', module)
   .add('Details', () => (
     <VirtualizationDetailHistoryTable
+      a11yActionMenuColumn={'Version action menu column'}
       historyItems={versionItems}
       i18nEmptyVersionsTitle={emptyVersionsTitle}
       i18nEmptyVersionsMsg={emptyVersionsMsg}
@@ -46,6 +47,7 @@ storiesOf('Data/Virtualizations/VirtualizationDetailHistoryTable', module)
   ))
   .add('Details - no history items', () => (
     <VirtualizationDetailHistoryTable
+      a11yActionMenuColumn={'Version action menu column'}
       historyItems={[]}
       i18nEmptyVersionsTitle={emptyVersionsTitle}
       i18nEmptyVersionsMsg={emptyVersionsMsg}

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -1,6 +1,7 @@
 {
   "activeConnectionsEmptyStateInfo": "There are no active connections available. Click Create Connection for new connection.",
   "activeConnectionsEmptyStateTitle": "No Active Connections",
+  "actionsColumnA11yMessage": "Version action menu column",
   "buildStatus": {
     "BUILDING": "Building",
     "CANCELLED": "Cancelled",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -1,6 +1,7 @@
 {
   "activeConnectionsEmptyStateInfo": "Non ci sono connessioni attive disponibili. Fai clic su Crea connessione per una nuova connessione.",
   "activeConnectionsEmptyStateTitle": "Nessuna Connessione Attiva",
+  "actionsColumnA11yMessage": "Colonna del menu azione versione",
   "buildStatus": {
     "BUILDING": "Costruzione",
     "CANCELLED": "Annullato",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.ru.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.ru.json
@@ -1,6 +1,7 @@
 {
   "activeConnectionsEmptyStateInfo": "Нет активных Соединений. Нажмите для создания нового Соединения.",
   "activeConnectionsEmptyStateTitle": "Нет активных Соединений",
+  "actionsColumnA11yMessage": "Колонка меню действий версии",
   "buildStatus": {
     "BUILDING": "Сборка",
     "CANCELLED": "Отменено",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationDetailsPage.tsx
@@ -139,6 +139,7 @@ export const VirtualizationDetailsPage: React.FunctionComponent = () => {
         >
           {() => (
             <VirtualizationDetailHistoryTable
+              a11yActionMenuColumn={t('actionsColumnA11yMessage')}
               isModified={virtualization.modified}
               i18nEmptyVersionsTitle={t('detailsVersionTableEmptyTitle')}
               i18nEmptyVersionsMsg={t('detailsVersionTableEmptyMsg')}


### PR DESCRIPTION
- see [TEIIDTOOLS-858 - Virtualization versions table - kebab actions should be justified to right](https://issues.jboss.org/browse/TEIIDTOOLS-858)
- see [TEIIDTOOLS-863 - Fix web console errors on virtualization details tab](https://issues.jboss.org/browse/TEIIDTOOLS-863)
- see [TEIIDTOOLS-864 - Fix VirtualizationDetailHistoryTable story](https://issues.jboss.org/browse/TEIIDTOOLS-864)
- added `aria-label` to version details `Table` to get rid of console log messages
- added format classes to each of the version details columns to move kebab to the right
- removed unneccessary `PageSection` and `Stack` from `VirtualizationDetailHistoryTable`
- in story, removed unused import and changed `historyItems` from fragment to div
<img width="1070" alt="virt-version-table" src="https://user-images.githubusercontent.com/557336/70056603-5d73a780-15a1-11ea-8899-f4223c08c05a.png">
