### PR TITLE
chore: drop pf-react support for extension integrations table

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
@@ -1,8 +1,9 @@
 import { Flex, FlexItem, Text } from '@patternfly/react-core';
 import {
   Table,
+  TableBody,
   TableHeader,
-  TableBody
+  TableVariant
 } from '@patternfly/react-table';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
@@ -102,6 +103,7 @@ export const ExtensionIntegrationsTable: React.FunctionComponent<
           aria-label={'extension-integrations-table'}
           cells={columns}
           rows={rows()}
+          variant={TableVariant.compact}
         >
           <TableHeader />
           <TableBody />

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
@@ -78,7 +78,7 @@ export const ExtensionIntegrationsTable: React.FunctionComponent<
   };
 
   return (
-    <div className="extension-group">
+    <div className={'extension-group'}>
       <Text>{props.i18nUsageMessage}</Text>
       {props.data.length !== 0 ? (
         <Table.PfProvider

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionIntegrationsTable.tsx
@@ -1,10 +1,17 @@
-import { Text } from '@patternfly/react-core';
-import { Table } from 'patternfly-react';
+import { Flex, FlexItem, Text } from '@patternfly/react-core';
+import {
+  Table,
+  TableHeader,
+  TableBody
+} from '@patternfly/react-table';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 
 export interface IExtensionIntegration {
-  id: string; // used to create link to integration details page
+  /**
+   * ID param is used to create link to Integration Details page
+   */
+  id: string;
   name: string;
   description: string;
 }
@@ -17,79 +24,88 @@ export interface IExtensionIntegrationsTableProps {
   data: IExtensionIntegration[];
 }
 
+/**
+ * Extension Integrations Table
+ * You can view see this component in the Extension detail page
+ * when an extension has been used at least once in an existing integration.
+ * @param props
+ * @constructor
+ */
 export const ExtensionIntegrationsTable: React.FunctionComponent<
   IExtensionIntegrationsTableProps
-> = props => {
-  const getColumns = () => {
-    const headerFormat = (value: string) => (
-      <Table.Heading>{value}</Table.Heading>
-    );
+  > = props => {
 
-    const clickableValueFormat = (
-      value: string,
-      { rowData }: { rowData: any }
-    ) => {
-      // rowData is an Integration type so 'name' property is what makes the integration unique
-      const onClick = () => onIntegrationSelected(rowData.id);
-      return (
-        <Table.Cell>
-          <a
-            data-testid={`extension-integrations-table-${toValidHtmlId(
-              rowData.name
-            )}-integration-link`}
-            href="javascript:void(0)"
-            onClick={onClick}
-          >
-            {value}
-          </a>
-        </Table.Cell>
-      );
+  const rows = () => {
+    const onIntegrationSelected = (integrationId: string) => {
+      props.onSelectIntegration(integrationId);
     };
 
-    // Creates 2 columns:
-    // 1. first column is integration name
-    // 2. second column is optional integration description.
-    return [
-      {
-        cell: {
-          formatters: [clickableValueFormat],
-        },
-        header: {
-          formatters: [headerFormat],
-          label: props.i18nName,
-        },
-        property: 'name', // must match the name of the IntegrationOverview.name property
-      },
-      {
-        cell: {
-          formatters: [(value: string) => <Table.Cell>{value}</Table.Cell>],
-        },
-        header: {
-          formatters: [headerFormat],
-          label: props.i18nDescription,
-        },
-        property: 'description', // must match the name of the IntegrationOverview.description property
-      },
-    ];
+    const newRows = props.data.map((integration, integrationIndex) => {
+      /**
+       * Necessary to pass event due to the following issue:
+       * https://github.com/facebook/react/issues/16382#issuecomment-530911232
+       * @param e
+       */
+      const onClick = (e: any) => {
+        e.preventDefault();
+        onIntegrationSelected(integration.id);
+        return false;
+      };
+
+      return [
+        {
+          cells: [
+            {
+              title: (
+                <Flex>
+                  <FlexItem key={integrationIndex + '-name'}>
+                    <a
+                      data-testid={`extension-integrations-table-${toValidHtmlId(
+                        integration.name
+                      )}-integration-link`}
+                      href={'#'}
+                      onClick={onClick}
+                    >
+                      {integration.name}
+                    </a>
+                  </FlexItem>
+                </Flex>
+              )
+            },
+            {
+              title: (
+                <Flex>
+                  <FlexItem key={integrationIndex + '-description'}>
+                    <span>{integration.description}</span>
+                  </FlexItem>
+                </Flex>
+              )
+            }
+          ],
+        }
+      ];
+    });
+
+    return newRows.reduce((a, b) => a.concat(b), []);
   };
 
-  const onIntegrationSelected = (integrationId: string) => {
-    props.onSelectIntegration(integrationId);
-  };
+  const columns = [
+    props.i18nName,
+    props.i18nDescription
+  ];
 
   return (
     <div className={'extension-group'}>
       <Text>{props.i18nUsageMessage}</Text>
       {props.data.length !== 0 ? (
-        <Table.PfProvider
-          striped={true}
-          bordered={true}
-          hover={true}
-          columns={getColumns()}
+        <Table
+          aria-label={'extension-integrations-table'}
+          cells={columns}
+          rows={rows()}
         >
-          <Table.Header />
-          <Table.Body rows={props.data} rowKey="name" />
-        </Table.PfProvider>
+          <TableHeader />
+          <TableBody />
+        </Table>
       ) : null}
     </div>
   );

--- a/app/ui-react/packages/ui/stories/Customization/ApiConnectorListView.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/ApiConnectorListView.stories.tsx
@@ -130,7 +130,7 @@ stories
           currentValue={''}
           filterTypes={[]}
           isSortAscending={true}
-          linkCreateApiConnector={action('/customizations/create')}
+          linkCreateApiConnector={text('createUrl', '/customizations/create')}
           resultsCount={0}
           sortTypes={[]}
           onUpdateCurrentValue={action('onUpdateCurrentValue')}
@@ -181,7 +181,7 @@ stories
           currentValue={''}
           filterTypes={[]}
           isSortAscending={true}
-          linkCreateApiConnector={action('/customizations/create')}
+          linkCreateApiConnector={text('createUrl', '/customizations/create')}
           resultsCount={0}
           sortTypes={[]}
           onUpdateCurrentValue={action('onUpdateCurrentValue')}

--- a/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
@@ -12,7 +12,7 @@ const stories = storiesOf(
 const storyNotes = '- Verify that the used by message makes sense with the number provided.\n';
 
 interface IExtensionIntegration {
-  id: string; // used to create link to integration details page
+  id: string;
   name: string;
   description: string;
 }
@@ -45,14 +45,14 @@ const integrations: IExtensionIntegration[] = [
 
 const usedByMessage0 = 'Used by 0 integrations';
 const usedByMessage1 = 'Used by 1 integration';
-const usedByMessage2 = 'Used by 2 integrations';
+const usedByMessage3 = 'Used by ' + (integrations.length ? integrations.length : 2) + ' integrations';
 
 stories.add(
   '0 Integrations',
   () => (
     <ExtensionIntegrationsTable
-      i18nDescription={text('Description', undefined)}
-      i18nName={text('Name', undefined)}
+      i18nDescription={text('i18nDescription', 'Description')}
+      i18nName={text('i18nName', 'Name')}
       i18nUsageMessage={usedByMessage0}
       onSelectIntegration={action('select')}
       data={[]}
@@ -65,8 +65,8 @@ stories.add(
   '1 Integration',
   () => (
     <ExtensionIntegrationsTable
-      i18nDescription={text('Description', undefined)}
-      i18nName={text('Name', undefined)}
+      i18nDescription={text('i18nDescription', 'Description')}
+      i18nName={text('i18nName', 'Name')}
       i18nUsageMessage={usedByMessage1}
       onSelectIntegration={action('select')}
       data={integration}
@@ -76,12 +76,12 @@ stories.add(
 );
 
 stories.add(
-  '2 Integrations',
+  '3 Integrations',
   () => (
     <ExtensionIntegrationsTable
-      i18nDescription={text('Description', undefined)}
-      i18nName={text('Name', undefined)}
-      i18nUsageMessage={usedByMessage2}
+      i18nDescription={text('i18nDescription', 'Description')}
+      i18nName={text('i18nName', 'Name')}
+      i18nUsageMessage={usedByMessage3}
       onSelectIntegration={action('select')}
       data={integrations}
     />

--- a/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
@@ -1,0 +1,93 @@
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { ExtensionIntegrationsTable } from '../../src';
+
+const stories = storiesOf(
+  'Customization/Extensions/Component/ExtensionIntegrationsTable',
+  module
+);
+
+const storyNotes = '- Verify that the used by message makes sense with the number provided.\n';
+
+interface IExtensionIntegration {
+  id: string; // used to create link to integration details page
+  name: string;
+  description: string;
+}
+
+const integration: IExtensionIntegration[] = [
+  {
+    id: 'i-M0boaSYifqPRAYunW2wz',
+    name: 'OpenShift Log Integration',
+    description: 'This is an integration that uses the OpenShift connection.'
+  }
+];
+
+const integrations: IExtensionIntegration[] = [
+  {
+    id: 'i-M0boaSYifqPRAYunW2wz',
+    name: 'OpenShift Log Integration',
+    description: 'This is an integration that uses the OpenShift connection.'
+  },
+  {
+    id: 'i-Lty73VPnQFjzDoL_Hzlz',
+    name: 'FHIR Timer Integration',
+    description: 'A deeply nested FHIR integration.'
+  },
+  {
+    id: 'i-LwOwlxUU-y_8EuXFwsMz',
+    name: 'Webhook to PostgresDB',
+    description: 'This integration uses the Webhook and PostgresDB connections.'
+  }
+];
+
+const usedByMessage0 = 'Used by 0 integrations';
+const usedByMessage1 = 'Used by 1 integration';
+const usedByMessage2 = 'Used by 2 integrations';
+
+//onSelectIntegration: (integrationId: string) => void;
+
+stories.add(
+  '0 Integrations',
+  () => (
+    <ExtensionIntegrationsTable
+      i18nDescription={text('Description', undefined)}
+      i18nName={text('Name', undefined)}
+      i18nUsageMessage={usedByMessage0}
+      onSelectIntegration={action('select')}
+      data={[]}
+    />
+  ),
+  { notes: storyNotes }
+);
+
+stories.add(
+  '1 Integration',
+  () => (
+    <ExtensionIntegrationsTable
+      i18nDescription={text('Description', undefined)}
+      i18nName={text('Name', undefined)}
+      i18nUsageMessage={usedByMessage1}
+      onSelectIntegration={action('select')}
+      data={integration}
+    />
+  ),
+  { notes: storyNotes }
+);
+
+stories.add(
+  '2 Integrations',
+  () => (
+    <ExtensionIntegrationsTable
+      i18nDescription={text('Description', undefined)}
+      i18nName={text('Name', undefined)}
+      i18nUsageMessage={usedByMessage2}
+      onSelectIntegration={action('select')}
+      data={integrations}
+    />
+  ),
+  { notes: storyNotes }
+);
+

--- a/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/ExtensionIntegrationsTable.stories.tsx
@@ -47,8 +47,6 @@ const usedByMessage0 = 'Used by 0 integrations';
 const usedByMessage1 = 'Used by 1 integration';
 const usedByMessage2 = 'Used by 2 integrations';
 
-//onSelectIntegration: (integrationId: string) => void;
-
 stories.add(
   '0 Integrations',
   () => (


### PR DESCRIPTION
**Epic**: https://issues.redhat.com/browse/ENTESB-12896

- Add a story for `ExtensionIntegrationsTable` component
- Drop `patternfly-react` support, migrate to `@patternfly/react-core` and `@patternfly/react-table`
- Remove annoying warning of React not supporting JS links in the future

**NOTE**: It's not currently possible to view this table other than in Storybook, so that's what the screenshots will be of.

**Before**

<img width="965" alt="Screenshot 2020-02-21 14 38 05" src="https://user-images.githubusercontent.com/3844502/75056888-cb0fdf80-54cf-11ea-9107-051f787c064a.png">

**After**

<img width="1174" alt="Screenshot 2020-02-21 17 18 51" src="https://user-images.githubusercontent.com/3844502/75056847-b6cbe280-54cf-11ea-92a0-1d88c53caaf3.png">

Some commments:
- I couldn't find anything in PF4 that had striped rows as an option.
- I used the 'compact' variant to make it look more like the current table.
- Lastly, it also seems it's not possible to omit the header row in the table, so it's there now, but the previous version looked weird with an empty header imo anyway.