### PR TITLE
chore: force the version of terser to the current latest (4.6.3) to see if it sorts UI CI build issue

### DIFF
--- a/app/ui-react/package.json
+++ b/app/ui-react/package.json
@@ -70,5 +70,8 @@
     "singleQuote": true,
     "semi": true
   },
-  "dependencies": {}
+  "dependencies": {},
+  "resolutions": {
+    "terser": "4.6.3"
+  }
 }

--- a/app/ui-react/packages/history/.size-snapshot.json
+++ b/app/ui-react/packages/history/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/history.js": {
     "bundled": 28557,
-    "minified": 12544,
-    "gzipped": 3664,
+    "minified": 12568,
+    "gzipped": 3668,
     "treeshaked": {
       "rollup": {
         "code": 208,
@@ -15,13 +15,13 @@
   },
   "umd/history.js": {
     "bundled": 33491,
-    "minified": 12084,
-    "gzipped": 3983
+    "minified": 12132,
+    "gzipped": 4083
   },
   "umd/history.min.js": {
     "bundled": 30854,
-    "minified": 10134,
-    "gzipped": 3566
+    "minified": 10185,
+    "gzipped": 3469
   },
   "esm/@syndesis/history.js": {
     "bundled": 28122,

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -7939,7 +7939,7 @@ commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@2.17.x, commander@~2.17.1:
+commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
@@ -21918,7 +21918,7 @@ source-map-support@^0.4.15, source-map-support@~0.4.0:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.9:
+source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
@@ -22922,15 +22922,7 @@ terser-webpack-plugin@^2.1.2:
     terser "^4.4.3"
     webpack-sources "^1.4.3"
 
-terser@^3.16.1, terser@^3.8.2:
-  version "3.16.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-3.16.1.tgz#5b0dd4fa1ffd0b0b43c2493b2c364fd179160493"
-  dependencies:
-    commander "~2.17.1"
-    source-map "~0.6.1"
-    source-map-support "~0.5.9"
-
-terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
+terser@4.6.3, terser@^3.16.1, terser@^3.8.2, terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.3.tgz#e33aa42461ced5238d352d2df2a67f21921f8d87"
   integrity sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==


### PR DESCRIPTION
The stack trace on CI (when the UI fails to build for no obvious reason) comes up in a few search hits that linked to some bug fixes, it looked we were pulling in a kinda old version, this ensures we're not using a version from over a year ago.