### PR TITLE
[ENTESB-12957] DynamoDB: No attributes to query throws NullPointer 

### DIFF
--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
@@ -138,7 +138,9 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
                         final String replacement = entry.getValue().toString();
 
                         element = element.replace(searchKey, replacement);
-                        attributes = attributes.replace(searchKey, replacement);
+                        if(attributes != null) {
+                            attributes = attributes.replace(searchKey, replacement);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If no attributes were defined on the step, a NullPointer was thrown when customizing the variables.

Same as: #7883 