### PR TITLE
fix: If a step has no configurable properties, show that and don't error out

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigure.tsx
@@ -1,7 +1,8 @@
-import { Card, CardBody, CardFooter, Text } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container, PageSection } from '../../Layout';
+import { IntegrationEditorNothingToConfigureAlert } from './IntegrationEditorNothingToConfigureAlert';
 
 export interface IIntegrationEditorNothingToConfigureProps {
   /**
@@ -29,10 +30,9 @@ export class IntegrationEditorNothingToConfigure extends React.Component<
             <Card>
               <CardBody>
                 <Container>
-                  <Text className="alert alert-info">
-                    <span className="pficon pficon-info" />
-                    {this.props.i18nAlert}
-                  </Text>
+                  <IntegrationEditorNothingToConfigureAlert
+                    i18nAlert={this.props.i18nAlert}
+                  />
                 </Container>
               </CardBody>
               <CardFooter className="syn-card__footer">

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigureAlert.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigureAlert.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@patternfly/react-core';
+import * as React from 'react';
+
+export interface IIntegrationEditorNothingToConfigureAlertProps {
+  i18nAlert: string;
+}
+
+export const IntegrationEditorNothingToConfigureAlert: React.FunctionComponent<IIntegrationEditorNothingToConfigureAlertProps> = ({
+  i18nAlert,
+}) => (
+  <Text className="alert alert-info">
+    <span className="pficon pficon-info" />
+    {i18nAlert}
+  </Text>
+);

--- a/app/ui-react/packages/ui/src/Integration/Editor/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/Editor/index.ts
@@ -9,6 +9,7 @@ export * from './IntegrationEditorConnectionsListItem';
 export * from './IntegrationEditorForm';
 export * from './IntegrationEditorLayout';
 export * from './IntegrationEditorNothingToConfigure';
+export * from './IntegrationEditorNothingToConfigureAlert';
 export * from './IntegrationEditorStepsAdderHeader';
 export * from './IntegrationEditorStepsList';
 export * from './IntegrationEditorStepsListItem';

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/NothingToConfigure.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/NothingToConfigure.tsx
@@ -1,6 +1,7 @@
 import { Action, ActionDescriptor } from '@syndesis/models';
 import { IntegrationEditorNothingToConfigure } from '@syndesis/ui';
 import * as React from 'react';
+import i18n from '../../../../../i18n';
 import { IWithConfigurationFormProps } from './WithConfigurationForm';
 
 export interface INothingToConfigureProps
@@ -22,9 +23,9 @@ export const NothingToConfigure: React.FunctionComponent<
   };
   return (
     <IntegrationEditorNothingToConfigure
-      i18nAlert={'There are no properties to configure for this action.'}
-      i18nBackAction={'Choose Action'}
-      i18nNext={'Next'}
+      i18nAlert={i18n.t('integrations:editor:endpoint:configureAction:noProperties')}
+      i18nBackAction={i18n.t('integrations:editor:endpoint:configureAction:chooseAction')}
+      i18nNext={i18n.t('shared:Next')}
       submitForm={submitForm}
       backActionHref={chooseActionHref}
     />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
@@ -6,7 +6,10 @@ import {
 } from '@syndesis/api';
 import { AutoForm, IFormValue } from '@syndesis/auto-form';
 import { ConfigurationProperty, StepKind } from '@syndesis/models';
-import { IntegrationEditorForm } from '@syndesis/ui';
+import {
+  IntegrationEditorForm,
+  IntegrationEditorNothingToConfigureAlert,
+} from '@syndesis/ui';
 import {
   allFieldsRequired,
   getRequiredStatusText,
@@ -82,9 +85,7 @@ export interface IWithConfigurationFormProps {
  * @see [moreConfigurationSteps]{@link IWithConfigurationFormProps#moreConfigurationSteps}
  * @see [values]{@link IWithConfigurationFormProps#values}
  */
-export const WithConfigurationForm: React.FunctionComponent<
-  IWithConfigurationFormProps
-> = props => {
+export const WithConfigurationForm: React.FunctionComponent<IWithConfigurationFormProps> = props => {
   const { t } = useTranslation('shared');
 
   const onSave = async (
@@ -104,14 +105,20 @@ export const WithConfigurationForm: React.FunctionComponent<
   let definition: { [key: string]: ConfigurationProperty };
   // if step is undefined, maybe we are dealing with an extension
   if (!step) {
-    const steps = getActionSteps(props.step.action!.descriptor!);
-    const actionStep = getActionStep(steps, 0);
-    definition = getActionStepDefinition(actionStep);
+    try {
+      const steps = getActionSteps(props.step.action!.descriptor!);
+      const actionStep = getActionStep(steps, 0);
+      definition = getActionStepDefinition(actionStep);
+    } catch (err) {
+      // tslint:disable-next-line:no-console
+      console.warn('Caught error accessing property definition: ', err);
+      definition = {};
+    }
     step = props.step;
   } else {
     definition = step.properties;
   }
-
+  const hasProperties = Object.keys(definition).length > 0;
   const initialValue = props.step.configuredProperties;
   const requiredPrompt = getRequiredStatusText(
     definition,
@@ -119,14 +126,12 @@ export const WithConfigurationForm: React.FunctionComponent<
     i18n.t('shared:FieldsMarkedWithStarRequired'),
     ''
   );
-
   const validator = (values: IFormValue) =>
     validateRequiredProperties(
       definition,
       (name: string) => `${name} is required`,
       values
     );
-
   return (
     <AutoForm<IFormValue>
       i18nRequiredProperty={t('shared:requiredFieldMessage')}
@@ -155,7 +160,15 @@ export const WithConfigurationForm: React.FunctionComponent<
               submitForm={submitForm}
               handleSubmit={handleSubmit}
             >
-              {fields}
+              {hasProperties ? (
+                fields
+              ) : (
+                <IntegrationEditorNothingToConfigureAlert
+                  i18nAlert={i18n.t(
+                    'integrations:editor:configureStep:noProperties'
+                  )}
+                />
+              )}
             </IntegrationEditorForm>
           ),
           isSubmitting,

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -86,6 +86,8 @@
     "confirmDeleteStepDialogTitle": "Confirm Delete",
     "endpoint": {
       "configureAction": {
+        "chooseAction": "Choose Action",
+        "noProperties": "There are no properties to configure for this action.",
         "descriptorFetchError": {
           "title": "Connection Configuration Required",
           "info": "A connection associated with this integration is no longer valid.",
@@ -98,6 +100,9 @@
       "startDescription": "Click the connection that starts the integration. If the connection you need is not available, click Create Connection.",
       "finishDescription": "Click the connection that completes the integration. If the connection you need is not available, click Create Connection.",
       "middleDescription": "A step specifies an operation on the data in the integration. Click one to add it."
+    },
+    "configureStep": {
+      "noProperties": "There are no properties to configure for this step."
     },
     "saveOrAddStep": "Save or Add Step",
     "save": {


### PR DESCRIPTION
fixes [ENTESB-12888](https://issues.redhat.com/browse/ENTESB-12888)

![image](https://user-images.githubusercontent.com/351660/73687005-17b58700-4697-11ea-9300-c0e9963311ca.png)

This also adds the same message for the split step as it also doesn't currently have configuration either.

@claudio4j FYI