### PR TITLE
feat: better error page for the action configuration form when the connection is misconfigured

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/UnrecoverableError.tsx
+++ b/app/ui-react/packages/ui/src/Shared/UnrecoverableError.tsx
@@ -1,88 +1,138 @@
-import { EmptyState } from 'patternfly-react';
+import {
+  Button,
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateSecondaryActions,
+  EmptyStateVariant,
+  Expandable,
+  Text,
+  Title,
+} from '@patternfly/react-core';
+import { ErrorCircleOIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { useState } from 'react';
 import * as React from 'react';
-import { ButtonLink, Container } from '../Layout';
+
+export enum UnrecoverableErrorIcon {
+  ERROR,
+  WARNING,
+}
 
 export interface IUnrecoverableErrorProps {
+  actions?: React.ReactNode;
   i18nTitle: string;
   i18nInfo: string;
-  i18nHelp: string;
-  i18nRefreshLabel: string;
-  i18nReportIssue: string;
+  i18nHelp?: string;
+  i18nRefreshLabel?: string;
+  i18nReportIssue?: string;
   i18nShowErrorInfoLabel?: string;
+  icon?: UnrecoverableErrorIcon;
   error?: Error;
   errorInfo?: React.ErrorInfo;
+  secondaryActions?: React.ReactNodeArray | false;
+}
+
+/**
+ * Helper function to customize the error page icon
+ * @param icon
+ */
+function useIcon(icon?: UnrecoverableErrorIcon) {
+  switch (icon) {
+    case UnrecoverableErrorIcon.WARNING:
+      return WarningTriangleIcon;
+    default:
+      return ErrorCircleOIcon;
+  }
+}
+
+function useIconColor(icon?: UnrecoverableErrorIcon) {
+  switch (icon) {
+    case UnrecoverableErrorIcon.WARNING:
+      return '#f0ab00';
+    default:
+      return '#c9190b';
+  }
 }
 
 export const UnrecoverableError: React.FC<IUnrecoverableErrorProps> = ({
+  actions,
   i18nTitle,
   i18nInfo,
   i18nHelp,
   i18nRefreshLabel,
   i18nReportIssue,
   i18nShowErrorInfoLabel,
+  icon,
   error,
   errorInfo,
+  secondaryActions,
 }) => {
   const [showErrorInfo, setShowErrorInfo] = useState(false);
   const toggleErrorInfo = () => setShowErrorInfo(!showErrorInfo);
   return (
-    <Container>
-      <EmptyState>
-        <EmptyState.Icon name={'error-circle-o'} />
-        <EmptyState.Title>{i18nTitle}</EmptyState.Title>
-        <EmptyState.Info>{i18nInfo}</EmptyState.Info>
-        <EmptyState.Help>{i18nHelp}</EmptyState.Help>
-        <EmptyState.Action>
-          <ButtonLink
-            data-testid={'unrecoverable-error-refresh-button'}
-            href={'.'}
-            as={'primary'}
-            size={'lg'}
-          >
-            {i18nRefreshLabel}
-          </ButtonLink>
-        </EmptyState.Action>
-        <EmptyState.Action secondary={true}>
-          {error && (
-            <>
-              <ButtonLink
-                data-testid={'unrecoverable-error-show-error-button'}
-                onClick={toggleErrorInfo}
-                style={{ marginBottom: 0 }}
+    <Card>
+      <CardBody>
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon color={useIconColor(icon)} icon={useIcon(icon)} />
+          <Title headingLevel="h5" size="lg">
+            {i18nTitle}
+          </Title>
+          <EmptyStateBody>
+            <Text>{i18nInfo}</Text>
+            <Text>{i18nHelp}</Text>
+            {error && (
+              <Expandable
+                isExpanded={showErrorInfo}
+                onToggle={toggleErrorInfo}
+                toggleText={i18nShowErrorInfoLabel}
               >
-                {i18nShowErrorInfoLabel}
-              </ButtonLink>
-              &nbsp;
-            </>
-          )}
-          <a
-            data-testid={'unrecoverable-error-report-issue-link'}
-            className={'btn btn-default'}
-            href={
-              'https://github.com/syndesisio/syndesis/issues/new?template=simple.md&labels=cat/bug&title=Error%20report'
-            }
-          >
-            {i18nReportIssue}
-          </a>
-        </EmptyState.Action>
-        {showErrorInfo && error && (
-          <EmptyState.Help
-            style={{
-              background: 'rgba(255, 255, 255, 0.8)',
-              border: '1px solid #dedede',
-              marginTop: 10,
-              padding: 10,
-              textAlign: 'left',
-            }}
-          >
-            {error.name}: {error.message}
-            {errorInfo && (
-              <pre style={{ marginTop: 10 }}>{errorInfo.componentStack}</pre>
+                <Text component={'p'} className={'pf-u-text-align-left'}>
+                  {error.name}: {error.message}
+                  {errorInfo && (
+                    <Text component={'pre'}>{errorInfo.componentStack}</Text>
+                  )}
+                </Text>
+              </Expandable>
             )}
-          </EmptyState.Help>
-        )}
-      </EmptyState>
-    </Container>
+          </EmptyStateBody>
+          <EmptyStatePrimary>
+            {typeof actions !== 'undefined' ? (
+              actions!
+            ) : (
+              <>
+                <Button
+                  data-testid={'unrecoverable-error-refresh-button'}
+                  variant={'primary'}
+                  onClick={() => window.location.reload()}
+                >
+                  {i18nRefreshLabel!}
+                </Button>
+              </>
+            )}
+          </EmptyStatePrimary>
+          <EmptyStateSecondaryActions>
+            {typeof secondaryActions !== 'undefined' ? (
+              <>{secondaryActions && secondaryActions}</>
+            ) : (
+              <>
+                <Button
+                  component={'a'}
+                  variant={'secondary'}
+                  data-testid={'unrecoverable-error-report-issue-link'}
+                  href={
+                    'https://github.com/syndesisio/syndesis/issues/new?template=simple.md&labels=cat/bug&title=Error%20report'
+                  }
+                >
+                  {i18nReportIssue}
+                </Button>
+              </>
+            )}
+          </EmptyStateSecondaryActions>
+        </EmptyState>
+      </CardBody>
+    </Card>
   );
 };

--- a/app/ui-react/packages/ui/stories/Shared/UnrecoverableError.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/UnrecoverableError.stories.tsx
@@ -18,6 +18,11 @@ stories.add('404', () => (
       )}
       i18nRefreshLabel={text('Refresh Label', 'Refresh')}
       i18nReportIssue={text('Report the issue', 'Report the issue')}
+      i18nShowErrorInfoLabel={text('Show Error Info', 'Show Error Info')}
+      error={{ name: '404', message: 'File not found'} as Error}
+      errorInfo={{
+        componentStack: "Stuff in here\nand more stuff\nand lines\nand stuff"
+      } as React.ErrorInfo}
     />
   </Router>
 ));

--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -89,8 +89,8 @@
       },
       "error": {
         "title": "Something is wrong",
-        "info": "An error occurred while talking with the server.",
-        "help": "Please check your internet connection.",
+        "info": "An error occurred while communicating with the server.",
+        "help": "Check your internet connection.",
         "refreshButton": "Click to refresh",
         "reportIssueButton": "Report the issue",
         "showErrorInfoButton": "Show error details"

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ActionDescriptorFetchError.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ActionDescriptorFetchError.tsx
@@ -1,0 +1,43 @@
+import * as H from '@syndesis/history';
+import {
+  ButtonLink,
+  UnrecoverableError,
+  UnrecoverableErrorIcon,
+} from '@syndesis/ui';
+import * as React from 'react';
+import { Translation } from 'react-i18next';
+
+export interface IActionDescriptorFetchError {
+  connectionDetailHref: H.LocationDescriptor;
+  error: Error | string;
+  errorInfo?: React.ErrorInfo;
+}
+
+export const ActionDescriptorFetchError: React.FC<
+  IActionDescriptorFetchError
+> = ({ connectionDetailHref, error, errorInfo }) => (
+  <Translation ns={['shared', 'integrations']}>
+    {t => (
+      <UnrecoverableError
+        i18nTitle={t(
+          'integrations:editor.endpoint.configureAction.descriptorFetchError.title'
+        )}
+        i18nInfo={t(
+          'integrations:editor.endpoint.configureAction.descriptorFetchError.info'
+        )}
+        i18nShowErrorInfoLabel={t('error.showErrorInfoButton')}
+        icon={UnrecoverableErrorIcon.WARNING}
+        actions={
+          <ButtonLink as={'primary'} href={connectionDetailHref}>
+            {t(
+              'integrations:editor.endpoint.configureAction.descriptorFetchError.buttonLabel'
+            )}
+          </ButtonLink>
+        }
+        secondaryActions={false}
+        error={typeof error === 'string' ? Error(error) : error}
+        errorInfo={errorInfo}
+      />
+    )}
+  </Translation>
+);

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -16,7 +16,8 @@ import {
 import { PageSection, PageSectionLoader } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
-import { ApiError } from '../../../../../shared';
+import resolvers from '../../../../connections/resolvers';
+import { ActionDescriptorFetchError } from './ActionDescriptorFetchError';
 import { ConfigurationForm } from './ConfigurationForm';
 import { NothingToConfigure } from './NothingToConfigure';
 
@@ -159,7 +160,12 @@ export const WithConfigurationForm: React.FunctionComponent<
           loaderChildren={<PageSectionLoader />}
           errorChildren={
             <PageSection>
-              <ApiError error={errorMessage!} />
+              <ActionDescriptorFetchError
+                connectionDetailHref={resolvers.connection.details({
+                  connection: props.connection,
+                })}
+                error={errorMessage!}
+              />
             </PageSection>
           }
         >

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -84,6 +84,15 @@
     "addToIntegration": "Add to Integration",
     "confirmDeleteStepDialogBody": "Are you sure you want to delete this step from the integration?",
     "confirmDeleteStepDialogTitle": "Confirm Delete",
+    "endpoint": {
+      "configureAction": {
+        "descriptorFetchError": {
+          "title": "Connection Configuration Required",
+          "info": "A connection associated with this integration is no longer valid.",
+          "buttonLabel": "Configure connection"
+        }
+      }
+    },
     "selectStep": {
       "title": "Choose a connection",
       "startDescription": "Click the connection that starts the integration. If the connection you need is not available, click Create Connection.",

--- a/app/ui-react/syndesis/src/shared/ApiError.tsx
+++ b/app/ui-react/syndesis/src/shared/ApiError.tsx
@@ -7,7 +7,7 @@ export interface IApiErrorProps {
   errorInfo?: React.ErrorInfo;
 }
 
-export const ApiError: React.SFC<IApiErrorProps> = props => (
+export const ApiError: React.FC<IApiErrorProps> = props => (
   <Translation ns={['shared']}>
     {t => (
       <UnrecoverableError


### PR DESCRIPTION
fixes [ENTESB-11444](https://issues.jboss.org/browse/ENTESB-11444)

I also fixed the refresh button for the generic API error component that's used everywhere else.

![image](https://user-images.githubusercontent.com/351660/70067281-07602d80-15bc-11ea-83f0-856f95059934.png)

