### PR TITLE
refactor(build): archive deployment profile

### DIFF
--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -33,11 +33,6 @@
 
   <properties>
     <image.build.directory>${project.basedir}/target/image</image.build.directory>
-    <!--
-      Should the ZIP file containing the settings.xml, dependencies and
-      licenses be attached and deployed in install/deploy phase
-    -->
-    <deploy.s2i.repository>${deploy.archives}</deploy.s2i.repository>
   </properties>
 
   <dependencies>
@@ -452,27 +447,19 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
+        <artifactId>maven-deploy-plugin</artifactId>
         <executions>
           <execution>
-            <!--
-              Generate a ZIP file containing the repository
-              settings.xml and license files
-            -->
-            <id>create-repository-zip</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <attach>${deploy.s2i.repository}</attach>
-              <descriptors>
-                <descriptor>src/main/assembly/repository.xml</descriptor>
-              </descriptors>
-            </configuration>
+            <id>basepom.default</id>
+            <phase />
+          </execution>
+          <execution>
+            <id>default-deploy</id>
+            <phase />
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 
@@ -522,6 +509,54 @@
         </plugins>
       </build>
 
+    </profile>
+
+    <profile>
+      <id>deploy-archives</id>
+      <activation>
+        <property>
+          <name>deploy.archives</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <!--
+                  Generate a ZIP file containing the repository
+                  settings.xml and license files
+                -->
+                <id>create-repository-zip</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <descriptors>
+                    <descriptor>src/main/assembly/repository.xml</descriptor>
+                  </descriptors>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>basepom.default</id>
+                <phase>deploy</phase>
+              </execution>
+              <execution>
+                <id>default-deploy</id>
+                <phase>deploy</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -36,32 +36,10 @@
     <yarn-verbose />
     <npm-verbose />
     <docker-base-image>centos/nginx-114-centos7</docker-base-image>
-    <deploy.ui.distribution>${deploy.archives}</deploy.ui.distribution>
   </properties>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>dist</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <attach>${deploy.ui.distribution}</attach>
-              <tarLongFileMode>posix</tarLongFileMode>
-              <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
-              <descriptors>
-                <descriptor>maven/assembly/unix-dist.xml</descriptor>
-              </descriptors>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
@@ -608,6 +586,52 @@
               <execution>
                 <id>default-install</id>
                 <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>deploy-archives</id>
+      <activation>
+        <property>
+          <name>deploy.archives</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>distribution-archive</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <tarLongFileMode>posix</tarLongFileMode>
+                  <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
+                  <descriptors>
+                    <descriptor>maven/assembly/unix-dist.xml</descriptor>
+                  </descriptors>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>basepom.default</id>
+                <phase>deploy</phase>
+              </execution>
+              <execution>
+                <id>default-deploy</id>
+                <phase>deploy</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
This changes the Maven configuration to remove the
`deploy.s2i.repository` and `deploy.ui.distribution` and instead rely on
the `deploy.archives` property. Which in turn activates the
`deploy-archives` profiles that include the assembly and deployment
Maven plugin configuration.

To build and deploy the build configuration needs to specify the
`-Ddeploy.archives=true` via command line, that way it's a system
property and it can activate the `deploy-archives` profile.

(cherry picked from commit 955e6e23ce7a56d97c3e6668aec45feb291a3b8f)

Backport of #7559