### PR TITLE
fix(deps): exclude javax.annotation-api

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1177,6 +1177,12 @@
         <artifactId>jaeger-spring-boot-starter</artifactId>
         <version>${project.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- ::::::::::: rest :::::::::::: -->
@@ -2652,6 +2658,12 @@
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-model</artifactId>
         <version>${kubernetes.client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>


### PR DESCRIPTION
Seems that there are duplicate but different classes in
`javax.annotation:javax.annotation-api:1.3.2` vs
`org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.2.Final`.

This excludes the `javax.annotation:javax.annotation-api` as the JBoss
one seems to be used more.

Caveat, on `master` we have excluded both the javax ones and the JBoss
ones in favor of the Jakarta versions.