### PR TITLE
chore: clean up UI prerequisite commands to minimize naming explicit packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,12 +119,10 @@ jobs:
       - run:
           name: Build UI
           command: |
-            apt-get update -y
-            apt-get install -y --force-yes libxss1 patch apt-transport-https
             echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
             curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
             apt-get update -y
-            apt-get install -y --force-yes --no-install-recommends  google-chrome-stable fontconfig fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-symbola fonts-noto ttf-freefont
+            apt-get install -y --force-yes libxss1 patch apt-transport-https google-chrome-stable
             ./tools/bin/syndesis build --batch-mode --module ui-react --docker | tee build_log.txt
       - save_cache:
           key: syndesis-yarn-ui-v2-{{ checksum "app/ui-react/yarn.lock" }}


### PR DESCRIPTION
There were two blocks doing apt get/install, I don't think it should be necessary to explicitly list all of those packages.