### PR TITLE
fix for ENTESB-11675 to add errorHandler field to the schema

### DIFF
--- a/app/ui-react/packages/api/src/constants.ts
+++ b/app/ui-react/packages/api/src/constants.ts
@@ -102,6 +102,7 @@ export const PRIMARY_FLOW_ID_METADATA_KEY = 'primaryFlowId';
 export const API_PROVIDER_END_ACTION_ID = 'io.syndesis:api-provider-end';
 export const FLOW_START_ACTION_ID = 'io.syndesis:flow-start';
 export const FLOW_END_ACTION_ID = 'io.syndesis:flow-end';
+export const WEBHOOK_INCOMING_ACTION_ID = 'io.syndesis:webhook-incoming';
 
 // Special sekret connection metadata keys
 export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -3,6 +3,7 @@ import {
   getActionById,
   getConnectionConnector,
   getConnectorActions,
+  WEBHOOK_INCOMING_ACTION_ID,
   WithActionDescriptor,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
@@ -138,7 +139,7 @@ export const WithConfigurationForm: React.FunctionComponent<IWithConfigurationFo
       props.actionId
     );
   // The API provider end action gets some special treatment
-  if (props.actionId === API_PROVIDER_END_ACTION_ID) {
+  if (props.actionId === API_PROVIDER_END_ACTION_ID || props.actionId === WEBHOOK_INCOMING_ACTION_ID) {
     const definitionOverride = applyErrorKeysToForm(action, props.errorKeys!);
     return (
       <ConfigurationForm


### PR DESCRIPTION
Adding the web hook action as one that needs to display an error handling widget