### PR TITLE
user doc: Updates for OpenAPI 3 support

### DIFF
--- a/doc/assemblies/customizing/as_developing-rest-api-client-connectors.adoc
+++ b/doc/assemblies/customizing/as_developing-rest-api-client-connectors.adoc
@@ -11,7 +11,7 @@ Representational State Transfer Application Programming Interfaces
 (REST APIs)
 that support Hypertext Transfer Protocol (HTTP).
 To do this, {prodname} requires a valid
-OpenAPI 2.0 document that describes a REST API that you want to connect to.
+OpenAPI 3 (or 2) document that describes a REST API that you want to connect to.
 If the API service provider does not make an OpenAPI document available
 then an experienced developer must create the OpenAPI document.
 
@@ -20,8 +20,8 @@ REST API connectors:
 
 * xref:about-api-client-connectors_{context}[]
 * xref:guidelines-for-openapi-documents_{context}[]
-// The following file contains content for a feature that was not actually added. 
-// So it is not linked in anywhere. But maybe some day, it will be. 
+// The following file contains content for a feature that was not actually added.
+// So it is not linked in anywhere. But maybe some day, it will be.
 // * xref:access-token-strategy[]
 * xref:providing-client-credentials_{context}[]
 * xref:refreshing-access-tokens_{context}[]

--- a/doc/assemblies/tutorials/as_amq2api-intro.adoc
+++ b/doc/assemblies/tutorials/as_amq2api-intro.adoc
@@ -20,7 +20,7 @@ it provides instructions for customizing
 and extending {prodname} by leading you through the procedures for:
 
 * Adding a custom data operation by uploading an extension.
-* Adding a custom REST API client connector by uploading an OpenAPI (Swagger) document.
+* Adding a custom REST API client connector by uploading an OpenAPI document.
 
 {prodname} provides the extension file and the OpenAPI document.
 
@@ -28,14 +28,14 @@ ifeval::["{location}" == "downstream"]
 .Prerequisites
 
 * You must be logged in to {prodname}.
-If you are not already logged in, see 
-link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.] 
+If you are not already logged in, see
+link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
 
-* You are working in a {prodname} evaluation environment that is running 
-on OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname} 
-environment that is running in an OpenShift Container Platform project in which 
-an administrator added the {prodname} sample data, which provides the *To Do* 
-app for confirming that the integration works as expected. 
+* You are working in a {prodname} evaluation environment that is running
+on OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname}
+environment that is running in an OpenShift Container Platform project in which
+an administrator added the {prodname} sample data, which provides the *To Do*
+app for confirming that the integration works as expected.
 endif::[]
 
 To implement the AMQ to REST API sample integration, the main steps are:

--- a/doc/modules/integrating-applications/c_how-it-works.adoc
+++ b/doc/modules/integrating-applications/c_how-it-works.adoc
@@ -9,11 +9,11 @@ more different applications or services without writing code. It also provides
 features that allow you to introduce code if it is needed for complex
 use cases.
 
-{prodname} lets you enable data transfer between different applications. 
-For example, a business analyst can use {prodname} to capture 
-tweets that mention customers and then leverage the data obtained from 
+{prodname} lets you enable data transfer between different applications.
+For example, a business analyst can use {prodname} to capture
+tweets that mention customers and then leverage the data obtained from
 Twitter to update Salesforce accounts. Another example is a service
-that makes stock trade recommendations. You can use {prodname} to 
+that makes stock trade recommendations. You can use {prodname} to
 capture recommendations for buying or selling stocks of interest
 and forward those recommendations to a service that automates stock transfers.
 
@@ -34,16 +34,16 @@ finish connection.
 . Give the integration a name.
 . Click *Publish* to start running the integration.
 
-Another kind of integration is an API provider integration. 
-An API provider integration allows REST API clients to invoke 
-commands that trigger execution of the integration. To create 
-and run an API provider integration, you upload an OpenAPI 2.0
+Another kind of integration is an API provider integration.
+An API provider integration allows REST API clients to invoke
+commands that trigger execution of the integration. To create
+and run an API provider integration, you upload an OpenAPI 3 (or 2)
 document to {prodname}. This document specifies the operations
-that clients can call. For each operation, you specify and 
+that clients can call. For each operation, you specify and
 configure the flow of connections and steps, such as data mapper
 or filter steps, that executes
-that operation. A simple integration has one primary flow while an 
-API provider integration has a primary flow for each operation. 
+that operation. A simple integration has one primary flow while an
+API provider integration has a primary flow for each operation.
 
 The {prodname} dashboard lets you monitor and manage integrations. You can
 see which integrations are running, and you can start, stop, and edit integrations.

--- a/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
@@ -5,7 +5,7 @@
 = Benefit, overview, and workflow for creating API provider integrations
 
 An API provider integration starts with a REST API service.
-This REST API service is defined by an OpenAPI (or 2)
+This REST API service is defined by an OpenAPI 3 (or 2)
 document that you provide when you create an API provider integration.
 After you publish an API provider integration,
 {prodname} deploys the REST API service on OpenShift.

--- a/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/c_overview-benefit-api-provider-integrations.adoc
@@ -4,71 +4,71 @@
 [id='overview-benefit-api-provider-integrations_{context}']
 = Benefit, overview, and workflow for creating API provider integrations
 
-An API provider integration starts with a REST API service. 
-This REST API service is defined by an OpenAPI 2.0
-document that you provide when you create an API provider integration. 
+An API provider integration starts with a REST API service.
+This REST API service is defined by an OpenAPI (or 2)
+document that you provide when you create an API provider integration.
 After you publish an API provider integration,
-{prodname} deploys the REST API service on OpenShift. 
+{prodname} deploys the REST API service on OpenShift.
 The benefit of an API provider integration
-is that REST API clients can invoke calls that trigger execution of the integration. 
+is that REST API clients can invoke calls that trigger execution of the integration.
 
 .Multiple execution flows
-An API provider integration has multiple execution paths, referred to as flows. 
+An API provider integration has multiple execution paths, referred to as flows.
 Each operation that the OpenAPI document defines has its own flow.
-In {prodname}, for each operation that the OpenAPI 
+In {prodname}, for each operation that the OpenAPI
 document defines, you add connections and other steps to the execution flow for that
 operation. These steps process the data
-as required for the particular operation. 
+as required for the particular operation.
 
 .Example execution flow
-For example, consider a human 
-resources application that calls a REST API service that {prodname} has 
+For example, consider a human
+resources application that calls a REST API service that {prodname} has
 made available. Suppose the call invokes the operation that adds a new
 employee. The operation flow that handles this call could:
 
-* Connect to an application that creates an expense report for new employee 
+* Connect to an application that creates an expense report for new employee
 equipment.
-* Connect to a SQL database to add an internal ticket for setting up new 
+* Connect to a SQL database to add an internal ticket for setting up new
 equipment.
-* Connect to Google mail to send a message to the new employee that provides 
-orientation information. 
+* Connect to Google mail to send a message to the new employee that provides
+orientation information.
 
 .Ways to trigger execution
-There are many ways to call the REST APIs that trigger integration execution, 
-including: 
+There are many ways to call the REST APIs that trigger integration execution,
+including:
 
 * A web browser page that takes data input and generates the call.
 * An application that explicitly calls the REST APIs, such as the `curl` utility.
-* Other APIs that call the REST API, for example, a webhook. 
+* Other APIs that call the REST API, for example, a webhook.
 
 .Ways to edit a flow
 For each operation, you can edit its flow by:
-   
+
 * Adding connections to the applications that need to process the data.
 * Adding steps between connections, including split, aggregate, and data mapping steps.
-* Mapping connection error messages to return codes in the HTTP response that finishes the flow. The 
+* Mapping connection error messages to return codes in the HTTP response that finishes the flow. The
 response goes to the application that invoked the call that triggered
-execution of the integration. 
+execution of the integration.
 
 .Workflow for creating an API provider integration
-The *general* workflow for creating an API provider integration is shown 
-in the following diagram: 
+The *general* workflow for creating an API provider integration is shown
+in the following diagram:
 
 image:images/integrating-applications/ApiProviderCreateIntegrationWorkflow.png[General workflow for creating an API provider integration]
 
 .Publishing an API provider integration
 After you publish an API provider integration, in the integration's
 summary page, {prodname} displays the external URL for your REST API service.
-This external URL is the base URL that clients use to 
+This external URL is the base URL that clients use to
 call your REST API services.
 
 .Testing an API provider integration
-To test an API provider integration's flows, you can use the `curl` utility. 
-For example, suppose that the following `curl` command triggers execution of the 
+To test an API provider integration's flows, you can use the `curl` utility.
+For example, suppose that the following `curl` command triggers execution of the
 flow for the *Get Task by ID* operation. The HTTP `GET` command is the
-default request so there is no requirement to specify `GET`. 
+default request so there is no requirement to specify `GET`.
 The last part of the URL specifies the ID of the task to get:
 
 ----
-curl -k https://i-task-api-proj319352.6a63.fuse-ignite.openshiftapps.com/api/todo/1 
+curl -k https://i-task-api-proj319352.6a63.fuse-ignite.openshiftapps.com/api/todo/1
 ----

--- a/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
+++ b/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
@@ -43,7 +43,7 @@ operations, upload the OpenAPI document.
 .. Click *Review/Edit* to open the API Designer editor.
 .. Review and edit as needed.
 +
-Optionally, if your document uses the OpenAPI 2 specification, you can click *Convert to OpenAPI 3* if you want the API Designer to convert your document to the OpenAPI 3 specification.
+Optionally, if your document uses the OpenAPI 2 specification, you can click *Convert to OpenAPI 3* if you want the API Designer to convert your document to conform with the OpenAPI 3 specification.
 
 .. In the upper right, click *Save* or *Cancel* to close the editor.
 .. Click *Next*.

--- a/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
+++ b/doc/modules/integrating-applications/p_create-api-provider-integration.adoc
@@ -32,9 +32,9 @@ to add to an operation's flow.
 . On the *Choose a connection* page, click *API Provider*.
 . On the *Start integration with an API call* page:
 +
-* If you have an OpenAPI 2.0 document that defines the REST API
+* If you have an OpenAPI document that defines the REST API
 operations, upload the OpenAPI document.
-* If you need to define the OpenAPI 2.0 document, select *Create*.
+* If you need to define the OpenAPI document, select *Create a new OpenAPI 3.x document* or *Create a new OpenAPI 2.x document*.
 
 . Click *Next*.
 +
@@ -42,6 +42,9 @@ operations, upload the OpenAPI document.
 +
 .. Click *Review/Edit* to open the API Designer editor.
 .. Review and edit as needed.
++
+Optionally, if your document uses the OpenAPI 2 specification, you can click *Convert to OpenAPI 3* if you want the API Designer to convert your document to the OpenAPI 3 specification.
+
 .. In the upper right, click *Save* or *Cancel* to close the editor.
 .. Click *Next*.
 

--- a/doc/modules/integrating-applications/r_access-token-strategy.adoc
+++ b/doc/modules/integrating-applications/r_access-token-strategy.adoc
@@ -1,15 +1,15 @@
 // This content is not included in any published doc.
 // This vendor extension was planned, but not added.
-// It might be implemented in the future. 
+// It might be implemented in the future.
 
 id='access-token-strategy']
 = Carrying the access token in a query parameter
 
 In messages between {prodname} and a REST API that uses OAuth2, the
-OAuth server expects the access token to be a `Bearer` value  
+OAuth server expects the access token to be a `Bearer` value
 in the `Authorization` header.
 If you need to, you can change this default behavior so that
-the access token is a parameter in the query that the OAuth server receives. 
+the access token is a parameter in the query that the OAuth server receives.
 
 ifeval::["{location}" == "downstream"]
 
@@ -21,8 +21,8 @@ https://access.redhat.com/support/offerings/techpreview/[Technology Preview feat
 ====
 endif::[]
 
-To specify that the access token is in a query parameter, 
-in the `securityDefinitions` section of the Swagger schema, 
+To specify that the access token is in a query parameter,
+in the `securityDefinitions` section of the OpenAPI schema,
 add the `x-token-strategy` vendor extension. In the example
 below, the last line specifies `x-token-strategy`:
 
@@ -39,14 +39,14 @@ securityDefinitions:
     x-token-strategy: OAUTH_TOKEN_PARAMETER
 ----
 
-The setting of the `x-token-strategy` vendor extension can be one of the 
+The setting of the `x-token-strategy` vendor extension can be one of the
 following:
 
 * `OAUTH_TOKEN_PARAMETER` indicates that the access token is in the
-`oauth_token` query parameter. 
+`oauth_token` query parameter.
 
 * `ACCESS_TOKEN_PARAMETER` indicates that the access token is in the
 `access_token` query parameter.
 
-* `AUTHORIZATION_HEADER`, the default, indicates that the access token 
-is in the `Authorization` header as an OAuth2 `Bearer` token. 
+* `AUTHORIZATION_HEADER`, the default, indicates that the access token
+is in the `Authorization` header as an OAuth2 `Bearer` token.

--- a/doc/modules/integrating-applications/r_alternatives-for-triggering-integration-execution.adoc
+++ b/doc/modules/integrating-applications/r_alternatives-for-triggering-integration-execution.adoc
@@ -4,32 +4,32 @@
 [id='alternatives-for-triggering-integration-execution_{context}']
 = Alternatives for triggering integration execution
 
-When you create an integration, the first step in the integration 
-determines how execution of the integration is triggered. 
+When you create an integration, the first step in the integration
+determines how execution of the integration is triggered.
 The first step in an integration can be one of the following:
 
-* *link:{LinkFuseOnlineIntegrationGuide}#connecting-to-applications_ug[Connection to an application or service]*. 
+* *link:{LinkFuseOnlineIntegrationGuide}#connecting-to-applications_ug[Connection to an application or service]*.
 You configure the connection
 for the particular application or service. Examples:
 +
-** A connection to Twitter can monitor tweets and trigger  
-execution of a simple integration when a tweet contains text that you specified. 
-** A connection to Salesforce can trigger execution of a simple integration when 
-anyone creates a new lead. 
-** A connection to AWS S3 can periodically poll a particular bucket 
-and trigger execution of a simple integration when the bucket contains files. 
- 
-* *link:{LinkFuseOnlineIntegrationGuide}#triggering-integrations-with-timers_create[Timer]*. {prodname} triggers execution of a simple integration at the interval that 
-you specify. This can be a simple timer or a `cron` job. 
+** A connection to Twitter can monitor tweets and trigger
+execution of a simple integration when a tweet contains text that you specified.
+** A connection to Salesforce can trigger execution of a simple integration when
+anyone creates a new lead.
+** A connection to AWS S3 can periodically poll a particular bucket
+and trigger execution of a simple integration when the bucket contains files.
+
+* *link:{LinkFuseOnlineIntegrationGuide}#triggering-integrations-with-timers_create[Timer]*. {prodname} triggers execution of a simple integration at the interval that
+you specify. This can be a simple timer or a `cron` job.
 
 * *link:{LinkFuseOnlineIntegrationGuide}#triggering-integrations-with-http-requests_ug[Webhook]*. A client can send an HTTP `GET` or `POST`
 request to an HTTP endpoint that {prodname} exposes. The request triggers
-execution of the simple integration.  
+execution of the simple integration.
 
-* *link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[API Provider]*. An API provider integration starts with a REST API service. 
-This REST API service is defined by an OpenAPI 2.0
-document that you provide when you create an API provider integration. 
+* *link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[API Provider]*. An API provider integration starts with a REST API service.
+This REST API service is defined by an OpenAPI 3 (or 2)
+document that you provide when you create an API provider integration.
 After you publish an API provider integration,
-{prodname} deploys the REST API service on OpenShift.  
-Any client with network access to the integration endpoints can trigger execution of 
+{prodname} deploys the REST API service on OpenShift.
+Any client with network access to the integration endpoints can trigger execution of
 the integration.

--- a/doc/modules/integrating-applications/r_requirements-for-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/r_requirements-for-api-provider-integrations.adoc
@@ -4,25 +4,25 @@
 [id='requirements-for-api-provider-integrations_{context}']
 = How OpenAPI operations relate to API provider integration flows
 
-An API provider integration's OpenAPI document defines the 
-operations that REST API clients can call. 
-Each OpenAPI operation has its own API provider integration flow. 
-Consequently, each operation can also have its own 
-REST API service URL. Each URL is defined by the API service's base URL 
-and optionally by a subpath. REST API calls specify an operation's 
-URL to trigger execution of the flow for that operation. 
+An API provider integration's OpenAPI document defines the
+operations that REST API clients can call.
+Each OpenAPI operation has its own API provider integration flow.
+Consequently, each operation can also have its own
+REST API service URL. Each URL is defined by the API service's base URL
+and optionally by a subpath. REST API calls specify an operation's
+URL to trigger execution of the flow for that operation.
 
-Your OpenAPI document determines which HTTP verbs (such as 
+Your OpenAPI document determines which HTTP verbs (such as
 `GET`, `POST`, `DELETE` and so on) you can specify
-in calls to your REST API service URLs. Examples of calls to 
-API provider URLs are in the 
-link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[instructions for trying out the API provider quickstart example].   
+in calls to your REST API service URLs. Examples of calls to
+API provider URLs are in the
+link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[instructions for trying out the API provider quickstart example].
 
-Your OpenAPI document also determines the possible HTTP status codes  
-that an operation can return. An operation’s return path can handle 
-only the responses that the OpenAPI document defines. 
-For example, an operation that deletes an 
-object based on its ID might define these possible responses: 
+Your OpenAPI document also determines the possible HTTP status codes
+that an operation can return. An operation’s return path can handle
+only the responses that the OpenAPI document defines.
+For example, an operation that deletes an
+object based on its ID might define these possible responses:
 
 [source,json]
 ----
@@ -41,19 +41,19 @@ object based on its ID might define these possible responses:
 
 .Illustration of an API provider integration example
 The following diagram shows an API provider integration that processes data
-about people. An external REST API client invokes the REST API URLs that are 
+about people. An external REST API client invokes the REST API URLs that are
 deployed by the API provider integration. Invocation of a URL triggers
-execution of the  
-flow for one REST operation. This API provider integration has 3 flows. 
-Each flow can use any connection or step that 
-is available in {prodname}. The REST API along with its flows 
+execution of the
+flow for one REST operation. This API provider integration has 3 flows.
+Each flow can use any connection or step that
+is available in {prodname}. The REST API along with its flows
 is one {prodname} API provider integration, which is deployed in one OpenShift pod.
 
 image:images/integrating-applications/api-provider.png[API provider integration with 3 flows]
 
 .Editing the OpenAPI document while creating an API provider integration
 
-After you specify an OpenAPI 2.0 document for your API provider 
+After you specify an OpenAPI document for your API provider 
 integration, you can update the document as needed while you define
 the execution flows for the API operations. To do this, click
 *View/Edit API Definition* in the upper right of a page in
@@ -66,16 +66,16 @@ Considerations while editing the OpenAPI document:
 
 * *`operationId` properties for synchronization*
 +
-Synchronization between the versions of the OpenAPI document in the API Designer 
-editor and in the {prodname} integration editor depend on a unique `operationId` 
-property that is assigned to each operation that is defined in the document. 
-You can assign a specific `operationId` property value to each operation, 
+Synchronization between the versions of the OpenAPI document in the API Designer
+editor and in the {prodname} integration editor depend on a unique `operationId`
+property that is assigned to each operation that is defined in the document.
+You can assign a specific `operationId` property value to each operation,
 or use the one that {prodname} generates automatically.
 
 * *Request and response definitions*
 +
 In each operation's definition, you can supply a JSON schema that
-defines the operation's request and response. 
+defines the operation's request and response.
 {prodname} uses the JSON schema:
 
 ** As the basis for the operation's input and output data shapes
@@ -83,8 +83,8 @@ defines the operation's request and response.
 
 * *No cyclic schema references*
 +
-A JSON schema for an API provider integration operation cannot have cyclic 
-schema references. 
-For example, a JSON schema that specifies a request or response 
-body cannot reference itself as a whole nor reference any part 
+A JSON schema for an API provider integration operation cannot have cyclic
+schema references.
+For example, a JSON schema that specifies a request or response
+body cannot reference itself as a whole nor reference any part
 of itself through intermediate JSON schemas.

--- a/doc/modules/tutorials/p_amq2api-create-rest-api-connector.adoc
+++ b/doc/modules/tutorials/p_amq2api-create-rest-api-connector.adoc
@@ -7,11 +7,11 @@
 {prodname} can create connectors for REST APIs
 that support Hypertext Transfer Protocol (HTTP)/1.0 or HTTP/1.1.
 To do this, {prodname} requires a valid
-OpenAPI 2.0 document that describes a REST API that you want to connect to.
+OpenAPI 3 (or 2) document that describes a REST API that you want to connect to.
 
 Your {prodname} environment provides the To Do app, which has a REST API
 for accessing a database that contains tasks. Your environment also provides
-an OpenAPI (Swagger) document for this API.
+an OpenAPI document for this API.
 
 .Procedure
 
@@ -20,19 +20,19 @@ OpenAPI document:
 .. In the {prodname} navigation panel, click *Home*.
 .. Copy the URL into a text editor.
 .. At the beginning of the URL, insert `*todo-*`.
-.. At the end of the URL, add `*swagger.json*`.
+.. At the end of the URL, add `*openapi.json*`.
 .. Use the `http` scheme instead of `https`.
 
 +
 The result is something like this:
-`\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/swagger.json`
+`\http://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/openapi.json`
 
 +
 [NOTE]
-Specification of `http` rather than `https` avoids a runtime error 
-if TLS certificates are not valid.  In production 
-environments, ensure that valid certificates are in place, 
-and always specify secure URLs (`https`) to obtain an OpenAPI document. 
+Specification of `http` rather than `https` avoids a runtime error
+if TLS certificates are not valid.  In production
+environments, ensure that valid certificates are in place,
+and always specify secure URLs (`https`) to obtain an OpenAPI document.
 
 
 . In the {prodname} navigation panel, click *Customizations* > *API Client Connectors*.
@@ -43,15 +43,15 @@ click *Next*.
 . On the *Review Actions* page, click *Next*. If you see
 a warning, you can ignore it.
 . Click *Next* again to accept *HTTP Basic Authentication*.
-. On the *Review/Edit Connector Details* page: 
+. On the *Review/Edit Connector Details* page:
 .. If you want to, you can
 change the values in the *Name* and *Description* fields.
-.. In the *Host* field, enter the name of the service host, 
-which is something like this: 
+.. In the *Host* field, enter the name of the service host,
+which is something like this:
 `\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com`.
-.. In the *Base URL* field, enter the part of the URL that follows the 
+.. In the *Base URL* field, enter the part of the URL that follows the
 host name in service requests: `/api`.
- 
+
 . Click *Save*.
 +
 {prodname} displays the *API Client Connectors*. There is a new entry for

--- a/doc/modules/tutorials/p_amq2api-upload-todo-app-icon.adoc
+++ b/doc/modules/tutorials/p_amq2api-upload-todo-app-icon.adoc
@@ -7,15 +7,15 @@
 To show the flow of an integration, {prodname} displays icons that identify
 the applications that the integration is connecting to. Your {prodname}
 environment provides an icon for the To Do app. Follow these instructions
-to upload it.  
+to upload it.
 
 .Procedure
 
 . Display the To Do app icon:
 
 .. In a new browser tab, paste the URL for your OpenAPI document.
-.. At the end of the URL, replace `swagger.json` with `images/todo_icon.png` 
-and click *Enter* to display the icon. For example: 
+.. At the end of the URL, replace `openapi.json` with `images/todo_icon.png` 
+and click *Enter* to display the icon. For example:
 `\https://todo-app-proj217402.6a63.fuse-ignite.openshiftapps.com/images/todo_icon.png`.
 
 . Save the `todo_icon.png` image.
@@ -23,11 +23,11 @@ and click *Enter* to display the icon. For example:
 . In {prodname}, on the *API Client Connectors* page, on the entry for
 the *Todo App API*, click *Details*.
 
-. On the *Connector Details* page, below the *Base URL* field, click *Edit*. 
+. On the *Connector Details* page, below the *Base URL* field, click *Edit*.
 
 . Next to the default connector icon, click *Choose File*.
 
 . Navigate to `todo_icon.png`, select it, and click *Open*.
 The icon appears near the top of the connector details page.
 
-. Below the *Base URL* field, click *Save*. 
+. Below the *Base URL* field, click *Save*.

--- a/doc/modules/tutorials/p_sf2db-confirm-works.adoc
+++ b/doc/modules/tutorials/p_sf2db-confirm-works.adoc
@@ -4,21 +4,21 @@
 [id='sf2db-confirm-working_{context}']
 = Confirming that the Salesforce to database integration works
 
-To confirm that the Salesforce to database integration is working, 
-create a new lead in Salesforce and then open the web app that 
-{prodname} provides for viewing updates to the sample database. 
+To confirm that the Salesforce to database integration is working,
+create a new lead in Salesforce and then open the web app that
+{prodname} provides for viewing updates to the sample database.
 
 .Prerequisites
 
 * In {prodname}, *Running* appears next to the name that you specified
 for the Salesforce to database sample integration when you published it.
-* You can access your Salesforce account. 
+* You can access your Salesforce account.
 
 .Procedure
 
 . In the left panel, click *Integrations*.
 . If necessary, wait until your sample integration is a *Running* integration.
- If you used the example name, you would see that 
+ If you used the example name, you would see that
 *Salesforce to Database Sample Integration* is *Running*.
 
 . In your Salesforce installation, create a new lead. Be
@@ -26,19 +26,19 @@ sure to enter data
 in the fields that you mapped: *Company*, *Email*, *FirstName*,
 *LastName*, *LeadSource*, *Status*, *Phone*, and *Rating*.
 . In a new browser window, insert `*todo-*` in front of the URL
-for your {prodname} environment. For example: 
+for your {prodname} environment. For example:
 `\https://todo-app-proj761432.6a63.fuse-ignite.openshiftapps.com/`.
 +
-Your {prodname} environment provides the To Do app, which has a 
-REST API for accessing a database that contains tasks. In the AMQ to REST 
+Your {prodname} environment provides the To Do app, which has a
+REST API for accessing a database that contains tasks. In the AMQ to REST
 API sample integration tutorial, there are instructions for uploading an
-OpenAPI (Swagger) document for the To Do app to create an API client connector. 
+OpenAPI document for the To Do app to create an API client connector. 
 
-. In the *To Do App* display, you should see a notification that a new 
-lead was created in the database. 
+. In the *To Do App* display, you should see a notification that a new
+lead was created in the database.
 
 . Optionally, view the integration log to troubleshoot an
-unexpected result or to learn more about integration execution: 
+unexpected result or to learn more about integration execution:
 
 .. In {prodname}, in the left panel, click *Integrations*.
 .. View your Salesforce to database integration.


### PR DESCRIPTION
This content is ready to merge.  Updates made to address the OpenAPI 3 support and changing "swagger" to "openapi". 
Google doc summary is here: https://docs.google.com/document/d/1ode8pCv03iiNCoGzOGvYIV6N9KLo87HZX5UH56XQCno