### PR TITLE
chore(c/kafka): change brokers type to `typeahead`

### DIFF
--- a/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
+++ b/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
@@ -108,7 +108,7 @@
       "order": "1",
       "required": true,
       "secret": false,
-      "type": "string"
+      "type": "typeahead"
     }
   },
   "tags": [


### PR DESCRIPTION
We're using new capabilities of Patternfly to have auto-complete
dropdowns, for that the `type` of the property needs to be `typeahead`.

This is added to the Kafka connector so when a Kafka connection is
created we can utilize the Strimzi discovery via the `syndesis-meta`.