### PR TITLE
fix: Use the connection name instead of the connector name in t…

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -98,6 +98,7 @@ export function toUIStep(step: Step | StepKind): IUIStep {
     case ENDPOINT:
     case CONNECTOR:
       // this step is a Connection step
+      const connectionName = step.name || step.connection!.name || step.connection!.connector!.name;
       return {
         ...step,
         description:
@@ -112,7 +113,7 @@ export function toUIStep(step: Step | StepKind): IUIStep {
           ...(step.connection!.metadata || {}),
           ...(step.metadata || {}),
         },
-        name: step.name || step.connection!.connector!.name!,
+        name: connectionName,
         outputDataShape,
         properties:
           step.action &&
@@ -121,7 +122,7 @@ export function toUIStep(step: Step | StepKind): IUIStep {
           step.action.descriptor.propertyDefinitionSteps.length &&
           step.action.descriptor.propertyDefinitionSteps[0].properties,
         title:
-          `${(step.connection && step.connection.name) || '<unknown>'}` +
+          `${connectionName} ` +
           step.action
             ? ` - ${(step.action && step.action.name) || '<unknown>'}`
             : '',


### PR DESCRIPTION
relates to #7600

Quick example:
![image](https://user-images.githubusercontent.com/351660/72555977-b3f42700-386b-11ea-9f69-a4d1bc52d17b.png)

vs. what it was showing:

![image](https://user-images.githubusercontent.com/351660/72556043-d128f580-386b-11ea-9fad-11bc85698a30.png)
