### PR TITLE
[ENTESB-11725] For Master: Google Sheets Validation was broken

### DIFF
--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -29,6 +29,9 @@
   <packaging>jar</packaging>
 
   <properties>
+    <!-- To review when api client gets updated if 1.34.0 is available for this -->
+    <!-- This dependency is aligned with the camel version -->
+    <google-api-camel-client-version>1.22.0</google-api-camel-client-version>
     <google-api-client-version>1.34.0</google-api-client-version>
     <google-api-services-sheets-version>v4-rev551-1.22.0</google-api-services-sheets-version>
   </properties>
@@ -44,6 +47,18 @@
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-jdk5</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- This also could be removed once we align versions up -->
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>${google-api-camel-client-version}</version>
+        <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava-jdk5</artifactId>
@@ -104,6 +119,10 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sheets</artifactId>
       <version>${google-api-services-sheets-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/CustomGoogleSheetsVerifierExtension.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/CustomGoogleSheetsVerifierExtension.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sheets;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.sheets.v4.Sheets;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.extension.verifier.ResultBuilder;
+import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
+import org.apache.camel.component.google.sheets.BatchGoogleSheetsClientFactory;
+import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
+import org.apache.camel.component.google.sheets.GoogleSheetsConfiguration;
+
+
+/**
+ * FIXME Remove this class when Camel dependency gets updated
+ **/
+public class CustomGoogleSheetsVerifierExtension
+    extends org.apache.camel.component.google.sheets.GoogleSheetsVerifierExtension {
+    public CustomGoogleSheetsVerifierExtension(String defaultScheme) {
+        super(defaultScheme);
+    }
+
+    public CustomGoogleSheetsVerifierExtension(String defaultScheme, CamelContext context) {
+        super(defaultScheme, context);
+    }
+
+    @Override
+    protected Result verifyConnectivity(Map<String, Object> parameters) {
+        ResultBuilder builder = ResultBuilder.withStatusAndScope(Result.Status.OK, Scope.CONNECTIVITY);
+
+        try {
+            GoogleSheetsConfiguration configuration =
+                this.setProperties(new GoogleSheetsConfiguration(), parameters);
+            GoogleSheetsClientFactory clientFactory = new BatchGoogleSheetsClientFactory();
+            Sheets client = clientFactory.makeClient(configuration.getClientId(), configuration.getClientSecret(),
+                configuration.getApplicationName(), configuration.getRefreshToken(),
+                configuration.getAccessToken());
+            client.spreadsheets().get(Optional.ofNullable(parameters.get("spreadsheetId")).map(Object::toString).orElse(UUID.randomUUID().toString())).execute();
+        } catch (GoogleJsonResponseException e) {
+            Integer code = e.getStatusCode();
+            //We may have a "404 spreadsheet no found" which is fine
+            //What we don't want is a bad credential error or similar
+            if (code != 404) {
+                buildError(builder, e);
+            }
+        } catch (Exception e) {
+            buildError(builder, e);
+        }
+
+        return builder.build();
+    }
+
+    private static void buildError(ResultBuilder builder, Exception var6) {
+        ResultErrorBuilder errorBuilder =
+            ResultErrorBuilder.withCodeAndDescription(VerificationError.StandardCode.AUTHENTICATION,
+                var6.getMessage()).detail("google_sheets_exception_message",
+                var6.getMessage()).detail(VerificationError.ExceptionAttribute.EXCEPTION_CLASS,
+                var6.getClass().getName()).detail(VerificationError.ExceptionAttribute.EXCEPTION_INSTANCE, var6);
+        builder.error(errorBuilder.build());
+    }
+}

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsVerifier.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsVerifier.java
@@ -18,17 +18,16 @@ package io.syndesis.connector.sheets;
 import io.syndesis.connector.support.verifier.api.ComponentVerifier;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.ComponentVerifierExtension;
-import org.apache.camel.component.google.sheets.GoogleSheetsVerifierExtension;
 
 public class GoogleSheetsVerifier extends ComponentVerifier {
 
     public GoogleSheetsVerifier() {
-        super("google-sheets", GoogleSheetsVerifierExtension.class);
+        super("google-sheets", CustomGoogleSheetsVerifierExtension.class);
     }
 
     @Override
     protected ComponentVerifierExtension resolveComponentVerifierExtension(CamelContext context, String scheme) {
-        return new GoogleSheetsVerifierExtension(scheme, context);
+        return new CustomGoogleSheetsVerifierExtension(scheme, context);
     }
 
 }


### PR DESCRIPTION
New Google API version returns a 404 error when the spreadsheet ID is not valid. Now we make sure that is not a validation error. A validation error will pop up when credentials are wrong (or some other unexpected issue).