### PR TITLE
feat: add a mechanism to hide top-level nav items

### DIFF
--- a/app/ui-react/packages/ui/src/Layout/PfVerticalNavItem.tsx
+++ b/app/ui-react/packages/ui/src/Layout/PfVerticalNavItem.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 export interface IPfVerticalNavItem {
   className?: string;
   exact?: boolean;
+  hidden?: boolean;
   isActive?: (match: any, location: any) => boolean;
   location?: any;
   strict?: boolean;
@@ -18,6 +19,7 @@ export interface IPfVerticalNavItem {
 function PfVerticalNavItem({
   className,
   exact,
+  hidden,
   isActive: isActiveProp,
   location,
   strict,
@@ -41,6 +43,10 @@ function PfVerticalNavItem({
     const isActive = !!(isActiveProp
       ? isActiveProp(match, childLocation)
       : match);
+
+    if (hidden) {
+      return null;
+    }
 
     return children ? (
       <NavExpandable title={label} isActive={isActive} isExpanded={isActive}>

--- a/app/ui-react/syndesis/config.minishift.json
+++ b/app/ui-react/syndesis/config.minishift.json
@@ -44,6 +44,9 @@
     "enabled": 1
   },
   "features": {
-    "logging": false
+    "extensions": true,
+    "integrations": true,
+    "connections": true,
+    "data": true
   }
 }

--- a/app/ui-react/syndesis/config.proxy.json
+++ b/app/ui-react/syndesis/config.proxy.json
@@ -43,6 +43,9 @@
     "enabled": 1
   },
   "features": {
-    "logging": false
+    "extensions": true,
+    "integrations": true,
+    "connections": true,
+    "data": true
   }
 }

--- a/app/ui-react/syndesis/config.staging.json
+++ b/app/ui-react/syndesis/config.staging.json
@@ -43,6 +43,9 @@
     "enabled": 1
   },
   "features": {
-    "logging": false
+    "extensions": true,
+    "integrations": true,
+    "connections": true,
+    "data": true
   }
 }

--- a/app/ui-react/syndesis/src/app/WithConfig.tsx
+++ b/app/ui-react/syndesis/src/app/WithConfig.tsx
@@ -1,3 +1,4 @@
+import { StringMap } from '@syndesis/models';
 import * as React from 'react';
 
 export interface IConfigFile {
@@ -17,9 +18,7 @@ export interface IConfigFile {
     dvUrl: string;
     enabled: number;
   };
-  features: {
-    logging: boolean;
-  };
+  features: StringMap<any>,
   branding: {
     logoWhiteBg: string;
     logoDarkBg: string;


### PR DESCRIPTION
 relates to [ENTESB-11500](https://issues.jboss.org/browse/ENTESB-11500)

This can be used to hide the "Extensions" nav item as needed, or any other item in the nav bar.  Note that this currently only works for the main navigation but this can be further built upon as needed to hide other elements as needed.

It's driven by the `features` attribute in the `config.json` file and I've added some examples:

![image](https://user-images.githubusercontent.com/351660/70152483-4e612800-167b-11ea-9bab-bfb334dfcd56.png)

The key name corresponds to the module name, i.e. "extensions" here is compared to the URL that the navigation item has for it's route.  So to hide the link to a section of the app you look at the URL bar, for example "extensions":

![image](https://user-images.githubusercontent.com/351660/70152676-a6982a00-167b-11ea-8c37-c9869a6e32d8.png)

That's the key you'd use in the `features` map.  And it won't blow up if these keys aren't present.

Oh, and also the "logging" entry that's being removed from the example config.json files is cruft.