### PR TITLE
fix(ENTESB-12610): Fix API connector description …

### DIFF
--- a/app/ui-react/packages/ui/stories/Customization/ApiConnectorListView.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/ApiConnectorListView.stories.tsx
@@ -54,7 +54,7 @@ const connectors = [
 
 const title = 'API Client Connectors';
 const description =
-  'Syndesis creates an API client connector when you upload a valid OpenAPI 2.0 specification that describes the API you want to connect to.';
+  'Syndesis creates an API client connector when you upload a valid OpenAPI specification that describes the API you want to connect to.';
 const createConnector = 'Create API Connector';
 const createConnectorTip = 'Upload file or use URL to create API connector';
 

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
@@ -1,7 +1,7 @@
 {
   "action": "<strong>{{actionName}}</strong> - {{actionDescription}}",
   "apiConnectorDetailsPageTitle": "Connector Details",
-  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> creates an API client connector when you upload a valid OpenAPI 2.0 specification that describes the API you want to connect to.",
+  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> creates an API client connector when you upload a valid OpenAPI specification that describes the API you want to connect to.",
   "apiConnectorsPageTitle": "API Client Connectors",
   "basePath": "Base URL",
   "ConnectorIcon": "Connector Icon",

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.it.json
@@ -1,7 +1,7 @@
 {
   "action": "<strong>{{actionName}}</strong> - {{actionDescription}}",
   "apiConnectorDetailsPageTitle": "Dettagli del Connettore",
-  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> crea un connettore client API quando carichi una specifica OpenAPI 2.0 valida che descrive l'API a cui desideri connetterti.",
+  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> crea un connettore client API quando carichi una specifica OpenAPI valida che descrive l'API a cui desideri connetterti.",
   "apiConnectorsPageTitle": "Connettori Client API",
   "basePath": "URL di Base",
   "ConnectorIcon": "Icona del Connettore",

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.ru.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.ru.json
@@ -1,7 +1,7 @@
 {
   "action": "<strong>{{actionName}}</strong> - {{actionDescription}}",
   "apiConnectorDetailsPageTitle": "Детали Коннектора",
-  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> предоставляет API Коннектор когда вы загружаете валидную OpenAPI 2.0 спецификацию, описываюшая API, с которым Вы хотите работать.",
+  "apiConnectorsPageDescription": "<strong>$t(shared:project.name)</strong> предоставляет API Коннектор когда вы загружаете валидную OpenAPI спецификацию, описываюшая API, с которым Вы хотите работать.",
   "apiConnectorsPageTitle": "API Коннектора",
   "basePath": "Базовый URL",
   "ConnectorIcon": "Иконка Коннектора",


### PR DESCRIPTION
… to not use OpenAPI specific version.

Connector description was using "2.0" version but now we support 2.x and 3.x OpenAPI specifications in API connector. So leave out the version altogether and have a more generic description.