### PR TITLE
fix(connector/aws): align sdk version

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -148,7 +148,7 @@
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.2.0</micrometer.version>
     <teiid.version>12.3.0</teiid.version>
-    <aws-java-sdk-core.version>1.11.269</aws-java-sdk-core.version>
+    <aws-java-sdk-core.version>1.11.415</aws-java-sdk-core.version>
 
     <javac.werror>-Werror</javac.werror>
   </properties>


### PR DESCRIPTION
We need to manually bump the AWS SDK library version in order to be aligned with the rest of libraries brought in by camel-aws component.

Closes ENTESB-12416