### PR TITLE
fix(TEIIDTOOLS-862) - Export action only exports latest version

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -100,20 +100,31 @@ export const useVirtualizationHelpers = () => {
   /**
    * Requests a `.zip` file of the virtualization be exported to the filesystem.
    * @param name the name of the virtualization
+   * @param revision the revision being exported or `undefined` if the current working state should be exported
    * @param fileName the name of the output file (must end with `.zip` or won't be used)
    * @throws an `Error` if there was a problem exporting the file
    */
-  const exportVirtualization = async (name: string, fileName?: string) => {
+  const exportVirtualization = async (
+    name: string, 
+    revision?: number, 
+    fileName?: string
+  ) => {
     let zipName = fileName;
 
     if (!zipName || !zipName.endsWith('.zip')) {
-      zipName = `${name}-export.zip`;
+      zipName = `${name}`;
+      if (revision) {
+        zipName += `-v` + revision;
+      }
+      zipName += '-export.zip';
     }
+
+    const url = `${apiContext.dvApiUri}virtualizations/${name}/export`;
 
     const response = await callFetch({
       headers: apiContext.headers,
       method: 'GET',
-      url: `${apiContext.dvApiUri}virtualizations/${name}/export`,
+      url: revision ? `${url}/${revision}` : url,
     });
 
     if (!response.ok) {

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
@@ -243,7 +243,7 @@ export const VirtualizationActionContainer: React.FunctionComponent<
       i18nLabel: t('shared:Export'),
       id: VirtualizationActionId.Export,
       onClick: async () => {
-        exportVirtualization(props.virtualization.name).catch((e: any) => {
+        exportVirtualization(props.virtualization.name, props.revision).catch((e: any) => {
           // notify user of error
           pushNotification(
             t('exportVirtualizationFailed', {


### PR DESCRIPTION
- see [TEIIDTOOLS-862](https://issues.redhat.com/browse/TEIIDTOOLS-862)
- this is the UI work
- added optional revision parameter to `useVirtualizationHelpers.exportVirtualization`
- changed output zip file name to reference reference version if revision parameter was passed in
- changed `VirtualizationActionContainer` to pass revision to the export action