### PR TITLE
fix(TEIIDTOOLS-856) - Revert button/action does not display for virtualizaton running - modified

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationActions.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationActions.tsx
@@ -14,11 +14,13 @@ import './VirtualizationActions.css';
 
 /**
  * Actions whose UI is a button.
+ * @property {string} iconClassName - a Patternfly or FontAwesome icon (ex., 'pf pficon-spinner2')
  * @property {string} id - a unique identifier of the the action
  * @property {string | JSX.Element} i18nLabel - the localized text displayed on the button
  * @property {string} i18nToolTip - the localized text for the button tooltip
  */
 export interface IVirtualizationAction extends IButtonLinkProps {
+  iconClassName?: string;
   id: string;
   i18nLabel: string | JSX.Element;
   i18nToolTip?: string;
@@ -53,7 +55,13 @@ export const VirtualizationActions: React.FunctionComponent<
   const [isOpen, setOpen] = React.useState(false);
 
   const createButton = (action: IVirtualizationAction): JSX.Element => {
-    const { id: dataTestId, i18nLabel, i18nToolTip, ...otherProps } = action;
+    const {
+      id: dataTestId,
+      i18nLabel,
+      i18nToolTip,
+      iconClassName,
+      ...otherProps
+    } = action;
     if (action.i18nToolTip) {
       return (
         <Tooltip content={i18nToolTip} position={'auto'}>
@@ -63,6 +71,7 @@ export const VirtualizationActions: React.FunctionComponent<
               data-testid={`virtualization-actions-${toValidHtmlId(dataTestId)}`}
               {...otherProps}
             >
+              {iconClassName && <span className={'pf pficon-spinner2'}>&nbsp;</span>}
               {i18nLabel}
             </ButtonLink>
             &nbsp;&nbsp;
@@ -78,6 +87,7 @@ export const VirtualizationActions: React.FunctionComponent<
           data-testid={`virtualization-actions-${toValidHtmlId(dataTestId)}`}
           {...otherProps}
         >
+          {iconClassName && <span className={'pf pficon-spinner2'}>&nbsp;</span>}
           {i18nLabel}
         </ButtonLink>
         &nbsp;&nbsp;

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
@@ -343,9 +343,10 @@ export const VirtualizationActionContainer: React.FunctionComponent<
      * The default revert action.
      */
     const revertAction: IVirtualizationAction = {
-      as: 'primary',
+      as: 'link',
       disabled: false,
       i18nLabel: t('shared:Revert'),
+      iconClassName: 'pf pficon-spinner2',
       id: VirtualizationActionId.Revert,
       onClick: async () => {
         setPromptActionOptions({

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -581,7 +581,7 @@ export function canPublish(virtualization: Virtualization): boolean {
 }
 
 /**
- * A virtualization can be reverted if a revision is available
+ * A virtualization can be reverted if a revision is available.
  * @param {Virtualization} virtualization the virtualization being checked
  * @param {number} revision the revision for revert
  * @returns `true`
@@ -590,7 +590,7 @@ export function canRevert(
   virtualization: Virtualization,
   revision?: number
 ): boolean {
-  return revision ? true : false;
+  return revision !== undefined;
 }
 
 /**


### PR DESCRIPTION
- see [TEIIDTOOLS-856](https://issues.jboss.org/browse/TEIIDTOOLS-856)
- it was determined in the meeting today that the revert action should never be shown in the breadcrumb actions
- added ability to add icons to `IVirtualizationAction`
- modified logic of `VirtualizationUtils.canRevert` so that it returns `false` if there is no revision passed in
- changed revert action in `VirtualizationActionContainer` to have an icon