### PR TITLE
chore(build): setup maven-buildtime-extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>co.leantechniques</groupId>
-        <artifactId>maven-buildtime-extension</artifactId>
-        <version>3.0.3</version>
-    </extension>
-</extensions>
-

--- a/app/.mvn/extensions.xml
+++ b/app/.mvn/extensions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<extensions>
+    <extension>
+        <groupId>co.leantechniques</groupId>
+        <artifactId>maven-buildtime-extension</artifactId>
+        <version>3.0.3</version>
+    </extension>
+</extensions>
+

--- a/app/.mvn/maven.config
+++ b/app/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dmaven.artifact.threads=8
+-Dmaven.artifact.threads=8 -Dbuildtime.output.log=true


### PR DESCRIPTION
Seems that we were missing the setup for the maven-buildtime-extension.
The intent was there to configure, the configuration wasn't applied as
the `.mvn` directory was at the wrong level and the property needed to
configure it was missing.

Now timing information for each plugin/module will be printed to stdout.