### PR TITLE
refactor(server): do not log 404 errors

### DIFF
--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -130,6 +130,7 @@ maven:
 logging:
   level:
     io.swagger.parser: WARN
+    io.syndesis.server.endpoint.v1.handler.exception.EntityNotFoundExceptionMapper: OFF
 
 prometheus:
   # prometheus service name


### PR DESCRIPTION
Deleting an entity from the database causes notification to be sent to
the UI, upon which the UI tries to reload that entity causing a HTTP 404
error in that case. I have perceived this as the majority of cases when
`EntityNotFoundException` is thrown and logged.

These log messages add no value as they could be caused by any recently
deleted and then re-fetched entity in the database.

This removes logging from the `EntityNotFoundExceptionMapper` solely
responsible for those exceptions being logged.