### PR TITLE
chore: Fix integration tests to not wait for other containers to start

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -40,7 +40,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.SocketUtils;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 /**
  * @author Christoph Deppisch
@@ -59,8 +58,12 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
     @Autowired
     private JmsEndpoint todoJms;
 
-    @ClassRule
-    public static JBossAMQBrokerContainer amqBrokerContainer = new JBossAMQBrokerContainer();
+    private static final JBossAMQBrokerContainer amqBrokerContainer;
+
+    static {
+        amqBrokerContainer = new JBossAMQBrokerContainer();
+        amqBrokerContainer.start();
+    }
 
     /**
      * Integration waits for messages on AMQ queue and maps incoming tasks to Http service. Both AMQ and Http connections use
@@ -74,8 +77,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
             .customize("$..configuredProperties.baseUrl",
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
-            .withNetwork(amqBrokerContainer.getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .withNetwork(amqBrokerContainer.getNetwork());
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -40,7 +40,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.SocketUtils;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 /**
  * @author Christoph Deppisch
@@ -59,8 +58,12 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
     @Autowired
     private JmsEndpoint todoJms;
 
-    @ClassRule
-    public static JBossAMQBrokerContainer amqBrokerContainer = new JBossAMQBrokerContainer();
+    private static final JBossAMQBrokerContainer amqBrokerContainer;
+
+    static {
+        amqBrokerContainer = new JBossAMQBrokerContainer();
+        amqBrokerContainer.start();
+    }
 
     /**
      * Integration periodically requests list of tasks (as Json array) from Http service and maps the results to AMQ queue.
@@ -74,8 +77,7 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
             .customize("$..configuredProperties.baseUrl",
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
-            .withNetwork(amqBrokerContainer.getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .withNetwork(amqBrokerContainer.getNetwork());
 
     @Test
     @CitrusTest


### PR DESCRIPTION
Nightly integration tests were failing for quite some time because of a Http request timeout in the Http-to-AMQ tests. I boiled this down to the integration runtime container wait strategy not being able to wait for the AMQ testcontainer to be pulled and started. Therefore the test logic started way too early (while container images still being pulled) and a Http request timeout causes the tests to fail.

Now using a static initializer for AMQ testcintainer instead of the @ClassRule