### PR TITLE
TEIIDTOOLS-912: When data source name in Syndesis have spaces, the Sy…

### DIFF
--- a/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
@@ -467,7 +467,8 @@ public class MetadataService extends DvService implements ServiceVdbGenerator.Sc
         return repositoryManager.runInTransaction(true, ()->{
             for (String teiidName : repositoryManager.findAllSchemaNames()) {
                 TeiidDataSource teiidSource = getMetadataInstance().getDataSource(teiidName);
-                RestSyndesisSourceStatus status = new RestSyndesisSourceStatus(teiidName);
+				RestSyndesisSourceStatus status = new RestSyndesisSourceStatus(
+						teiidSource.getSyndesisDataSource().getSyndesisName());
                 if (teiidSource != null) {
                     setSchemaStatus(teiidSource.getSyndesisId(), status);
                 }


### PR DESCRIPTION
…ndesis removes the spaces but while reporting it does not restore thus the matching fails etween what is in the metadata source and syndesis source, this patch will fix to send back correct name