### PR TITLE
fix(table): adjust rows format for SqlResultsTable

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlResultsTable.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlResultsTable.tsx
@@ -59,16 +59,17 @@ const getClassName = (value: string) => {
 
 // row cells are sized based upon the data value lengths
 const getSizedRows = (rows: string[][]) => {
-  const sizedRows: (IRow | string[])[] = [];
+  const sizedRows: Array<IRow | string[]> = [];
   for (const row of rows) {
     const rowData: IRow[] = Object.entries(row).map((node, index) => {
+      // @ts-ignore
       const [key, value] = node;
       return node.map(() => {
         return {
-          title: value,
           props: {
             className: getClassName(value),
           },
+          title: value
         }
       })[0];
     })

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/SqlResultsTable.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/SqlResultsTable.tsx
@@ -59,19 +59,22 @@ const getClassName = (value: string) => {
 
 // row cells are sized based upon the data value lengths
 const getSizedRows = (rows: string[][]) => {
-  const sizedRows: IRow[][] = [];
+  const sizedRows: (IRow | string[])[] = [];
   for (const row of rows) {
-    const rowValues: IRow[] = [];
-    for (const rowValue of row) {
-      const theValue = {
-        props: {
-          className: getClassName(rowValue),
-        },
-        title: rowValue,
-      } as IRow;
-      rowValues.push(theValue);
-    }
-    sizedRows.push(rowValues);
+    const rowData: IRow[] = Object.entries(row).map((node, index) => {
+      const [key, value] = node;
+      return node.map(() => {
+        return {
+          title: value,
+          props: {
+            className: getClassName(value),
+          },
+        }
+      })[0];
+    })
+    sizedRows.push({
+      cells: rowData
+    });
   }
   return sizedRows.length > 0 ? sizedRows : [];
 };


### PR DESCRIPTION
This PR updates the rows definition for the `SqlResultsTable` component. The storybook entry now seems to run just fine without errors. I haven't yet tested this component within the app, looking into that now.

Should help close https://issues.redhat.com/browse/TEIIDTOOLS-898

<img width="483" alt="Screen Shot 2020-03-06 at 10 27 12 AM" src="https://user-images.githubusercontent.com/5942899/76101795-fe0ca580-5f9c-11ea-9081-19af9373567c.png">

<img width="997" alt="Screen Shot 2020-03-06 at 11 23 02 AM" src="https://user-images.githubusercontent.com/5942899/76101829-0bc22b00-5f9d-11ea-97f6-b345405a0c38.png">
