### PR TITLE
[Backport-1.9.x]: Add unsupported OpenAPI 3.x feature warnings for provided APIs

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRules.java
@@ -53,7 +53,10 @@ public final class Oas30ValidationRules extends OpenApiValidationRules<Oas30Resp
                 Oas30ValidationRules::validateUnsupportedCallbacksFeature,
                 Oas30ValidationRules::validateUnsupportedLinksFeature
             ),
-            Collections.singletonList(Oas30ValidationRules::validateServerBasePaths));
+            Arrays.asList(
+                Oas30ValidationRules::validateUnsupportedCallbacksFeature,
+                Oas30ValidationRules::validateUnsupportedLinksFeature,
+                Oas30ValidationRules::validateServerBasePaths));
     }
 
     public static Oas30ValidationRules get(final APIValidationContext context) {


### PR DESCRIPTION
Manual backport #7745 

Unsupported features warnings are valid for both consumed and provided APIs in Syndesis.