### PR TITLE
refactor: archive deployment configuration

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -35,6 +35,8 @@
   <properties>
     <!-- Global Syndesis version -->
     <syndesis.version>${project.version}</syndesis.version>
+    <!-- should archives of S2I and UI modules be deployed to a Maven repository -->
+    <deploy.archives>false</deploy.archives>
 
     <!-- Atlasmap version -->
     <atlasmap.version>1.42.10</atlasmap.version>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -37,7 +37,7 @@
       Should the ZIP file containing the settings.xml, dependencies and
       licenses be attached and deployed in install/deploy phase
     -->
-    <deploy.repository>false</deploy.repository>
+    <deploy.s2i.repository>${deploy.archives}</deploy.s2i.repository>
   </properties>
 
   <dependencies>
@@ -465,7 +465,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <attach>${deploy.repository}</attach>
+              <attach>${deploy.s2i.repository}</attach>
               <descriptors>
                 <descriptor>src/main/assembly/repository.xml</descriptor>
               </descriptors>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -36,6 +36,7 @@
     <yarn-verbose />
     <npm-verbose />
     <docker-base-image>centos/nginx-114-centos7</docker-base-image>
+    <deploy.ui.distribution>${deploy.archives}</deploy.ui.distribution>
   </properties>
 
   <build>
@@ -51,7 +52,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <attach>false</attach>
+              <attach>${deploy.ui.distribution}</attach>
               <tarLongFileMode>posix</tarLongFileMode>
               <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
               <descriptors>


### PR DESCRIPTION
When we build downstream we need the archives from the `s2i` (the
repository) and `ui-react` (distribution archive) need to be deployed to
the Maven repository. This was removed for the `ui-react` in #7022.

This refactors this by reintroducing (opt-in) the archive deployment via
`deploy.archives` Maven property (i.e. `-Ddeploy.archives=true`), or
individually via `deploy.s2i.repository` and `deploy.ui.distribution`.

(cherry picked from commit 56a0145005a1b47ba2dd9faead2d018ba7d573b9)

Backport of #7554