### PR TITLE
fix(ui): `value` instead of `label` in typeahead

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormTypeaheadComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormTypeaheadComponent.tsx
@@ -117,7 +117,7 @@ export const FormTypeaheadComponent: React.FunctionComponent<
           <SelectOption
             key={`${index}-${opt.label}`}
             label={opt.label}
-            value={opt.label || props.field.name[props.field.value]}
+            value={opt.value || props.field.name[props.field.value]}
           />
         )
         })}


### PR DESCRIPTION
patternfly-react doesn't seem to allow us to have one value displayed
and another value bound/kept as value. That means that our `enum`
`label/value` can't be used as we intended: to have the `label`
displayed and to have the `value` kept as `configuredProperty`. So this
simply displays the `value` from the `enum` instead, which will make
that value bound to `configuredProperty` as well.