### PR TITLE
chore: migrate API connector list item

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.css
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.css
@@ -1,0 +1,11 @@
+.api-connector-list-item .api-connector-list-item__icon-wrapper {
+  width: 7em;
+}
+
+.api-connector-list-item .api-connector-list-item__text-wrapper {
+  margin-top: 7px;
+}
+
+.api-connector-list-item .api-connector-list-item__used-by {
+  margin-top: 16px;
+}

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
@@ -1,11 +1,11 @@
 import * as H from '@syndesis/history';
 import {
-  Button,
-  ListViewInfoItem,
-  ListViewItem,
-  OverlayTrigger,
-  Tooltip,
-} from 'patternfly-react';
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 import { ButtonLink } from '../../Layout';
@@ -14,6 +14,7 @@ import {
   ConfirmationDialog,
   ConfirmationIconType,
 } from '../../Shared';
+import './ApiConnectorListItem.css';
 
 export interface IApiConnectorListItemProps {
   apiConnectorDescription?: string;
@@ -68,26 +69,6 @@ export class ApiConnectorListItem extends React.Component<
     this.props.onDelete(this.props.apiConnectorId);
   }
 
-  public getDeleteTooltip() {
-    return (
-      <Tooltip id="deleteTip">
-        {this.props.i18nDeleteTip
-          ? this.props.i18nDeleteTip
-          : this.props.i18nDelete}
-      </Tooltip>
-    );
-  }
-
-  public getDetailsTooltip() {
-    return (
-      <Tooltip id="detailsTip">
-        {this.props.i18nDetailsTip
-          ? this.props.i18nDetailsTip
-          : this.props.i18nDetails}
-      </Tooltip>
-    );
-  }
-
   public showDeleteDialog() {
     this.setState({
       showDeleteDialog: true,
@@ -108,61 +89,63 @@ export class ApiConnectorListItem extends React.Component<
           onCancel={this.doCancel}
           onConfirm={this.doDelete}
         />
-        <ListViewItem
-          data-testid={`api-connector-list-item-${toValidHtmlId(
-            this.props.apiConnectorName
-          )}-list-item`}
-          actions={
-            <>
-              <OverlayTrigger
-                overlay={this.getDetailsTooltip()}
-                placement="top"
+        <DataListItem aria-labelledby={'single-action-item1'}
+                      data-testid={`api-connector-list-item-${toValidHtmlId(this.props.apiConnectorName)}-list-item`}
+                      className={'api-connector-list-item'}
+        >
+          <DataListItemRow>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell width={1} key={0}>
+                  {this.props.apiConnectorIcon ? (
+                    <div className={'api-connector-list-item__icon-wrapper'}>
+                      <img
+                        src={this.props.apiConnectorIcon}
+                        alt={this.props.apiConnectorName}
+                        width={46}
+                      />
+                    </div>
+                  ) : null}
+                </DataListCell>,
+                <DataListCell key={'primary content'} width={4}>
+                  <div className={'api-connector-list-item__text-wrapper'}>
+                    <b>{this.props.apiConnectorName}</b><br/>
+                    {
+                      this.props.apiConnectorDescription
+                        ? this.props.apiConnectorDescription
+                        : ''
+                    }
+                  </div>
+                </DataListCell>,
+                <DataListCell key={'secondary content'} width={4}>
+                  <div className={'api-connector-list-item__used-by'}>
+                    {this.props.i18nUsedByMessage}
+                  </div>
+                </DataListCell>
+              ]}
+            />
+            <DataListAction
+              aria-labelledby={'single-action-item1 single-action-action1'}
+              id={'single-action-action1'}
+              aria-label={'Actions'}
+            >
+              <ButtonLink
+                data-testid={'api-connector-list-item-details-button'}
+                href={this.props.detailsPageLink}
+                as={'default'}
               >
-                <ButtonLink
-                  data-testid={'api-connector-list-item-details-button'}
-                  href={this.props.detailsPageLink}
-                  as={'default'}
-                >
-                  {this.props.i18nDetails}
-                </ButtonLink>
-              </OverlayTrigger>
-              <OverlayTrigger overlay={this.getDeleteTooltip()} placement="top">
-                <Button
-                  data-testid={'api-connector-list-item-delete-button'}
-                  bsStyle="default"
-                  disabled={this.props.usedBy !== 0}
-                  onClick={this.showDeleteDialog}
-                >
-                  {this.props.i18nDelete}
-                </Button>
-              </OverlayTrigger>
-            </>
-          }
-          additionalInfo={[
-            <ListViewInfoItem key={1}>
-              {this.props.i18nUsedByMessage}
-            </ListViewInfoItem>,
-          ]}
-          description={
-            this.props.apiConnectorDescription
-              ? this.props.apiConnectorDescription
-              : ''
-          }
-          heading={this.props.apiConnectorName}
-          hideCloseIcon={true}
-          leftContent={
-            this.props.apiConnectorIcon ? (
-              <div className="blank-slate-pf-icon">
-                <img
-                  src={this.props.apiConnectorIcon}
-                  alt={this.props.apiConnectorName}
-                  width={46}
-                />
-              </div>
-            ) : null
-          }
-          stacked={true}
-        />
+                {this.props.i18nDetails}
+              </ButtonLink>
+              <ButtonLink
+                data-testid={'api-connector-list-item-delete-button'}
+                disabled={this.props.usedBy !== 0}
+                onClick={this.showDeleteDialog}
+              >
+                {this.props.i18nDelete}
+              </ButtonLink>
+            </DataListAction>
+          </DataListItemRow>
+        </DataListItem>
       </>
     );
   }

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
@@ -1,11 +1,12 @@
-import * as H from '@syndesis/history';
 import {
   DataListAction,
   DataListCell,
   DataListItem,
   DataListItemCells,
-  DataListItemRow
+  DataListItemRow,
+  Tooltip
 } from '@patternfly/react-core';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { useState } from 'react';
 import { toValidHtmlId } from '../../helpers';
@@ -48,7 +49,9 @@ export const ApiConnectorListItem: React.FC<
     i18nDelete,
     i18nDeleteModalMessage,
     i18nDeleteModalTitle,
+    i18nDeleteTip,
     i18nDetails,
+    i18nDetailsTip,
     i18nUsedByMessage,
     onDelete,
     usedBy
@@ -124,20 +127,45 @@ export const ApiConnectorListItem: React.FC<
             id={'single-action-action1'}
             aria-label={'Actions'}
           >
-            <ButtonLink
-              data-testid={'api-connector-list-item-details-button'}
-              href={detailsPageLink}
-              as={'default'}
+            <Tooltip
+              position={'top'}
+              enableFlip={true}
+              content={
+                <div id={'detailsTip'}>
+                  {i18nDetailsTip
+                    ? i18nDetailsTip
+                    : i18nDetails}
+                </div>
+              }
             >
-              {i18nDetails}
-            </ButtonLink>
-            <ButtonLink
-              data-testid={'api-connector-list-item-delete-button'}
-              disabled={usedBy !== 0}
-              onClick={showDeleteDialogAction}
+              <ButtonLink
+                data-testid={'api-connector-list-item-details-button'}
+                href={detailsPageLink}
+                as={'default'}
+              >
+                {i18nDetails}
+              </ButtonLink>
+            </Tooltip>
+
+            <Tooltip
+              position={'top'}
+              enableFlip={true}
+              content={
+                <div id={'deleteTip'}>
+                  {i18nDeleteTip
+                    ?i18nDeleteTip
+                    : i18nDelete}
+                </div>
+              }
             >
-              {i18nDelete}
-            </ButtonLink>
+              <ButtonLink
+                data-testid={'api-connector-list-item-delete-button'}
+                disabled={usedBy !== 0}
+                onClick={showDeleteDialogAction}
+              >
+                {i18nDelete}
+              </ButtonLink>
+            </Tooltip>
           </DataListAction>
         </DataListItemRow>
       </DataListItem>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
@@ -7,6 +7,7 @@ import {
   DataListItemRow
 } from '@patternfly/react-core';
 import * as React from 'react';
+import { useState } from 'react';
 import { toValidHtmlId } from '../../helpers';
 import { ButtonLink } from '../../Layout';
 import {
@@ -34,119 +35,113 @@ export interface IApiConnectorListItemProps {
   usedBy: number;
 }
 
-export interface IApiConnectorListItemState {
-  showDeleteDialog: boolean;
-}
+export const ApiConnectorListItem: React.FC<
+  IApiConnectorListItemProps
+> = (
+  {
+    apiConnectorDescription,
+    apiConnectorId,
+    apiConnectorIcon,
+    apiConnectorName,
+    detailsPageLink,
+    i18nCancelLabel,
+    i18nDelete,
+    i18nDeleteModalMessage,
+    i18nDeleteModalTitle,
+    i18nDetails,
+    i18nUsedByMessage,
+    onDelete,
+    usedBy
+  }) => {
+  // initial visibility of delete dialog
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-export class ApiConnectorListItem extends React.Component<
-  IApiConnectorListItemProps,
-  IApiConnectorListItemState
-> {
-  public constructor(props: IApiConnectorListItemProps) {
-    super(props);
+  const doCancel = () => {
+    setShowDeleteDialog(false);
+  };
 
-    this.state = {
-      showDeleteDialog: false, // initial visibility of delete dialog
-    };
-
-    this.doCancel = this.doCancel.bind(this);
-    this.doDelete = this.doDelete.bind(this);
-    this.showDeleteDialog = this.showDeleteDialog.bind(this);
-  }
-
-  public doCancel() {
-    this.setState({
-      showDeleteDialog: false, // hide dialog
-    });
-  }
-
-  public doDelete() {
-    this.setState({
-      showDeleteDialog: false, // hide dialog
-    });
+  const doDelete = () => {
+    setShowDeleteDialog(false);
 
     // TODO: disable components while delete is processing
-    this.props.onDelete(this.props.apiConnectorId);
-  }
+    onDelete(apiConnectorId);
+  };
 
-  public showDeleteDialog() {
-    this.setState({
-      showDeleteDialog: true,
-    });
-  }
+  const showDeleteDialogAction = () => {
+    setShowDeleteDialog(true);
+  };
 
-  public render() {
-    return (
-      <>
-        <ConfirmationDialog
-          buttonStyle={ConfirmationButtonStyle.DANGER}
-          i18nCancelButtonText={this.props.i18nCancelLabel}
-          i18nConfirmButtonText={this.props.i18nDelete}
-          i18nConfirmationMessage={this.props.i18nDeleteModalMessage}
-          i18nTitle={this.props.i18nDeleteModalTitle}
-          icon={ConfirmationIconType.DANGER}
-          showDialog={this.state.showDeleteDialog}
-          onCancel={this.doCancel}
-          onConfirm={this.doDelete}
-        />
-        <DataListItem aria-labelledby={'single-action-item1'}
-                      data-testid={`api-connector-list-item-${toValidHtmlId(this.props.apiConnectorName)}-list-item`}
-                      className={'api-connector-list-item'}
-        >
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell width={1} key={0}>
-                  {this.props.apiConnectorIcon ? (
-                    <div className={'api-connector-list-item__icon-wrapper'}>
-                      <img
-                        src={this.props.apiConnectorIcon}
-                        alt={this.props.apiConnectorName}
-                        width={46}
-                      />
-                    </div>
-                  ) : null}
-                </DataListCell>,
-                <DataListCell key={'primary content'} width={4}>
-                  <div className={'api-connector-list-item__text-wrapper'}>
-                    <b>{this.props.apiConnectorName}</b><br/>
-                    {
-                      this.props.apiConnectorDescription
-                        ? this.props.apiConnectorDescription
-                        : ''
-                    }
+  return (
+    <>
+      <ConfirmationDialog
+        buttonStyle={ConfirmationButtonStyle.DANGER}
+        i18nCancelButtonText={i18nCancelLabel}
+        i18nConfirmButtonText={i18nDelete}
+        i18nConfirmationMessage={i18nDeleteModalMessage}
+        i18nTitle={i18nDeleteModalTitle}
+        icon={ConfirmationIconType.DANGER}
+        showDialog={showDeleteDialog}
+        onCancel={doCancel}
+        onConfirm={doDelete}
+      />
+      <DataListItem aria-labelledby={'single-action-item1'}
+                    data-testid={`api-connector-list-item-${toValidHtmlId(apiConnectorName)}-list-item`}
+                    className={'api-connector-list-item'}
+      >
+        <DataListItemRow>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell width={1} key={0}>
+                {apiConnectorIcon ? (
+                  <div className={'api-connector-list-item__icon-wrapper'}>
+                    <img
+                      src={apiConnectorIcon}
+                      alt={apiConnectorName}
+                      width={46}
+                    />
                   </div>
-                </DataListCell>,
-                <DataListCell key={'secondary content'} width={4}>
-                  <div className={'api-connector-list-item__used-by'}>
-                    {this.props.i18nUsedByMessage}
-                  </div>
-                </DataListCell>
-              ]}
-            />
-            <DataListAction
-              aria-labelledby={'single-action-item1 single-action-action1'}
-              id={'single-action-action1'}
-              aria-label={'Actions'}
+                ) : null}
+              </DataListCell>,
+              <DataListCell key={'primary content'} width={4}>
+                <div className={'api-connector-list-item__text-wrapper'}>
+                  <b>{apiConnectorName}</b><br/>
+                  {
+                    apiConnectorDescription
+                      ? apiConnectorDescription
+                      : ''
+                  }
+                </div>
+              </DataListCell>,
+              <DataListCell key={'secondary content'} width={4}>
+                <div className={'api-connector-list-item__used-by'}>
+                  {i18nUsedByMessage}
+                </div>
+              </DataListCell>
+            ]}
+          />
+          <DataListAction
+            aria-labelledby={'single-action-item1 single-action-action1'}
+            id={'single-action-action1'}
+            aria-label={'Actions'}
+          >
+            <ButtonLink
+              data-testid={'api-connector-list-item-details-button'}
+              href={detailsPageLink}
+              as={'default'}
             >
-              <ButtonLink
-                data-testid={'api-connector-list-item-details-button'}
-                href={this.props.detailsPageLink}
-                as={'default'}
-              >
-                {this.props.i18nDetails}
-              </ButtonLink>
-              <ButtonLink
-                data-testid={'api-connector-list-item-delete-button'}
-                disabled={this.props.usedBy !== 0}
-                onClick={this.showDeleteDialog}
-              >
-                {this.props.i18nDelete}
-              </ButtonLink>
-            </DataListAction>
-          </DataListItemRow>
-        </DataListItem>
-      </>
-    );
-  }
-}
+              {i18nDetails}
+            </ButtonLink>
+            <ButtonLink
+              data-testid={'api-connector-list-item-delete-button'}
+              disabled={usedBy !== 0}
+              onClick={showDeleteDialogAction}
+            >
+              {i18nDelete}
+            </ButtonLink>
+          </DataListAction>
+        </DataListItemRow>
+      </DataListItem>
+    </>
+  );
+
+};


### PR DESCRIPTION
.. to drop patternfly-react usage, convert to functional component and use hooks.

Epic: [[ENTESB-12896] Migration from PF3 to PF4 for Fuse Online](https://issues.redhat.com/browse/ENTESB-12896)

<img width="1382" alt="Screenshot 2020-02-14 13 02 47" src="https://user-images.githubusercontent.com/3844502/74534188-1d2e8f00-4f2b-11ea-96cc-6755d840fb17.png">

<img width="1377" alt="Screenshot 2020-02-14 13 00 43" src="https://user-images.githubusercontent.com/3844502/74534180-1738ae00-4f2b-11ea-84aa-085aaeb72a3b.png">

<img width="1377" alt="Screenshot 2020-02-14 13 00 49" src="https://user-images.githubusercontent.com/3844502/74534186-199b0800-4f2b-11ea-9542-34af21e540ac.png">
