### PR TITLE
refactor: use JsonUnit instead of JSONAssert

### DIFF
--- a/app/common/util/pom.xml
+++ b/app/common/util/pom.xml
@@ -90,6 +90,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
+    </dependency>
     <!-- for @SkipNull test -->
     <dependency>
       <groupId>org.immutables</groupId>
@@ -106,17 +110,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
 
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 

--- a/app/connector/aws-ddb/pom.xml
+++ b/app/connector/aws-ddb/pom.xml
@@ -135,14 +135,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBGenericOperation.java
@@ -27,10 +27,9 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.connector.support.test.ConnectorTestSupport;
 import org.apache.camel.ProducerTemplate;
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public abstract class AWSDDBGenericOperation extends ConnectorTestSupport {
 
@@ -208,7 +207,7 @@ public abstract class AWSDDBGenericOperation extends ConnectorTestSupport {
      * To run this test you need to change the values of the parameters for real values of an
      * actual account
      */
-    public void runIt() throws JSONException {
+    public void runIt() {
 
         assertNotNull(context());
 
@@ -218,8 +217,7 @@ public abstract class AWSDDBGenericOperation extends ConnectorTestSupport {
             String result = template.requestBody("direct:start",
                 AWSDDBConfiguration.ELEMENT_VALUE, String.class);
 
-            JSONAssert.assertEquals(AWSDDBConfiguration.ELEMENT_VALUE, result,
-                JSONCompareMode.STRICT);
+            assertThatJson(result).isEqualTo(AWSDDBConfiguration.ELEMENT_VALUE);
 
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertTwiceTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertTwiceTest.java
@@ -16,11 +16,10 @@
 package io.syndesis.connector.aws.ddb;
 
 import org.apache.camel.ProducerTemplate;
-import org.json.JSONException;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @Ignore("Make sure the AWSDDBConfiguration has the proper credentials before running this test")
 public class AWSDDBInsertTwiceTest extends AWSDDBGenericOperation {
@@ -47,7 +46,7 @@ public class AWSDDBInsertTwiceTest extends AWSDDBGenericOperation {
      * To run this test you need to change the values of the parameters for real values of an
      * actual account
      */
-    public void runIt() throws JSONException {
+    public void runIt() {
 
         assertNotNull(context());
 
@@ -57,17 +56,14 @@ public class AWSDDBInsertTwiceTest extends AWSDDBGenericOperation {
         String result = template.requestBody("direct:start",
             "{\"#attribute\":\"to overwrite\"}", String.class);
 
-        JSONAssert.assertEquals("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
-                                    + "\", \"attr\":\"to overwrite\"}",
-            result,
-            JSONCompareMode.STRICT);
+        assertThatJson(result).isEqualTo("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
+                                    + "\", \"attr\":\"to overwrite\"}");
 
         result = template.requestBody("direct:start",
             "{\"#attribute\":\"final value\"}", String.class);
 
-        JSONAssert.assertEquals("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
-                                    + "\", \"attr\":\"final value\"}", result,
-            JSONCompareMode.STRICT);
+        assertThatJson(result).isEqualTo("{\"clave\":\"" + AWSDDBConfiguration.RANDOM_ID
+                                    + "\", \"attr\":\"final value\"}");
 
     }
 

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataAdapterTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataAdapterTest.java
@@ -31,15 +31,14 @@ import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class AWSDDBMetadataAdapterTest {
 
     @Test
-    public void adaptTest() throws JsonProcessingException, JSONException {
+    public void adaptTest() throws JsonProcessingException {
         CamelContext camelContext = new DefaultCamelContext();
         AWSDDBConnectorMetaDataExtension ext = new AWSDDBConnectorMetaDataExtension(camelContext);
         Map<String, Object> parameters = new HashMap<>();
@@ -104,12 +103,12 @@ public class AWSDDBMetadataAdapterTest {
             "  }\n" +
             "}";
 
-        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
 
     @Test
-    public void adaptRemovalTest() throws JsonProcessingException, JSONException {
+    public void adaptRemovalTest() throws JsonProcessingException {
         CamelContext camelContext = new DefaultCamelContext();
         AWSDDBConnectorMetaDataExtension ext = new AWSDDBConnectorMetaDataExtension(camelContext);
         Map<String, Object> parameters = new HashMap<>();
@@ -169,7 +168,7 @@ public class AWSDDBMetadataAdapterTest {
             "  }\n" +
             "}\n";
 
-        JSONAssert.assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
 }

--- a/app/connector/debezium/pom.xml
+++ b/app/connector/debezium/pom.xml
@@ -96,8 +96,6 @@
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit-assertj</artifactId>
-      <version>2.12.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -127,14 +127,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesCustomizerTest.java
@@ -32,11 +32,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.util.ConnectorOptions;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -113,7 +113,7 @@ public class GoogleSheetsGetValuesCustomizerTest extends AbstractGoogleSheetsCus
         Assert.assertEquals(expectedValueModel.size(), model.size());
         Iterator<String> modelIterator = model.iterator();
         for (String expected : expectedValueModel) {
-            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+            assertThatJson(modelIterator.next()).isEqualTo(String.format(expected, getSpreadsheetId()));
         }
     }
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsGetValuesSplitResultsCustomizerTest.java
@@ -32,10 +32,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.util.ConnectorOptions;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -98,6 +98,6 @@ public class GoogleSheetsGetValuesSplitResultsCustomizerTest extends AbstractGoo
         Assert.assertEquals("get", ConnectorOptions.extractOption(options, "methodName"));
 
         String model = inbound.getIn().getBody(String.class);
-        JSONAssert.assertEquals(String.format(expectedValueModel, getSpreadsheetId()), model, JSONCompareMode.STRICT);
+        assertThatJson(model).isEqualTo(String.format(expectedValueModel, getSpreadsheetId()));
     }
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsMetadataAdapterTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
+
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
@@ -32,14 +33,13 @@ import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.commons.io.IOUtils;
-import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static org.junit.Assert.assertTrue;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsMetadataAdapterTest {
@@ -78,7 +78,7 @@ public class GoogleSheetsMetadataAdapterTest {
     }
 
     @Test
-    public void adaptForMetadataTest() throws IOException, JSONException {
+    public void adaptForMetadataTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         GoogleSheetsMetaDataExtension ext = new GoogleSheetsMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -104,6 +104,6 @@ public class GoogleSheetsMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource(expectedJson), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsNamedColumnsTest.java
@@ -34,11 +34,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.util.ConnectorOptions;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @RunWith(Parameterized.class)
 public class GoogleSheetsNamedColumnsTest extends AbstractGoogleSheetsCustomizerTestSupport {
@@ -100,7 +100,7 @@ public class GoogleSheetsNamedColumnsTest extends AbstractGoogleSheetsCustomizer
         Assert.assertEquals(model.size(), body.size());
         Iterator<String> modelIterator = body.iterator();
         for (String expected : model) {
-            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+            assertThatJson(modelIterator.next()).isEqualTo(String.format(expected, getSpreadsheetId()));
         }
     }
 

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsRetrieveValuesCustomizerTest.java
@@ -30,11 +30,11 @@ import org.apache.camel.impl.DefaultExchange;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.util.ConnectorOptions;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
@@ -109,7 +109,7 @@ public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleShee
         Assert.assertEquals(expectedValueModel.size(), model.size());
         Iterator<String> modelIterator = model.iterator();
         for (String expected : expectedValueModel) {
-            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+            assertThatJson(modelIterator.next()).isEqualTo(String.format(expected, getSpreadsheetId()));
         }
     }
 
@@ -147,7 +147,7 @@ public class GoogleSheetsRetrieveValuesCustomizerTest extends AbstractGoogleShee
         Assert.assertEquals(expectedValueModel.size(), model.size());
         Iterator<String> modelIterator = model.iterator();
         for (String expected : expectedValueModel) {
-            JSONAssert.assertEquals(String.format(expected, getSpreadsheetId()), modelIterator.next(), JSONCompareMode.STRICT);
+            assertThatJson(modelIterator.next()).isEqualTo(String.format(expected, getSpreadsheetId()));
         }
     }
 }

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -203,9 +203,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.java-json-tools</groupId>
@@ -231,11 +230,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -30,8 +30,6 @@ import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.camel.component.properties.PropertiesParser;
 import org.apache.camel.spring.SpringCamelContext;
 import org.junit.BeforeClass;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +49,8 @@ import io.syndesis.connector.odata.server.ODataTestServer;
 import io.syndesis.connector.odata.server.ODataTestServer.Options;
 import io.syndesis.connector.support.util.PropertyBuilder;
 import io.syndesis.integration.runtime.IntegrationRouteBuilder;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public abstract class AbstractODataTest implements ODataConstants {
 
@@ -245,7 +245,7 @@ public abstract class AbstractODataTest implements ODataConstants {
     protected void testResult(MockEndpoint result, int exchangeIdx, String testDataFile) throws Exception {
         String json = extractJsonFromExchgMsg(result, exchangeIdx);
         String expected = testData(testDataFile);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
     }
 
     @SuppressWarnings( "unchecked" )
@@ -254,7 +254,7 @@ public abstract class AbstractODataTest implements ODataConstants {
         assertEquals(testDataFiles.length, json.size());
         for (int i = 0; i < testDataFiles.length; ++i) {
             String expected = testData(testDataFiles[i]);
-            JSONAssert.assertEquals(expected, json.get(i), JSONCompareMode.LENIENT);
+            assertThatJson(json.get(i)).isEqualTo(expected);
         }
     }
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/ODataSerializerTest.java
@@ -40,8 +40,6 @@ import org.apache.olingo.commons.api.edm.FullQualifiedName;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
@@ -56,6 +54,9 @@ import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import io.syndesis.common.model.DataShape;
 import io.syndesis.connector.odata.customizer.json.ClientCollectionValueSerializer;
 import io.syndesis.connector.odata.customizer.json.ClientComplexValueSerializer;
@@ -104,7 +105,7 @@ public class ODataSerializerTest extends AbstractODataTest {
     private void checkEntity(ClientEntity entity, String testDataFile) throws Exception {
         String json = OBJECT_MAPPER.writeValueAsString(entity);
         String expected = testData(testDataFile);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
     }
 
     @Test

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -27,20 +27,21 @@ import org.apache.camel.spring.SpringCamelContext;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.connector.odata.server.ODataTestServer;
 import io.syndesis.connector.support.util.PropertyBuilder;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -194,11 +195,11 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         assertEquals(20, json.size());
 
         String expected = testData(REF_SERVER_PEOPLE_DATA_1);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(0)).isEqualTo(expected);
         expected = testData(REF_SERVER_PEOPLE_DATA_2);
-        JSONAssert.assertEquals(expected, json.get(1), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(1)).isEqualTo(expected);
         expected = testData(REF_SERVER_PEOPLE_DATA_3);
-        JSONAssert.assertEquals(expected, json.get(2), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(2)).isEqualTo(expected);
     }
 
     @Test
@@ -301,11 +302,11 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         List<String> json = extractJsonFromExchgMsg(result, 0, List.class);
         assertEquals(3, json.size());
         String expected = testData(TEST_SERVER_DATA_1_WITH_COUNT);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(0)).isEqualTo(expected);
         expected = testData(TEST_SERVER_DATA_2_WITH_COUNT);
-        JSONAssert.assertEquals(expected, json.get(1), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(1)).isEqualTo(expected);
         expected = testData(TEST_SERVER_DATA_3_WITH_COUNT);
-        JSONAssert.assertEquals(expected, json.get(2), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(2)).isEqualTo(expected);
     }
 
     @Test
@@ -455,11 +456,11 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
 
         String expected;
         expected = testData(TEST_SERVER_DATA_1);
-        JSONAssert.assertEquals(expected, json.get(0), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(0)).isEqualTo(expected);
         expected = testData(TEST_SERVER_DATA_2);
-        JSONAssert.assertEquals(expected, json.get(1), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(1)).isEqualTo(expected);
         expected = testData(TEST_SERVER_DATA_3);
-        JSONAssert.assertEquals(expected, json.get(2), JSONCompareMode.LENIENT);
+        assertThatJson(json.get(2)).isEqualTo(expected);
 
         //
         // Check backup consumer options carried through to olingo4 component
@@ -511,7 +512,7 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
         String expected = testData(REF_SERVER_AIRPORT_DATA_1);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
 
         //
         // Check backup consumer options carried through to olingo4 component

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteSplitResultsTest.java
@@ -30,14 +30,14 @@ import org.apache.camel.component.olingo4.Olingo4Endpoint;
 import org.apache.camel.spring.SpringCamelContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
@@ -424,7 +424,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
         String expected = testData(TEST_SERVER_DATA_1_WITH_COUNT);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
     }
 
     @Test
@@ -449,12 +449,12 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
         String expected = testData(TEST_SERVER_DATA_2);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
 
         json = extractJsonFromExchgMsg(result, 1, String.class);
         assertNotNull(json);
         expected = testData(TEST_SERVER_DATA_1);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
     }
 
     @Test
@@ -566,22 +566,22 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
             switch (i) {
                 case 0:
                     expected = testData(TEST_SERVER_DATA_1);
-                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+                    assertThatJson(json).isEqualTo(expected);
                     break;
                 case 1:
                     expected = testData(TEST_SERVER_DATA_2);
-                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+                    assertThatJson(json).isEqualTo(expected);
                     break;
                 case 2:
                     expected = testData(TEST_SERVER_DATA_3);
-                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+                    assertThatJson(json).isEqualTo(expected);
                     break;
                 default:
                     //
                     // Subsequent polling messages should be empty
                     //
                     expected = testData(TEST_SERVER_DATA_EMPTY);
-                    JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+                    assertThatJson(json).isEqualTo(expected);
             }
         }
 
@@ -628,7 +628,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
         String expected = testData(REF_SERVER_AIRPORT_DATA_1);
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+        assertThatJson(json).isEqualTo(expected);
 
         //
         // Check backup consumer options carried through to olingo4 component

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataCreateTests.java
@@ -23,8 +23,6 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
@@ -44,6 +42,8 @@ import io.syndesis.connector.odata.AbstractODataRouteTest;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.customizer.ODataCreateCustomizer;
 import io.syndesis.connector.support.util.PropertyBuilder;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -148,7 +148,7 @@ public class ODataCreateTests extends AbstractODataRouteTest {
         result.assertIsSatisfied();
 
         String entityJson = extractJsonFromExchgMsg(result, 0, String.class);
-        JSONAssert.assertEquals(inputJson, entityJson, JSONCompareMode.LENIENT);
+        assertThatJson(entityJson).whenIgnoringPaths("ID", "SerialNumbers", "Specification").isEqualTo(inputJson);
 
         assertEquals(initialResultCount + 1, defaultTestServer.getResultCount());
     }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataDeleteTests.java
@@ -24,8 +24,6 @@ import org.apache.olingo.commons.api.http.HttpStatusCode;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
@@ -45,6 +43,8 @@ import io.syndesis.connector.odata.AbstractODataRouteTest;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.customizer.ODataDeleteCustomizer;
 import io.syndesis.connector.support.util.PropertyBuilder;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -147,7 +147,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
 
         String status = extractJsonFromExchgMsg(result, 0);
         String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-        JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+        assertThatJson(status).isEqualTo(expected);
 
         assertEquals(initialResultCount - 1, defaultTestServer.getResultCount());
     }
@@ -188,7 +188,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
 
         String status = extractJsonFromExchgMsg(result, 0);
         String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-        JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+        assertThatJson(status).isEqualTo(expected);
 
         assertEquals(initialResultCount - 1, defaultTestServer.getResultCount());
     }
@@ -229,7 +229,7 @@ public class ODataDeleteTests extends AbstractODataRouteTest {
 
         String status = extractJsonFromExchgMsg(result, 0);
         String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-        JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+        assertThatJson(status).isEqualTo(expected);
 
         assertEquals(0, defaultTestServer.getResultCount());
     }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataReadTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataReadTests.java
@@ -27,8 +27,6 @@ import org.apache.camel.component.olingo4.Olingo4Endpoint;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
@@ -36,6 +34,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.ConnectorAction;
@@ -150,7 +151,7 @@ public class ODataReadTests extends AbstractODataRouteTest {
         result.assertIsSatisfied();
 
         String entityJson = extractJsonFromExchgMsg(result, 0, String.class);
-        JSONAssert.assertEquals(testData(TEST_SERVER_DATA_1, AbstractODataReadRouteTest.class), entityJson, JSONCompareMode.LENIENT);
+        assertThatJson(entityJson).isEqualTo(testData(TEST_SERVER_DATA_1, AbstractODataReadRouteTest.class));
         assertEquals(initialResultCount, defaultTestServer.getResultCount());
 
         //
@@ -197,7 +198,7 @@ public class ODataReadTests extends AbstractODataRouteTest {
         result.assertIsSatisfied();
 
         String entityJson = extractJsonFromExchgMsg(result, 0, String.class);
-        JSONAssert.assertEquals(testData(TEST_SERVER_DATA_2, AbstractODataReadRouteTest.class), entityJson, JSONCompareMode.LENIENT);
+        assertThatJson(entityJson).isEqualTo(testData(TEST_SERVER_DATA_2, AbstractODataReadRouteTest.class));
         assertEquals(initialResultCount, defaultTestServer.getResultCount());
     }
 
@@ -250,7 +251,7 @@ public class ODataReadTests extends AbstractODataRouteTest {
             }
 
             assertNotNull(expectedData);
-            JSONAssert.assertEquals(testData(expectedData, AbstractODataReadRouteTest.class), entityJson, JSONCompareMode.LENIENT);
+            assertThatJson(entityJson).isEqualTo(testData(expectedData, AbstractODataReadRouteTest.class));
             assertEquals(initialResultCount, defaultTestServer.getResultCount());
         }
     }
@@ -286,6 +287,6 @@ public class ODataReadTests extends AbstractODataRouteTest {
         result.assertIsSatisfied();
 
         String entityJson = extractJsonFromExchgMsg(result, 0, String.class);
-        JSONAssert.assertEquals(testData(REF_SERVER_PEOPLE_DATA_KLAX_LOC, AbstractODataReadRouteTest.class), entityJson, JSONCompareMode.LENIENT);
+        assertThatJson(entityJson).isEqualTo(testData(REF_SERVER_PEOPLE_DATA_KLAX_LOC, AbstractODataReadRouteTest.class));
     }
 }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -49,8 +49,6 @@ import org.apache.olingo.commons.api.http.HttpStatusCode;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
@@ -70,6 +68,8 @@ import io.syndesis.connector.odata.AbstractODataRouteTest;
 import io.syndesis.connector.odata.component.ODataComponentFactory;
 import io.syndesis.connector.odata.customizer.ODataPatchCustomizer;
 import io.syndesis.connector.support.util.PropertyBuilder;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -219,7 +219,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
 
         String status = extractJsonFromExchgMsg(result, 0);
         String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-        JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+        assertThatJson(status).isEqualTo(expected);
 
         assertEquals(initialResultCount, defaultTestServer.getResultCount());
 
@@ -286,7 +286,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
 
             String status = extractJsonFromExchgMsg(result, i);
             String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-            JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+            assertThatJson(status).isEqualTo(expected);
 
             assertEquals(initialResultCount, defaultTestServer.getResultCount());
 
@@ -444,7 +444,7 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
 
             String status = extractJsonFromExchgMsg(result, 0);
             String expected = createResponseJson(HttpStatusCode.NO_CONTENT);
-            JSONAssert.assertEquals(expected, status, JSONCompareMode.LENIENT);
+            assertThatJson(status).isEqualTo(expected);
 
             String newName = queryProperty(refServiceURI, resourcePath, keyPredicate, nameProperty);
             assertEquals(newMiddleName, newName);

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -144,10 +144,9 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
+   <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -167,11 +166,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataAdapterTest.java
@@ -16,7 +16,6 @@
 package io.syndesis.connector.sql;
 
 import static org.assertj.core.api.Assertions.fail;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -34,15 +33,15 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.commons.io.IOUtils;
-import org.json.JSONException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.syndesis.connector.sql.common.DbEnum;
 import io.syndesis.connector.sql.stored.SqlStoredConnectorMetaDataExtension;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class SqlMetadataAdapterTest {
     private static final String DERBY_DEMO_ADD2_SQL =
@@ -102,7 +101,7 @@ public class SqlMetadataAdapterTest {
     }
 
     @Test
-    public void adaptForSqlTest() throws IOException, JSONException {
+    public void adaptForSqlTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -117,12 +116,12 @@ public class SqlMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_metadata.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
 
     }
 
     @Test
-    public void adaptForSqlNoParamTest() throws IOException, JSONException {
+    public void adaptForSqlNoParamTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -137,11 +136,11 @@ public class SqlMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_no_param_metadata.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
     @Test
-    public void adaptForSqlUpdateTest() throws IOException, JSONException {
+    public void adaptForSqlUpdateTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -156,11 +155,11 @@ public class SqlMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_update_metadata.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
     @Test
-    public void adaptForSqlBatchUpdateTest() throws IOException, JSONException {
+    public void adaptForSqlBatchUpdateTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -176,11 +175,11 @@ public class SqlMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_batch_update_metadata.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
     @Test
-    public void adaptForSqlUpdateNoParamTest() throws IOException, JSONException {
+    public void adaptForSqlUpdateNoParamTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlConnectorMetaDataExtension ext = new SqlConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -195,11 +194,11 @@ public class SqlMetadataAdapterTest {
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/name_sql_update_no_param_metadata.json"), StandardCharsets.UTF_8).trim();
         ObjectWriter writer = JsonUtils.writer();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
     }
 
     @Test
-    public void adaptForSqlStoredTest() throws IOException, JSONException {
+    public void adaptForSqlStoredTest() throws IOException {
         CamelContext camelContext = new DefaultCamelContext();
         SqlStoredConnectorMetaDataExtension ext = new SqlStoredConnectorMetaDataExtension(camelContext);
         Map<String,Object> parameters = new HashMap<>();
@@ -215,18 +214,18 @@ public class SqlMetadataAdapterTest {
 
         String expectedListOfProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
         String actualListOfProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
-        assertEquals(expectedListOfProcedures, actualListOfProcedures, JSONCompareMode.STRICT);
+        assertThatJson(actualListOfProcedures).isEqualTo(expectedListOfProcedures);
 
         parameters.put(SqlMetadataRetrieval.PATTERN, SqlMetadataRetrieval.FROM_PATTERN);
         String expectedListOfStartProcedures = IOUtils.toString(this.getClass().getResource("/sql/stored_procedure_list.json"), StandardCharsets.UTF_8).trim();
         String actualListOfStartProcedures = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData);
-        assertEquals(expectedListOfStartProcedures, actualListOfStartProcedures, JSONCompareMode.STRICT);
+        assertThatJson(actualListOfStartProcedures).isEqualTo(expectedListOfStartProcedures);
 
         parameters.put("procedureName", "DEMO_ADD");
         SyndesisMetadata syndesisMetaData2 = adapter.adapt(camelContext, "sql", "sql-stored-connector", parameters, metadata.get());
         String expectedMetadata = IOUtils.toString(this.getClass().getResource("/sql/demo_add_metadata.json"), StandardCharsets.UTF_8).trim();
         String actualMetadata = writer.with(writer.getConfig().getDefaultPrettyPrinter()).writeValueAsString(syndesisMetaData2);
-        assertEquals(expectedMetadata, actualMetadata, JSONCompareMode.STRICT);
+        assertThatJson(actualMetadata).isEqualTo(expectedMetadata);
 
     }
 }

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -70,12 +70,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <optional>true</optional>
-    </dependency>
-
 
     <!-- deps -->
     <dependency>
@@ -125,9 +119,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/ProjectGeneratorTest.java
@@ -61,21 +61,20 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @SuppressWarnings({ "PMD.ExcessiveImports", "PMD.ExcessiveMethodLength" })
 @RunWith(Parameterized.class)
@@ -688,7 +687,7 @@ public class ProjectGeneratorTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    private void assertFileContentsJson(ProjectGeneratorConfiguration generatorConfiguration, Path actualFilePath, String expectedFileName) throws URISyntaxException, IOException, JSONException {
+    private void assertFileContentsJson(ProjectGeneratorConfiguration generatorConfiguration, Path actualFilePath, String expectedFileName) throws URISyntaxException, IOException {
         URL resource = null;
         String overridePath = generatorConfiguration.getTemplates().getOverridePath();
         String methodName = testName.getMethodName();
@@ -711,7 +710,7 @@ public class ProjectGeneratorTest {
         final String actual = new String(Files.readAllBytes(actualFilePath), StandardCharsets.UTF_8).trim();
         final String expected = new String(Files.readAllBytes(Paths.get(resource.toURI())), StandardCharsets.UTF_8).trim();
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
+        assertThatJson(actual).isEqualTo(expected);
     }
 
     private Path generate(Integration integration, ProjectGeneratorConfiguration generatorConfiguration, TestResourceManager resourceManager) throws IOException {

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -448,18 +448,6 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1072,8 +1072,9 @@
             <bannedDependencies>
               <excludes>
                 <exclude>org.hamcrest:*</exclude>
+                <exclude>org.skyscreamer:jsonassert</exclude>
               </excludes>
-              <message>Prefer using AssertJ for assertions</message>
+              <message>Prefer using AssertJ with JsonUnit for assertions</message>
               <searchTransitive>false</searchTransitive>
             </bannedDependencies>
           </rules>
@@ -2369,6 +2370,13 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>net.javacrumbs.json-unit</groupId>
+        <artifactId>json-unit-assertj</artifactId>
+        <version>2.12.0</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- ========================================== -->
 
       <!-- === Atlasmap -->
@@ -2516,12 +2524,6 @@
         <groupId>io.atlasmap</groupId>
         <artifactId>atlasmap-maven-plugin</artifactId>
         <version>${atlasmap.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.vaadin.external.google</groupId>
-        <artifactId>android-json</artifactId>
-        <version>0.0.20131108.vaadin1</version>
       </dependency>
 
       <dependency>

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -181,9 +181,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
     <dependency>
@@ -201,12 +200,6 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGeneratorTest.java
@@ -39,14 +39,12 @@ import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.connection.ConnectorSettings;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.server.api.generator.APIValidationContext;
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static io.syndesis.server.api.generator.openapi.TestHelper.reformatJson;
 import static io.syndesis.server.api.generator.openapi.TestHelper.resource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class OpenApiConnectorGeneratorTest {
 
@@ -292,7 +290,7 @@ public class OpenApiConnectorGeneratorTest {
     }
 
     @Test
-    public void shouldParseSpecificationWithSecurityRequirements() throws JSONException {
+    public void shouldParseSpecificationWithSecurityRequirements() {
         final OpenApiModelInfo info = OpenApiConnectorGenerator.parseSpecification(new ConnectorSettings.Builder()
             .putConfiguredProperty("specification", "{\"swagger\":\"2.0\",\"paths\":{\"/api\":{\"get\":{\"security\":[{\"secured\":[]}]}}}}")
             .build(),
@@ -304,9 +302,7 @@ public class OpenApiConnectorGeneratorTest {
         assertThat(model.paths.getPathItem("/api").get.security.get(0).getScopes("secured")).isEmpty();
 
         final String resolvedSpecification = info.getResolvedSpecification();
-        JSONAssert.assertEquals(
-            "{\"swagger\":\"2.0\",\"paths\":{\"/api\":{\"get\":{\"security\":[{\"secured\":[]}]}}}}",
-            resolvedSpecification, JSONCompareMode.STRICT);
+        assertThatJson(resolvedSpecification).isEqualTo("{\"swagger\":\"2.0\",\"paths\":{\"/api\":{\"get\":{\"security\":[{\"secured\":[]}]}}}}");
 
         final ObjectNode resolvedJsonGraph = info.getResolvedJsonGraph();
         final JsonNode securityRequirement = resolvedJsonGraph.get("paths").get("/api").get("get").get("security");

--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -227,15 +227,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
   </dependencies>

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/AcquisitionMethodTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/AcquisitionMethodTest.java
@@ -16,17 +16,16 @@
 package io.syndesis.server.credential;
 
 import io.syndesis.common.util.json.JsonUtils;
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class AcquisitionMethodTest {
 
     @Test
-    public void shouldSerializeAsExpected() throws JsonProcessingException, JSONException {
+    public void shouldSerializeAsExpected() throws JsonProcessingException {
         final AcquisitionMethod acquisitionMethod = new AcquisitionMethod.Builder()
             .description("description")
             .icon("icon")
@@ -36,6 +35,6 @@ public class AcquisitionMethodTest {
 
         final String json = JsonUtils.writer().writeValueAsString(acquisitionMethod);
         final String expected = "{\"description\":\"description\",\"icon\":\"icon\",\"label\":\"label\",\"type\":\"OAUTH2\",\"configured\":false}";
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
+        assertThatJson(json).isEqualTo(expected);
     }
 }

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -389,15 +389,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/dto/MixedTest.java
@@ -21,36 +21,35 @@ import java.util.Map;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 
 import io.syndesis.common.util.json.JsonUtils;
-import org.json.JSONException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class MixedTest {
 
     @Test
-    public void shouldSerializeAsEmptyMap() throws JSONException {
-        assertEquals("{}", serialize(create()), true);
+    public void shouldSerializeAsEmptyMap() {
+        assertThatJson(serialize(create())).isEqualTo("{}");
     }
 
     @Test
-    public void shouldSerializeMultipleValue() throws JSONException {
+    public void shouldSerializeMultipleValue() {
         final ConfigurationProperty.PropertyValue val1 = new ConfigurationProperty.PropertyValue.Builder().label("label").value("value")
             .build();
 
         final Map<String, String> val2 = Collections.singletonMap("key", "value");
 
-        assertEquals("{\"label\": \"label\", \"value\": \"value\", \"key\": \"value\"}", serialize(create(val1, val2)), true);
+        assertThatJson(serialize(create(val1, val2))).isEqualTo("{\"label\": \"label\", \"value\": \"value\", \"key\": \"value\"}");
     }
 
     @Test
-    public void shouldSerializeSimpleValue() throws JSONException {
+    public void shouldSerializeSimpleValue() {
         final ConfigurationProperty.PropertyValue val = new ConfigurationProperty.PropertyValue.Builder().label("label").value("value")
             .build();
 
-        assertEquals("{\"label\": \"label\", \"value\": \"value\"}", serialize(create(val)), true);
+        assertThatJson(serialize(create(val))).isEqualTo("{\"label\": \"label\", \"value\": \"value\"}");
     }
 
     private static Mixed create(final Object... parts) {

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -37,7 +37,6 @@ import io.syndesis.server.dao.manager.EncryptionComponent;
 import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.endpoint.v1.dto.MetaData;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
-import org.json.JSONException;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -158,7 +157,7 @@ public class ConnectionActionHandlerTest {
     }
 
     @Test
-    public void shouldElicitActionPropertySuggestions() throws JSONException {
+    public void shouldElicitActionPropertySuggestions() {
         final DynamicActionMetadata suggestions = new DynamicActionMetadata.Builder()
             .putProperty("sObjectName",
                 Collections.singletonList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Contact", "Contact")))

--- a/app/server/inspector/pom.xml
+++ b/app/server/inspector/pom.xml
@@ -103,15 +103,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/inspector/src/test/java/io/syndesis/server/inspector/SpecificationClassInspectorTest.java
+++ b/app/server/inspector/src/test/java/io/syndesis/server/inspector/SpecificationClassInspectorTest.java
@@ -22,18 +22,16 @@ import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.server.inspector.DataMapperBaseInspector.Context;
 
 import org.apache.commons.io.IOUtils;
-import org.json.JSONException;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class SpecificationClassInspectorTest {
 
     @Test
-    public void shouldFindNestedClassesWithinFullJson() throws IOException, JSONException {
+    public void shouldFindNestedClassesWithinFullJson() throws IOException {
         final SpecificationClassInspector inspector = new SpecificationClassInspector();
 
         final String specification = read("/twitter4j.Status.full.json");
@@ -42,7 +40,7 @@ public class SpecificationClassInspectorTest {
 
         final String json = inspector.fetchJsonFor("twitter4j.GeoLocation", context);
 
-        assertEquals(json, read("/twitter4j.GeoLocation.json"), JSONCompareMode.STRICT);
+        assertThatJson(json).isEqualTo(read("/twitter4j.GeoLocation.json"));
     }
 
     private static String read(final String path) throws IOException {

--- a/app/server/logging/jaeger/pom.xml
+++ b/app/server/logging/jaeger/pom.xml
@@ -160,9 +160,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
   </dependencies>

--- a/app/server/logging/jaeger/src/test/java/io/syndesis/server/logging/jaeger/service/JaegerActivityTrackingServiceTest.java
+++ b/app/server/logging/jaeger/src/test/java/io/syndesis/server/logging/jaeger/service/JaegerActivityTrackingServiceTest.java
@@ -26,10 +26,11 @@ import javax.ws.rs.WebApplicationException;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.server.endpoint.v1.handler.activity.Activity;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 /*
 
@@ -68,7 +69,7 @@ public class JaegerActivityTrackingServiceTest {
         // print the activitiesJson to replace the content of expected-activities.json
         // System.out.println(activitiesJson);
         String expectedActivitiesJson = resource("expected-activities.json").trim();
-        JSONAssert.assertEquals(expectedActivitiesJson, activitiesJson, true);
+        assertThatJson(activitiesJson).isEqualTo(expectedActivitiesJson);
     }
 
 

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -743,12 +743,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
@@ -782,6 +776,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
     <dependency>
@@ -942,15 +941,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <scope>test</scope>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
@@ -30,11 +30,8 @@ import io.syndesis.server.api.generator.openapi.OpenApiConnectorGenerator;
 import io.syndesis.server.runtime.BaseITCase;
 import okio.Okio;
 import org.apache.commons.io.IOUtils;
-import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -46,6 +43,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 @ContextConfiguration
 public class CustomSwaggerConnectorITCase extends BaseITCase {
@@ -87,7 +86,7 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
     }
 
     @Test
-    public void shouldOfferCustomConnectorInfoForUploadedSwagger() throws IOException, JSONException {
+    public void shouldOfferCustomConnectorInfoForUploadedSwagger() throws IOException {
         final ConnectorSettings connectorSettings = new ConnectorSettings.Builder().connectorTemplateId(TEMPLATE_ID).build();
 
         final ResponseEntity<APISummary> response = post("/api/v1/connectors/custom/info",
@@ -107,9 +106,7 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
         assertThat(got).isEqualToIgnoringGivenFields(expected, "icon", "configuredProperties");
         assertThat(got.getIcon()).matches(s -> s.isPresent() && s.get().startsWith("data:image"));
         assertThat(got.getConfiguredProperties().keySet()).containsOnly("specification");
-        JSONAssert.assertEquals(got.getConfiguredProperties().get("specification"),
-            IOUtils.toString(getClass().getResourceAsStream("/io/syndesis/server/runtime/test-swagger.json"), StandardCharsets.UTF_8),
-            JSONCompareMode.LENIENT);
+        assertThatJson(got.getConfiguredProperties().get("specification")).isEqualTo(IOUtils.toString(getClass().getResourceAsStream("/io/syndesis/server/runtime/test-swagger.json"), StandardCharsets.UTF_8));
     }
 
     private static MultiValueMap<String, Object> multipartBodyForInfo(final ConnectorSettings connectorSettings, final InputStream is)

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/ApiIntegrationUpdateITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/ApiIntegrationUpdateITCase.java
@@ -34,11 +34,8 @@ import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.runtime.BaseITCase;
 
-import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -56,6 +53,8 @@ import static io.syndesis.server.runtime.integration.MultipartUtil.MULTIPART;
 import static io.syndesis.server.runtime.integration.MultipartUtil.specification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class ApiIntegrationUpdateITCase extends BaseITCase {
 
@@ -84,7 +83,7 @@ public class ApiIntegrationUpdateITCase extends BaseITCase {
     }
 
     @Test
-    public void shouldUpdateApiIntegration() throws IOException, JSONException {
+    public void shouldUpdateApiIntegration() throws IOException {
         final String integrationId = existing.getId().get();
         put("/api/v1/integrations/" + integrationId + "/specification", specification("/io/syndesis/server/runtime/updated-test-swagger.json"), Void.class,
             tokenRule.validToken(), HttpStatus.NO_CONTENT, MULTIPART);
@@ -117,11 +116,11 @@ public class ApiIntegrationUpdateITCase extends BaseITCase {
 
         final String givenJson = getResourceAsText("io/syndesis/server/runtime/updated-test-swagger.json");
         final String receivedJson = new String(specificationResponse.getBody().getByteArray(), StandardCharsets.UTF_8);
-        JSONAssert.assertEquals(givenJson, receivedJson, JSONCompareMode.LENIENT);
+        assertThatJson(receivedJson).whenIgnoringPaths("$..operationId").isEqualTo(givenJson);
     }
 
     @Test
-    public void shouldUpdateApiIntegrationViaApiGenerator() throws IOException, JSONException {
+    public void shouldUpdateApiIntegrationViaApiGenerator() throws IOException {
         final MultiValueMap<Object, Object> update = specification("/io/syndesis/server/runtime/updated-test-swagger.json");
         update.add("integration", integration(existing));
 
@@ -158,7 +157,7 @@ public class ApiIntegrationUpdateITCase extends BaseITCase {
         final OpenApi openApi = resourceManager.loadOpenApiDefinition(openApiResource.getId().get()).get();
 
         final String givenJson = getResourceAsText("io/syndesis/server/runtime/updated-test-swagger.json");
-        JSONAssert.assertEquals(givenJson, new String(openApi.getDocument(), StandardCharsets.UTF_8), JSONCompareMode.LENIENT);
+        assertThatJson(new String(openApi.getDocument(), StandardCharsets.UTF_8)).whenIgnoringPaths("$..operationId").isEqualTo(givenJson);
     }
 
     static HttpEntity<Resource> integration(final Integration integration) throws JsonProcessingException {


### PR DESCRIPTION
JsonUnit provides nicer integration with AssertJ, doesn't have the
dependency issue[1] JSONAssert has, is maintained (JSONAssert doesn't
seem to be) and generates much nicer failure messages:

```
Different value found in node "spreadsheetId", expected: <"6364c6b9-ea7f-4caf-916b-3baeb6622c24x"> but was: <"6364c6b9-ea7f-4caf-916b-3baeb6622c24">.
```
or
```
Different keys found in node "", extra: "ID","SerialNumbers","Specification", expected: <{"Description":"New Monitor with Resolution 1920 x 1080 @ 60Hz","Name":"NEC Screen"}> but was: <{"Description":"New Monitor with Resolution 1920 x 1080 @ 60Hz","ID":4,"Name":"NEC Screen","SerialNumbers":[],"Specification":""}>
```

[1] https://github.com/skyscreamer/JSONassert/issues/99