### PR TITLE
user doc: Remove Tech Preview note for DynamoDB connector

### DIFF
--- a/doc/assemblies/connecting/as_connecting-to-amazon-dynamodb.adoc
+++ b/doc/assemblies/connecting/as_connecting-to-amazon-dynamodb.adoc
@@ -10,19 +10,6 @@ data to a DynamoDB table, or remove data from a DynamoDB
 table. To do this, create an Amazon DynamoDB 
 connection and then add that connection to an integration flow.
 
-ifeval::["{location}" == "downstream"]
-[IMPORTANT]
-====
-Connecting to DynamoDB is a Technology Preview feature only. Technology Preview features are 
-not supported with Red Hat production service level agreements (SLAs) and might not be 
-functionally complete. Red Hat does not recommend using them in production. 
-These features provide early access to upcoming product features, enabling 
-customers to test functionality and provide feedback during the development process. 
-For more information about the support scope of Red Hat Technology Preview features, 
-see link:https://access.redhat.com/support/offerings/techpreview/[]. 
-====
-endif::[]
-
 For details, see:
 
 * xref:create-dynamodb-connections_{context}[]


### PR DESCRIPTION
This just removes the conditionalized note that says the DynamoDB connector is a Technology Preview feature. Maria tells me that no other updates to the doc for the DynamoDB connector are needed for 7.6. 