### PR TITLE
Fix: virtualization state not geting updated

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationEditorPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationEditorPage.tsx
@@ -161,9 +161,9 @@ export const VirtualizationEditorPage: React.FunctionComponent<IVirtualizationEd
   React.useEffect(() => {
     const publishedDetails: VirtualizationPublishingDetails = getPublishingDetails(
       appContext.config.consoleUrl,
-      props.routeState.virtualization
-        ? props.routeState.virtualization
-        : props.virtualization
+      props.virtualization.name
+        ? props.virtualization
+        : props.routeState.virtualization
     ) as VirtualizationPublishingDetails;
 
     setCurrPublishedState(publishedDetails);
@@ -294,10 +294,7 @@ export const VirtualizationEditorPage: React.FunctionComponent<IVirtualizationEd
           publishingStepText={currPublishedState.stepText}
           virtualizationDescription={getDescription()}
           virtualizationName={props.routeParams.virtualizationId}
-          isWorking={
-            (!props.virtualization && !props.routeState.virtualization) ||
-            !currPublishedState
-          }
+          isWorking={!props.virtualization || !currPublishedState}
           onChangeDescription={doSetDescription}
         />
       </PageSection>


### PR DESCRIPTION
- Jira issue https://issues.redhat.com/browse/TEIIDTOOLS-919

- With this PR for rendering the Virtualization header, when we reload the `VirtualizationEditorPage` component we check if `currPublishedState` is set to the default value then we use the `props.routeState.virtualization`.

- screenshot
![image](https://user-images.githubusercontent.com/8264372/73068779-16839d80-3ed2-11ea-8545-df4cd291802a.png)
