### PR TITLE
fix(TEIIDTOOLS-867) - Preview query fails when view name has a dash

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -490,15 +490,8 @@ export function isStateOperationInProgress(
  * @param viewDefinition the ViewDefinition
  */
 export function getPreviewSql(viewDefinition: ViewDefinition): string {
-  const match = viewDefinition.name.match(/^[0-9a-zA-Z]+$/);
-  let viewName = viewDefinition.name;
-
-  // if a non-alphanumeric character found wrap in double quotes
-  if (match === null) {
-    viewName = '"' + viewDefinition.name + '"';
-  }
-
-  return 'SELECT * FROM ' + viewName;
+  // replace any double quotes in name with 2 double quotes and wrap in double quotes
+  return 'SELECT * FROM "' + viewDefinition.name.replace(/"/g, '""') + '"';
 }
 
 /**

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -490,7 +490,15 @@ export function isStateOperationInProgress(
  * @param viewDefinition the ViewDefinition
  */
 export function getPreviewSql(viewDefinition: ViewDefinition): string {
-  return 'SELECT * FROM ' + viewDefinition.name;
+  const match = viewDefinition.name.match(/^[0-9a-zA-Z]+$/);
+  let viewName = viewDefinition.name;
+
+  // if a non-alphanumeric character found wrap in double quotes
+  if (match === null) {
+    viewName = '"' + viewDefinition.name + '"';
+  }
+
+  return 'SELECT * FROM ' + viewName;
 }
 
 /**


### PR DESCRIPTION
- see [TEIIDTOOLS-867](https://issues.jboss.org/browse/TEIIDTOOLS-867)
- if view name has non-alphanumeric characters the view name is wrapped in double quotes before requesting the preview results