### PR TITLE
feat(server): autodiscovery circuit breaker call

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import io.syndesis.common.model.Ordered;
 import io.syndesis.common.model.WithTags;
-import io.syndesis.common.model.connection.DynamicActionMetadata.ActionPropertySuggestion;
+import io.syndesis.common.model.connection.WithDynamicProperties.ActionPropertySuggestion;
 
 import org.immutables.value.Value;
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/DynamicConnectionPropertiesMetadata.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/DynamicConnectionPropertiesMetadata.java
@@ -19,23 +19,18 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.syndesis.common.model.DataShape;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(builder = DynamicActionMetadata.Builder.class)
-public interface DynamicActionMetadata extends WithDynamicProperties {
+@JsonDeserialize(builder = DynamicConnectionPropertiesMetadata.Builder.class)
+public interface DynamicConnectionPropertiesMetadata extends WithDynamicProperties {
 
-    DynamicActionMetadata NOTHING = new DynamicActionMetadata.Builder().build();
+    DynamicConnectionPropertiesMetadata NOTHING = new DynamicConnectionPropertiesMetadata.Builder().build();
 
-    final class Builder extends ImmutableDynamicActionMetadata.Builder {
-        // make ImmutableDynamicActionMetadata.Builder accessible
+    final class Builder extends ImmutableDynamicConnectionPropertiesMetadata.Builder {
+        // make ImmutableDynamicConnectionPropertiesMetadata.Builder accessible
     }
 
     @Override
     Map<String, List<ActionPropertySuggestion>> properties();
-
-    DataShape inputShape();
-
-    DataShape outputShape();
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/WithDynamicProperties.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/WithDynamicProperties.java
@@ -19,23 +19,24 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.syndesis.common.model.DataShape;
 import org.immutables.value.Value;
 
-@Value.Immutable
-@JsonDeserialize(builder = DynamicActionMetadata.Builder.class)
-public interface DynamicActionMetadata extends WithDynamicProperties {
+public interface WithDynamicProperties {
 
-    DynamicActionMetadata NOTHING = new DynamicActionMetadata.Builder().build();
+    @Value.Immutable
+    @JsonDeserialize(builder = ActionPropertySuggestion.Builder.class)
+    interface ActionPropertySuggestion {
 
-    final class Builder extends ImmutableDynamicActionMetadata.Builder {
-        // make ImmutableDynamicActionMetadata.Builder accessible
+        final class Builder extends ImmutableActionPropertySuggestion.Builder {
+            public static ActionPropertySuggestion of(final String value, final String displayValue) {
+                return new ActionPropertySuggestion.Builder().value(value).displayValue(displayValue).build();
+            }
+        }
+
+        String displayValue();
+
+        String value();
     }
 
-    @Override
     Map<String, List<ActionPropertySuggestion>> properties();
-
-    DataShape inputShape();
-
-    DataShape outputShape();
 }

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -209,11 +209,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
@@ -276,11 +271,6 @@
     <dependency>
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -140,7 +140,7 @@ public class ConnectionActionHandler {
         // lastly put all connection properties
         parameters.putAll(encryptionComponent.decrypt(connection.getConfiguredProperties()));
 
-        final HystrixExecutable<DynamicActionMetadata> meta = createMetadataCommand(action, parameters);
+        final HystrixExecutable<DynamicActionMetadata> meta = createMetadataCommandAction(action, parameters);
         final DynamicActionMetadata dynamicActionMetadata = meta.execute();
 
         final ConnectorDescriptor enrichedDescriptor = applyMetadataTo(generatedDescriptor, dynamicActionMetadata);
@@ -155,9 +155,9 @@ public class ConnectionActionHandler {
         return Response.status(status).entity(metaResult).build();
     }
 
-    protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
-        final Map<String, String> parameters) {
-        return new MetadataCommand(config, connectorId, action, parameters);
+    protected HystrixExecutable<DynamicActionMetadata> createMetadataCommandAction(final ConnectorAction action,
+                                                                                   final Map<String, String> parameters) {
+        return new MetadataCommandAction(config, connectorId, action, parameters);
     }
 
     private static DataShape adaptDataShape(final Optional<DataShape> maybeDataShape) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorPropertiesHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorPropertiesHandler.java
@@ -15,41 +15,34 @@
  */
 package io.syndesis.server.endpoint.v1.handler.connection;
 
-import java.util.Map;
-
 import javax.ws.rs.POST;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import java.util.Collections;
 
+import com.netflix.hystrix.HystrixExecutable;
 import io.swagger.annotations.Api;
+import io.syndesis.common.model.connection.DynamicConnectionPropertiesMetadata;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
 
 @Api(value = "properties")
 public class ConnectorPropertiesHandler {
-    private final String metaPropertiesUrl;
+    private final MetadataConfigurationProperties config;
 
     public ConnectorPropertiesHandler(final MetadataConfigurationProperties config) {
-        metaPropertiesUrl = String.format("http://%s/api/v1/connectors/%%s/properties/meta", config.getService());
+        this.config = config;
     }
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public Response enrichWithDynamicProperties(@PathParam("id") final String connectorId, final Map<String, Object> props) {
-        // TODO replace properly with circuit breaker
-        String metadataUrl = String.format(metaPropertiesUrl, connectorId);
-        Client client = createClient();
-        WebTarget target = client.target(metadataUrl);
-
-        return target.request().post(Entity.entity(props, MediaType.APPLICATION_JSON_TYPE));
+    public DynamicConnectionPropertiesMetadata dynamicConnectionProperties(@PathParam("id") final String connectorId) {
+        final HystrixExecutable<DynamicConnectionPropertiesMetadata> meta = createMetadataConnectionPropertiesCommand(connectorId);
+        return meta.execute();
     }
 
-    Client createClient() {
-        return ClientBuilder.newClient();
+    protected HystrixExecutable<DynamicConnectionPropertiesMetadata> createMetadataConnectionPropertiesCommand(final String connectorId) {
+        return new MetadataConnectionPropertiesCommand(config, connectorId, Collections.emptyMap());
     }
+
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommandAction.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataCommandAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.connection;
+
+import java.util.Map;
+
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.connection.DynamicActionMetadata;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
+
+class MetadataCommandAction extends MetadataCommand<DynamicActionMetadata> {
+
+    private final String metadataUrl;
+
+    MetadataCommandAction(MetadataConfigurationProperties configuration,
+                          final String connectorId,
+                          final ConnectorAction action,
+                          Map<String, String> parameters) {
+        super(configuration, DynamicActionMetadata.class, parameters);
+        this.metadataUrl = String.format("http://%s/api/v1/connectors/%s/actions/%s", configuration.getService(), connectorId, action.getId().get());
+    }
+
+    @Override
+    protected DynamicActionMetadata getFallback() {
+        return DynamicActionMetadata.NOTHING;
+    }
+
+    @Override
+    protected String getMetadataURL() {
+        return metadataUrl;
+    }
+
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataConnectionPropertiesCommand.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/MetadataConnectionPropertiesCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.v1.handler.connection;
+
+import java.util.Map;
+
+import io.syndesis.common.model.connection.DynamicConnectionPropertiesMetadata;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
+
+class MetadataConnectionPropertiesCommand extends MetadataCommand<DynamicConnectionPropertiesMetadata> {
+
+    private final String metadataUrl;
+
+    MetadataConnectionPropertiesCommand(MetadataConfigurationProperties configuration,
+                          final String connectorId,
+                          Map<String, String> parameters) {
+        super(configuration, DynamicConnectionPropertiesMetadata.class, parameters);
+        this.metadataUrl = String.format("http://%s/api/v1/connectors/%s/properties/meta", configuration.getService(), connectorId);
+    }
+
+    @Override
+    protected DynamicConnectionPropertiesMetadata getFallback() {
+        return DynamicConnectionPropertiesMetadata.NOTHING;
+    }
+
+    @Override
+    protected String getMetadataURL() {
+        return metadataUrl;
+    }
+
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -119,8 +119,8 @@ public class ConnectionActionHandlerTest {
 
         handler = new ConnectionActionHandler(connection, new MetadataConfigurationProperties(), new EncryptionComponent(null)) {
             @Override
-            protected HystrixExecutable<DynamicActionMetadata> createMetadataCommand(final ConnectorAction action,
-                final Map<String, String> parameters) {
+            protected HystrixExecutable<DynamicActionMetadata> createMetadataCommandAction(final ConnectorAction action,
+                                                                                           final Map<String, String> parameters) {
                 metadataCommandParameters = parameters;
                 return metadataCommand;
             }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
@@ -15,60 +15,40 @@
  */
 package io.syndesis.server.endpoint.v1.handler.connection;
 
-import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayInputStream;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-
-import io.syndesis.server.verifier.MetadataConfigurationProperties;
-
-import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
-import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Test;
-import org.springframework.context.ApplicationContext;
-
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-
+import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.connection.DynamicConnectionPropertiesMetadata;
+import io.syndesis.common.model.connection.WithDynamicProperties;
+import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
 import io.syndesis.server.credential.Credentials;
 import io.syndesis.server.dao.file.FileDataManager;
 import io.syndesis.server.dao.file.IconDao;
 import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.dao.manager.EncryptionComponent;
-import io.syndesis.server.inspector.Inspectors;
-import io.syndesis.common.model.ListResult;
-import io.syndesis.common.model.action.ConnectorAction;
-import io.syndesis.common.model.action.ConnectorDescriptor;
-import io.syndesis.common.model.connection.ConfigurationProperty;
-import io.syndesis.common.model.connection.Connection;
-import io.syndesis.common.model.connection.Connector;
-import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
-import io.syndesis.common.model.integration.Flow;
-import io.syndesis.common.model.integration.Integration;
-import io.syndesis.common.model.integration.Step;
 import io.syndesis.server.endpoint.v1.state.ClientSideState;
+import io.syndesis.server.inspector.Inspectors;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
 import io.syndesis.server.verifier.Verifier;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -76,6 +56,15 @@ import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Okio;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ConnectorHandlerTest {
 
@@ -127,7 +116,7 @@ public class ConnectorHandlerTest {
             final StreamingOutput so = (StreamingOutput) response.getEntity();
             final ByteArrayOutputStream bos = new ByteArrayOutputStream();
             try (BufferedSink sink = Okio.buffer(Okio.sink(bos)); BufferedSource source = new Buffer();
-                ImageInputStream iis = ImageIO.createImageInputStream(source.inputStream());) {
+                 ImageInputStream iis = ImageIO.createImageInputStream(source.inputStream());) {
                 so.write(sink.outputStream());
                 source.readAll(sink);
                 final Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
@@ -191,15 +180,14 @@ public class ConnectorHandlerTest {
             }
         };
 
-        @SuppressWarnings("resource")
-        final Response metaResponse = responseWithEntity("{}");
+        final DynamicConnectionPropertiesMetadata metaResponse = DynamicConnectionPropertiesMetadata.NOTHING;
 
-        when(connectorPropertiesHandler.enrichWithDynamicProperties("connectorId", null)).thenReturn(metaResponse);
+        when(connectorPropertiesHandler.dynamicConnectionProperties("connectorId")).thenReturn(metaResponse);
 
         final Connector connector = new Connector.Builder()
             .id("connectorId")
             .build();
-        final Connector withDynamicProperties = connectorHandler.enrichWithDynamicProperties(connector);
+        final Connector withDynamicProperties = connectorHandler.enrichConnectorWithDynamicProperties(connector);
 
         final Connector expected = new Connector.Builder()
             .id("connectorId")
@@ -221,16 +209,19 @@ public class ConnectorHandlerTest {
             }
         };
 
-        @SuppressWarnings("resource")
-        final Response metaResponse = responseWithEntity("{\"properties\":{\"property\":[{\"displayValue\":\"Value 1\",\"value\":\"value1\"},{\"displayValue\":\"Value 2\",\"value\":\"value2\"}]}}");
-
-        when(connectorPropertiesHandler.enrichWithDynamicProperties("connectorId", null)).thenReturn(metaResponse);
+        final DynamicConnectionPropertiesMetadata metaResponse = new DynamicConnectionPropertiesMetadata.Builder()
+            .putProperty("property", Arrays.asList(
+                new WithDynamicProperties.ActionPropertySuggestion.Builder().displayValue("Value 1").value("value1").build(),
+                new WithDynamicProperties.ActionPropertySuggestion.Builder().displayValue("Value 2").value("value2").build()
+                )
+            ).build();
+        when(connectorPropertiesHandler.dynamicConnectionProperties("connectorId")).thenReturn(metaResponse);
 
         final Connector connector = new Connector.Builder()
             .id("connectorId")
             .putProperty("property", new ConfigurationProperty.Builder().build())
             .build();
-        final Connector withDynamicProperties = connectorHandler.enrichWithDynamicProperties(connector);
+        final Connector withDynamicProperties = connectorHandler.enrichConnectorWithDynamicProperties(connector);
 
         final Connector expected = new Connector.Builder()
             .id("connectorId")
@@ -240,37 +231,6 @@ public class ConnectorHandlerTest {
             .build();
 
         assertThat(withDynamicProperties).isEqualTo(expected);
-    }
-
-    private static Response responseWithEntity(final String data) {
-        final ClientConfiguration configuration = new ClientConfiguration(ResteasyProviderFactory.getInstance().register(JacksonJsonProvider.class));
-        final Response metaResponse = spy(new ClientResponse(configuration) {
-            @Override
-            protected InputStream getInputStream() {
-                return new ByteArrayInputStream(data.getBytes(StandardCharsets.US_ASCII));
-            }
-
-            @Override
-            protected void setInputStream(InputStream is) {
-                // nop
-            }
-
-            @Override
-            public void releaseConnection() throws IOException {
-                // nop
-            }
-
-            @Override
-            public void releaseConnection(boolean consumeInputStream) throws IOException {
-                // nop
-            }
-
-            @Override
-            public MediaType getMediaType() {
-                return MediaType.APPLICATION_JSON_TYPE;
-            }
-        });
-        return metaResponse;
     }
 
     @Test
@@ -286,14 +246,14 @@ public class ConnectorHandlerTest {
             }
         };
 
-        @SuppressWarnings("resource")
-        final Response metaResponse = Response.serverError().build();
-        when(connectorPropertiesHandler.enrichWithDynamicProperties("connectorId", null)).thenReturn(metaResponse);
+        //It would never provide an error, as in such case circuit breaker provide the fallback implementation
+        final DynamicConnectionPropertiesMetadata metaResponse = DynamicConnectionPropertiesMetadata.NOTHING;
+        when(connectorPropertiesHandler.dynamicConnectionProperties("connectorId")).thenReturn(metaResponse);
 
         final Connector connector = new Connector.Builder()
             .id("connectorId")
             .build();
-        final Connector withDynamicProperties = connectorHandler.enrichWithDynamicProperties(connector);
+        final Connector withDynamicProperties = connectorHandler.enrichConnectorWithDynamicProperties(connector);
 
         final Connector expected = new Connector.Builder()
             .id("connectorId")
@@ -320,10 +280,10 @@ public class ConnectorHandlerTest {
     }
 
     private static Integration newIntegration(List<Step> steps) {
-      return new Integration.Builder()
-          .id("test")
-          .name("test")
-          .addFlow(new Flow.Builder().steps(steps).build())
-          .build();
+        return new Integration.Builder()
+            .id("test")
+            .name("test")
+            .addFlow(new Flow.Builder().steps(steps).build())
+            .build();
     }
 }


### PR DESCRIPTION
* Added circuit breaker instead of plain REST call to meta connection properties
* Refactored common-model to add dynamic metadata modeling
* Refactored MetadataCommand to be used as abstract base for MetadataCommandAction and MetadataConnectionPropertiesCommand
* Refactored unit test to use DynamicConnectionPropertiesMetadata instead of raw Response
* Removed useless pom dependencies

Closes ENTESB-12498