### PR TITLE
chore: extensions list migration part II

### DIFF
--- a/app/ui-react/packages/ui/__tests__/Customization/ExtensionDetail.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ExtensionDetail.spec.tsx
@@ -62,7 +62,7 @@ export default describe('ExtensionDetail', () => {
       </Router>
     );
 
-    const { getByText, queryAllByText } = render(comp);
+    const { queryAllByText } = render(comp);
 
     // extension name
     expect(queryAllByText(name)).toHaveLength(1);
@@ -75,8 +75,6 @@ export default describe('ExtensionDetail', () => {
 
     // delete button
     expect(queryAllByText(deleteLabel)).toHaveLength(1);
-    const deleteButton = getByText(deleteLabel);
-    expect(deleteButton).toHaveAttribute('disabled'); // delete should be disabled
 
     // overview section title
     expect(queryAllByText(overviewLabel)).toHaveLength(1);
@@ -100,7 +98,6 @@ export default describe('ExtensionDetail', () => {
 
     const { getAllByRole, getByText } = render(comp);
     const deleteButton = getByText(deleteLabel);
-    expect(deleteButton).not.toHaveAttribute('disabled'); // delete should be enabled
 
     // click the delete button so that the delete confirmation dialog opens
     fireEvent.click(deleteButton);
@@ -120,7 +117,6 @@ export default describe('ExtensionDetail', () => {
     );
     const { getAllByRole, getByText, queryByRole } = render(comp);
     const deleteButton = getByText(deleteLabel);
-    expect(deleteButton).not.toHaveAttribute('disabled'); // delete should be enabled
 
     // click the delete button so that the delete confirmation dialog opens
     fireEvent.click(deleteButton);

--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -49,7 +49,7 @@
     "react": "^16.6.0",
     "react-content-loader": "^4.0.1",
     "react-docgen-typescript-loader": "^3.1.0",
-    "react-dom": "^16.6.0",
+    "react-dom": "16.9.0",
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "rimraf": "^3.0.2",
@@ -82,7 +82,7 @@
     "patternfly-react": "^2.34.3",
     "react": "^16.6.0",
     "react-content-loader": "^3.2.0",
-    "react-dom": "^16.6.0",
+    "react-dom": "16.9.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
   },

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.css
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.css
@@ -11,6 +11,6 @@
   display: inline-block;
 }
 
-.extension-detail__titleButtons .btn + button {
-  margin-left: 4px;
+.extension-detail__titleButtons button {
+  margin-left: 5px;
 }

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Card,
   CardBody,
   Level,
@@ -8,13 +9,9 @@ import {
   TextContent,
   Title,
   TitleLevel,
+  Tooltip,
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import {
-  Button,
-  OverlayTrigger,
-  Tooltip,
-} from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink, Container } from '../../Layout';
 import {
@@ -132,22 +129,6 @@ export const ExtensionDetail: React.FunctionComponent<
     props.onDelete();
   };
 
-  const getDeleteTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="deleteTip">
-        {props.i18nDeleteTip ? props.i18nDeleteTip : props.i18nDelete}
-      </Tooltip>
-    );
-  };
-
-  const getUpdateTooltip = (): JSX.Element => {
-    return (
-      <Tooltip id="updateTip">
-        {props.i18nUpdateTip ? props.i18nUpdateTip : props.i18nUpdate}
-      </Tooltip>
-    );
-  };
-
   const showConfirmationDialog = () => {
     setShowDeleteDialog(true);
   };
@@ -169,35 +150,47 @@ export const ExtensionDetail: React.FunctionComponent<
         <Level gutter={'sm'}>
           <TextContent>
             <Title
-              size="xl"
+              size={'xl'}
               headingLevel={TitleLevel.h1}
-              className="extension-detail__extensionTitle"
+              className={'extension-detail__extensionTitle'}
             >
               {props.extensionName}
             </Title>
-            <Text className="extension-detail__extensionId">
+            <Text className={'extension-detail__extensionId'}>
               {props.i18nIdMessage}
             </Text>
           </TextContent>
-          <LevelItem className="extension-detail__titleButtons">
-            <OverlayTrigger overlay={getUpdateTooltip()} placement="top">
-              <ButtonLink
-                data-testid={'extension-detail-update-button'}
-                href={props.linkUpdateExtension}
-                as={'primary'}
-              >
+          <LevelItem className={'extension-detail__titleButtons'}>
+            <Tooltip
+              id={'updateTip'}
+              position={'top'}
+              content={
+                props.i18nUpdateTip ? props.i18nUpdateTip : props.i18nUpdate
+              }
+              enableFlip={true}
+            >
+              <ButtonLink data-testid={'extension-detail-update-button'}
+                          href={props.linkUpdateExtension}
+                          as={'primary'}>
                 {props.i18nUpdate}
               </ButtonLink>
-            </OverlayTrigger>
-            <OverlayTrigger overlay={getDeleteTooltip()} placement="top">
+            </Tooltip>
+            <Tooltip
+              id={'deleteTip'}
+              position={'top'}
+              content={
+                props.i18nDeleteTip ? props.i18nDeleteTip : props.i18nDelete
+              }
+              enableFlip={true}
+            >
               <Button
-                bsStyle="default"
+                variant={'tertiary'}
                 disabled={props.extensionUses !== 0}
                 onClick={showConfirmationDialog}
               >
                 {props.i18nDelete}
               </Button>
-            </OverlayTrigger>
+            </Tooltip>
           </LevelItem>
         </Level>
       </PageSection>
@@ -206,27 +199,27 @@ export const ExtensionDetail: React.FunctionComponent<
           <CardBody>
             <TextContent>
               <Title
-                headingLevel="h5"
-                size="md"
-                className="customization-details__heading"
+                headingLevel={'h5'}
+                size={'md'}
+                className={'customization-details__heading'}
               >
                 {props.i18nOverviewSectionTitle}
               </Title>
               <Container>{props.overviewSection}</Container>
 
               <Title
-                headingLevel="h5"
-                size="md"
-                className="customization-details__heading"
+                headingLevel={'h5'}
+                size={'md'}
+                className={'customization-details__heading'}
               >
                 {props.i18nSupportsSectionTitle}
               </Title>
               <Container>{props.supportsSection}</Container>
 
               <Title
-                headingLevel="h5"
-                size="md"
-                className="customization-details__heading"
+                headingLevel={'h5'}
+                size={'md'}
+                className={'customization-details__heading'}
               >
                 {props.i18nUsageSectionTitle}
               </Title>

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionDetail.tsx
@@ -16,8 +16,7 @@ import {
   Tooltip,
 } from 'patternfly-react';
 import * as React from 'react';
-import { ButtonLink } from '../../Layout';
-import { Container } from '../../Layout/Container';
+import { ButtonLink, Container } from '../../Layout';
 import {
   ConfirmationButtonStyle,
   ConfirmationDialog,

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportCard.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportCard.tsx
@@ -1,7 +1,6 @@
-import { Card, CardBody } from '@patternfly/react-core';
-import { Alert } from 'patternfly-react';
+import { Alert, Card, CardBody } from '@patternfly/react-core';
 import * as React from 'react';
-import { DndFileChooser } from '../../Shared/DndFileChooser';
+import { DndFileChooser } from '../../Shared';
 
 export interface IExtensionImportCardProps {
   /**
@@ -68,9 +67,7 @@ export const ExtensionImportCard: React.FunctionComponent<
     <Card>
       <CardBody>
         {props.i18nAlertMessage ? (
-          <Alert type={'error'}>
-            <span>{props.i18nAlertMessage}</span>
-          </Alert>
+          <Alert variant={'danger'} title={props.i18nAlertMessage} />
         ) : null}
         <DndFileChooser
           disableDropzone={props.dndDisabled}

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
@@ -1,6 +1,8 @@
 import {
+  Button,
   Card,
   CardBody,
+  GridItem,
   Stack,
   TextContent,
   TextList,
@@ -10,7 +12,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Button, Grid } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../../Layout';
 import './ExtensionImportReview.css';
@@ -118,12 +119,12 @@ export const ExtensionImportReview: React.FunctionComponent<
 > = props => {
   const getActions = (): JSX.Element => {
     if (!props.actions) {
-      return <Grid.Col />;
+      return <GridItem />;
     }
 
     return (
       <TextContent>
-        <TextList className="extension-import-review__actions-list">
+        <TextList className={'extension-import-review__actions-list'}>
           {props.actions
             ? props.actions.map((action, index) => (
                 <TextListItem
@@ -147,13 +148,13 @@ export const ExtensionImportReview: React.FunctionComponent<
   };
 
   return (
-    <Card className="extension-import-review">
+    <Card className={'extension-import-review'}>
       <CardBody>
-        <Stack gutter="md">
+        <Stack gutter={'md'}>
           <Title
-            headingLevel="h1"
-            size="xl"
-            className="extension-import-review__title"
+            headingLevel={'h1'}
+            size={'xl'}
+            className={'extension-import-review__title'}
           >
             {props.i18nTitle}
           </Title>
@@ -161,55 +162,55 @@ export const ExtensionImportReview: React.FunctionComponent<
             <TextList component={TextListVariants.dl}>
               <TextListItem
                 component={TextListItemVariants.dt}
-                className="extension-import-review__propertyLabel"
+                className={'extension-import-review__propertyLabel'}
               >
                 {props.i18nIdLabel}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dd}
-                className="extension-import-review__propertyValue"
+                className={'extension-import-review__propertyValue'}
               >
                 {props.extensionId}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dt}
-                className="extension-import-review__propertyLabel"
+                className={'extension-import-review__propertyLabel'}
               >
                 {props.i18nNameLabel}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dd}
-                className="extension-import-review__propertyValue"
+                className={'extension-import-review__propertyValue'}
               >
                 {props.extensionName}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dt}
-                className="extension-import-review__propertyLabel"
+                className={'extension-import-review__propertyLabel'}
               >
                 {props.i18nDescriptionLabel}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dd}
-                className="extension-import-review__propertyValue"
+                className={'extension-import-review__propertyValue'}
               >
                 {props.extensionDescription ? props.extensionDescription : null}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dt}
-                className="extension-import-review__propertyLabel"
+                className={'extension-import-review__propertyLabel'}
               >
                 {props.i18nTypeLabel}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dd}
-                className="extension-import-review__propertyValue"
+                className={'extension-import-review__propertyValue'}
               >
                 {props.i18nExtensionTypeMessage}
               </TextListItem>
               <TextListItem
                 component={TextListItemVariants.dt}
-                className="extension-import-review__propertyLabel"
+                className={'extension-import-review__propertyLabel'}
               >
                 {props.i18nActionsLabel}
               </TextListItem>
@@ -218,13 +219,13 @@ export const ExtensionImportReview: React.FunctionComponent<
               </TextListItem>
             </TextList>
           </TextContent>
-          <div className="extension-import-review__buttonBar">
-            <Button bsStyle="primary" onClick={handleImport}>
+          <div className={'extension-import-review__buttonBar'}>
+            <Button variant={'primary'} onClick={handleImport}>
               {props.i18nImport}
             </Button>
             <ButtonLink
               data-testid={'extension-import-review-cancel-button'}
-              className="extension-import-review__cancelButton"
+              className={'extension-import-review__cancelButton'}
               href={props.cancelLink}
               as={'default'}
             >

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -19709,6 +19709,16 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
+react-dom@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.15.0"
+
 react-dom@^16.6.0, react-dom@^16.8.3:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -21365,6 +21375,14 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ENTESB-12896

This PR includes dropping `patternfly-react` (PF3) and adding support for PF4 for the following components:
- `ExtensionDetail`
- `ExtensionImportCard`
- `ExtensionImportReview`

Apologies in advance for some of the formatting changes, especially in `ExtensionImportReview`. 😅 

---

`ExtensionDetail`:

<img width="1382" alt="Screenshot 2020-02-19 13 54 05" src="https://user-images.githubusercontent.com/3844502/74843750-4896ec80-5324-11ea-81fc-27db2f622640.png">

Alert for `ExtensionImportCard`:

<img width="1373" alt="Screenshot 2020-02-19 14 11 55" src="https://user-images.githubusercontent.com/3844502/74843756-4d5ba080-5324-11ea-928a-49f5b6e54b7a.png">

`ExtensionImportReview`:

<img width="1370" alt="Screenshot 2020-02-19 14 17 01" src="https://user-images.githubusercontent.com/3844502/74843771-5187be00-5324-11ea-8839-f50115adc09b.png">

Tested with an extension that has no 'Actions' (e.g. Delay):

<img width="1358" alt="Screenshot 2020-02-19 14 19 23" src="https://user-images.githubusercontent.com/3844502/74843784-551b4500-5324-11ea-820f-9b341e406dab.png">

