### PR TITLE
chore(build): make buildtime extension opt-in

### DIFF
--- a/app/.mvn/maven.config
+++ b/app/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dmaven.artifact.threads=8 -Dbuildtime.output.log=true -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt
+-Dmaven.artifact.threads=8 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt


### PR DESCRIPTION
The buildtime Maven extension generates a long list of plugin execution
times at the end ov Maven execution. When an error is reported in the
build it's followed by this long list of build plugin timings. This
makes it cumbersome to scroll to the error.

This makes the buildtime extension opt-in, i.e. to activate the
extension `-Dbuildtime.output.log=true` must be specified.