### PR TITLE
fix: Fix integration runtime health checks in nightly integration tests

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/gmail/WebhookToGMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/gmail/WebhookToGMail_IT.java
@@ -48,6 +48,6 @@ public class WebhookToGMail_IT extends SyndesisIntegrationTestSupport {
             .method(HttpMethod.GET)
             .seconds(10L)
             .status(HttpStatus.OK)
-            .url(String.format("http://localhost:%s/health", integrationContainer.getManagementPort()));
+            .url(String.format("http://localhost:%s/actuator/health", integrationContainer.getManagementPort()));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/googlecalendar/WebhookToGoogleCalendar_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/googlecalendar/WebhookToGoogleCalendar_IT.java
@@ -49,6 +49,6 @@ public class WebhookToGoogleCalendar_IT extends SyndesisIntegrationTestSupport {
             .method(HttpMethod.GET)
             .seconds(10L)
             .status(HttpStatus.OK)
-            .url(String.format("http://localhost:%s/health", integrationContainer.getManagementPort()));
+            .url(String.format("http://localhost:%s/actuator/health", integrationContainer.getManagementPort()));
     }
 }


### PR DESCRIPTION
Spring Boot 2.x uses a different health actuator endpoint.