### PR TITLE
fix: Stabilize nightly integration tests

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -135,7 +135,7 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(TODO_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(60000L)
+                    .timeout(180000L)
                     .build();
         }
     }


### PR DESCRIPTION
- Try to fix flaky tests by increasing the timeout settings on mocked Http server

[ci skip]