### PR TITLE
fix(ENTESB-12856): Enhance Google calendar date time with seconds of hour

### DIFF
--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventModel.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventModel.java
@@ -28,15 +28,18 @@ import com.google.api.services.calendar.model.EventDateTime;
 
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
 import static io.syndesis.connector.calendar.GoogleCalendarUtils.formatAtendees;
 
 public class GoogleCalendarEventModel {
 
-    private static final DateTimeFormatter LOCAL_HOUR_MINUTES = new DateTimeFormatterBuilder()
+    private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2)
         .appendLiteral(':')
         .appendValue(MINUTE_OF_HOUR, 2)
+        .appendLiteral(':')
+        .appendValue(SECOND_OF_MINUTE, 2)
         .toFormatter();
 
     private String title;
@@ -168,7 +171,7 @@ public class GoogleCalendarEventModel {
             final TemporalAccessor dateTime = DateTimeFormatter.ISO_DATE_TIME.parse(asRfc3339);
 
             startDate = DateTimeFormatter.ISO_LOCAL_DATE.format(dateTime);
-            startTime = LOCAL_HOUR_MINUTES.format(dateTime);
+            startTime = LOCAL_DATE_TIME.format(dateTime);
         } else {
             final String asRfc3339 = start.getDate().toStringRfc3339();
             final TemporalAccessor date = DateTimeFormatter.ISO_DATE.parse(asRfc3339);
@@ -193,7 +196,7 @@ public class GoogleCalendarEventModel {
             TemporalAccessor dateTime = DateTimeFormatter.ISO_DATE_TIME.parse(asRfc3339);
 
             endDate = DateTimeFormatter.ISO_LOCAL_DATE.format(dateTime);
-            endTime = LOCAL_HOUR_MINUTES.format(dateTime);
+            endTime = LOCAL_DATE_TIME.format(dateTime);
         } else {
             final String asRfc3339 = end.getDate().toStringRfc3339();
             final TemporalAccessor date = DateTimeFormatter.ISO_DATE.parse(asRfc3339);

--- a/app/connector/google-calendar/src/test/java/io/syndesis/connector/calendar/GoogleCalendarEventModelTest.java
+++ b/app/connector/google-calendar/src/test/java/io/syndesis/connector/calendar/GoogleCalendarEventModelTest.java
@@ -56,13 +56,16 @@ public class GoogleCalendarEventModelTest {
         expected.setDescription("description");
         expected.setAttendees("a1@mail.com,a2@mail.com");
         expected.setStartDate("2018-05-18");
-        expected.setStartTime("15:30");
+        expected.setStartTime("15:30:00");
         expected.setEndDate("2018-05-18");
-        expected.setEndTime("16:30");
+        expected.setEndTime("16:30:00");
         expected.setLocation("location");
         expected.setEventId("eventId");
 
         assertThat(eventModel).isEqualToComparingFieldByField(expected);
+        googleModel.setStart(date("2018-05-18T15:30:00.000Z"));
+        googleModel.setEnd(date("2018-05-18T16:30:00.000Z"));
+        assertThat(eventModel.asEvent()).isEqualTo(googleModel);
     }
 
     @Test
@@ -82,7 +85,7 @@ public class GoogleCalendarEventModelTest {
         eventModel.setStart(dateTime("2018-05-18T15:30:00+02:00"));
 
         assertThat(eventModel.getStartDate()).isEqualTo("2018-05-18");
-        assertThat(eventModel.getStartTime()).isEqualTo("15:30");
+        assertThat(eventModel.getStartTime()).isEqualTo("15:30:00");
     }
 
     @Test
@@ -102,7 +105,7 @@ public class GoogleCalendarEventModelTest {
         eventModel.setEnd(dateTime("2018-05-18T15:30:00+02:00"));
 
         assertThat(eventModel.getEndDate()).isEqualTo("2018-05-18");
-        assertThat(eventModel.getEndTime()).isEqualTo("15:30");
+        assertThat(eventModel.getEndTime()).isEqualTo("15:30:00");
     }
 
     @Test

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/AuthenticationCustomizerTest.java
@@ -151,7 +151,7 @@ public class AuthenticationCustomizerTest {
     }
 
     @Test
-    public void shouldSupportAllAuthenticatioValues() {
+    public void shouldSupportAllAuthenticationValues() {
         final ComponentProxyComponent component = new SwaggerProxyComponent("test", "test");
         final CamelContext context = mock(CamelContext.class);
         component.setCamelContext(context);
@@ -168,7 +168,7 @@ public class AuthenticationCustomizerTest {
     }
 
     @Test
-    public void shouldSupportNamedAuthenticatioValues() {
+    public void shouldSupportNamedAuthenticationValues() {
         final ComponentProxyComponent component = new SwaggerProxyComponent("test", "test");
         final CamelContext context = mock(CamelContext.class);
         component.setCamelContext(context);


### PR DESCRIPTION
Need to enhance Google calendar datetime model representation with seconds in order to meet Rfc3339 standard in newer versions of google-http-client.

Fixes ENTESB-12856