### PR TITLE
fix: Show the column details for selected tables

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationHelpers.tsx
@@ -535,13 +535,13 @@ export const useVirtualizationHelpers = () => {
    * @param virtualalization the virtualization
    */
   const getSourceInfoForView = async (
-    virtualization: Virtualization
+    virtualizationName: string
   ): Promise<ViewSourceInfo> => {
     const response = await callFetch({
       headers: {},
       method: 'GET',
       url: `${apiContext.dvApiUri}metadata/runtimeMetadata/${
-        virtualization.name
+        virtualizationName
       }`,
     });
     if (!response.ok) {

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -137,6 +137,11 @@ export interface TableColumns {
   columnNames: string[];
 }
 
+export interface ConnectionTable {
+  name: string;
+  tables: SourceTable[];
+}
+
 export interface ViewDefinitionStatus {
   status: string;
   message: string;

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
@@ -24,16 +24,14 @@ export interface ISelectedConnectionListViewProps {
   name: string;
   connectionName: string;
   index: number;
+  rows: string[][];
   onTabelRemoved: (connectionName: string, teiidName: string) => void;
 }
 
 export const SelectedConnectionListView: React.FunctionComponent<ISelectedConnectionListViewProps> = props => {
   const columns = ['', ''];
-  const rows = [
-    ['one', 'two'],
-    ['three', 'four'],
-    ['one', 'two'],
-  ];
+
+  const rows = props.rows;
 
   const onTrashClickHandler = () => {
     props.onTabelRemoved(props.connectionName, props.name);

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -1,8 +1,16 @@
-import { SchemaNodeInfo, Virtualization } from '@syndesis/models';
+import { useVirtualizationHelpers } from '@syndesis/api';
+import { ConnectionTable } from '@syndesis/models';
+import {
+  SchemaNodeInfo,
+  ViewSourceInfo,
+  Virtualization,
+} from '@syndesis/models';
 import { CreateViewHeader, ViewCreateLayout } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { UIContext } from '../../../../app';
 import resolvers from '../../../resolvers';
 import { ConnectionSchemaContent, ConnectionTables } from '../../shared';
 
@@ -36,6 +44,25 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
   const { t } = useTranslation(['data', 'shared']);
   const schemaNodeInfo: SchemaNodeInfo[] = props.selectedSchemaNodes;
   const virtualization = state.virtualization;
+  const { pushNotification } = useContext(UIContext);
+  const [connectionTableColumns, setConnectionTableColumns] = React.useState<
+    ConnectionTable[]
+  >([]);
+  const { getSourceInfoForView } = useVirtualizationHelpers();
+
+  React.useEffect(() => {
+    const loadSourceTableInfo = async () => {
+      try {
+        const results: ViewSourceInfo = await getSourceInfoForView(
+          virtualization.name
+        );
+        setConnectionTableColumns(results.schemas);
+      } catch (error) {
+        pushNotification(error.message, 'error');
+      }
+    };
+    loadSourceTableInfo();
+  }, [virtualization.name, getSourceInfoForView, pushNotification]);
 
   return (
     <ViewCreateLayout
@@ -71,6 +98,7 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
         <ConnectionTables
           selectedSchemaNodes={props.selectedSchemaNodes}
           onNodeDeselected={props.handleNodeDeselected}
+          columnDetails={connectionTableColumns}
         />
       }
     />

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -256,7 +256,7 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
       const loadSourceTableInfo = async () => {
         try {
           const results: ViewSourceInfo = await getSourceInfoForView(
-            virtualization
+            virtualization.name
           );
           setSourceTableColumns(
             generateTableColumns(results as ViewSourceInfo)

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
@@ -1,4 +1,4 @@
-import { SchemaNodeInfo } from '@syndesis/models';
+import { ConnectionTable, SchemaNodeInfo, SourceColumn } from '@syndesis/models';
 import {
   SelectedConnectionListView,
   SelectedConnectionTables,
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 export interface IConnectionTablesProps {
   selectedSchemaNodes: SchemaNodeInfo[];
+  columnDetails: ConnectionTable[];
   onNodeDeselected: (connectionName: string, teiidName: string) => void;
 }
 
@@ -25,6 +26,20 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
     setExpanded(newArray);
   };
 
+  const getSeletedTableColumns = (connectionName: string, tabelName: string) => {
+    let columnList: SourceColumn[] = [];
+    for(const connection of props.columnDetails){
+      if(connection.name === connectionName){
+        for(const table of connection.tables){
+          if(table.name === tabelName){
+            columnList = table.columns;
+          }
+        }
+      }
+    }
+    return columnList.map( (column: SourceColumn) =>[ column.name, column.datatype])
+  }
+
   return (
     <SelectedConnectionTables 
       selectedSchemaNodesLength={props.selectedSchemaNodes.length}
@@ -40,6 +55,7 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
             toggle={toggle}
             expanded={expanded}
             onTabelRemoved={props.onNodeDeselected}
+            rows={getSeletedTableColumns(info.connectionName, info.teiidName)}
           />
         ))}
     </SelectedConnectionTables>


### PR DESCRIPTION
- Jira issue https://issues.redhat.com/browse/TEIIDTOOLS-900

- With this PR now we are also showing the column details for selected tables.

- Geeting the column details for /metadata/runtimeMetadata/{virtualizationName} 

- Screenshot
![image](https://user-images.githubusercontent.com/8264372/71898799-313ede00-3180-11ea-9ebf-168853c18485.png)
