### PR TITLE
DV backport for TEIIDTOOLS-924

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationEditorPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationEditorPage.tsx
@@ -299,7 +299,7 @@ export const VirtualizationEditorPage: React.FunctionComponent<IVirtualizationEd
         />
       </PageSection>
       <PageSection variant={'light'} noPadding={true}>
-        <VirtualizationNavBar virtualization={props.virtualization} />
+        <VirtualizationNavBar virtualization={props.routeState.virtualization} />
       </PageSection>
       <PageSection variant={'light'} noPadding={true}>
         {props.children}


### PR DESCRIPTION
Backport to 1.9.x - 
Fix: route param being directly used without resolving value