### PR TITLE
fix(endpoint): all methods for reflective sorting

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/ReflectionUtils.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/ReflectionUtils.java
@@ -45,7 +45,7 @@ public final class ReflectionUtils {
 
     static Method extractMethod(Class<?> clazz, String fieldName, Class<?>... types) {
         try {
-            Method method = clazz.getDeclaredMethod("get" + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
+            Method method = clazz.getMethod("get" + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
             Class<?> returnType = method.getReturnType();
             for (Class<?> type : types) {
                 if (returnType.isAssignableFrom(type)) {

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
@@ -21,15 +21,14 @@ import java.util.List;
 import java.util.function.Function;
 
 import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.integration.Integration;
+
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 
-/**
- * @author roland
- * @since 13/12/16
- */
 public class ReflectiveSorterTest {
 
     @Test
@@ -108,6 +107,21 @@ public class ReflectiveSorterTest {
         }
         assertEquals(getTestData().size(), sorted.getTotalCount());
 
+    }
+
+    /**
+     * @see https://github.com/syndesisio/syndesis/issues/7471
+     */
+    @Test
+    public void shouldSortIntegrationsByVersion() {
+        final Integration v1 = new Integration.Builder().version(1).build();
+        final Integration v2 = new Integration.Builder().version(2).build();
+        final Integration v3 = new Integration.Builder().version(3).build();
+        final ListResult<Integration> integrations = ListResult.of(v3, v1, v2);
+
+        final ReflectiveSorter<Integration> sorter = new ReflectiveSorter<>(Integration.class, getOptions("version", null));
+
+        assertThat(sorter.apply(integrations)).containsExactly(v1, v2, v3);
     }
 
     private static SortOptions getOptions(String type, String direction) {


### PR DESCRIPTION
This changes the `ReflectionUtils` to include all methods available on a
class rather than the methods that are declared on a class. This will
help in finding the `getVersion` method on `Integration` interface.

Fixes #7471