### PR TITLE
chore: Update to AtlasMap 1.43.0 - 1.9x.

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-760016</camel.version>
-    <atlasmap.version>1.42.10</atlasmap.version>
+    <atlasmap.version>1.43.0</atlasmap.version>
     <jackson.databind.version>2.9.9</jackson.databind.version>
     <mongo.driver.version>3.6.3</mongo.driver.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,7 +37,7 @@
     <syndesis.version>${project.version}</syndesis.version>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>1.42.10</atlasmap.version>
+    <atlasmap.version>1.43.0</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-react/packages/atlasmap-assembly/package.json
+++ b/app/ui-react/packages/atlasmap-assembly/package.json
@@ -91,7 +91,7 @@
     "@angular/platform-browser": "7.2.7",
     "@angular/platform-browser-dynamic": "7.2.7",
     "@angular/router": "7.2.7",
-    "@atlasmap/atlasmap-data-mapper": "^1.42.10",
+    "@atlasmap/atlasmap-data-mapper": "^1.43.0",
     "@types/jasmine": "^3.3.9",
     "@types/jasmine-jquery": "^1.5.32",
     "@types/jasminewd2": "^2.0.3",

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -313,10 +313,10 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap-data-mapper@^1.42.10":
-  version "1.42.10"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.42.10.tgz#bd9f5466b3bbc8f129a84c96d6efcf2a308d3717"
-  integrity sha512-NEbEVOb55X3rasSyG3M/Q/4CDekxa5vDZUpVVXDt8KQ23hJs9F0rsaE0LgMRLDGEEr6fFvnRbNq612+AA+lSww==
+"@atlasmap/atlasmap-data-mapper@^1.43.0":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap-data-mapper/-/atlasmap-data-mapper-1.43.0.tgz#4a27c62980ec89eaba6f1930d381c675703b9c94"
+  integrity sha512-ytenpgZ0ZZ0NW0Mwq5LUFvp2/oxcxySirEDvlhD8NXBHkZRe/eMe88UHyJYkZhcgLFRka4ncucc78ZezOZ7lig==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Backport of #7513 and #7517 to `1.9.x`