### PR TITLE
fix(ENTESB-12218): Add support for OpenAPI 3.x global parameter definitions

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
@@ -46,9 +46,19 @@ public abstract class OpenApiValidationRules<T extends OasResponse, S extends Se
 
     private final List<Function<OpenApiModelInfo, OpenApiModelInfo>> rules = new ArrayList<>();
 
-    protected OpenApiValidationRules(final APIValidationContext context) {
+    /**
+     * Constructor initializes rules based on given validation context and specific rules for consumer and producer APIs.
+     * Subclasses may provide special rules in addition to generic rules added in this base class.
+     * @param context the validation context specifying the consumer or provider API
+     * @param consumerRules specific rules to add for consumed APIs
+     * @param providerRules specific rules to add for provided APIs
+     */
+    protected OpenApiValidationRules(final APIValidationContext context,
+                                     final List<Function<OpenApiModelInfo, OpenApiModelInfo>> consumerRules,
+                                     final List<Function<OpenApiModelInfo, OpenApiModelInfo>> providerRules) {
         switch (context) {
         case CONSUMED_API:
+            rules.addAll(consumerRules);
             rules.add(this::validateResponses);
             rules.add(this::validateConsumedAuthTypes);
             rules.add(this::validateScheme);
@@ -57,6 +67,7 @@ public abstract class OpenApiValidationRules<T extends OasResponse, S extends Se
             rules.add(this::validateOperationsGiven);
             return;
         case PROVIDED_API:
+            rules.addAll(providerRules);
             rules.add(this::validateResponses);
             rules.add(this::validateProvidedAuthTypes);
             rules.add(this::validateUniqueOperationIds);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
@@ -39,7 +39,7 @@ import io.syndesis.server.api.generator.openapi.OpenApiValidationRules;
 public class Oas20ValidationRules extends OpenApiValidationRules<Oas20Response, Oas20SecurityScheme, Oas20SchemaDefinition> {
 
     Oas20ValidationRules(APIValidationContext context) {
-        super(context);
+        super(context, Collections.emptyList(), Collections.emptyList());
     }
 
     public static Oas20ValidationRules get(final APIValidationContext context) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30FormDataHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30FormDataHelper.java
@@ -48,6 +48,10 @@ final class Oas30FormDataHelper {
         public static boolean isFormDataMediaType(String type) {
             return Arrays.stream(values()).anyMatch(m -> m.mediaType.equals(type));
         }
+
+        public String mediaType() {
+            return mediaType;
+        }
     }
 
     /**

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ModelHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ModelHelper.java
@@ -17,12 +17,9 @@ package io.syndesis.server.api.generator.openapi.v3;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.apicurio.datamodels.core.models.common.Server;
 import io.apicurio.datamodels.core.models.common.ServerVariable;
@@ -32,7 +29,6 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30MediaType;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Parameter;
-import io.apicurio.datamodels.openapi.v3.models.Oas30ParameterDefinition;
 import io.apicurio.datamodels.openapi.v3.models.Oas30RequestBody;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Response;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Schema;
@@ -47,60 +43,6 @@ final class Oas30ModelHelper {
 
     private Oas30ModelHelper() {
         // utility class
-    }
-
-    /**
-     * Iterate through list of generic path parameters on the given operation and collect those of given type.
-     * @param operation given path item.
-     * @return typed list of path parameters.
-     */
-    static List<Oas30Parameter> getParameters(Oas30Operation operation) {
-        List<Oas30Parameter> parameters = OasModelHelper.getParameters(operation)
-            .stream()
-            .filter(Oas30Parameter.class::isInstance)
-            .map(Oas30Parameter.class::cast)
-            .collect(Collectors.toList());
-
-        if (Oas30FormDataHelper.hasFormDataBody(operation.requestBody)) {
-            //add form urlencoded properties as we handle those as parameters
-            Optional<Oas30MediaType> formDataContent = Oas30FormDataHelper.getFormDataContent(operation.requestBody.content);
-            formDataContent.ifPresent(oas30MediaType -> Optional.ofNullable(oas30MediaType.schema.properties).orElse(Collections.emptyMap()).forEach((name, property) -> {
-                Oas30Parameter formParameter = new Oas30Parameter(name);
-                formParameter.schema = property;
-                formParameter.in = "formData";
-                formParameter.$ref = property.$ref;
-                formParameter.description = property.description;
-                parameters.add(formParameter);
-            }));
-        }
-
-        return parameters;
-    }
-
-    /**
-     * Iterate through list of generic path parameters on the given path item and collect those of given type.
-     * @param pathItem given path item.
-     * @return typed list of path parameters.
-     */
-    static List<Oas30Parameter> getParameters(OasPathItem pathItem) {
-        return OasModelHelper.getParameters(pathItem)
-            .stream()
-            .filter(Oas30Parameter.class::isInstance)
-            .map(Oas30Parameter.class::cast)
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Get parameter definitions on OpenAPI document if any.
-     * @param openApiDoc given specification.
-     * @return typed list of path parameter definitions.
-     */
-    static Map<String, Oas30ParameterDefinition> getParameters(Oas30Document openApiDoc) {
-        if (openApiDoc.components == null || openApiDoc.components.parameters == null) {
-            return Collections.emptyMap();
-        }
-
-        return openApiDoc.components.parameters;
     }
 
     static Oas30SchemaDefinition dereference(final OasSchema model, final Oas30Document openApiDoc) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
@@ -81,7 +81,7 @@ public class Oas30PropertyGenerators extends OpenApiPropertyGenerator<Oas30Docum
 
     @Override
     protected String getFlow(Oas30SecurityScheme scheme) {
-        return Oas30ModelHelper.getAuthFlow(scheme);
+        return getAuthFlow(scheme);
     }
 
     @Override
@@ -96,5 +96,38 @@ public class Oas30PropertyGenerators extends OpenApiPropertyGenerator<Oas30Docum
         }
 
         return info.getV3Model().servers.stream().map(Oas30ModelHelper::getScheme).collect(Collectors.toList());
+    }
+
+    /**
+     * Extracts authorization flow name from security scheme. In OpenAPI 3.x the security scheme "oauth2" can define multiple authorization flow types.
+     * This method searches for authorizationCode flow type first in favor of any other flow type as this is the one Syndesis is supporting at the moment.
+     *
+     * Only if that specific flow type is not specified go and visit other flow types defined. Returns null when no authorization flow type is defined
+     * which is usually the case for non oauth2 security schemes.
+     * @param scheme the security scheme maybe holding authorization flows.
+     * @return the name of the authorization flow if any or null otherwise.
+     */
+    private static String getAuthFlow(Oas30SecurityScheme scheme) {
+        if (scheme.flows == null) {
+            return null;
+        }
+
+        if (scheme.flows.authorizationCode != null) {
+            return "authorizationCode";
+        }
+
+        if (scheme.flows.clientCredentials != null) {
+            return "clientCredentials";
+        }
+
+        if (scheme.flows.password != null) {
+            return "password";
+        }
+
+        if (scheme.flows.implicit != null) {
+            return "implicit";
+        }
+
+        return null;
     }
 }

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30DataShapeGeneratorHelperTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30DataShapeGeneratorHelperTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.api.generator.openapi.v3;
+
+import java.util.List;
+
+import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+import io.apicurio.datamodels.openapi.v3.models.Oas30MediaType;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Parameter;
+import io.apicurio.datamodels.openapi.v3.models.Oas30ParameterDefinition;
+import io.apicurio.datamodels.openapi.v3.models.Oas30PathItem;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class Oas30DataShapeGeneratorHelperTest {
+
+    @Test
+    public void shouldGetEmptyOperationParameters() {
+        Oas30Document openApiDoc = new Oas30Document();
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        pathItem.get = operation;
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).isEmpty();
+    }
+
+    @Test
+    public void shouldGetOperationParameters() {
+        Oas30Document openApiDoc = new Oas30Document();
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        pathItem.get = operation;
+
+        Oas30Parameter idParameter = (Oas30Parameter) operation.createParameter();
+        idParameter.in = "path";
+        idParameter.name = "id";
+        operation.addParameter(idParameter);
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).hasSize(1);
+        Assertions.assertThat(operationParameters).contains(idParameter);
+    }
+
+    @Test
+    public void shouldGetOperationParametersAndReferences() {
+        Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.components = openApiDoc.createComponents();
+        Oas30ParameterDefinition globalParameter = openApiDoc.components.createParameterDefinition("version");
+        openApiDoc.components.addParameterDefinition("Version", globalParameter);
+        openApiDoc.components.addParameterDefinition("Unused", openApiDoc.components.createParameterDefinition("unused"));
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        pathItem.get = operation;
+
+        Oas30Parameter versionParameter = (Oas30Parameter) operation.createParameter();
+        versionParameter.$ref = "#components/parameters/Version";
+        versionParameter.in = "header";
+        operation.addParameter(versionParameter);
+
+        Oas30Parameter idParameter = (Oas30Parameter) operation.createParameter();
+        idParameter.in = "path";
+        idParameter.name = "id";
+        operation.addParameter(idParameter);
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).hasSize(2);
+        Assertions.assertThat(operationParameters).contains(globalParameter, idParameter);
+    }
+
+    @Test
+    public void shouldGetOperationParametersJoinedWithPathItemParametersAndReferences() {
+        Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.components = openApiDoc.createComponents();
+        Oas30ParameterDefinition globalParameter = openApiDoc.components.createParameterDefinition("version");
+        openApiDoc.components.addParameterDefinition("Version", globalParameter);
+        openApiDoc.components.addParameterDefinition("Unused", openApiDoc.components.createParameterDefinition("unused"));
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Parameter pathParameter = (Oas30Parameter) pathItem.createParameter();
+        pathParameter.$ref = "#components/parameters/Version";
+        pathItem.addParameter(pathParameter);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        pathItem.get = operation;
+
+        Oas30Parameter operationParameter = (Oas30Parameter) operation.createParameter();
+        operationParameter.in = "path";
+        operationParameter.name = "id";
+        operation.addParameter(operationParameter);
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).hasSize(2);
+        Assertions.assertThat(operationParameters).contains(globalParameter, operationParameter);
+    }
+
+    @Test
+    public void shouldNotHaveDuplicateOperationParameters() {
+        Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.components = openApiDoc.createComponents();
+        Oas30ParameterDefinition globalParameter = openApiDoc.components.createParameterDefinition("version");
+        openApiDoc.components.addParameterDefinition("Version", globalParameter);
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Parameter pathParameter = (Oas30Parameter) pathItem.createParameter();
+        pathParameter.$ref = "#components/parameters/Version";
+        pathItem.addParameter(pathParameter);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        pathItem.get = operation;
+
+        Oas30Parameter operationParameter = (Oas30Parameter) operation.createParameter();
+        operationParameter.$ref = "#components/parameters/Version";
+        operation.addParameter(operationParameter);
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).hasSize(1);
+        Assertions.assertThat(operationParameters).contains(globalParameter);
+    }
+
+    @Test
+    public void shouldGetOperationParameterFromFormData() {
+        Oas30Document openApiDoc = new Oas30Document();
+
+        openApiDoc.paths = openApiDoc.createPaths();
+        Oas30PathItem pathItem = (Oas30PathItem) openApiDoc.paths.createPathItem("/test/{id}");
+        openApiDoc.paths.addPathItem("test", pathItem);
+
+        Oas30Operation operation = (Oas30Operation) pathItem.createOperation("get");
+        operation.requestBody = operation.createRequestBody();
+        Oas30MediaType formData = operation.requestBody.createMediaType("formData");
+        formData.schema = formData.createSchema();
+        formData.schema.addProperty("name", formData.createSchema());
+        formData.schema.addProperty("age", formData.createSchema());
+        operation.requestBody.content.put(Oas30FormDataHelper.MediaType.FORM_URLENCODED.mediaType(), formData);
+        pathItem.get = operation;
+
+        List<Oas30Parameter> operationParameters = Oas30DataShapeGeneratorHelper.getOperationParameters(openApiDoc, operation);
+        Assertions.assertThat(operationParameters).hasSize(2);
+        Assertions.assertThat(operationParameters).allMatch(p -> "formData".equals(p.in));
+        Assertions.assertThat(operationParameters).anyMatch(p -> "name".equals(p.name));
+        Assertions.assertThat(operationParameters).anyMatch(p -> "age".equals(p.name));
+    }
+}

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
@@ -41,7 +41,7 @@ public class Oas30ParameterGeneratorTest {
         final Oas30Schema petIdSchema = Oas30ModelHelper.getSchema(petIdPathParameter).orElseThrow(IllegalStateException::new);
 
         final ConfigurationProperty configurationProperty =
-            Oas30ParameterGenerator.createPropertyFromParameter(petIdPathParameter, petIdSchema.type, Oas30ModelHelper.javaTypeFor(petIdSchema),
+            Oas30ParameterGenerator.createPropertyFromParameter(petIdPathParameter, petIdSchema.type, Oas30ParameterGenerator.javaTypeFor(petIdSchema),
                 petIdSchema.default_, petIdSchema.enum_);
 
         final ConfigurationProperty expected = new ConfigurationProperty.Builder()//

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRulesTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRulesTest.java
@@ -236,4 +236,33 @@ public class Oas30ValidationRulesTest {
             .message("No paths defined")
             .build());
     }
+
+    @Test
+    public void shouldNotGenerateWarningForSameServerBasePath() {
+        final Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.addServer("https://development.syndesis.io/v1", "Development server");
+        openApiDoc.addServer("https://staging.syndesis.io/v1", "Staging server");
+        openApiDoc.addServer("https://api.syndesis.io/v1", "Production server");
+
+        final OpenApiModelInfo info = new OpenApiModelInfo.Builder().model(openApiDoc).build();
+
+        final OpenApiModelInfo validated = Oas30ValidationRules.validateServerBasePaths(info);
+        assertThat(validated.getErrors()).isEmpty();
+        assertThat(validated.getWarnings()).isEmpty();
+    }
+
+    @Test
+    public void shouldGenerateWarningForDifferingServerBasePaths() {
+        final Oas30Document openApiDoc = new Oas30Document();
+        openApiDoc.addServer("https://syndesis.io/development", "Development server");
+        openApiDoc.addServer("https://syndesis.io/staging", "Staging server");
+        openApiDoc.addServer("https://syndesis.io/api", "Production server");
+
+        final OpenApiModelInfo info = new OpenApiModelInfo.Builder().model(openApiDoc).build();
+
+        final OpenApiModelInfo validated = Oas30ValidationRules.validateServerBasePaths(info);
+        assertThat(validated.getErrors()).isEmpty();
+        assertThat(validated.getWarnings()).containsOnly(new Violation.Builder().error("differing-base-paths")
+            .message("Specified servers do not share the same base path. REST endpoint will use '/development' as base path.").build());
+    }
 }


### PR DESCRIPTION
Based on PR #7455 

OpenAPI 3.x adds global reusable parameter definitions that can be referenced in the OpenAPI specification. We need to resolve the parameter references when extracting all operation parameters.