### PR TITLE
user doc: Add note about source fields in data mapper - might not contain data

### DIFF
--- a/doc/assemblies/integrating-applications/as_mapping-data.adoc
+++ b/doc/assemblies/integrating-applications/as_mapping-data.adoc
@@ -12,6 +12,16 @@ been obtained or processed to data fields that the next connection in the
 flow can process.
 {prodname} provides a data mapper to help you do this. In a flow,
 at each point where you need to map data fields, add a data mapper step.
+
+[IMPORTANT]
+The data mapper displays the largest possible set of source fields that can 
+be provided by the previous integration step. However, not all connections 
+provide data in each displayed source field. For example, a change to a 
+third-party application might discontinue providing data in a particular field. 
+As you create an integration, if you notice that data mapping is not behaving 
+as you expect, ensure that a source field that you want to map contains the 
+data that you expect.
+
 Details for mapping data fields are in the following topics:
 
 * xref:identify-where-data-mapping-is-needed_{context}[]

--- a/doc/modules/integrating-applications/p_add-data-mapping-step.adoc
+++ b/doc/modules/integrating-applications/p_add-data-mapping-step.adoc
@@ -13,6 +13,15 @@ suppose the integration data contains a `Name` field and the next
 connection in the flow has a `CustomerName` field. You need to
 map the source `Name` field to the target `CustomerName` field.
 
+[IMPORTANT]
+The data mapper displays the largest possible set of source fields that can 
+be provided by the previous integration step. However, not all connections 
+provide data in each displayed source field. For example, a change to a 
+third-party application might discontinue providing data in a particular field. 
+As you create an integration, if you notice that data mapping is not behaving 
+as you expect, ensure that a source field that you want to map contains the 
+data that you expect.
+
 .Prerequisite
 
 You are creating or editing a flow. 

--- a/doc/modules/integrating-applications/p_map-one-source-field-to-one-target-field.adoc
+++ b/doc/modules/integrating-applications/p_map-one-source-field-to-one-target-field.adoc
@@ -68,3 +68,12 @@ the name of the source field.
 default *Map* action. 
 . In the *Target* section, enter the name of the
 field that you want to map to and click *Enter*. 
+
+.Troubleshooting tip
+The data mapper displays the largest possible set of source fields that can 
+be provided by the previous integration step. However, not all connections 
+provide data in each displayed source field. For example, a change to a 
+third-party application might discontinue providing data in a particular field. 
+As you create an integration, if you notice that data mapping is not behaving 
+as you expect, ensure that a source field that you want to map contains the 
+data that you expect.


### PR DESCRIPTION
Matej Kralik identified a problem where a data mapper source field might not contain data. We agreed to add a troubleshooting tip to the doc to check the incoming payload to make sure that the field you are mapping to contains what you expect. Matej and Fintan approved the wording. The note is in three different places. 