### PR TITLE
[ENTESB-12774]  The AWS dynamo db connector seems to be unable to insert multiple items into the ddb table.

### DIFF
--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
@@ -22,10 +22,6 @@ import java.util.Map;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.syndesis.connector.support.util.ConnectorOptions;
-import org.apache.camel.CamelContext;
-import org.apache.camel.TypeConverter;
-import org.apache.camel.util.EndpointHelper;
-import org.apache.camel.util.IntrospectionSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +49,8 @@ public final class Util {
 
 
         String element = ConnectorOptions.extractOption(options, parameterName, "");
+
+        LOG.trace("Element to process [" + parameterName + "]: " + element);
 
         if (!element.isEmpty()) {
             try {
@@ -101,36 +99,5 @@ public final class Util {
             return value.getSS();
         }
         return null;
-    }
-
-
-
-    public static <T> T setProperties(T instance, Map<String, Object> properties,
-                                  CamelContext camelContext) {
-        if (camelContext == null) {
-            throw new IllegalStateException("Camel context is null");
-        }
-
-        try {
-            if (!properties.isEmpty()) {
-                final TypeConverter converter = camelContext.getTypeConverter();
-
-                IntrospectionSupport.setProperties(converter, instance, properties);
-
-                for (Map.Entry<String, Object> entry : properties.entrySet()) {
-                    if (entry.getValue() instanceof String) {
-                        String value = (String) entry.getValue();
-                        if (EndpointHelper.isReferenceParameter(value)) {
-                            IntrospectionSupport.setProperty(camelContext, converter, instance, entry.getKey(), null, value, true);
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException(
-            "Get information about tables failed.", e);
-        }
-
-        return instance;
     }
 }

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
@@ -44,6 +44,7 @@ public final class AWSDDBConfiguration {
     //TODO change this to your table constraints
 
     public static final String ELEMENT_VALUE = "{\"clave\":\"" + RANDOM_ID + "\", \"attr\":\"attribute\"}";
+    public static final String ELEMENT_VALUE_VARIABLE = "{\"clave\":\"" + RANDOM_ID + "\", \"attr\":\":#attribute\"}";
     public static final String KEY_VALUE = "{\"clave\":\"" + RANDOM_ID + "\"}";
     public static final String ATTRIBUTES_VALUE = "clave, attr";
     //TODO change this to your table constraints

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
@@ -27,6 +27,7 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.support.test.ConnectorTestSupport;
 import org.apache.camel.ProducerTemplate;
+import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -207,7 +208,7 @@ public abstract class AWSDDBGenericOperation extends ConnectorTestSupport {
      * To run this test you need to change the values of the parameters for real values of an
      * actual account
      */
-    public void runIt() {
+    public void runIt() throws JSONException {
 
         assertNotNull(context());
 

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertTwiceTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertTwiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.aws.ddb;
+
+import org.apache.camel.ProducerTemplate;
+import org.json.JSONException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+@Ignore("Make sure the AWSDDBConfiguration has the proper credentials before running this test")
+public class AWSDDBInsertTwiceTest extends AWSDDBGenericOperation {
+
+    @Override
+    String getConnectorId() {
+        return "io.syndesis:aws-ddb-putitem-to-connector";
+    }
+
+    @Override
+    String getCustomizer() {
+        return "io.syndesis.connector.aws.ddb.customizer" +
+                   ".DDBConnectorCustomizerPutItem";
+    }
+
+    @Override
+    String getElement() {
+        return AWSDDBConfiguration.ELEMENT_VALUE_VARIABLE;
+    }
+
+    @Test
+    @Override
+    /**
+     * To run this test you need to change the values of the parameters for real values of an
+     * actual account
+     */
+    public void runIt() throws JSONException {
+
+        assertNotNull(context());
+
+        ProducerTemplate template = context().createProducerTemplate();
+
+        @SuppressWarnings("unchecked")
+        String result = template.requestBody("direct:start",
+            "{\"#attribute\":\"to overwrite\"}", String.class);
+
+        JSONAssert.assertEquals("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
+                                    + "\", \"attr\":\"to overwrite\"}",
+            result,
+            JSONCompareMode.STRICT);
+
+        result = template.requestBody("direct:start",
+            "{\"#attribute\":\"final value\"}", String.class);
+
+        JSONAssert.assertEquals("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
+                                    + "\", \"attr\":\"final value\"}", result,
+            JSONCompareMode.STRICT);
+
+    }
+
+}


### PR DESCRIPTION
Bug fix: the variable parameters of the connector were stored on the main properties of the connector instead of being really variable.