### PR TITLE
fix: Increase default message timeout for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ jobs:
             mkdir -p ~/integrations/
             mkdir -p ~/junit/
             mkdir -p ~/logs/
-            ./tools/bin/syndesis integration-test --output /home/circleci/integrations | tee ~/logs/test_log.txt
+            ./tools/bin/syndesis integration-test --output /home/circleci/integrations --default-timeout 180 | tee ~/logs/test_log.txt
             cp ./app/test/integration-test/target/integration-runtime.log ~/logs/
       - run:
           name: Collect test results

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -45,6 +45,8 @@
     <syndesis.output.directory>${project.build.directory}/integrations</syndesis.output.directory>
     <syndesis.project.mount.path>/tmp/src</syndesis.project.mount.path>
     <syndesis.image.tag>${syndesis.version}</syndesis.image.tag>
+    <syndesis.container.startup.timeout>120</syndesis.container.startup.timeout>
+    <syndesis.default.timeout>60</syndesis.default.timeout>
   </properties>
 
   <dependencies>
@@ -251,6 +253,8 @@
             <syndesis.output.directory>${syndesis.output.directory}</syndesis.output.directory>
             <syndesis.project.mount.path>${syndesis.project.mount.path}</syndesis.project.mount.path>
             <syndesis.image.tag>${syndesis.image.tag}</syndesis.image.tag>
+            <syndesis.default.timeout>${syndesis.default.timeout}</syndesis.default.timeout>
+            <syndesis.container.startup.timeout>${syndesis.container.startup.timeout}</syndesis.container.startup.timeout>
           </systemProperties>
         </configuration>
         <executions>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -118,7 +118,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(TODO_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(60000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .build();
         }
     }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -135,7 +135,7 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(TODO_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(180000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .build();
         }
     }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
@@ -16,12 +16,15 @@
 
 package io.syndesis.test.itest.ftp;
 
+import java.time.Duration;
+
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.container.IteratingConditionExpression;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
+import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.apache.commons.net.ftp.FTPCmd;
 import org.apache.ftpserver.DataConnectionConfiguration;
@@ -62,7 +65,7 @@ public class FtpSplitToDB_IT extends FtpTestSupport {
     public void testFtpSplitToDB(@CitrusResource TestRunner runner) {
         runner.receive(receiveMessageBuilder -> receiveMessageBuilder
                 .endpoint(ftpTestServer)
-                .timeout(60000L)
+                .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                 .message(FtpMessage.command(FTPCmd.RETR).arguments("todo.json")));
 
         runner.send(sendMessageBuilder -> sendMessageBuilder

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
@@ -16,12 +16,15 @@
 
 package io.syndesis.test.itest.ftp;
 
+import java.time.Duration;
+
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.container.IteratingConditionExpression;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
+import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.apache.commons.net.ftp.FTPCmd;
 import org.apache.ftpserver.DataConnectionConfiguration;
@@ -62,7 +65,7 @@ public class FtpToDB_IT extends FtpTestSupport {
     public void testFtpToDB(@CitrusResource TestRunner runner) {
         runner.receive(receiveMessageBuilder -> receiveMessageBuilder
                 .endpoint(ftpTestServer)
-                .timeout(60000L)
+                .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                 .message(FtpMessage.command(FTPCmd.RETR).arguments("todo.json")));
 
         runner.send(sendMessageBuilder -> sendMessageBuilder

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
@@ -16,6 +16,8 @@
 
 package io.syndesis.test.itest.http;
 
+import java.time.Duration;
+
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
@@ -137,7 +139,7 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(TODO_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(60000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .build();
         }
     }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
@@ -18,6 +18,7 @@ package io.syndesis.test.itest.mail;
 
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.time.Duration;
 
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
@@ -163,7 +164,7 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
         @Bean
         public MailServer mailServer() {
             return CitrusEndpoints.mail().server()
-                    .timeout(60000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .autoStart(true)
                     .autoAccept(true)
                     .port(MAIL_SERVER_PORT)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
@@ -18,6 +18,7 @@ package io.syndesis.test.itest.sheets;
 
 import javax.servlet.Filter;
 import javax.sql.DataSource;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -26,6 +27,7 @@ import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.dsl.runner.TestRunnerBeforeTestSupport;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.http.servlet.RequestCachingServletFilter;
+import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.itest.SyndesisIntegrationTestSupport;
 import io.syndesis.test.itest.sheets.util.GzipServletFilter;
 import org.springframework.context.annotation.Bean;
@@ -46,7 +48,6 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
     }
 
     @Configuration
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public static class EndpointConfig {
 
         @Bean
@@ -59,7 +60,7 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(GOOGLE_SHEETS_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(60000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .filters(filterMap)
                     .build();
         }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -17,6 +17,7 @@
 package io.syndesis.test.itest.sql;
 
 import javax.sql.DataSource;
+import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.annotations.CitrusResource;
@@ -25,6 +26,7 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.dsl.runner.TestRunnerBeforeTestSupport;
 import com.consol.citrus.http.server.HttpServer;
+import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import io.syndesis.test.itest.SyndesisIntegrationTestSupport;
 import org.junit.ClassRule;
@@ -105,7 +107,7 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
                     .server()
                     .port(HTTP_TEST_SERVER_PORT)
                     .autoStart(true)
-                    .timeout(60000L)
+                    .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .build();
         }
 

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -86,6 +86,10 @@ public final class SyndesisTestEnvironment {
     private static final String SYNDESIS_PROJECT_MOUNT_PATH = SYNDESIS_PREFIX + "project.mount.path";
     private static final String SYNDESIS_PROJECT_MOUNT_PATH_ENV = SYNDESIS_ENV_PREFIX + "PROJECT_MOUNT_PATH";
 
+    private static final String SYNDESIS_TIMEOUT_DEFAULT = "60";
+    private static final String SYNDESIS_DEFAULT_TIMEOUT = SYNDESIS_PREFIX + "default.timeout";
+    private static final String SYNDESIS_DEFAULT_TIMEOUT_ENV = SYNDESIS_ENV_PREFIX + "DEFAULT_TIMEOUT";
+
     /**
      * Prevent instantiation of utility class.
      */
@@ -178,5 +182,10 @@ public final class SyndesisTestEnvironment {
     public static String getProjectMountPath() {
         return System.getProperty(SYNDESIS_PROJECT_MOUNT_PATH, System.getenv(SYNDESIS_PROJECT_MOUNT_PATH_ENV) != null ?
                 System.getenv(SYNDESIS_PROJECT_MOUNT_PATH_ENV) : SYNDESIS_PROJECT_MOUNT_PATH_DEFAULT);
+    }
+
+    public static int getDefaultTimeout() {
+        return Integer.parseInt(System.getProperty(SYNDESIS_DEFAULT_TIMEOUT, System.getenv(SYNDESIS_DEFAULT_TIMEOUT_ENV) != null ?
+            System.getenv(SYNDESIS_DEFAULT_TIMEOUT_ENV) : SYNDESIS_TIMEOUT_DEFAULT));
     }
 }

--- a/tools/bin/commands/integration-test
+++ b/tools/bin/commands/integration-test
@@ -6,14 +6,15 @@ integration-test::description() {
 
 integration-test::usage() {
     cat - <<EOT
--t  --test <test_name>         The test to run
--c  --clean                    Run clean builds (mvn clean)
-    --release <version>        Syndesis version to use
-    --image <tag>              Syndesis S2i image tag to use
-    --logging                  Container logging enabled
-    --s2i                      S2i build enabled
-    --mount-path <path>        Container mount path for integration projects
--o  --output <directory_path>  Integration project output directory
+-t  --test <test_name>          The test to run
+-c  --clean                     Run clean builds (mvn clean)
+    --release <version>         Syndesis version to use
+    --image <tag>               Syndesis S2i image tag to use
+    --logging                   Container logging enabled
+    --s2i                       S2i build enabled
+    --mount-path <path>         Container mount path for integration projects
+    --default-timeout <seconds> Default timeout in seconds used in mocked server components
+-o  --output <directory_path>   Integration project output directory
 EOT
 }
 
@@ -63,6 +64,11 @@ maven_args() {
     local mount_path="$(readopt --mount-path)"
     if [ -n "${mount_path}" ]; then
         args="$args -Dsyndesis.project.mount.path=${mount_path}"
+    fi
+
+    local timeout="$(readopt --default-timeout)"
+    if [ -n "${timeout}" ]; then
+        args="$args -Dsyndesis.default.timeout=${timeout}"
     fi
 
     args="$args -Dskip.integration.tests=false"


### PR DESCRIPTION
Integration tests are flaky on CircleCi because of message receive timeouts
- Use default timeout setting for all mocked server components
- Make default timeout settable via system properties
- Add default message timeout setting on syndesis CLI
- Increase timeout setting for CircleCI build jobs to 180s