### PR TITLE
user doc: Add note that recommends specifying data type

### DIFF
--- a/doc/modules/connecting/p_adding-amq-connection-finish.adoc
+++ b/doc/modules/connecting/p_adding-amq-connection-finish.adoc
@@ -34,7 +34,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and 
+However, a structured data type is recommended. For example, if you want 
+to map the connection input/output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and 
 select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.

--- a/doc/modules/connecting/p_adding-amq-connection-middle.adoc
+++ b/doc/modules/connecting/p_adding-amq-connection-middle.adoc
@@ -68,7 +68,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input/output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-amq-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-amq-connection-start.adoc
@@ -47,7 +47,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-amqp-connection-middle.adoc
+++ b/doc/modules/connecting/p_adding-amqp-connection-middle.adoc
@@ -73,13 +73,16 @@ the basis of the content of the message body.
 
 . Click *Next* to specify the action's input and output type. 
 
-
 . In the *Select Type* field, if the data type does not need to be known, 
 accept *Type specification not required* 
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input/output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-amqp-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-amqp-connection-start.adoc
@@ -47,7 +47,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-dropbox-connection-finish.adoc
+++ b/doc/modules/connecting/p_adding-dropbox-connection-finish.adoc
@@ -39,7 +39,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-dropbox-connection-middle.adoc
+++ b/doc/modules/connecting/p_adding-dropbox-connection-middle.adoc
@@ -44,7 +44,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input/output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-dropbox-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-dropbox-connection-start.adoc
@@ -30,7 +30,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-ftp-finish-middle-connection.adoc
+++ b/doc/modules/connecting/p_adding-ftp-finish-middle-connection.adoc
@@ -70,7 +70,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-ftp-start-connection.adoc
+++ b/doc/modules/connecting/p_adding-ftp-start-connection.adoc
@@ -46,7 +46,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-http-connections.adoc
+++ b/doc/modules/connecting/p_adding-http-connections.adoc
@@ -58,7 +58,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input/output in a data mapper step then you must specify 
+the data type. The data mapper cannot dislay fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-irc-connection-receive.adoc
+++ b/doc/modules/connecting/p_adding-irc-connection-receive.adoc
@@ -35,7 +35,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-irc-connection-send.adoc
+++ b/doc/modules/connecting/p_adding-irc-connection-send.adoc
@@ -36,7 +36,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-kafka-connection-finish-middle.adoc
+++ b/doc/modules/connecting/p_adding-kafka-connection-finish-middle.adoc
@@ -32,7 +32,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-kafka-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-kafka-connection-start.adoc
@@ -35,7 +35,7 @@ However, a structured data type is recommended. For example, if you want
 to map the Kafka connection output to a subsequent step then you must 
 specify the data type. The data mapper does not recognize unstructured data. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-mongodb-connections-read.adoc
+++ b/doc/modules/connecting/p_adding-mongodb-connections-read.adoc
@@ -82,7 +82,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-mqtt-connection-finish-middle.adoc
+++ b/doc/modules/connecting/p_adding-mqtt-connection-finish-middle.adoc
@@ -32,7 +32,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-mqtt-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-mqtt-connection-start.adoc
@@ -31,7 +31,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-s3-connection-finish.adoc
+++ b/doc/modules/connecting/p_adding-s3-connection-finish.adoc
@@ -44,7 +44,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-s3-connection-middle.adoc
+++ b/doc/modules/connecting/p_adding-s3-connection-middle.adoc
@@ -45,7 +45,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_adding-s3-connection-start.adoc
+++ b/doc/modules/connecting/p_adding-s3-connection-start.adoc
@@ -53,7 +53,11 @@ accept *Type specification not required*
 and click *Next*. You do not need to follow the rest of these
 instructions. 
 +
-Otherwise, click in the *Select Type* field and select one of the following as the schema type:
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.
 The document's media type is `application/schema+json`. 

--- a/doc/modules/connecting/p_calling-a-knative-service-from-a-simple-integration.adoc
+++ b/doc/modules/connecting/p_calling-a-knative-service-from-a-simple-integration.adoc
@@ -47,7 +47,11 @@ or if the output from the previous integration step is the expected type,
 accept *Type specification not required* and click *Next*. 
 You do not need to follow this subset of instructions.
 +
-Otherwise, click in the *Select Type* field and select one of the following 
+A structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following 
 as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.

--- a/doc/modules/connecting/p_sending-messages-to-a-knative-channel.adoc
+++ b/doc/modules/connecting/p_sending-messages-to-a-knative-channel.adoc
@@ -46,7 +46,11 @@ or if the output from the previous integration step is the expected type,
 accept *Type specification not required* and click *Next*. 
 You do not need to follow the rest of these instructions.
 +
-Otherwise, click in the *Select Type* field and select one of the following 
+However, a structured data type is recommended. For example, if you want 
+to map the connection input in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following 
 as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.

--- a/doc/modules/connecting/p_subscribing-to-a-knative-channel-to-obtain-messages.adoc
+++ b/doc/modules/connecting/p_subscribing-to-a-knative-channel-to-obtain-messages.adoc
@@ -46,7 +46,11 @@ This is the type that the connection passes to the next step in the integration.
 accept *Type specification not required* and click *Next*. You do not need to 
 follow the rest of these instructions.
 +
-Otherwise, click in the *Select Type* field and select one of the following 
+However, a structured data type is recommended. For example, if you want 
+to map the connection output in a data mapper step then you must specify 
+the data type. The data mapper cannot display fields for unstructured data.
++
+To specify the data type, click in the *Select Type* field and select one of the following 
 as the schema type:
 +
 * *JSON schema* is a document that describes the structure of JSON data.

--- a/doc/modules/connecting/r_how-to-specify-the-schema-in-a-database-connection.adoc
+++ b/doc/modules/connecting/r_how-to-specify-the-schema-in-a-database-connection.adoc
@@ -92,3 +92,16 @@ Specify any value in the *Username* and *Password* fields. Leave the *Schema* fi
 The driver is already available in {prodname}. 
 
 |===
+
+ifeval::["{location}" == "downstream"]
+[IMPORTANT]
+====
+Data virtualization is a Technology Preview feature only. Technology Preview features are 
+not supported with Red Hat production service level agreements (SLAs) and might not be 
+functionally complete. Red Hat does not recommend using them in production. 
+These features provide early access to upcoming product features, enabling 
+customers to test functionality and provide feedback during the development process. 
+For more information about the support scope of Red Hat Technology Preview features, 
+see link:https://access.redhat.com/support/offerings/techpreview/[]. 
+====
+endif::[]

--- a/doc/modules/integrating-applications/p_configure-publish-api-provider-quickstart.adoc
+++ b/doc/modules/integrating-applications/p_configure-publish-api-provider-quickstart.adoc
@@ -99,10 +99,10 @@ API calls specify URLs that start with this base URL.
 +
 If you are using {prodname} on OpenShift Container
 Platform, if the external URL is not on the integration’s summary page,
-then an administrator has set the `OPENSHIFT_MANAGEMENT_URL_FOR3SCALE` environment
-variable. When this environment variable is set, Red Hat 3scale
-publishes your API provider integration, which means that 3scale
-controls access to the integration’s API. To test the integration,
+then an administrator has enabled Red Hat 3scale discovery. 
+This means that Red Hat 3scale controls access to the integraion's API
+and also publishes your API provider integration. 
+To test the integration,
 open the 3scale dashboard to obtain the integration’s URL.
 +
 If you do not want Red Hat 3scale to control access to the integration’s

--- a/doc/modules/integrating-applications/p_try-api-provider-quickstart.adoc
+++ b/doc/modules/integrating-applications/p_try-api-provider-quickstart.adoc
@@ -14,7 +14,7 @@ triggers.
 * {prodname} indicates that the *TaskAPI* integration is *Running*. 
 * If your {prodname} environment is running on OCP, 
 {prodname} is not configured to expose APIs to 3scale or
-you disabled discovery. 
+you disabled discovery for the *TaskAPI* integration. 
 
 .Procedure
 


### PR DESCRIPTION
When Stefan reviewed the new doc for enabling auto-discovery of Kafka brokers (AMQ Streams), he suggested adding a note to the doc that recommends that the user specify the connection's input/output type if they want to map fields. I added this note to all the instances of the procedure for specify the data type. 

I also update the description of how discovery in 3scale is set for API provider integrations. 

And I re-inserted the Tech Preview note for data virtualization. This note renders only downstream. 