### PR TITLE
fix(ENTESB-12352) api provider integration step can be replaced

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -16,6 +16,7 @@ export interface IIntegrationEditorFormProps {
    * The callback fired when submitting the form.
    * @param e
    */
+  isBackAllowed: boolean;
   isValid: boolean;
   isLoading: boolean;
   error?: string;
@@ -62,6 +63,7 @@ export class IntegrationEditorForm extends React.Component<
                   <>
                     <ButtonLink
                       id={'integration-editor-form-back-button'}
+                      disabled={!this.props.isBackAllowed}
                       href={this.props.backActionHref}
                     >
                       <i className={'fa fa-chevron-left'} />{' '}

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -59,11 +59,10 @@ export class IntegrationEditorForm extends React.Component<
                 </Container>
               </CardBody>
               <CardFooter className="syn-card__footer">
-                {this.props.backActionHref && (
+                {(this.props.backActionHref && this.props.isBackAllowed) && (
                   <>
                     <ButtonLink
                       id={'integration-editor-form-back-button'}
-                      disabled={!this.props.isBackAllowed}
                       href={this.props.backActionHref}
                     >
                       <i className={'fa fa-chevron-left'} />{' '}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -26,6 +26,7 @@ import { IWithConfigurationFormProps } from './WithConfigurationForm';
 export interface IConfigurationFormProps
   extends Pick<IWithConfigurationFormProps, 'configurationPage'>,
     Pick<IWithConfigurationFormProps, 'initialValue'>,
+    Pick<IWithConfigurationFormProps, 'isBackAllowed'>,
     Pick<IWithConfigurationFormProps, 'oldAction'>,
     Pick<IWithConfigurationFormProps, 'onUpdatedIntegration'>,
     Pick<IWithConfigurationFormProps, 'chooseActionHref'> {
@@ -33,6 +34,7 @@ export interface IConfigurationFormProps
   descriptor: ActionDescriptor;
   definitionOverride?: IConfigurationProperties;
   children: any;
+  isBackAllowed: boolean;
 }
 
 export const ConfigurationForm: React.FunctionComponent<
@@ -42,6 +44,7 @@ export const ConfigurationForm: React.FunctionComponent<
   configurationPage,
   descriptor,
   definitionOverride,
+  isBackAllowed,
   initialValue,
   oldAction,
   chooseActionHref,
@@ -94,6 +97,10 @@ export const ConfigurationForm: React.FunctionComponent<
       typeof step.description === 'undefined'
         ? action.name
         : `${action.name} - ${step.description}`;
+    console.log('definition: ' + JSON.stringify(definition));
+    console.log('step: ' + JSON.stringify(step));
+    console.log('action: ' + JSON.stringify(action));
+    console.log('oldAction: ' + JSON.stringify(oldAction));
     return (
       <AutoForm<IFormValue>
         i18nRequiredProperty={t('shared:requiredFieldMessage')}
@@ -106,12 +113,15 @@ export const ConfigurationForm: React.FunctionComponent<
         validateInitial={validator}
         key={key}
       >
-        {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => (
+        {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => {
+          console.log('isBackAllowed from ConfForm: ' + isBackAllowed);
+          return (
           <>
             <IntegrationEditorForm
               i18nFormTitle={formTitle}
               i18nBackAction={'Choose Action'}
               i18nNext={'Next'}
+              isBackAllowed={isBackAllowed}
               isValid={isValid}
               isLoading={isSubmitting}
               submitForm={() => {
@@ -125,7 +135,8 @@ export const ConfigurationForm: React.FunctionComponent<
               {fields}
             </IntegrationEditorForm>
           </>
-        )}
+          )
+        }}
       </AutoForm>
     );
   } catch (e) {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -97,10 +97,6 @@ export const ConfigurationForm: React.FunctionComponent<
       typeof step.description === 'undefined'
         ? action.name
         : `${action.name} - ${step.description}`;
-    console.log('definition: ' + JSON.stringify(definition));
-    console.log('step: ' + JSON.stringify(step));
-    console.log('action: ' + JSON.stringify(action));
-    console.log('oldAction: ' + JSON.stringify(oldAction));
     return (
       <AutoForm<IFormValue>
         i18nRequiredProperty={t('shared:requiredFieldMessage')}
@@ -114,7 +110,6 @@ export const ConfigurationForm: React.FunctionComponent<
         key={key}
       >
         {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => {
-          console.log('isBackAllowed from ConfForm: ' + isBackAllowed);
           return (
           <>
             <IntegrationEditorForm

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -2,6 +2,7 @@ import {
   getFlow,
   getStep,
   getSteps,
+  isApiProviderFlow,
   isEndStep,
   isStartStep,
   requiresInputDescribeDataShape,
@@ -117,6 +118,15 @@ export class ConfigureActionPage extends React.Component<
                 (this.props.mode === 'editing' && useOldStepConfig
                   ? oldStepConfig!.configuredProperties
                   : {});
+
+              /**
+               * First, get the flow, and then check if API provider to determine
+               * whether or not to allow the user to press back on the Configure
+               * Action page.
+               */
+              const flow = getFlow(state.integration, params.flowId);
+              const allowBack = !isApiProviderFlow(flow!);
+
               const onUpdatedIntegration = async ({
                 action,
                 moreConfigurationSteps,
@@ -256,7 +266,7 @@ export class ConfigureActionPage extends React.Component<
                         configurationPage={pageAsNumber}
                         errorKeys={errorKeys}
                         initialValue={configuredProperties}
-                        isBackAllowed={false}
+                        isBackAllowed={allowBack}
                         oldAction={
                           useOldStepConfig && oldStepConfig!.action
                             ? oldStepConfig!.action!

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -256,6 +256,7 @@ export class ConfigureActionPage extends React.Component<
                         configurationPage={pageAsNumber}
                         errorKeys={errorKeys}
                         initialValue={configuredProperties}
+                        isBackAllowed={false}
                         oldAction={
                           useOldStepConfig && oldStepConfig!.action
                             ? oldStepConfig!.action!

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -71,6 +71,12 @@ export interface IWithConfigurationFormProps {
    */
   initialValue?: { [key: string]: string };
 
+  /**
+   * Boolean value that determines whether or not the Back button is allowed on the
+   * configuration form.
+   */
+  isBackAllowed: boolean;
+
   chooseActionHref: H.LocationDescriptor;
 
   /**

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
@@ -49,12 +49,14 @@ export class ConfigureStepPage extends React.Component<
   IConfigureStepPageProps
 > {
   public render() {
+
     return (
       <WithIntegrationHelpers>
         {({ addStep, updateStep }) => (
           <WithRouteData<IConfigureStepRouteParams, IConfigureStepRouteState>>
             {(params, state, { history }) => {
               const positionAsNumber = parseInt(params.position, 10);
+
               const onUpdatedIntegration = async ({
                 values,
               }: IOnUpdatedIntegrationProps) => {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
@@ -78,6 +78,7 @@ export class ConfigureStepPage extends React.Component<
 
               return (
                 <WithConfigurationForm
+                  isBackAllowed={false}
                   step={state.step}
                   onUpdatedIntegration={onUpdatedIntegration}
                 >

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/ConfigureStepPage.tsx
@@ -1,4 +1,4 @@
-import { getSteps, WithIntegrationHelpers } from '@syndesis/api';
+import { getSteps,WithIntegrationHelpers } from '@syndesis/api';
 import * as H from '@syndesis/history';
 import { Integration } from '@syndesis/models';
 import { IntegrationEditorLayout } from '@syndesis/ui';
@@ -78,9 +78,17 @@ export class ConfigureStepPage extends React.Component<
                 );
               };
 
+              /**
+               * Used to determine determine whether or not the user is allowed
+               * to press back on the Configure Step page. Leaving as a generic
+               * boolean until we need to add logic here, as this property is
+               * required for the WithConfigurationForm component anyway.
+               */
+              const allowBack = false;
+
               return (
                 <WithConfigurationForm
-                  isBackAllowed={false}
+                  isBackAllowed={allowBack}
                   step={state.step}
                   onUpdatedIntegration={onUpdatedIntegration}
                 >

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
@@ -51,6 +51,10 @@ export interface IWithConfigurationFormProps {
    */
   step: StepKind;
   /**
+   * determines whether or not 'Back' should be allowed.
+   */
+  isBackAllowed: boolean;
+  /**
    * the render prop that will receive the ready-to-be-rendered form and some
    * helpers.
    *
@@ -145,6 +149,7 @@ export const WithConfigurationForm: React.FunctionComponent<
                   : step!.name
               }
               i18nNext={t('shared:Next')}
+              isBackAllowed={props.isBackAllowed}
               isValid={isValid}
               isLoading={isSubmitting}
               submitForm={submitForm}


### PR DESCRIPTION
This PR fixes the bug that allows users to replace the API provider step when creating an integration.

### API provider step no longer allows users to go back and change/replace the action:

<img width="786" alt="Screenshot 2020-01-23 16 03 40" src="https://user-images.githubusercontent.com/3844502/73008585-c12e8a00-3e06-11ea-97e0-33187f267d41.png">

### Dropbox step, as an example, remains unaffected:

<img width="849" alt="Screenshot 2020-01-23 16 04 31" src="https://user-images.githubusercontent.com/3844502/73008596-c55aa780-3e06-11ea-86cf-9ed609ab7154.png">

- [Reference Jira](https://issues.redhat.com/browse/ENTESB-12352)