### PR TITLE
chore(build): enable proxy.golang.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,6 +501,7 @@ jobs:
       - image: circleci/golang:1.12.5
     environment:
       DOCKER_IMAGES: syndesis-operator
+      GOPROXY: https://proxy.golang.org
       <<: *common_env
     steps:
       - setup_remote_docker


### PR DESCRIPTION
In an effort to stabilize the operator (golang) build this configures
the use of proxy.golang.org for the operator build on CircleCI.