### PR TITLE
chore: Extensions List Migration

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.css
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.css
@@ -1,0 +1,15 @@
+.extension-list-item .extension-list-item__icon-wrapper {
+  width: 7em;
+}
+
+.extension-list-item .extension-list-item__text-wrapper {
+  margin-top: 7px;
+}
+
+.extension-list-item .extension-list-item__type, .extension-list-item .extension-list-item__used-by {
+  margin-top: 16px;
+}
+
+.extension-list-item .extension-list-item__actions {
+  margin-top: 10px;
+}

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.tsx
@@ -1,11 +1,12 @@
 import * as H from '@syndesis/history';
 import {
-  Button,
-  ListViewInfoItem,
-  ListViewItem,
-  OverlayTrigger,
-  Tooltip,
-} from 'patternfly-react';
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Tooltip
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 import { ButtonLink } from '../../Layout';
@@ -14,6 +15,7 @@ import {
   ConfirmationDialog,
   ConfirmationIconType,
 } from '../../Shared';
+import './ExtensionListItem.css';
 
 export interface IExtensionListItemProps {
   detailsPageLink: H.LocationDescriptor;
@@ -62,30 +64,6 @@ export const ExtensionListItem: React.FunctionComponent<
     props.onDelete(props.extensionId);
   };
 
-  const getDeleteTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="deleteTip">
-        {props.i18nDeleteTip ? props.i18nDeleteTip : props.i18nDelete}
-      </Tooltip>
-    );
-  };
-
-  const getDetailsTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="detailsTip">
-        {props.i18nDetailsTip ? props.i18nDetailsTip : props.i18nDetails}
-      </Tooltip>
-    );
-  };
-
-  const getUpdateTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="updateTip">
-        {props.i18nUpdateTip ? props.i18nUpdateTip : props.i18nUpdate}
-      </Tooltip>
-    );
-  };
-
   const showConfirmationDialog = () => {
     setShowDeleteDialog(true);
   };
@@ -104,13 +82,52 @@ export const ExtensionListItem: React.FunctionComponent<
         onCancel={doCancel}
         onConfirm={doDelete}
       />
-      <ListViewItem
-        data-testid={`extension-list-item-${toValidHtmlId(
-          props.extensionName
-        )}-list-item`}
-        actions={
-          <>
-            <OverlayTrigger overlay={getDetailsTooltip()} placement="top">
+      <DataListItem aria-labelledby={'extension list item'}
+                    className={'extension-list-item'}
+                    data-testid={`extension-list-item-${toValidHtmlId(
+                      props.extensionName
+                    )}-list-item`}
+      >
+        <DataListItemRow>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell width={1} key={0} className={'extension-list-item__icon-wrapper'}>
+                {props.extensionIcon}
+              </DataListCell>,
+              <DataListCell key={'primary content'} width={4}>
+                <div className={'extension-list-item__text-wrapper'}>
+                  <b>{props.extensionName}</b><br/>
+                  {
+                    props.extensionDescription ? props.extensionDescription : ''
+                  }
+                </div>
+              </DataListCell>,
+
+              <DataListCell key={'type content'} width={3} className={'extension-list-item__type'}>
+                {props.i18nExtensionType}
+              </DataListCell>,
+              <DataListCell key={'used by content'} width={3} className={'extension-list-item__used-by'}>
+                {props.i18nUsedByMessage}
+              </DataListCell>
+            ]}
+          />
+          <DataListAction
+            aria-labelledby={'extension list actions'}
+            id={'extension-list-action'}
+            aria-label={'Actions'}
+            className={'extension-list-item__actions'}
+          >
+            <Tooltip
+              position={'top'}
+              enableFlip={true}
+              content={
+                <div id={'detailsTip'}>
+                  {props.i18nDetailsTip
+                    ? props.i18nDetailsTip
+                    : props.i18nDetails}
+                </div>
+              }
+            >
               <ButtonLink
                 data-testid={'extension-list-item-details-button'}
                 href={props.detailsPageLink}
@@ -118,8 +135,17 @@ export const ExtensionListItem: React.FunctionComponent<
               >
                 {props.i18nDetails}
               </ButtonLink>
-            </OverlayTrigger>
-            <OverlayTrigger overlay={getUpdateTooltip()} placement="top">
+            </Tooltip>
+
+            <Tooltip
+              position={'top'}
+              enableFlip={true}
+              content={
+                <div id={'updateTip'}>
+                  {props.i18nUpdateTip ? props.i18nUpdateTip : props.i18nUpdate}
+                </div>
+              }
+            >
               <ButtonLink
                 data-testid={'extension-list-item-update-button'}
                 href={props.linkUpdateExtension}
@@ -127,35 +153,30 @@ export const ExtensionListItem: React.FunctionComponent<
               >
                 {props.i18nUpdate}
               </ButtonLink>
-            </OverlayTrigger>
-            <OverlayTrigger overlay={getDeleteTooltip()} placement="top">
-              <Button
+            </Tooltip>
+
+            <Tooltip
+              position={'top'}
+              enableFlip={true}
+              content={
+                <div id={'deleteTip'}>
+                  {props.i18nDeleteTip
+                    ?props.i18nDeleteTip
+                    : props.i18nDelete}
+                </div>
+              }
+            >
+              <ButtonLink
                 data-testid={'extension-list-item-delete-button'}
-                bsStyle="default"
                 disabled={props.usedBy !== 0}
                 onClick={showConfirmationDialog}
               >
                 {props.i18nDelete}
-              </Button>
-            </OverlayTrigger>
-          </>
-        }
-        additionalInfo={[
-          <ListViewInfoItem key={1}>
-            {props.i18nExtensionType}
-          </ListViewInfoItem>,
-          <ListViewInfoItem key={2}>
-            {props.i18nUsedByMessage}
-          </ListViewInfoItem>,
-        ]}
-        description={
-          props.extensionDescription ? props.extensionDescription : ''
-        }
-        heading={props.extensionName}
-        hideCloseIcon={true}
-        leftContent={props.extensionIcon}
-        stacked={true}
-      />
+              </ButtonLink>
+            </Tooltip>
+          </DataListAction>
+        </DataListItemRow>
+      </DataListItem>
     </>
   );
 };

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListItem.tsx
@@ -1,4 +1,3 @@
-import * as H from '@syndesis/history';
 import {
   DataListAction,
   DataListCell,
@@ -7,6 +6,7 @@ import {
   DataListItemRow,
   Tooltip
 } from '@patternfly/react-core';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 import { ButtonLink } from '../../Layout';

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
@@ -1,11 +1,15 @@
-import { Text, Title } from '@patternfly/react-core';
-import * as H from '@syndesis/history';
 import {
+  DataList,
   EmptyState,
-  ListView,
-  OverlayTrigger,
-  Tooltip,
-} from 'patternfly-react';
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Text,
+  Title,
+  Tooltip
+} from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, PageSection } from '../../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../../Shared';
@@ -25,53 +29,48 @@ export interface IExtensionListViewProps extends IListViewToolbarProps {
 export const ExtensionListView: React.FunctionComponent<
   IExtensionListViewProps
 > = props => {
-  const getImportTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="importTip">
-        {props.i18nLinkImportExtensionTip
-          ? props.i18nLinkImportExtensionTip
-          : props.i18nLinkImportExtension}
-      </Tooltip>
-    );
-  };
-
   return (
     <PageSection>
       <ListViewToolbar {...props}>
-        <div className="form-group">
-          <OverlayTrigger overlay={getImportTooltip()} placement="top">
-            <ButtonLink
-              data-testid={'extension-list-view-import-button'}
-              href={props.linkImportExtension}
-              as={'primary'}
-            >
-              {props.i18nLinkImportExtension}
-            </ButtonLink>
-          </OverlayTrigger>
+        <div className={'form-group'}>
+          <ButtonLink data-testid={'extension-list-view-import-button'}
+                      href={props.linkImportExtension}
+                      as={'primary'}>
+            {props.i18nLinkImportExtension}
+          </ButtonLink>
         </div>
       </ListViewToolbar>
-      {props.i18nTitle !== '' && <Title size="lg">{props.i18nTitle}</Title>}
+      {props.i18nTitle !== '' && <Title size={'lg'}>{props.i18nTitle}</Title>}
       {props.i18nDescription !== '' && (
         <Text dangerouslySetInnerHTML={{ __html: props.i18nDescription }} />
       )}
       {props.children ? (
-        <ListView>{props.children}</ListView>
+        <DataList aria-label={'extension list'}>{props.children}</DataList>
       ) : (
-        <EmptyState>
-          <EmptyState.Icon />
-          <EmptyState.Title>{props.i18nEmptyStateTitle}</EmptyState.Title>
-          <EmptyState.Info>{props.i18nEmptyStateInfo}</EmptyState.Info>
-          <EmptyState.Action>
-            <OverlayTrigger overlay={getImportTooltip()} placement="top">
-              <ButtonLink
-                data-testid={'extension-list-view-empty-state-import-button'}
-                href={props.linkImportExtension}
-                as={'primary'}
-              >
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={AddCircleOIcon}/>
+          <Title headingLevel={'h5'} size={'lg'}>
+            {props.i18nEmptyStateTitle}
+          </Title>
+          <EmptyStateBody>{props.i18nEmptyStateInfo}</EmptyStateBody>
+          <Tooltip
+            position={'top'}
+            content={
+              props.i18nLinkImportExtensionTip
+                ? props.i18nLinkImportExtensionTip
+                : props.i18nLinkImportExtension
+            }
+            enableFlip={true}
+          >
+            <>
+              <br/>
+              <ButtonLink data-testid={'extension-list-view-empty-state-import-button'}
+                          href={props.linkImportExtension}
+                          as={'primary'}>
                 {props.i18nLinkImportExtension}
               </ButtonLink>
-            </OverlayTrigger>
-          </EmptyState.Action>
+            </>
+          </Tooltip>
         </EmptyState>
       )}
     </PageSection>

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
@@ -26,48 +26,58 @@ export interface IExtensionListViewProps extends IListViewToolbarProps {
   linkImportExtension: H.LocationDescriptor;
 }
 
-export const ExtensionListView: React.FunctionComponent<
-  IExtensionListViewProps
-> = props => {
+export const ExtensionListView: React.FunctionComponent<IExtensionListViewProps> = (
+  {
+    children,
+    i18nDescription,
+    i18nEmptyStateInfo,
+    i18nEmptyStateTitle,
+    i18nLinkImportExtension,
+    i18nLinkImportExtensionTip,
+    i18nTitle,
+    linkImportExtension,
+    ...rest
+  }
+) => {
   return (
     <PageSection>
-      <ListViewToolbar {...props}>
+      <ListViewToolbar {...rest}>
         <div className={'form-group'}>
           <ButtonLink data-testid={'extension-list-view-import-button'}
-                      href={props.linkImportExtension}
+                      href={linkImportExtension}
                       as={'primary'}>
-            {props.i18nLinkImportExtension}
+            {i18nLinkImportExtension}
           </ButtonLink>
         </div>
       </ListViewToolbar>
-      {props.i18nTitle !== '' && <Title size={'lg'}>{props.i18nTitle}</Title>}
-      {props.i18nDescription !== '' && (
-        <Text dangerouslySetInnerHTML={{ __html: props.i18nDescription }} />
+      {i18nTitle !== '' && <Title size={'lg'}>{i18nTitle}</Title>}
+      {i18nDescription !== '' && (
+        <Text dangerouslySetInnerHTML={{ __html: i18nDescription }}/>
       )}
-      {props.children ? (
-        <DataList aria-label={'extension list'}>{props.children}</DataList>
+      {children ? (
+        <DataList aria-label={'extension list'}>{children}</DataList>
       ) : (
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={AddCircleOIcon}/>
           <Title headingLevel={'h5'} size={'lg'}>
-            {props.i18nEmptyStateTitle}
+            {i18nEmptyStateTitle}
           </Title>
-          <EmptyStateBody>{props.i18nEmptyStateInfo}</EmptyStateBody>
+          <EmptyStateBody>{i18nEmptyStateInfo}</EmptyStateBody>
           <Tooltip
             position={'top'}
             content={
-              props.i18nLinkImportExtensionTip
-                ? props.i18nLinkImportExtensionTip
-                : props.i18nLinkImportExtension
+              i18nLinkImportExtensionTip
+                ? i18nLinkImportExtensionTip
+                : i18nLinkImportExtension
             }
             enableFlip={true}
           >
             <>
               <br/>
               <ButtonLink data-testid={'extension-list-view-empty-state-import-button'}
-                          href={props.linkImportExtension}
+                          href={linkImportExtension}
                           as={'primary'}>
-                {props.i18nLinkImportExtension}
+                {i18nLinkImportExtension}
               </ButtonLink>
             </>
           </Tooltip>

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionListView.tsx
@@ -34,6 +34,8 @@ export const ExtensionListView: React.FunctionComponent<IExtensionListViewProps>
     i18nEmptyStateTitle,
     i18nLinkImportExtension,
     i18nLinkImportExtensionTip,
+    i18nName,
+    i18nNameFilterPlaceholder,
     i18nTitle,
     linkImportExtension,
     ...rest


### PR DESCRIPTION
Drops patternfly-react support from ExtensionListView + ExtensionListItem in favor of @patternfly/react-core. Other components from Extensions are missing, but coming up in a separate PR to keep reviewing easier.

EPIC: https://issues.redhat.com/browse/ENTESB-12896

<img width="1384" alt="Screenshot 2020-02-18 11 43 18" src="https://user-images.githubusercontent.com/3844502/74734729-0c418e80-5247-11ea-996e-44f4c0eac0f6.png">

<img width="1377" alt="Screenshot 2020-02-18 11 43 25" src="https://user-images.githubusercontent.com/3844502/74734732-0ea3e880-5247-11ea-8298-4804602fdd15.png">
