### PR TITLE
chore: bump yarn and add terser workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,8 +672,6 @@ workflows:
           <<: *ignore_cherry_pick_branches
       - ui:
           <<: *ignore_cherry_pick_branches
-          requires:
-            - dv
       - common:
           <<: *ignore_cherry_pick_branches
       - operator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,10 +670,10 @@ workflows:
               only: master
       - license-check:
           <<: *ignore_cherry_pick_branches
-      - ui-doc:
-          <<: *ignore_cherry_pick_branches
       - ui:
           <<: *ignore_cherry_pick_branches
+          requires:
+            - dv
       - common:
           <<: *ignore_cherry_pick_branches
       - operator:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -54,7 +54,7 @@
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.9.1</frontend-maven-plugin-version>
     <node.version>v10.15.1</node.version>
-    <yarn.version>v1.13.0</yarn.version>
+    <yarn.version>v1.22.0</yarn.version>
 
     <hibernate.validator.version>6.1.0.Final</hibernate.validator.version>
 

--- a/app/ui-react/package.json
+++ b/app/ui-react/package.json
@@ -70,8 +70,5 @@
     "singleQuote": true,
     "semi": true
   },
-  "dependencies": {},
-  "resolutions": {
-    "terser": "4.6.3"
-  }
+  "dependencies": {}
 }

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -87,6 +87,18 @@
           </execution>
 
           <execution>
+            <id>yarn-list</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>list</arguments>
+              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
+            </configuration>
+          </execution>
+
+          <execution>
             <id>yarn-lint</id>
             <phase>verify</phase>
             <goals>

--- a/app/ui-react/syndesis/craco.config.js
+++ b/app/ui-react/syndesis/craco.config.js
@@ -1,20 +1,20 @@
+const TerserPlugin = require('terser-webpack-plugin');
+
 module.exports = function({ env, paths }) {
   return {
-    // disable the custom loading of sourcemaps, it's too slow
-    /*
     webpack: {
-      configure: (webpackConfig, { env, paths }) => {
-        webpackConfig.module.rules[2].oneOf = webpackConfig.module.rules[2].oneOf.map(
-          r => {
-            if (r.loader && r.loader.indexOf('babel-loader') >= 0) {
-              r.options.sourceMaps = true;
-            }
-            return r;
-          }
-        );
-        return webpackConfig;
-      },
+      configure: (webpackConfig, { env, paths }) => ({
+        ...webpackConfig,
+
+        optimization: {
+          ...webpackConfig.optimization,
+          minimizer: [
+            new TerserPlugin({
+              parallel: 2,
+            }),
+          ],
+        },
+      }),
     },
-    */
   };
 };

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -22017,7 +22017,7 @@ source-map-support@^0.4.15, source-map-support@~0.4.0:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
@@ -23000,7 +23000,16 @@ terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@4.6.3, terser@^3.16.1, terser@^3.8.2, terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
+terser@^3.16.1, terser@^3.8.2:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
+  integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
+  dependencies:
+    commander "^2.19.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.10"
+
+terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.3.tgz#e33aa42461ced5238d352d2df2a67f21921f8d87"
   integrity sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==


### PR DESCRIPTION
Bumps yarn to the latest 1.x (1.22.0)

Also adds a workaround for https://github.com/facebook/create-react-app/issues/8320 to hopefully sort the terser error on CI.

Also skips the ui-doc job for now as it performs a second UI build but we don't currently do anything with the output.