### PR TITLE
fix(c/sql): use standard column names (#7591)

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
@@ -95,7 +95,7 @@ public final class SqlSupport {
                     final String name = procedureSet.getString("PROCEDURE_NAME");
                     final StoredProcedureMetadata storedProcedureMetadata = getStoredProcedureMetadata(connection,
                         catalog, schemaPattern, name);
-                    storedProcedureMetadata.setName(procedureSet.getString("PROCEDURE_NAME"));
+                    storedProcedureMetadata.setName(name);
                     storedProcedureMetadata.setType(procedureSet.getString("PROCEDURE_TYPE"));
                     storedProcedureMetadata.setRemark(procedureSet.getString("REMARKS"));
                     storedProcedures.put(storedProcedureMetadata.getName(), storedProcedureMetadata);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbPostgresql.java
@@ -15,26 +15,11 @@
  */
 package io.syndesis.connector.sql.db;
 
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 public class DbPostgresql extends DbStandard {
 
     @Override
     public String getDefaultSchema(String dbUser) {
         return "public";
-    }
-
-    @Override
-    public ResultSet fetchProcedureColumns(final DatabaseMetaData meta, final String catalog, final String schema, final String procedureName) throws SQLException {
-        return meta.getFunctionColumns(catalog, schema, procedureName, null);
-    }
-
-    @Override
-    public ResultSet fetchProcedures(final DatabaseMetaData meta, final String catalog, final String schemaPattern,
-            final String procedurePattern) throws SQLException {
-        return meta.getFunctions(catalog, schemaPattern, procedurePattern);
     }
 
     @Override

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtensionTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtensionTest.java
@@ -44,7 +44,7 @@ public class SqlStoredConnectorMetaDataExtensionTest {
         when(databaseMetaData.getDatabaseProductName()).thenReturn("POSTGRESQL");
 
         final ResultSet result = mock(ResultSet.class);
-        when(databaseMetaData.getFunctionColumns("catalog", "schema", "procedureName", null)).thenReturn(result);
+        when(databaseMetaData.getProcedureColumns("catalog", "schema", "procedureName", null)).thenReturn(result);
 
         when(result.next()).thenReturn(true, true, true, false);
         when(result.getString("COLUMN_NAME")).thenReturn("A", "B", "C");
@@ -93,7 +93,7 @@ public class SqlStoredConnectorMetaDataExtensionTest {
         when(databaseMetaData.getDatabaseProductName()).thenReturn("POSTGRESQL");
 
         final ResultSet result = mock(ResultSet.class);
-        when(databaseMetaData.getFunctionColumns("catalog", "schema", "procedureName", null)).thenReturn(result);
+        when(databaseMetaData.getProcedureColumns("catalog", "schema", "procedureName", null)).thenReturn(result);
 
         when(result.next()).thenReturn(true, false);
         when(result.getString("COLUMN_NAME")).thenReturn("A");


### PR DESCRIPTION
fix(c/sql): use standard column names

(cherry picked from commit 3b77647d06e611abaf675495d4b6bde5c1c1166f)