### PR TITLE
fix: Fixed nightly integration tests on CircleCi

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -48,9 +48,9 @@ import org.testcontainers.containers.wait.strategy.Wait;
 @ContextConfiguration(classes = AMQToHttp_IT.EndpointConfig.class)
 public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
 
-    private static final int TODO_SERVER_POD = SocketUtils.findAvailableTcpPort();
+    private static final int TODO_SERVER_PORT = SocketUtils.findAvailableTcpPort();
     static {
-        Testcontainers.exposeHostPorts(TODO_SERVER_POD);
+        Testcontainers.exposeHostPorts(TODO_SERVER_PORT);
     }
 
     @Autowired
@@ -72,7 +72,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
             .fromExport(AMQToHttp_IT.class.getResource("AMQToHttp-export"))
             .customize("$..configuredProperties.schedulerExpression", "5000")
             .customize("$..configuredProperties.baseUrl",
-                        String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_POD))
+                        String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
             .withNetwork(amqBrokerContainer.getNetwork())
             .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
@@ -116,7 +116,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
         public HttpServer todoApiServer() {
             return CitrusEndpoints.http()
                     .server()
-                    .port(TODO_SERVER_POD)
+                    .port(TODO_SERVER_PORT)
                     .autoStart(true)
                     .timeout(60000L)
                     .build();

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
@@ -42,9 +42,9 @@ import org.testcontainers.containers.GenericContainer;
 @ContextConfiguration(classes = HttpToHttp_IT.EndpointConfig.class)
 public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
 
-    private static final int TODO_SERVER_POD = SocketUtils.findAvailableTcpPort();
+    private static final int TODO_SERVER_PORT = SocketUtils.findAvailableTcpPort();
     static {
-        Testcontainers.exposeHostPorts(TODO_SERVER_POD);
+        Testcontainers.exposeHostPorts(TODO_SERVER_PORT);
     }
 
     @Autowired
@@ -62,7 +62,7 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
             .fromExport(HttpToHttp_IT.class.getResource("HttpToHttp-export"))
             .customize("$..configuredProperties.schedulerExpression", "5000")
             .customize("$..configuredProperties.baseUrl",
-                        String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_POD))
+                        String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
             .withExposedPorts(SyndesisTestEnvironment.getServerPort(),
                               SyndesisTestEnvironment.getManagementPort());
@@ -135,7 +135,7 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
         public HttpServer todoApiServer() {
             return CitrusEndpoints.http()
                     .server()
-                    .port(TODO_SERVER_POD)
+                    .port(TODO_SERVER_PORT)
                     .autoStart(true)
                     .timeout(60000L)
                     .build();

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -37,7 +37,7 @@ public final class SyndesisTestEnvironment {
     private static final String CAMELK_RUNTIME_VERSION = "camelk.runtime.version";
     private static final String CAMELK_RUNTIME_VERSION_ENV = "CAMELK_RUNTIME_VERSION";
 
-    private static final String SYNDESIS_VERSION_DEFAULT = "1.8-SNAPSHOT";
+    private static final String SYNDESIS_VERSION_DEFAULT = "2.0-SNAPSHOT";
     private static final String SYNDESIS_VERSION = SYNDESIS_PREFIX + "version";
     private static final String SYNDESIS_VERSION_ENV = SYNDESIS_ENV_PREFIX + "VERSION";
 

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -319,7 +319,7 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
                     .add("-f")
                     .add(SyndesisTestEnvironment.getProjectMountPath())
                     .add(SyndesisTestEnvironment.getIntegrationRuntime().getCommand())
-                    .add("-Dsettings.localRepository=/tmp/artifacts/m2");
+                    .add("-Dmaven.repo.local=/tmp/artifacts/m2");
 
             if (enableDebug) {
                 commandLine.add(getDebugJvmArguments());


### PR DESCRIPTION
Use maven.repo.local property instead of settings.localRepository to set the local Maven repository for integration runtime container.