### PR TITLE
user doc: update Box connector doc

### DIFF
--- a/doc/assemblies/connecting/as_connecting-to-box.adoc
+++ b/doc/assemblies/connecting/as_connecting-to-box.adoc
@@ -12,20 +12,6 @@ to Box.
 A connection to Box cannot start a simple integration. In other words, 
 you cannot use a Box connection to trigger integration execution. 
 
-
-ifeval::["{location}" == "downstream"]
-[IMPORTANT]
-====
-Connecting to Box is a Technology Preview feature only. Technology Preview features are 
-not supported with Red Hat production service level agreements (SLAs) and might not be 
-functionally complete. Red Hat does not recommend using them in production. 
-These features provide early access to upcoming product features, enabling 
-customers to test functionality and provide feedback during the development process. 
-For more information about the support scope of Red Hat Technology Preview features, 
-see link:https://access.redhat.com/support/offerings/techpreview/[]. 
-====
-endif::[]
-
 The following topics provide the details:
 
 * xref:register-with-box_{context}[]

--- a/doc/modules/connecting/p_adding-box-connection-finish.adoc
+++ b/doc/modules/connecting/p_adding-box-connection-finish.adoc
@@ -27,7 +27,7 @@ In this example: `\https://app.box.com/folder/89490291417`, the folder
 ID is `89490291417`. In this release, you can upload only a single file. 
 . Optional. In the *File name* field, enter the name for a new file or 
 an existing file. If you specify the name of a file that is already
-in the specified Box folder, the connection appends content to that file.
+in the specified Box folder, the connection overwrites the file that is in the folder.
 +
 The input to the connection must be a file that you want to upload 
 to Box. If you do not specify a file name, the connection uploads a file 

--- a/doc/modules/connecting/p_adding-box-connection-middle.adoc
+++ b/doc/modules/connecting/p_adding-box-connection-middle.adoc
@@ -53,7 +53,7 @@ In this example: `\https://app.box.com/folder/89490291417`, the folder
 ID is `89490291417`. In this release, you can upload only a single file. 
 .. Optional. In the *File name* field, enter the name for a new file.
 If you specify the name of a file that is already
-in the specified Box folder, it is a runtime error.
+in the specified Box folder, the connection overwrites the file that is in the folder.
 +
 The input to the connection must be a file that you want to upload 
 to Box. If you do not specify a file name, the connection uploads a file 

--- a/doc/modules/connecting/r_how-to-specify-the-schema-in-a-database-connection.adoc
+++ b/doc/modules/connecting/r_how-to-specify-the-schema-in-a-database-connection.adoc
@@ -92,16 +92,3 @@ Specify any value in the *Username* and *Password* fields. Leave the *Schema* fi
 The driver is already available in {prodname}. 
 
 |===
-
-ifeval::["{location}" == "downstream"]
-[IMPORTANT]
-====
-Data Virtualization is a Technology Preview feature only. Technology Preview features are 
-not supported with Red Hat production service level agreements (SLAs) and might not be 
-functionally complete. Red Hat does not recommend using them in production. 
-These features provide early access to upcoming product features, enabling 
-customers to test functionality and provide feedback during the development process. 
-For more information about the support scope of Red Hat Technology Preview features, 
-see link:https://access.redhat.com/support/offerings/techpreview/[]. 
-====
-endif::[]


### PR DESCRIPTION
For the 7.6 user doc for the Box connector, I removed the Tech Preview note, and I updated the description of the file name specification when uploading a file to Box. Claudio reviewed these updates. 

In an unrelated file, I removed a Tech Preview note about data virtualization, so I wouldn't forget to do it. 