### PR TITLE
TEIIDTOOLS-837 fix connection display with Create View Wizard

### DIFF
--- a/app/ui-react/packages/api/src/index.ts
+++ b/app/ui-react/packages/api/src/index.ts
@@ -29,6 +29,7 @@ export * from './useVirtualizationMetrics';
 export * from './useVirtualizationHelpers';
 export * from './useVirtualizationConnectionSchema';
 export * from './useVirtualizationConnectionStatuses';
+export * from './useVirtualizationRuntimeMetadata';
 export * from './useVirtualization';
 export * from './useVirtualizations';
 export * from './WithActionDescriptor';

--- a/app/ui-react/packages/api/src/useVirtualizationRuntimeMetadata.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationRuntimeMetadata.tsx
@@ -1,0 +1,30 @@
+import { ViewSourceInfo } from '@syndesis/models';
+import { useApiResource } from './useApiResource';
+import { usePolling } from './usePolling';
+
+/**
+ * @param virtualizationName the name of the virtualization whose metadata is being requested
+ * @param disableUpdates `true` if polling should be enabled (defaults to `false`)
+ */
+export const useVirtualizationRuntimeMetadata = (
+  virtualizationName: string,
+  disableUpdates: boolean = false
+) => {
+  const { read, ...rest } = useApiResource<ViewSourceInfo>({
+    defaultValue: {
+      schemas: [],
+      viewName: ''
+    },
+    url: `metadata/runtimeMetadata/${virtualizationName}`,
+    useDvApiUrl: true,
+  });
+
+  if (!disableUpdates) {
+    usePolling({ callback: read, delay: 10000 });
+  }
+
+  return {
+    ...rest,
+    read,
+  };
+};

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaList.tsx
@@ -11,6 +11,7 @@ import { ListView } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../../../Layout';
 import './ConnectionSchemaList.css';
+import { ConnectionSchemaListSkeleton } from './ConnectionSchemaListSkeleton';
 
 export interface IConnectionSchemaListProps {
   hasListData: boolean;
@@ -18,12 +19,17 @@ export interface IConnectionSchemaListProps {
   i18nEmptyStateTitle: string;
   i18nLinkCreateConnection: string;
   linkToConnectionCreate: H.LocationDescriptor;
+  loading: boolean;
 }
 
 export const ConnectionSchemaList: React.FunctionComponent<IConnectionSchemaListProps> = props => {
   return (
     <>
-      {props.hasListData ? (
+      {props.loading ? (
+        <ListView>
+          <ConnectionSchemaListSkeleton width={800} />
+        </ListView>
+      ) : props.hasListData ? (
         <Flex
           breakpointMods={[{ modifier: 'column', breakpoint: 'md' }]}
           className={'connection-schema-list_content'}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.css
@@ -1,0 +1,3 @@
+.connection-schema-list-item__status {
+  margin-left: 8px;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
@@ -1,17 +1,19 @@
-import { ListView, ListViewIcon, ListViewItem } from 'patternfly-react';
+import { Label, ListView, ListViewItem, Spinner } from 'patternfly-react';
 import * as React from 'react';
 import { toValidHtmlId } from '../../../helpers';
+import { ConnectionStatus } from '../../DvConnection/DvConnectionCard';
+import './ConnectionSchemaListItem.css';
 
 export interface IConnectionSchemaListItemProps {
-  icon?: string;
   connectionName: string;
   connectionDescription: string;
+  dvStatus: string;
   haveSelectedSource: boolean;
+  icon: React.ReactNode;
+  loading: boolean;
 }
 
-export const ConnectionSchemaListItem: React.FunctionComponent<
-  IConnectionSchemaListItemProps
-> = props => {
+export const ConnectionSchemaListItem: React.FunctionComponent<IConnectionSchemaListItemProps> = props => {
   return (
     <>
       <ListViewItem
@@ -24,13 +26,24 @@ export const ConnectionSchemaListItem: React.FunctionComponent<
         }
         hideCloseIcon={true}
         leftContent={
-          props.icon ? (
-            <div className="blank-slate-pf-icon">
-              <img src={props.icon} alt={props.connectionName} width={46} />
-            </div>
-          ) : (
-            <ListViewIcon name={'database'} />
-          )
+          <span>
+            {props.icon}
+            {props.loading && props.dvStatus !== ConnectionStatus.ACTIVE ? (
+              <Spinner loading={true} inline={true} />
+            ) : (
+              <></>
+            )}
+            <Label
+              className="connection-schema-list-item__status"
+              type={
+                props.dvStatus === ConnectionStatus.ACTIVE
+                  ? 'success'
+                  : 'danger'
+              }
+            >
+              {props.dvStatus}
+            </Label>
+          </span>
         }
         initExpanded={props.haveSelectedSource}
         stacked={false}

--- a/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaList.stories.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import {
   ConnectionSchemaList,
   ConnectionSchemaListItem,
+  ConnectionStatus,
   SchemaNodeListItem,
 } from '../../../src';
 
@@ -67,6 +68,9 @@ const connectionItems = [
     connectionName={connectionName1}
     connectionDescription={connectionDescription1}
     haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    icon={<div />}
+    loading={false}
   />,
   <ConnectionSchemaListItem
     key="connectionListItem2"
@@ -74,6 +78,9 @@ const connectionItems = [
     connectionDescription={connectionDescription2}
     children={conn2NodeItems}
     haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    icon={<div />}
+    loading={false}
   />,
   <ConnectionSchemaListItem
     key="connectionListItem3"
@@ -81,6 +88,9 @@ const connectionItems = [
     connectionDescription={connectionDescription3}
     children={conn3NodeItems}
     haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    icon={<div />}
+    loading={false}
   />,
 ];
 

--- a/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/ConnectionSchemaListItem.stories.tsx
@@ -1,17 +1,53 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { ConnectionSchemaListItem } from '../../../src';
+import { ConnectionSchemaListItem, ConnectionStatus } from '../../../src';
 
 const stories = storiesOf('Data/Views/ConnectionSchemaListItem', module);
 
 const connectionName = 'Connection_1';
 const connectionDescription = 'Connection_1 description';
 
-stories.add('sample connection schema item', () => (
+stories.add('ACTIVE, not loading', () => (
   <ConnectionSchemaListItem
     connectionName={connectionName}
     connectionDescription={connectionDescription}
     haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    icon={<div />}
+    loading={false}
+  />
+));
+
+stories.add('ACTIVE, loading', () => (
+  <ConnectionSchemaListItem
+    connectionName={connectionName}
+    connectionDescription={connectionDescription}
+    haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    icon={<div />}
+    loading={true}
+  />
+));
+
+stories.add('INACTIVE, loading', () => (
+  <ConnectionSchemaListItem
+    connectionName={connectionName}
+    connectionDescription={connectionDescription}
+    haveSelectedSource={false}
+    dvStatus={ConnectionStatus.INACTIVE}
+    icon={<div />}
+    loading={true}
+  />
+));
+
+stories.add('FAILED, not loading', () => (
+  <ConnectionSchemaListItem
+    connectionName={connectionName}
+    connectionDescription={connectionDescription}
+    haveSelectedSource={false}
+    dvStatus={ConnectionStatus.FAILED}
+    icon={<div />}
+    loading={false}
   />
 ));

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -235,12 +235,12 @@ function getViewDefinition(
  * based on the Virtualization connection status and selection state
  * @param conns the connections
  * @param virtualizationsSourceStatuses the available virtualization sources
- * @param selectedConn name of a selected connection
+ * @param selectedConn name of a selected connection (optional)
  */
 export function generateDvConnections(
   conns: Connection[],
   virtualizationsSourceStatuses: VirtualizationSourceStatus[],
-  selectedConn: string
+  selectedConn?: string
 ): Connection[] {
   const dvConns: Connection[] = [];
   for (const conn of conns) {
@@ -269,7 +269,7 @@ export function generateDvConnections(
       // loading (true/false)
       schemaLoading = String(virtSrcStatus.loading);
       // selection
-      if (conn.name === selectedConn) {
+      if (selectedConn && conn.name === selectedConn) {
         selectionState = String(true);
       }
       conn.options = {
@@ -500,9 +500,8 @@ export function getPreviewSql(viewDefinition: ViewDefinition): string {
  */
 export function getQueryRows(qResults: QueryResults): string[][] {
   const allRows = qResults.rows ? qResults.rows : [];
-  return allRows
-    .map(row => row.row);
-} 
+  return allRows.map(row => row.row);
+}
 
 /**
  * Get columns from the query results


### PR DESCRIPTION
Resolving issues TTOOLS-837, TTOOLS-835, ENTESB-12364
Modify the SelectSourcesPage (first page of the CreateView wizard) to correct issues with display of connections and refresh of the connection schema.  The connections shown on the createView and importViews wizards were not consistent, and the schema in the createView wizard was not updating correctly
- adds 'useVirtualizationRuntimeMetadata' - allows usage of hook with polling interval
- 'SelectSourcesPage' now utilizing hooks to obtain the connections/dvSourceStatus/schema.  info is supplied to ConnectionSchemaContent
- 'ConnectionSchemaContent' now utilizes the Connection/status info to include the connection status
- 'ConnectionListItem' was improved to display the appropriate connection type icon / status / loading indicators
- updated the relevant stories
