### PR TITLE
user doc: Updates to doc for DynamoDB connector based on comments from Tomas

### DIFF
--- a/doc/assemblies/connecting/as_connecting-to-aws.adoc
+++ b/doc/assemblies/connecting/as_connecting-to-aws.adoc
@@ -7,28 +7,29 @@
 
 A {prodname} integration can connect to the following Amazon web services: 
 
+* DynamoDB
 * Simple Notification Service (SNS)
 * Simple Queue Service (SQS)
 * Simple Storage Service (S3)
-* DynamoDB
+
 
 You must obtain AWS credentials before you can create a connection 
 to an Amazon web service. For details, see:
 
 * xref:obtaining-aws-credentials_{context}[]
+* xref:connecting-to-amazon-dynamodb_{context}[]
 * xref:connecting-to-amazon-sns_{context}[]
 * xref:connecting-to-amazon-sqs_{context}[]
 * xref:connecting-to-amazon-s3_{context}[]
-* xref:connecting-to-amazon-dynamodb_{context}[]
 
 include::../../modules/connecting/p_obtaining-aws-credentials.adoc[leveloffset=+1]
+
+include::../../assemblies/connecting/as_connecting-to-amazon-dynamodb.adoc[leveloffset=+1]
 
 include::../../assemblies/connecting/as_connecting-to-amazon-sns.adoc[leveloffset=+1]
 
 include::../../assemblies/connecting/as_connecting-to-amazon-sqs.adoc[leveloffset=+1]
 
 include::../../assemblies/connecting/as_connecting-to-amazon-s3.adoc[leveloffset=+1]
-
-include::../../assemblies/connecting/as_connecting-to-amazon-dynamodb.adoc[leveloffset=+1]
 
 :context: connectors

--- a/doc/modules/connecting/p_creating-amazon-dynamodb-connections.adoc
+++ b/doc/modules/connecting/p_creating-amazon-dynamodb-connections.adoc
@@ -10,7 +10,7 @@ connect to Amazon DynamoDB in an integration.
 .Prerequisites
 
 * You must have an AWS access key. See 
-link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
+link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials for creating connections to Amazon services].
 * You must know which AWS region contains the DynamoDB table that
 you want the connection to access. 
 * You must know the name of the DynamoDB table that you want the 
@@ -23,7 +23,7 @@ connects to DynamoDB.
 display any available connections.
 . In the upper right, click *Create Connection* to display
 {prodname} connectors.
-. Click the *AWS DDB* connector.
+. Click the *Amazon DynamoDB* connector.
 . In the *Access Key* field, enter an Amazon access key ID that is 
 part of a user access key in the AWS account that manages 
 the DynamoDB table that you want the connection to access. 

--- a/doc/modules/connecting/p_obtaining-aws-credentials.adoc
+++ b/doc/modules/connecting/p_obtaining-aws-credentials.adoc
@@ -2,7 +2,7 @@
 // as_connecting-to-aws.adoc
 
 [id='obtaining-aws-credentials_{context}']
-= Obtaining AWS credentials for creating {prodname} connections
+= Obtaining AWS credentials for creating connections to Amazon services
 
 To create a connection to an Amazon service, you must have an access
 key that is associated with an AWS account. This is the AWS account 


### PR DESCRIPTION
I updated the name of the connector to "Amazon DynamoDB".
I ensured that the link to the section about obtaining AWS credentials is correct.
I reordered the sections to put the DynamoDB content first since it is alphabetically first as far as service names. 