### PR TITLE
user doc: Fix two typos and clarify one sentence.

### DIFF
--- a/doc/modules/connecting/p_adding-mongodb-connections-read.adoc
+++ b/doc/modules/connecting/p_adding-mongodb-connections-read.adoc
@@ -48,7 +48,7 @@ tracking is enabled for the database that you want the connection
 to read. 
 .. In the *Field used to store the tracking progress* field, optionally
 specify the name of a field that is in the specified collection.
-A MongoDB administrator must have configured this field to track ... ?
+A MongoDB administrator must have configured this field.
 .. In the *DB used to store tail tracking* field, optionally enter 
 the name of the MongoDB database that contains tail tracking information. 
 .. In the *Collection used to store tail tracking* field, optionally enter

--- a/doc/modules/connecting/p_obtaining-email-to-trigger-integration-execution.adoc
+++ b/doc/modules/connecting/p_obtaining-email-to-trigger-integration-execution.adoc
@@ -35,8 +35,8 @@ that elapses between polls for messages. Or, to specify a different polling inte
 enter a number and select its time unit. 
 .. In the *Maximum Emails* field, enter the largest number 
 of messages that one poll operation can return. The default is 5.
-If the number of messages that can be returned is greater than the 
-setting of *Maximum Emails*, the connection returns the oldest 
+If the inbox or folder contains more than the maximum number of messages 
+that can be returned, the connection returns the oldest 
 messages up to the number set for *Maximum Emails*.
 +
 Set *Maximum Emails* to *`-1`* if you want each poll to obtain: 

--- a/doc/modules/tutorials/p_register-with-twitter.adoc
+++ b/doc/modules/tutorials/p_register-with-twitter.adoc
@@ -13,7 +13,7 @@ In an integration, to connect to Twitter, the first thing you must do is
 register your {prodname} environment as a client application
 that can access Twitter.
 This lets you create any number of integrations that connect
-to Twitter. In other words, you need to regCopyCallbackister a particular
+to Twitter. In other words, you need to register a particular
 {prodname} environment with Twitter only once.
 
 In each {prodname} environment, there can be only one registration


### PR DESCRIPTION
Translation of the connector guide uncovered two typos and a very confusing sentence. I corrected these issues. 