### PR TITLE
fix(ENTESB-12856): Set Google calendar date time field properly

### DIFF
--- a/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventModel.java
+++ b/app/connector/google-calendar/src/main/java/io/syndesis/connector/calendar/GoogleCalendarEventModel.java
@@ -252,7 +252,7 @@ public class GoogleCalendarEventModel {
         if (startTime == null) {
             start.setDate(DateTime.parseRfc3339(startDate));
         } else {
-            start.setDate(DateTime.parseRfc3339(startDate + "T" + startTime));
+            start.setDateTime(DateTime.parseRfc3339(startDate + "T" + startTime));
         }
 
         return start;
@@ -264,7 +264,7 @@ public class GoogleCalendarEventModel {
         if (endTime == null) {
             end.setDate(DateTime.parseRfc3339(endDate));
         } else {
-            end.setDate(DateTime.parseRfc3339(endDate + "T" + endTime));
+            end.setDateTime(DateTime.parseRfc3339(endDate + "T" + endTime));
         }
 
         return end;

--- a/app/connector/google-calendar/src/test/java/io/syndesis/connector/calendar/GoogleCalendarEventModelTest.java
+++ b/app/connector/google-calendar/src/test/java/io/syndesis/connector/calendar/GoogleCalendarEventModelTest.java
@@ -63,8 +63,8 @@ public class GoogleCalendarEventModelTest {
         expected.setEventId("eventId");
 
         assertThat(eventModel).isEqualToComparingFieldByField(expected);
-        googleModel.setStart(date("2018-05-18T15:30:00.000Z"));
-        googleModel.setEnd(date("2018-05-18T16:30:00.000Z"));
+        googleModel.setStart(dateTime("2018-05-18T15:30:00.000Z"));
+        googleModel.setEnd(dateTime("2018-05-18T16:30:00.000Z"));
         assertThat(eventModel.asEvent()).isEqualTo(googleModel);
     }
 


### PR DESCRIPTION
Event model was using date field instead of date time field in Google event API.