### PR TITLE
feat(connector): enable meta dynamic properties

### DIFF
--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/meta/ODataMetaDataRetrievalTest.java
@@ -139,7 +139,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -180,7 +180,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -225,7 +225,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -265,7 +265,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -306,7 +306,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -346,7 +346,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -393,7 +393,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -434,7 +434,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //
@@ -476,7 +476,7 @@ public class ODataMetaDataRetrievalTest extends AbstractODataTest {
         SyndesisMetadata metadata = retrieval.fetch(context, componentId, actionId, parameters);
         assertNotNull(metadata);
 
-        Map<String, List<PropertyPair>> properties = metadata.properties;
+        Map<String, List<PropertyPair>> properties = metadata.getProperties();
         assertFalse(properties.isEmpty());
 
         //

--- a/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrievalTest.java
+++ b/app/connector/salesforce/src/test/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrievalTest.java
@@ -81,9 +81,9 @@ public class SalesforceMetadataRetrievalTest {
         final SyndesisMetadata metadata = adapter.adapt(null, null, null, properties,
             MetaDataBuilder.on(CONTEXT).withAttribute("scope", "object").withPayload(payload).build());
 
-        assertThat(metadata.properties).containsKey("sObjectIdName");
+        assertThat(metadata.getProperties()).containsKey("sObjectIdName");
 
-        final List<PropertyPair> values = metadata.properties.get("sObjectIdName");
+        final List<PropertyPair> values = metadata.getProperties().get("sObjectIdName");
 
         assertThat(values).containsOnly(new PropertyPair("uniqueProperty1", "Unique property 1"),
             new PropertyPair("uniqueProperty2", "Unique property 2"));
@@ -116,9 +116,9 @@ public class SalesforceMetadataRetrievalTest {
         final SyndesisMetadata metadata = adapter.adapt(null, null, null, NOT_USED,
             MetaDataBuilder.on(CONTEXT).withPayload(globalObjectsPayload).build());
 
-        assertThat(metadata.properties).containsKey("sObjectName");
+        assertThat(metadata.getProperties()).containsKey("sObjectName");
 
-        final List<PropertyPair> values = metadata.properties.get("sObjectName");
+        final List<PropertyPair> values = metadata.getProperties().get("sObjectName");
 
         assertThat(values).containsOnly(new PropertyPair("Object1", "Object1 Label"),
             new PropertyPair("Object2", "Object2 Label"));
@@ -132,9 +132,9 @@ public class SalesforceMetadataRetrievalTest {
         final SyndesisMetadata metadata = adapter.adapt(null, null, null, NOT_USED,
             MetaDataBuilder.on(CONTEXT).withAttribute("scope", "object_types").withPayload(payload).build());
 
-        assertThat(metadata.properties).containsKey("sObjectName");
+        assertThat(metadata.getProperties()).containsKey("sObjectName");
 
-        final List<PropertyPair> values = metadata.properties.get("sObjectName");
+        final List<PropertyPair> values = metadata.getProperties().get("sObjectName");
 
         assertThat(values).containsOnly(new PropertyPair("Object1", "Object1 Label"),
             new PropertyPair("Object2", "Object2 Label"));

--- a/app/connector/support/verifier/pom.xml
+++ b/app/connector/support/verifier/pom.xml
@@ -54,6 +54,17 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/MetadataRetrieval.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/MetadataRetrieval.java
@@ -38,6 +38,15 @@ public interface MetadataRetrieval {
      */
     SyndesisMetadata fetch(CamelContext context, String componentId, String actionId, Map<String, Object> properties);
 
+    /**
+     * Provide all dynamic properties configured for the specific connector.
+     * It can use {@link CamelContext} to retrieve {@link MetaData} or use other Syndesis internal components
+     * to provide such properties.
+     */
+    default SyndesisMetadataProperties fetchProperties(CamelContext context, String componentId, String actionId, Map<String, Object> properties) {
+        return SyndesisMetadataProperties.EMPTY;
+    }
+
     default RuntimeException handle(final Exception e) {
         return new SyndesisServerException(e.getMessage() + ". Unable to fetch and process metadata", e);
     }

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadata.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadata.java
@@ -16,14 +16,13 @@
 package io.syndesis.connector.support.verifier.api;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
 import io.syndesis.common.model.DataShape;
 import org.apache.camel.util.ObjectHelper;
 
-public final class SyndesisMetadata {
+public final class SyndesisMetadata extends SyndesisMetadataProperties {
     // The empty metadata instance
     public static final SyndesisMetadata EMPTY = new SyndesisMetadata(Collections.emptyMap(), null, null);
 
@@ -37,22 +36,10 @@ public final class SyndesisMetadata {
      */
     public final DataShape outputShape;
 
-    /**
-     * A Map keyed by action property name with a list of {@link PropertyPair}
-     * values that are applicable to for that property.
-     */
-    public final Map<String, List<PropertyPair>> properties;
-
     public SyndesisMetadata(final Map<String, List<PropertyPair>> properties, final DataShape inputShape, final DataShape outputShape) {
-        this.properties = properties;
+        super(properties);
         this.inputShape = inputShape;
         this.outputShape = outputShape;
-
-        if (properties != null) {
-            for (final List<PropertyPair> propertyPairs : properties.values()) {
-                Collections.sort(propertyPairs, Comparator.comparing(PropertyPair::getDisplayValue));
-            }
-        }
     }
 
     // *********************

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadataProperties.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/SyndesisMetadataProperties.java
@@ -1,0 +1,31 @@
+package io.syndesis.connector.support.verifier.api;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class SyndesisMetadataProperties {
+
+    public static final SyndesisMetadataProperties EMPTY = new SyndesisMetadataProperties(Collections.emptyMap());
+
+    /**
+     * A Map keyed by action property name with a list of {@link PropertyPair}
+     * values that are applicable to for that property.
+     */
+    protected final Map<String, List<PropertyPair>> properties;
+
+    public SyndesisMetadataProperties(Map<String, List<PropertyPair>> properties) {
+        this.properties = properties;
+
+        if (properties != null && !properties.isEmpty()) {
+            for (final List<PropertyPair> propertyPairs : properties.values()) {
+                Collections.sort(propertyPairs, Comparator.comparing(PropertyPair::getDisplayValue));
+            }
+        }
+    }
+
+    public Map<String, List<PropertyPair>> getProperties() {
+        return properties;
+    }
+}

--- a/app/connector/support/verifier/src/test/java/io/syndesis/connector/support/verifier/api/ConnectorMetadataTest.java
+++ b/app/connector/support/verifier/src/test/java/io/syndesis/connector/support/verifier/api/ConnectorMetadataTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.verifier.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.syndesis.connector.support.verifier.api.sample.SampleConnectorMetaDataRetrieval;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectorMetadataTest {
+
+    @Test
+    public void verifyMetadataPropertyEchoed() {
+        SampleConnectorMetaDataRetrieval metaDataRetrieval = new SampleConnectorMetaDataRetrieval();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("brokers", null);
+        properties.put("anotherProperty", null);
+        SyndesisMetadataProperties dynamicProperties = metaDataRetrieval
+            .fetchProperties(null, "test", "test", properties);
+
+        assertThat(dynamicProperties.getProperties().get("brokers"))
+            .containsOnly(new PropertyPair("brokers", "BROKERS"));
+        assertThat(dynamicProperties.getProperties().get("anotherProperty"))
+            .containsOnly(new PropertyPair("anotherProperty", "ANOTHERPROPERTY"));
+    }
+
+}

--- a/app/connector/support/verifier/src/test/java/io/syndesis/connector/support/verifier/api/sample/SampleConnectorMetaDataRetrieval.java
+++ b/app/connector/support/verifier/src/test/java/io/syndesis/connector/support/verifier/api/sample/SampleConnectorMetaDataRetrieval.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.support.verifier.api.sample;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
+import io.syndesis.connector.support.verifier.api.PropertyPair;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadataProperties;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.MetaDataExtension;
+
+public class SampleConnectorMetaDataRetrieval extends ComponentMetadataRetrieval {
+
+    @Override
+    protected SyndesisMetadata adapt(CamelContext context, String componentId, String actionId, Map<String, Object> properties, MetaDataExtension.MetaData metadata) {
+        return null;
+    }
+
+    @Override
+    public SyndesisMetadataProperties fetchProperties(CamelContext context, String componentId, String actionId, Map<String, Object> properties) {
+        Map<String, List<PropertyPair>> echoProperties = SampleConnectorMetaDataRetrieval.echoProperties(properties);
+        return new SyndesisMetadataProperties(echoProperties);
+    }
+
+    private static Map<String, List<PropertyPair>> echoProperties(Map<String, Object> properties) {
+        Map<String, List<PropertyPair>> echoProperties = new HashMap<>();
+        for(Map.Entry<String, Object> x : properties.entrySet()){
+            List<PropertyPair> propertyPairs = new ArrayList<>();
+            propertyPairs.add(new PropertyPair(x.getKey(), x.getKey().toUpperCase()));
+            echoProperties.put(x.getKey(),propertyPairs);
+        }
+        return echoProperties;
+    }
+}

--- a/app/meta/src/test/java/io/syndesis/connector/meta/v1/ActionDefinitionEndpointTest.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/v1/ActionDefinitionEndpointTest.java
@@ -51,7 +51,7 @@ public class ActionDefinitionEndpointTest {
             final PetstoreMetadataRetrieval adapter = new PetstoreMetadataRetrieval(PAYLOAD, PROPERTIES, INPUT, OUTPUT);
             final SyndesisMetadata metadata = adapter.fetch(context, "petstore", "dog-food", Collections.emptyMap());
 
-            assertThat(metadata.properties).isSameAs(PROPERTIES);
+            assertThat(metadata.getProperties()).isSameAs(PROPERTIES);
             assertThat(metadata.inputShape).isSameAs(INPUT);
             assertThat(metadata.outputShape).isSameAs(OUTPUT);
         } finally {


### PR DESCRIPTION
* Adding a new method in the MetadataRetrieval interface to allow any Connector to expose a list of dynamic properties
* Fixing a few unit test that were not using getter accessor method

Closes ENTESB-12482