### PR TITLE
fix(ENTESB-12960): Missing version placeholder.

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -31,6 +31,7 @@
     <camel.version>2.23.2.fuse-760024</camel.version>
     <atlasmap.version>1.43.4</atlasmap.version>
     <jackson.databind.version>2.9.10.1</jackson.databind.version>
+    <mongodb.version>3.9.0</mongodb.version>
   </properties>
 
   <!-- Metadata need to publish to central -->


### PR DESCRIPTION
When building the image for an integration with Mongo, missing versino made it fail.