### PR TITLE
fix(tools): fix pre-commit configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm-run-all pre-commit:*",
-      "pre-push": "npm-run-all pre-push:*",
+      "pre-commit": "npm-run-all 'pre-commit:*'",
+      "pre-push": "npm-run-all 'pre-push:*'",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "scripts": {
     "pre-commit:lint-staged": "lint-staged",
-    "pre-commit:add-operator-assets-vfsdata": "git add install/operator/pkg/generator/assets_vfsdata.go",
     "pre-commit:ui-react": "cd app/ui-react && yarn pre-commit",
     "pre-push:ui-react": "./tools/bin/syndesis -m ui-react --incremental"
   }


### PR DESCRIPTION
Seems that in the Husky upgrade the hooks interact with the shell, and
that the shell expansion is now in place. That is, running the
pre-commit hook would fail with an error like:

    "zsh:1: no matches found: pre-commit:*"

This simply adds quotes around the hooks so the arguments for
`npm-run-all` are taken verbatim and not expanded by the shell.

Also it seems that the `git add` is no longer required so this removes
it.