### PR TITLE
Fix syndesis minishift install and dev --cleanup

### DIFF
--- a/tools/bin/commands/crc
+++ b/tools/bin/commands/crc
@@ -53,7 +53,7 @@ crc::run() {
     source "$(basedir)/commands/util/operator_funcs"
 
     release_tag="$(readopt --tag)"
-    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]]; then
+    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]] || [[ $(hasflag --full-reset) ]]; then
         if [[ -f ${OPERATOR_BINARY} ]]; then
             rm ${OPERATOR_BINARY}
         fi

--- a/tools/bin/commands/dev
+++ b/tools/bin/commands/dev
@@ -192,12 +192,17 @@ dev::run() {
         # error deleting blob sha256:1daebdc712936afb9b1ba54cfd8b06ad55470e05ad346dc8156c448ed2223c6b from the registry: 401 Unauthorized
         # the following block retrieves the full image address to remove it
         if [[ $prune_output == *"error deleting blob"* ]]; then
-            echo Error removing some images, forcing their removal.
+            echo "There were errors trying to prune images, forcing their removal."
             local imgs=`echo $prune_output|grep 'error deleting blob' | awk '{print $4}'  ORS='|' | sed 's/|$//g'`
-            oc --as system:admin get images --show-kind=true|awk '{print $1}'|grep -E "$imgs" | while read img; do
-                oc --as system:admin delete $img;
-            done
+            oc --as system:admin get images --show-kind=true|awk '{print $1}'|grep -E "$imgs" | xargs oc --as system:admin delete
         fi
+        eval $(minishift docker-env)
+        docker login -u $(oc whoami) -p $(oc whoami -t) $(minishift openshift registry) >/dev/null 2>&1
+        echo 'Removing dangling images from openshift image registry...'
+        docker rmi $(docker images -f "dangling=true" -q) >/dev/null 2>&1
+        docker logout $(minishift openshift registry) >/dev/null 2>&1
+        eval $(minishift docker-env -u)
+
         set -e
 
         if [ $(hasflag --nuke) ]; then

--- a/tools/bin/commands/install
+++ b/tools/bin/commands/install
@@ -46,7 +46,7 @@ install::run() {
     source "$(basedir)/commands/util/operator_funcs"
 
     release_tag="$(readopt --tag)"
-    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]]; then
+    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]] || [[ $(hasflag --full-reset) ]]; then
         if [[ -f ${OPERATOR_BINARY} ]]; then
             rm ${OPERATOR_BINARY}
         fi

--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -55,7 +55,7 @@ minishift::run() {
     source "$(basedir)/commands/util/operator_funcs"
 
     release_tag="$(readopt --tag)"
-    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]]; then
+    if [[ $(hasflag -f --force-binary-download) ]] || [[ -n "$release_tag" ]] || [[ $(hasflag --full-reset) ]]; then
         if [[ -f ${OPERATOR_BINARY} ]]; then
             rm ${OPERATOR_BINARY}
         fi

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -88,16 +88,25 @@ download_operator_binary() {
     esac
 
     if [[ "${pattern}" != "unknown" ]]; then
-        release_uri="https://api.github.com/repos/syndesisio/syndesis/releases?per_page=1"
         release_tag="$(readopt --tag)"
+        url=""
         if [[ -n "$release_tag" ]]; then
             release_uri="https://api.github.com/repos/syndesisio/syndesis/releases/tags/${release_tag}"
+            url=$(curl -s $release_uri \
+                | grep browser_download_url \
+                | grep ${pattern} \
+                | cut -d '"' -f 4)
+        else
+            # retrieve the last 4 releases and get the latest 2.0 release
+            url=$(curl -s "https://api.github.com/repos/syndesisio/syndesis/releases?per_page=4" \
+                | grep "download/2" \
+                | grep browser_download_url \
+                | grep ${pattern} \
+                | cut -d '"' -f 4 \
+                | sort -nr \
+                | head -1)
+            release_tag=$(echo $url| awk -F '/' '{print $8}')
         fi
-
-        url=$(curl -s $release_uri \
-            | grep browser_download_url \
-            | grep ${pattern} \
-            | cut -d '"' -f 4)
 
         if $(curl -sL ${url} | tar xz -C $(dirname ${OPERATOR_BINARY})); then
             chmod +x ${OPERATOR_BINARY}
@@ -107,7 +116,7 @@ download_operator_binary() {
         fi
 
         if $(check_operator_binary); then
-            echo "operator binary successfully downloaded"
+            echo "operator binary version $release_tag successfully downloaded"
             return 0
         else
             echo "operator binary download failed. Please try manually downloading from ${url} into $(dirname ${OPERATOR_BINARY})"


### PR DESCRIPTION
Fix syndesis minishift install scripts to download syndesis-operator 2.x
when a tag is not specified
Enhance dev --cleanup removes dangling docker images
Enhance --full-reset also removes ~/.syndesis/bin/syndesis-operator