### PR TITLE
backport: Adapt DV UI to publishing/deployment backend changes - TEIIDTOOLS-914

### DIFF
--- a/app/ui-react/packages/api/src/useVirtualization.tsx
+++ b/app/ui-react/packages/api/src/useVirtualization.tsx
@@ -16,6 +16,7 @@ export const useVirtualization = (
 ) => {
   const { read, resource, ...rest } = useApiResource<Virtualization>({
     defaultValue: {
+      deployedState: 'NOTFOUND',
       description: '',
       empty: true,
       id: '',

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -1,5 +1,12 @@
 // TODO remove when these values are advertised by the swagger
 export interface Virtualization {
+  deployedMessage?: string;
+  deployedState:
+    | 'NOTFOUND'
+    | 'DEPLOYING'
+    | 'FAILED'
+    | 'RUNNING';
+  deployedRevision?: number;
   empty: boolean;
   id: string;
   modified: boolean;
@@ -7,10 +14,12 @@ export interface Virtualization {
   odataHostName?: string;
   podNamespace?: string;
   publishPodName?: string;
+  publishedMessage?: string;
   publishedState:
     | 'BUILDING'
     | 'CANCELLED'
     | 'CONFIGURING'
+    | 'COMPLETE'
     | 'DELETE_SUBMITTED'
     | 'DELETE_REQUEUE'
     | 'DELETE_DONE'
@@ -162,6 +171,7 @@ export interface VirtualizationPublishingDetails {
     | 'BUILDING'
     | 'CANCELLED'
     | 'CONFIGURING'
+    | 'COMPLETE'
     | 'DELETE_SUBMITTED'
     | 'DELETE_REQUEUE'
     | 'DELETE_DONE'
@@ -185,6 +195,7 @@ export interface TeiidStatus {
       | 'BUILDING'
       | 'CANCELLED'
       | 'CONFIGURING'
+      | 'COMPLETE'
       | 'DELETE_SUBMITTED'
       | 'DELETE_REQUEUE'
       | 'DELETE_DONE'
@@ -206,6 +217,7 @@ export interface BuildStatus {
     | 'BUILDING'
     | 'CANCELLED'
     | 'CONFIGURING'
+    | 'COMPLETE'
     | 'DELETE_SUBMITTED'
     | 'DELETE_REQUEUE'
     | 'DELETE_DONE'

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.css
@@ -14,7 +14,8 @@
 }
 
 .publish-status-with-progress_text {
-    margin-right: 15px;
+    margin-right: 10px;
+    margin-left: 10px;
     font-size: 1rem;
     font-weight: 600;
 }

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
@@ -78,7 +78,12 @@ export const PublishStatusWithProgress: React.FunctionComponent<IPublishStatusWi
         />
       )}
       <span className={'publish-status-with-progress_text'}>
-        {props.i18nPublishState}
+        <Label
+          className={'publish-status-with-progress_Label'}
+          type={props.labelType}
+        >
+          {props.i18nPublishState}
+        </Label>
         {props.publishVersion && ` version ${props.publishVersion}`}
       </span>
       {(props.i18nPublishState === 'Stopped' ||

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/models.ts
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/models.ts
@@ -1,5 +1,6 @@
 export const NOTFOUND = 'NOTFOUND';
 export const SUBMITTED = 'SUBMITTED';
+export const COMPLETE = 'COMPLETE';
 export const CONFIGURING = 'CONFIGURING';
 export const BUILDING = 'BUILDING';
 export const DEPLOYING = 'DEPLOYING';
@@ -14,6 +15,7 @@ export const UNPUBLISH_SUBMITTED = 'UNPUBLISH_SUBMITTED';
 export type VirtualizationPublishState =
   | 'NOTFOUND'
   | 'SUBMITTED'
+  | 'COMPLETE'
   | 'CONFIGURING'
   | 'BUILDING'
   | 'DEPLOYING'

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationMetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationMetricsPage.tsx
@@ -87,7 +87,7 @@ export const VirtualizationMetricsPage: React.FunctionComponent = () => {
           }
         >
           {() => {
-            return virtualization.publishedState === 'RUNNING' ? (
+            return virtualization.deployedState === 'RUNNING' ? (
               <DvMetricsContainer
                 resultSetCacheProps={{
                   a11yInfoCloseButton: t('metricsCacheHitRatioA11yInfoClose'),

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationVersionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationVersionsPage.tsx
@@ -36,8 +36,8 @@ const getDraftActions = (virtualization: Virtualization) => {
 
 const getVersionActions = (virtualization: Virtualization, edition: number) => {
   const kebabItems =
-    virtualization.publishedState === 'RUNNING' &&
-    edition === virtualization.publishedRevision
+    virtualization.deployedState === 'RUNNING' &&
+    edition === virtualization.deployedRevision
       ? [VirtualizationActionId.Stop, VirtualizationActionId.Export]
       : [
           VirtualizationActionId.Start,
@@ -67,9 +67,11 @@ const getSortedEditions = (
   for (const edition of sorted) {
     const versionItem: IVirtualizationVersionItem = {
       actions: getVersionActions(virtualization, edition.revision),
-      publishedState: getVersionPublishedState(
+      publishedState: getVersionState(
         edition.revision,
+        virtualization.deployedState,
         virtualization.publishedState,
+        virtualization.deployedRevision,
         virtualization.publishedRevision
       ),
       timePublished: edition.createdAt
@@ -82,23 +84,33 @@ const getSortedEditions = (
   return versionItems;
 };
 
-const getVersionPublishedState = (
+const getVersionState = (
   itemVersion: number,
+  virtDeployedState: string,
   virtPublishedState: string,
+  virtDeployedRevision?: number,
   virtPublishedRevision?: number
 ) => {
-  if (virtPublishedRevision && virtPublishedRevision === itemVersion) {
-    if (virtPublishedState === 'RUNNING') {
-      return 'RUNNING';
-    } else if (virtPublishedState === 'FAILED') {
-      return 'FAILED';
-    } else if (virtPublishedState === 'NOTFOUND') {
-      return 'NOTFOUND';
-    } else {
-      return 'IN_PROGRESS';
+  // First consider the version deployed state
+  let virtState: any = 'NOTFOUND';
+  if (virtDeployedRevision && virtDeployedRevision === itemVersion) {
+    if (virtDeployedState === 'RUNNING') {
+      virtState = 'RUNNING';
+    } else if (virtDeployedState === 'FAILED') {
+      virtState = 'FAILED';
+    } else if (virtDeployedState === 'DEPLOYING') {
+      virtState = 'IN_PROGRESS';
     }
   }
-  return 'NOTFOUND';
+  // If no deploy status found, consider the version publish state
+  if (virtState === 'NOTFOUND' && virtPublishedRevision && virtPublishedRevision === itemVersion) {
+    if (virtPublishedState === 'FAILED') {
+      virtState = 'FAILED';
+    } else if (virtPublishedState !== 'COMPLETE') {
+      virtState = 'IN_PROGRESS';
+    }
+  }
+  return virtState;
 };
 
 /**


### PR DESCRIPTION
Backport for 1.9.x.  These changes adapt the UI to changes on the DV backend to resolve virtualization publishing issues.
- model changes to add deployedState, deployedRevision, deployedMessage
- VirtualizationVersionsPage changes - the version table can now show published virtualization version and in-progress virtualization simultaneously.
- PublishStatusWithProgress changed to utilize status label same as virtualizationListItem
