### PR TITLE
chore: drop pf-react dep from ApiConnectorListView

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -1,6 +1,15 @@
-import { DataList, Text, Title } from '@patternfly/react-core';
 import {
+  Button,
+  DataList,
   EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Text,
+  Title
+} from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import {
   OverlayTrigger,
   Tooltip,
 } from 'patternfly-react';
@@ -52,28 +61,28 @@ export class ApiConnectorListView extends React.Component<
         {this.props.children ? (
           <DataList aria-label={'api connector list'}>{this.props.children}</DataList>
         ) : (
-          <EmptyState>
-            <EmptyState.Icon />
-            <EmptyState.Title>
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon icon={AddCircleOIcon} />
+            <Title size={'lg'}>
               {this.props.i18nEmptyStateTitle}
-            </EmptyState.Title>
-            <EmptyState.Info>{this.props.i18nEmptyStateInfo}</EmptyState.Info>
-            <EmptyState.Action>
-              <OverlayTrigger
-                overlay={this.getCreateConnectorTooltip()}
-                placement="top"
-              >
-                <ButtonLink
-                  data-testid={
-                    'api-connector-list-view-empty-state-create-button'
-                  }
-                  href={this.props.linkCreateApiConnector}
-                  as={'primary'}
-                >
-                  {this.props.i18nLinkCreateApiConnector}
-                </ButtonLink>
-              </OverlayTrigger>
-            </EmptyState.Action>
+            </Title>
+            <EmptyStateBody>{this.props.i18nEmptyStateInfo}</EmptyStateBody>
+            <Tooltip
+              position={'top'}
+              content={
+                <div id={'createTip'}>
+                {this.props.i18nLinkCreateApiConnectorTip
+                    ? this.props.i18nLinkCreateApiConnectorTip
+                    : this.props.i18nLinkCreateApiConnector}
+                </div>
+              }
+            >
+              <Button data-testid={'api-connector-list-view-empty-state-create-button'}
+                      href={this.props.linkCreateApiConnector}
+                      variant={'primary'}>
+                {this.props.i18nLinkCreateApiConnector}
+              </Button>
+            </Tooltip>
           </EmptyState>
         )}
       </PageSection>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -1,7 +1,6 @@
-import { Text, Title } from '@patternfly/react-core';
+import { DataList, Text, Title } from '@patternfly/react-core';
 import {
   EmptyState,
-  ListView,
   OverlayTrigger,
   Tooltip,
 } from 'patternfly-react';
@@ -51,7 +50,7 @@ export class ApiConnectorListView extends React.Component<
           />
         )}
         {this.props.children ? (
-          <ListView>{this.props.children}</ListView>
+          <DataList aria-label={'api connector list'}>{this.props.children}</DataList>
         ) : (
           <EmptyState>
             <EmptyState.Icon />

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -31,25 +31,12 @@ export class ApiConnectorListView extends React.Component<
     return (
       <PageSection>
         <ListViewToolbar {...this.props}>
-          <div className="form-group">
-            <Tooltip
-              position={'top'}
-              content={
-                this.props.i18nLinkCreateApiConnectorTip
-                  ? this.props.i18nLinkCreateApiConnectorTip
-                  : this.props.i18nLinkCreateApiConnector
-              }
-              enableFlip={true}
-            >
-              <>
-                <br/>
-                <ButtonLink data-testid={'api-connector-list-view-create-button'}
-                            href={this.props.linkCreateApiConnector}
-                            as={'primary'}>
-                  {this.props.i18nLinkCreateApiConnector}
-                </ButtonLink>
-              </>
-            </Tooltip>
+          <div className={'form-group'}>
+            <ButtonLink data-testid={'api-connector-list-view-create-button'}
+                        href={this.props.linkCreateApiConnector}
+                        as={'primary'}>
+              {this.props.i18nLinkCreateApiConnector}
+            </ButtonLink>
           </div>
         </ListViewToolbar>
         {this.props.i18nTitle !== '' && (

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -1,18 +1,14 @@
 import {
-  Button,
   DataList,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
   Text,
-  Title
+  Title,
+  Tooltip
 } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons';
-import {
-  OverlayTrigger,
-  Tooltip,
-} from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink, PageSection } from '../../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../../Shared';
@@ -36,18 +32,24 @@ export class ApiConnectorListView extends React.Component<
       <PageSection>
         <ListViewToolbar {...this.props}>
           <div className="form-group">
-            <OverlayTrigger
-              overlay={this.getCreateConnectorTooltip()}
-              placement="top"
+            <Tooltip
+              position={'top'}
+              content={
+                this.props.i18nLinkCreateApiConnectorTip
+                  ? this.props.i18nLinkCreateApiConnectorTip
+                  : this.props.i18nLinkCreateApiConnector
+              }
+              enableFlip={true}
             >
-              <ButtonLink
-                data-testid={'api-connector-list-view-create-button'}
-                href={this.props.linkCreateApiConnector}
-                as={'primary'}
-              >
-                {this.props.i18nLinkCreateApiConnector}
-              </ButtonLink>
-            </OverlayTrigger>
+              <>
+                <br/>
+                <ButtonLink data-testid={'api-connector-list-view-create-button'}
+                            href={this.props.linkCreateApiConnector}
+                            as={'primary'}>
+                  {this.props.i18nLinkCreateApiConnector}
+                </ButtonLink>
+              </>
+            </Tooltip>
           </div>
         </ListViewToolbar>
         {this.props.i18nTitle !== '' && (
@@ -63,39 +65,31 @@ export class ApiConnectorListView extends React.Component<
         ) : (
           <EmptyState variant={EmptyStateVariant.full}>
             <EmptyStateIcon icon={AddCircleOIcon} />
-            <Title size={'lg'}>
+            <Title headingLevel={'h5'} size={'lg'}>
               {this.props.i18nEmptyStateTitle}
             </Title>
             <EmptyStateBody>{this.props.i18nEmptyStateInfo}</EmptyStateBody>
             <Tooltip
               position={'top'}
               content={
-                <div id={'createTip'}>
-                {this.props.i18nLinkCreateApiConnectorTip
-                    ? this.props.i18nLinkCreateApiConnectorTip
-                    : this.props.i18nLinkCreateApiConnector}
-                </div>
+                this.props.i18nLinkCreateApiConnectorTip
+                  ? this.props.i18nLinkCreateApiConnectorTip
+                  : this.props.i18nLinkCreateApiConnector
               }
+              enableFlip={true}
             >
-              <Button data-testid={'api-connector-list-view-empty-state-create-button'}
-                      href={this.props.linkCreateApiConnector}
-                      variant={'primary'}>
-                {this.props.i18nLinkCreateApiConnector}
-              </Button>
+              <>
+                <br/>
+                <ButtonLink data-testid={'api-connector-list-view-empty-state-create-button'}
+                            href={this.props.linkCreateApiConnector}
+                            as={'primary'}>
+                  {this.props.i18nLinkCreateApiConnector}
+                </ButtonLink>
+              </>
             </Tooltip>
           </EmptyState>
         )}
       </PageSection>
-    );
-  }
-
-  private getCreateConnectorTooltip() {
-    return (
-      <Tooltip id="createTip">
-        {this.props.i18nLinkCreateApiConnectorTip
-          ? this.props.i18nLinkCreateApiConnectorTip
-          : this.props.i18nLinkCreateApiConnector}
-      </Tooltip>
     );
   }
 }

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -24,59 +24,67 @@ export interface IApiConnectorListViewProps extends IListViewToolbarProps {
   linkCreateApiConnector: string;
 }
 
-export class ApiConnectorListView extends React.Component<
-  IApiConnectorListViewProps
-> {
-  public render() {
-    return (
-      <PageSection>
-        <ListViewToolbar {...this.props}>
-          <div className={'form-group'}>
-            <ButtonLink data-testid={'api-connector-list-view-create-button'}
-                        href={this.props.linkCreateApiConnector}
-                        as={'primary'}>
-              {this.props.i18nLinkCreateApiConnector}
-            </ButtonLink>
-          </div>
-        </ListViewToolbar>
-        {this.props.i18nTitle !== '' && (
-          <Title size="xl">{this.props.i18nTitle}</Title>
-        )}
-        {this.props.i18nDescription !== '' && (
-          <Text
-            dangerouslySetInnerHTML={{ __html: this.props.i18nDescription }}
-          />
-        )}
-        {this.props.children ? (
-          <DataList aria-label={'api connector list'}>{this.props.children}</DataList>
-        ) : (
-          <EmptyState variant={EmptyStateVariant.full}>
-            <EmptyStateIcon icon={AddCircleOIcon} />
-            <Title headingLevel={'h5'} size={'lg'}>
-              {this.props.i18nEmptyStateTitle}
-            </Title>
-            <EmptyStateBody>{this.props.i18nEmptyStateInfo}</EmptyStateBody>
-            <Tooltip
-              position={'top'}
-              content={
-                this.props.i18nLinkCreateApiConnectorTip
-                  ? this.props.i18nLinkCreateApiConnectorTip
-                  : this.props.i18nLinkCreateApiConnector
-              }
-              enableFlip={true}
-            >
-              <>
-                <br/>
-                <ButtonLink data-testid={'api-connector-list-view-empty-state-create-button'}
-                            href={this.props.linkCreateApiConnector}
-                            as={'primary'}>
-                  {this.props.i18nLinkCreateApiConnector}
-                </ButtonLink>
-              </>
-            </Tooltip>
-          </EmptyState>
-        )}
-      </PageSection>
-    );
-  }
-}
+export const ApiConnectorListView: React.FunctionComponent<IApiConnectorListViewProps> = (
+  {
+    children,
+    i18nDescription,
+    i18nEmptyStateInfo,
+    i18nEmptyStateTitle,
+    i18nLinkCreateApiConnector,
+    i18nLinkCreateApiConnectorTip,
+    i18nName,
+    i18nTitle,
+    linkCreateApiConnector,
+    ...rest
+  }) => {
+  return (
+    <PageSection>
+      <ListViewToolbar {...rest}>
+        <div className={'form-group'}>
+          <ButtonLink data-testid={'api-connector-list-view-create-button'}
+                      href={linkCreateApiConnector}
+                      as={'primary'}>
+            {i18nLinkCreateApiConnector}
+          </ButtonLink>
+        </div>
+      </ListViewToolbar>
+      {i18nTitle !== '' && (
+        <Title size="xl">{i18nTitle}</Title>
+      )}
+      {i18nDescription !== '' && (
+        <Text
+          dangerouslySetInnerHTML={{ __html: i18nDescription }}
+        />
+      )}
+      {children ? (
+        <DataList aria-label={'api connector list'}>{children}</DataList>
+      ) : (
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={AddCircleOIcon}/>
+          <Title headingLevel={'h5'} size={'lg'}>
+            {i18nEmptyStateTitle}
+          </Title>
+          <EmptyStateBody>{i18nEmptyStateInfo}</EmptyStateBody>
+          <Tooltip
+            position={'top'}
+            content={
+              i18nLinkCreateApiConnectorTip
+                ? i18nLinkCreateApiConnectorTip
+                : i18nLinkCreateApiConnector
+            }
+            enableFlip={true}
+          >
+            <>
+              <br/>
+              <ButtonLink data-testid={'api-connector-list-view-empty-state-create-button'}
+                          href={linkCreateApiConnector}
+                          as={'primary'}>
+                {i18nLinkCreateApiConnector}
+              </ButtonLink>
+            </>
+          </Tooltip>
+        </EmptyState>
+      )}
+    </PageSection>
+  );
+};


### PR DESCRIPTION
Epic: [ENTESB-12896](https://issues.redhat.com/browse/ENTESB-12896)

Drop `patternfly-react` (PF3) dependency to instead use `@patternfly/react-core` (PF4) stuffs in the `ApiConnectorListView` component.

Screenshot:

<img width="638" alt="Screenshot 2020-02-11 15 37 28 copy" src="https://user-images.githubusercontent.com/3844502/74253002-6c37b280-4ce6-11ea-9c3d-7faaafbcbba8.png">


Includes:
- ListView => DataList
- Tooltip
- Empty state
- Icon, etc.

Note: Similar to https://github.com/syndesisio/syndesis/pull/7863 had some issues capturing the tooltip.