### PR TITLE
fix(ENTESB-12218): Add OpenAPI 3.x specific validation rule

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
@@ -46,9 +46,19 @@ public abstract class OpenApiValidationRules<T extends OasResponse, S extends Se
 
     private final List<Function<OpenApiModelInfo, OpenApiModelInfo>> rules = new ArrayList<>();
 
-    protected OpenApiValidationRules(final APIValidationContext context) {
+    /**
+     * Constructor initializes rules based on given validation context and specific rules for consumer and producer APIs.
+     * Subclasses may provide special rules in addition to generic rules added in this base class.
+     * @param context the validation context specifying the consumer or provider API
+     * @param consumerRules specific rules to add for consumed APIs
+     * @param providerRules specific rules to add for provided APIs
+     */
+    protected OpenApiValidationRules(final APIValidationContext context,
+                                     final List<Function<OpenApiModelInfo, OpenApiModelInfo>> consumerRules,
+                                     final List<Function<OpenApiModelInfo, OpenApiModelInfo>> providerRules) {
         switch (context) {
         case CONSUMED_API:
+            rules.addAll(consumerRules);
             rules.add(this::validateResponses);
             rules.add(this::validateConsumedAuthTypes);
             rules.add(this::validateScheme);
@@ -57,6 +67,7 @@ public abstract class OpenApiValidationRules<T extends OasResponse, S extends Se
             rules.add(this::validateOperationsGiven);
             return;
         case PROVIDED_API:
+            rules.addAll(providerRules);
             rules.add(this::validateResponses);
             rules.add(this::validateProvidedAuthTypes);
             rules.add(this::validateUniqueOperationIds);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
@@ -39,7 +39,7 @@ import io.syndesis.server.api.generator.openapi.OpenApiValidationRules;
 public class Oas20ValidationRules extends OpenApiValidationRules<Oas20Response, Oas20SecurityScheme, Oas20SchemaDefinition> {
 
     Oas20ValidationRules(APIValidationContext context) {
-        super(context);
+        super(context, Collections.emptyList(), Collections.emptyList());
     }
 
     public static Oas20ValidationRules get(final APIValidationContext context) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
@@ -81,7 +81,7 @@ public class Oas30PropertyGenerators extends OpenApiPropertyGenerator<Oas30Docum
 
     @Override
     protected String getFlow(Oas30SecurityScheme scheme) {
-        return Oas30ModelHelper.getAuthFlow(scheme);
+        return getAuthFlow(scheme);
     }
 
     @Override
@@ -96,5 +96,38 @@ public class Oas30PropertyGenerators extends OpenApiPropertyGenerator<Oas30Docum
         }
 
         return info.getV3Model().servers.stream().map(Oas30ModelHelper::getScheme).collect(Collectors.toList());
+    }
+
+    /**
+     * Extracts authorization flow name from security scheme. In OpenAPI 3.x the security scheme "oauth2" can define multiple authorization flow types.
+     * This method searches for authorizationCode flow type first in favor of any other flow type as this is the one Syndesis is supporting at the moment.
+     *
+     * Only if that specific flow type is not specified go and visit other flow types defined. Returns null when no authorization flow type is defined
+     * which is usually the case for non oauth2 security schemes.
+     * @param scheme the security scheme maybe holding authorization flows.
+     * @return the name of the authorization flow if any or null otherwise.
+     */
+    private static String getAuthFlow(Oas30SecurityScheme scheme) {
+        if (scheme.flows == null) {
+            return null;
+        }
+
+        if (scheme.flows.authorizationCode != null) {
+            return "authorizationCode";
+        }
+
+        if (scheme.flows.clientCredentials != null) {
+            return "clientCredentials";
+        }
+
+        if (scheme.flows.password != null) {
+            return "password";
+        }
+
+        if (scheme.flows.implicit != null) {
+            return "implicit";
+        }
+
+        return null;
     }
 }

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
@@ -41,7 +41,7 @@ public class Oas30ParameterGeneratorTest {
         final Oas30Schema petIdSchema = Oas30ModelHelper.getSchema(petIdPathParameter).orElseThrow(IllegalStateException::new);
 
         final ConfigurationProperty configurationProperty =
-            Oas30ParameterGenerator.createPropertyFromParameter(petIdPathParameter, petIdSchema.type, Oas30ModelHelper.javaTypeFor(petIdSchema),
+            Oas30ParameterGenerator.createPropertyFromParameter(petIdPathParameter, petIdSchema.type, Oas30ParameterGenerator.javaTypeFor(petIdSchema),
                 petIdSchema.default_, petIdSchema.enum_);
 
         final ConfigurationProperty expected = new ConfigurationProperty.Builder()//

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRulesTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRulesTest.java
@@ -236,4 +236,33 @@ public class Oas30ValidationRulesTest {
             .message("No paths defined")
             .build());
     }
+
+    @Test
+    public void shouldNotGenerateWarningForSameServerBasePath() {
+        final Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.addServer("https://development.syndesis.io/v1", "Development server");
+        openApiDoc.addServer("https://staging.syndesis.io/v1", "Staging server");
+        openApiDoc.addServer("https://api.syndesis.io/v1", "Production server");
+
+        final OpenApiModelInfo info = new OpenApiModelInfo.Builder().model(openApiDoc).build();
+
+        final OpenApiModelInfo validated = Oas30ValidationRules.validateServerBasePaths(info);
+        assertThat(validated.getErrors()).isEmpty();
+        assertThat(validated.getWarnings()).isEmpty();
+    }
+
+    @Test
+    public void shouldGenerateWarningForDifferingServerBasePaths() {
+        final Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.addServer("https://syndesis.io/development", "Development server");
+        openApiDoc.addServer("https://syndesis.io/staging", "Staging server");
+        openApiDoc.addServer("https://syndesis.io/api", "Production server");
+
+        final OpenApiModelInfo info = new OpenApiModelInfo.Builder().model(openApiDoc).build();
+
+        final OpenApiModelInfo validated = Oas30ValidationRules.validateServerBasePaths(info);
+        assertThat(validated.getErrors()).isEmpty();
+        assertThat(validated.getWarnings()).containsOnly(new Violation.Builder().error("differing-base-paths")
+            .message("Specified servers do not share the same base path. REST endpoint will use '/development' as base path.").build());
+    }
 }


### PR DESCRIPTION
Validate the specified server URLs share the same base path for OpenAPI 3.x APIs provided by Syndesis.

OpenAPI 3.x is able to specify multiple servers with host URLs. Validates that the specified server URLs share the same base path. Generated REST endpoint can only use one single base path and in case there are differing base paths defined in server URLs we raise a warning.