### PR TITLE
user doc: Add xref to Syndesis community doc for developing connectors

### DIFF
--- a/doc/modules/customizing/r_develop-connector-extensions.adoc
+++ b/doc/modules/customizing/r_develop-connector-extensions.adoc
@@ -7,7 +7,11 @@
 If {prodname} does not provide a connector for the application or 
 service that you want to connect to in an integration, 
 an experienced developer can code an extension that contributes a 
-new connector to {prodname}.
+new connector to {prodname}. This documentation provides an introduction
+to developing a connector extension. For details about developing a 
+connector, see 
+link:https://syndesis.io/docs/connectors/[Developing Syndesis connectors]
+on the Syndesis community site. 
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
In the user doc in Integrating Applications with Fuse Online, where it provides an overview of developing a connector extension, I added a link to the doc on the Syndesis community web site that describes in detail how to develop a connector. 