### PR TITLE
chore: migrate integration flow step and integrations empty state

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/IntegrationFlowStep.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationFlowStep.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@patternfly/react-core';
 import classnames from 'classnames';
-import { OverlayTrigger, Tooltip } from 'patternfly-react';
 import * as React from 'react';
 import './IntegrationFlowStep.css';
 
@@ -32,9 +32,6 @@ export class IntegrationFlowStep extends React.Component<
   };
 
   public render() {
-    const tooltip = (
-      <Tooltip id={'integration-flow-step'}>{this.props.i18nTooltip}</Tooltip>
-    );
     const icon = (
       <div className={'integration-flow-step__icon'}>{this.props.icon}</div>
     );
@@ -52,14 +49,13 @@ export class IntegrationFlowStep extends React.Component<
           </>
         ) : (
           <div className={'integration-flow-step__iconWrapper'}>
-            <OverlayTrigger
-              overlay={tooltip}
-              placement="right"
-              trigger={['hover', 'focus']}
-              rootClose={false}
+            <Tooltip
+              content={this.props.i18nTooltip}
+              enableFlip={true}
+              position={'right'}
             >
               {icon}
-            </OverlayTrigger>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsEmptyState.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsEmptyState.tsx
@@ -1,5 +1,13 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
 import * as H from '@syndesis/history';
-import { EmptyState, OverlayTrigger, Tooltip } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';
 
@@ -11,40 +19,36 @@ export interface IIntegrationsEmptyStateProps {
   linkCreateIntegration: H.LocationDescriptor;
 }
 
-export class IntegrationsEmptyState extends React.Component<
-  IIntegrationsEmptyStateProps
-> {
-  public getCreateIntegrationTooltip() {
-    return (
-      <Tooltip id="createTip">
-        {this.props.i18nCreateIntegrationTip
-          ? this.props.i18nCreateIntegrationTip
-          : this.props.i18nCreateIntegration}
-      </Tooltip>
-    );
-  }
-
-  public render() {
-    return (
-      <EmptyState>
-        <EmptyState.Icon />
-        <EmptyState.Title>{this.props.i18nEmptyStateTitle}</EmptyState.Title>
-        <EmptyState.Info>{this.props.i18nEmptyStateInfo}</EmptyState.Info>
-        <EmptyState.Action>
-          <OverlayTrigger
-            overlay={this.getCreateIntegrationTooltip()}
-            placement="top"
-          >
-            <ButtonLink
-              data-testid={'integrations-empty-state-create-button'}
-              href={this.props.linkCreateIntegration}
-              as={'primary'}
-            >
-              {this.props.i18nCreateIntegration}
-            </ButtonLink>
-          </OverlayTrigger>
-        </EmptyState.Action>
-      </EmptyState>
-    );
-  }
-}
+export const IntegrationsEmptyState: React.FunctionComponent<IIntegrationsEmptyStateProps> = ({
+  i18nCreateIntegration,
+  i18nCreateIntegrationTip,
+  i18nEmptyStateInfo,
+  i18nEmptyStateTitle,
+  linkCreateIntegration,
+}) => (
+  <EmptyState variant={EmptyStateVariant.full}>
+    <EmptyStateIcon icon={AddCircleOIcon} />
+    <Title headingLevel="h5" size="lg">
+      {i18nEmptyStateTitle}
+    </Title>
+    <EmptyStateBody>{i18nEmptyStateInfo}</EmptyStateBody>
+    <Tooltip
+      content={
+        i18nCreateIntegrationTip
+          ? i18nCreateIntegrationTip
+          : i18nCreateIntegration
+      }
+    >
+      <>
+        <br />
+        <ButtonLink
+          data-testid={'integrations-empty-state-create-button'}
+          href={linkCreateIntegration}
+          as={'primary'}
+        >
+          {i18nCreateIntegration}
+        </ButtonLink>
+      </>
+    </Tooltip>
+  </EmptyState>
+);


### PR DESCRIPTION
relates to [ENTESB-12896](https://issues.redhat.com/browse/ENTESB-12896)

new empty state for now:
![image](https://user-images.githubusercontent.com/351660/74175978-d37d3600-4c04-11ea-88ed-5e9deb7e3a38.png)

I can't get the tooltip to capture, it's the one used in the unexpanded IVP like when looking at a data mapper step.

