### PR TITLE
fix: server/meta startup

### DIFF
--- a/app/meta/src/main/java/io/syndesis/connector/meta/v1/V1.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/v1/V1.java
@@ -15,6 +15,9 @@
  */
 package io.syndesis.connector.meta.v1;
 
+import java.util.Collections;
+import java.util.Set;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
@@ -31,11 +34,15 @@ import org.springframework.stereotype.Component;
 public class V1 extends Application {
 
     public V1() {
-        BeanConfig beanConfig = new BeanConfig();
+        BeanConfig beanConfig = new BeanConfig() {
+            @Override
+            public Set<Class<?>> classes() {
+                return Collections.singleton(V1.class);
+            }
+        };
         beanConfig.setVersion("v1");
         beanConfig.setSchemes(new String[]{"http", "https"});
         beanConfig.setBasePath("/api/v1");
-        beanConfig.setResourcePackage(getClass().getPackage().getName());
         beanConfig.setScan(true);
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/V1Application.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/V1Application.java
@@ -15,10 +15,14 @@
  */
 package io.syndesis.server.endpoint.v1;
 
+import java.util.Collections;
+import java.util.Set;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import io.swagger.jaxrs.config.BeanConfig;
+
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,12 +30,16 @@ import org.springframework.stereotype.Component;
 public class V1Application extends Application {
 
     public V1Application() {
-        BeanConfig beanConfig = new BeanConfig();
+        BeanConfig beanConfig = new BeanConfig() {
+            @Override
+            public Set<Class<?>> classes() {
+                return Collections.singleton(V1Application.class);
+            }
+        };
         beanConfig.setVersion("v1");
         beanConfig.setTitle("Syndesis Rest API");
         beanConfig.setSchemes(new String[]{"http", "https"});
         beanConfig.setBasePath("/api/v1");
-        beanConfig.setResourcePackage(getClass().getPackage().getName());
         beanConfig.setScan(true);
     }
 


### PR DESCRIPTION
This is a dirty fix to circumvent "clever" classpath scanning from
`swagger-jaxrs` that fails on Reflections tripping over closing a
directory in a JAR file which in turn closes the whole JAR file stream
and prevents the further scanning and fails the app startup.

A proper fix is upgrading to the 2.x line of `swagger-core` which
doesn't rely on Reflections to do classpath scanning.

Ref #7556