### PR TITLE
fix(openshift): cascade `BuildConfig` deletion

### DIFF
--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -492,7 +492,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     }
 
     private boolean removeBuildConfig(String projectName) {
-        return openShiftClient.buildConfigs().withName(projectName).delete();
+        return openShiftClient.buildConfigs().withName(projectName).withPropagationPolicy("Foreground").delete();
     }
 
     private void ensureSecret(String name, DeploymentData deploymentData) {


### PR DESCRIPTION
When deleting an integration the `Build` would be left over preventing
the future integration with the same name, and hence the same `Build`
name to be built and started. This makes sure that the deletion of
`BuildConfig` is propagated explicitly by using `Foreground`[1]
cascading deletion.

Ref. https://issues.redhat.com/browse/ENTESB-12493

[1] https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion