### PR TITLE
fix: Integration tests in nightly build

### DIFF
--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -58,12 +58,8 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
     @Autowired
     private JmsEndpoint todoJms;
 
-    private static final JBossAMQBrokerContainer amqBrokerContainer;
-
-    static {
-        amqBrokerContainer = new JBossAMQBrokerContainer();
-        amqBrokerContainer.start();
-    }
+    @ClassRule
+    public static JBossAMQBrokerContainer amqBrokerContainer = new JBossAMQBrokerContainer();
 
     /**
      * Integration waits for messages on AMQ queue and maps incoming tasks to Http service. Both AMQ and Http connections use
@@ -77,6 +73,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
             .customize("$..configuredProperties.baseUrl",
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
+            .dependsOn(amqBrokerContainer)
             .withNetwork(amqBrokerContainer.getNetwork());
 
     @Test

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -58,12 +58,8 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
     @Autowired
     private JmsEndpoint todoJms;
 
-    private static final JBossAMQBrokerContainer amqBrokerContainer;
-
-    static {
-        amqBrokerContainer = new JBossAMQBrokerContainer();
-        amqBrokerContainer.start();
-    }
+    @ClassRule
+    public static JBossAMQBrokerContainer amqBrokerContainer = new JBossAMQBrokerContainer();
 
     /**
      * Integration periodically requests list of tasks (as Json array) from Http service and maps the results to AMQ queue.
@@ -77,6 +73,7 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
             .customize("$..configuredProperties.baseUrl",
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
+            .dependsOn(amqBrokerContainer)
             .withNetwork(amqBrokerContainer.getNetwork());
 
     @Test


### PR DESCRIPTION
AMQ testcontainer was failing because of latest changes introducing duplicate initializing of the same container. Revert changes to using a JUnit ClassRule in combination with introducing dependsOn dependency so integration runtime container waits for the AMQ container to start properly.