### PR TITLE
chore: migrate some labels, revisit some label colors, migrate detail header dropdown

### DIFF
--- a/app/ui-react/packages/history/.size-snapshot.json
+++ b/app/ui-react/packages/history/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/history.js": {
     "bundled": 28557,
-    "minified": 12568,
-    "gzipped": 3668,
+    "minified": 12544,
+    "gzipped": 3664,
     "treeshaked": {
       "rollup": {
         "code": 208,
@@ -15,13 +15,13 @@
   },
   "umd/history.js": {
     "bundled": 33491,
-    "minified": 12132,
-    "gzipped": 4083
+    "minified": 12084,
+    "gzipped": 3983
   },
   "umd/history.min.js": {
     "bundled": 30854,
-    "minified": 10185,
-    "gzipped": 3469
+    "minified": 10134,
+    "gzipped": 3566
   },
   "esm/@syndesis/history.js": {
     "bundled": 28122,

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -51,11 +51,6 @@ export interface IConnectionProps {
   techPreviewPopoverHtml?: React.ReactNode;
 }
 
-export interface IConnectionCardState {
-  isMenuOpen: boolean;
-  showDeleteDialog: boolean;
-}
-
 export const ConnectionCard: React.FunctionComponent<IConnectionProps> = ({
   description,
   href,

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailBreadcrumb.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailBreadcrumb.tsx
@@ -1,10 +1,14 @@
+import {
+  Dropdown,
+  DropdownPosition,
+  KebabToggle,
+} from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { DropdownKebab } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { toValidHtmlId } from '../../helpers';
 import { Breadcrumb, ButtonLink } from '../../Layout';
-import { IMenuActions } from '../../Shared';
+import { IMenuActions, PfDropdownItem } from '../../Shared';
 import './IntegrationDetailBreadcrumb.css';
 
 export interface IIntegrationDetailBreadcrumbProps {
@@ -17,89 +21,112 @@ export interface IIntegrationDetailBreadcrumbProps {
   i18nHome?: string;
   i18nIntegrations?: string;
   i18nPageTitle?: string;
-  integrationId?: string;
   integrationsHref?: H.LocationDescriptor;
   menuActions?: IMenuActions[];
 }
 
-export class IntegrationDetailBreadcrumb extends React.Component<
-  IIntegrationDetailBreadcrumbProps
-> {
-  public render() {
-    return (
-      <Breadcrumb
-        actions={
-          <>
-            <ButtonLink
-              data-testid={'integration-detail-breadcrumb-export-button'}
-              to={this.props.exportHref}
-              onClick={this.props.exportAction}
-              children={this.props.exportLabel}
+export const IntegrationDetailBreadcrumb: React.FunctionComponent<IIntegrationDetailBreadcrumbProps> = ({
+  editHref,
+  editLabel,
+  exportAction,
+  exportHref,
+  exportLabel,
+  homeHref,
+  i18nHome,
+  i18nIntegrations,
+  i18nPageTitle,
+  integrationsHref,
+  menuActions,
+}) => {
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  return (
+    <Breadcrumb
+      actions={
+        <>
+          <ButtonLink
+            data-testid={'integration-detail-breadcrumb-export-button'}
+            to={exportHref}
+            onClick={exportAction}
+            children={exportLabel}
+          />
+          &nbsp;&nbsp;
+          <ButtonLink
+            data-testid={'integration-detail-breadcrumb-edit-button'}
+            as={'primary'}
+            href={editHref}
+            children={editLabel}
+          />
+          {menuActions && (
+            <Dropdown
+              data-testid={'integration-detail-breadcrumb-dropdown'}
+              toggle={
+                <KebabToggle
+                  data-testid={'integration-detail-breadcrumb-kebab-toggle'}
+                  onToggle={setIsMenuOpen}
+                />
+              }
+              isOpen={isMenuOpen}
+              isPlain={true}
+              position={DropdownPosition.right}
+              dropdownItems={menuActions!.map((menuAction, index) => (
+                <PfDropdownItem
+                  key={`dropdown-item-${index}`}
+                  onClick={event => {
+                    setIsMenuOpen(false);
+                    if (menuAction && menuAction.onClick) {
+                      menuAction.onClick(event as any);
+                    }
+                  }}
+                >
+                  {menuAction.href ? (
+                    <Link
+                      data-testid={`integration-detail-breadcrumb-${toValidHtmlId(
+                        menuAction.label.toString()
+                      )}`}
+                      className="pf-c-dropdown__menu-item"
+                      to={menuAction.href}
+                      role={'menuitem'}
+                      tabIndex={index + 1}
+                    >
+                      {menuAction.label}
+                    </Link>
+                  ) : (
+                    <a
+                      data-testid={`integration-detail-breadcrumb-${toValidHtmlId(
+                        menuAction.label.toString()
+                      )}`}
+                      className="pf-c-dropdown__menu-item"
+                      href={'javascript:void(0)'}
+                      role={'menuitem'}
+                      tabIndex={index + 1}
+                    >
+                      {menuAction.label}
+                    </a>
+                  )}
+                </PfDropdownItem>
+              ))}
             />
-            &nbsp;&nbsp;
-            <ButtonLink
-              data-testid={'integration-detail-breadcrumb-edit-button'}
-              className="btn btn-primary"
-              href={this.props.editHref}
-              children={this.props.editLabel}
-            />
-            <DropdownKebab
-              id={`integration-${this.props.integrationId}-action-menu`}
-              pullRight={true}
-            >
-              {this.props.menuActions
-                ? this.props.menuActions.map((a, idx) => (
-                    <li role={'presentation'} key={idx}>
-                      {a.href ? (
-                        <Link
-                          data-testid={`integration-detail-breadcrumb-${toValidHtmlId(
-                            a.label.toString()
-                          )}`}
-                          to={a.href}
-                          onClick={a.onClick}
-                          role={'menuitem'}
-                          tabIndex={idx + 1}
-                        >
-                          {a.label}
-                        </Link>
-                      ) : (
-                        <a
-                          data-testid={`integration-detail-breadcrumb-${toValidHtmlId(
-                            a.label.toString()
-                          )}`}
-                          href={'javascript:void(0)'}
-                          onClick={a.onClick}
-                          role={'menuitem'}
-                          tabIndex={idx + 1}
-                        >
-                          {a.label}
-                        </a>
-                      )}
-                    </li>
-                  ))
-                : null}
-            </DropdownKebab>
-          </>
-        }
-      >
-        <span>
-          <Link
-            data-testid={'integration-detail-breadcrumb-home-link'}
-            to={this.props.homeHref!}
-          >
-            {this.props.i18nHome}
-          </Link>
-        </span>
-        <span>
-          <Link
-            data-testid={'integration-detail-breadcrumb-integrations-link'}
-            to={this.props.integrationsHref!}
-          >
-            {this.props.i18nIntegrations}
-          </Link>
-        </span>
-        <span>{this.props.i18nPageTitle}</span>
-      </Breadcrumb>
-    );
-  }
-}
+          )}
+        </>
+      }
+    >
+      <span>
+        <Link
+          data-testid={'integration-detail-breadcrumb-home-link'}
+          to={homeHref!}
+        >
+          {i18nHome}
+        </Link>
+      </span>
+      <span>
+        <Link
+          data-testid={'integration-detail-breadcrumb-integrations-link'}
+          to={integrationsHref!}
+        >
+          {i18nIntegrations}
+        </Link>
+      </span>
+      <span>{i18nPageTitle}</span>
+    </Breadcrumb>
+  );
+};

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
@@ -1,4 +1,5 @@
-import { Label } from 'patternfly-react';
+import { Label } from '@patternfly/react-core';
+import { global_default_color_100 } from '@patternfly/react-tokens';
 import * as React from 'react';
 import { IntegrationStatusDetail } from '../IntegrationStatusDetail';
 import { IntegrationState } from '../models';
@@ -46,7 +47,11 @@ export class IntegrationDetailInfo extends React.PureComponent<
               Published version {this.props.version}
             </div>
           )}
-          {this.props.currentState === 'Unpublished' && <Label>Stopped</Label>}
+          {this.props.currentState === 'Unpublished' && (
+            <Label style={{ background: global_default_color_100.value }}>
+              Stopped
+            </Label>
+          )}
         </>
       </div>
     );

--- a/app/ui-react/packages/ui/src/Integration/IntegrationStatus.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationStatus.tsx
@@ -1,4 +1,5 @@
 import { Label } from '@patternfly/react-core';
+import { global_active_color_100, global_danger_color_100, global_default_color_100 } from '@patternfly/react-tokens';
 import classnames from 'classnames';
 import * as React from 'react';
 import {
@@ -29,20 +30,24 @@ export class IntegrationStatus extends React.Component<
         ? 'primary'
         : 'default';
     let label = PENDING; // it's a parachute
+    let style:any = { background: global_default_color_100.value };
     switch (this.props.currentState) {
       case PUBLISHED:
         label = this.props.i18nPublished;
+        style = { background: global_active_color_100.value };
         break;
       case UNPUBLISHED:
         label = this.props.i18nUnpublished;
         break;
       case ERROR:
         label = this.props.i18nError;
+        style = { background: global_danger_color_100 };
         break;
     }
     return (
       <Label
         data-testid={'integration-status-status-label'}
+        style={style}
         className={classnames('', labelType, this.props.className)}
       >
         {label}

--- a/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
@@ -1,6 +1,7 @@
 import {
   Card,
   CardBody,
+  Label,
   Text,
   TextContent,
   TextList,
@@ -10,7 +11,10 @@ import {
   TextVariants,
   Title,
 } from '@patternfly/react-core';
-import { Label } from 'patternfly-react';
+import {
+  global_danger_color_100,
+  global_warning_color_100,
+} from '@patternfly/react-tokens';
 import * as React from 'react';
 import { Container } from '../Layout';
 
@@ -109,7 +113,10 @@ export class OpenApiReviewActions extends React.Component<
                   className={'review-actions__heading'}
                 >
                   {this.props.i18nErrorsHeading}
-                  <Label bsStyle={'danger'} className={'heading__label'}>
+                  <Label
+                    style={{ background: global_danger_color_100.value }}
+                    className={'heading__label'}
+                  >
                     {this.props.errorMessages.length}
                   </Label>
                 </Title>
@@ -134,7 +141,10 @@ export class OpenApiReviewActions extends React.Component<
                   className={'review-actions__heading'}
                 >
                   {this.props.i18nWarningsHeading}
-                  <Label bsStyle={'warning'} className={'heading__label'}>
+                  <Label
+                    style={{ background: global_warning_color_100.value }}
+                    className={'heading__label'}
+                  >
                     {this.props.warningMessages.length}
                   </Label>
                 </Title>

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailHeader.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailHeader.tsx
@@ -105,7 +105,6 @@ export const IntegrationDetailHeader: React.FunctionComponent<
               i18nHome={t('shared:Home')}
               i18nIntegrations={t('shared:Integrations')}
               i18nPageTitle={t('integrations:detail:pageTitle')}
-              integrationId={props.data.integration.id}
               integrationsHref={resolvers.integrations.list()}
               menuActions={breadcrumbMenuActions}
             />


### PR DESCRIPTION
relates to [ENTESB-12896](https://issues.redhat.com/browse/ENTESB-12896)

Using the "default" color for stopped, "primary" for running and "danger" for error so at least there's different colors again:

![image](https://user-images.githubusercontent.com/351660/74866666-3c5d6000-5321-11ea-9c48-8106c1269785.png)

Also fixed up the edit button in the detail header:

![image](https://user-images.githubusercontent.com/351660/74866730-526b2080-5321-11ea-812e-3f68cdc101e4.png)
