### PR TITLE
fix(ENTESB-12545): Revert workaround due to missing camel-rest-openapi in Camel BOMs

### DIFF
--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -76,6 +76,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-rest-openapi</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
+++ b/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
@@ -17,6 +17,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
@@ -219,7 +219,7 @@ public class DescriptorTest {
             .putMetadata("hide-from-connection-pages", "true")
             .addDependencies(
                 mavenDependency("io.syndesis.connector:connector-rest-swagger:" + SYNDESIS_VERSION),
-                //mavenDependency("org.apache.camel:camel-rest-openapi:" + CAMEL_VERSION),
+                mavenDependency("org.apache.camel:camel-rest-openapi:" + CAMEL_VERSION),
                 mavenDependency("org.apache.camel:camel-http4:" + CAMEL_VERSION))
             .build();
 

--- a/app/server/api-generator/src/test/resources/openapi/v2/basic_auth.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/basic_auth.unified_connector.json
@@ -44,6 +44,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/complex_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/complex_xml.unified_connector.json
@@ -50,6 +50,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/damage_service.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/damage_service.unified_connector.json
@@ -79,6 +79,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/kie-server.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/kie-server.unified_connector.json
@@ -6927,6 +6927,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/machine_history.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/machine_history.unified_connector.json
@@ -79,6 +79,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/petstore.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/petstore.unified_connector.json
@@ -626,6 +626,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/petstore_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/petstore_xml.unified_connector.json
@@ -621,6 +621,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/reverb.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/reverb.unified_connector.json
@@ -4709,6 +4709,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v2/todo.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v2/todo.unified_connector.json
@@ -187,6 +187,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/basic_auth.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/basic_auth.unified_connector.json
@@ -45,6 +45,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/complex_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/complex_xml.unified_connector.json
@@ -51,6 +51,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/damage_service.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/damage_service.unified_connector.json
@@ -81,6 +81,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/kie-server.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/kie-server.unified_connector.json
@@ -6274,6 +6274,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/machine_history.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/machine_history.unified_connector.json
@@ -81,6 +81,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/petstore.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/petstore.unified_connector.json
@@ -571,6 +571,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/petstore_xml.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/petstore_xml.unified_connector.json
@@ -565,6 +565,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/reverb.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/reverb.unified_connector.json
@@ -3930,6 +3930,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/server/api-generator/src/test/resources/openapi/v3/todo.unified_connector.json
+++ b/app/server/api-generator/src/test/resources/openapi/v3/todo.unified_connector.json
@@ -169,6 +169,10 @@
       "type": "MAVEN"
     },
     {
+      "id": "org.apache.camel:camel-rest-openapi:@camel.version@",
+      "type": "MAVEN"
+    },
+    {
       "id": "org.apache.camel:camel-http4:@camel.version@",
       "type": "MAVEN"
     }

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector-export/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector-export/model.json
@@ -197,6 +197,10 @@
             "type": "MAVEN"
           },
           {
+            "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+            "type": "MAVEN"
+          },
+          {
             "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
             "type": "MAVEN"
           }
@@ -621,6 +625,10 @@
       "dependencies": [
         {
           "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+          "type": "MAVEN"
+        },
+        {
+          "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
           "type": "MAVEN"
         },
         {
@@ -1284,6 +1292,10 @@
                       "type": "MAVEN"
                     },
                     {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+                      "type": "MAVEN"
+                    },
+                    {
                       "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     }
@@ -1684,6 +1696,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {
@@ -2090,6 +2106,10 @@
                       "type": "MAVEN"
                     },
                     {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+                      "type": "MAVEN"
+                    },
+                    {
                       "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     }
@@ -2455,6 +2475,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {
@@ -2852,6 +2876,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector-export/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector-export/model.json
@@ -197,6 +197,10 @@
             "type": "MAVEN"
           },
           {
+            "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+            "type": "MAVEN"
+          },
+          {
             "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
             "type": "MAVEN"
           }
@@ -621,6 +625,10 @@
       "dependencies": [
         {
           "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+          "type": "MAVEN"
+        },
+        {
+          "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
           "type": "MAVEN"
         },
         {
@@ -1284,6 +1292,10 @@
                       "type": "MAVEN"
                     },
                     {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+                      "type": "MAVEN"
+                    },
+                    {
                       "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     }
@@ -1684,6 +1696,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {
@@ -2090,6 +2106,10 @@
                       "type": "MAVEN"
                     },
                     {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
+                      "type": "MAVEN"
+                    },
+                    {
                       "id": "org.apache.camel:camel-http4:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     }
@@ -2455,6 +2475,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {
@@ -2852,6 +2876,10 @@
                   "dependencies": [
                     {
                       "id": "io.syndesis.connector:connector-rest-swagger:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    },
+                    {
+                      "id": "org.apache.camel:camel-rest-openapi:2.23.2.fuse-760011",
                       "type": "MAVEN"
                     },
                     {


### PR DESCRIPTION
Used to have camel-rest-openapi as compile time dependency as workaround for ENTESB-12545 As ENTESB-12545 has been fixed we do not need this workaround in Syndesis anymore.

Relates to ENTESB-12218