### PR TITLE
chore: upgrade pf for OAuth components

### DIFF
--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Form, Grid, GridItem } from '@patternfly/react-core';
+import { Alert, Button, Form, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IOAuthAppExpanderBodyProps {
@@ -30,43 +30,37 @@ export const OAuthAppExpanderBody: React.FC<
     showSuccess
   }) => {
   return (
-    <>
+    <Stack gutter={'md'}>
       {showSuccess && (
-        <Grid sm={11}>
-          <GridItem>
-            <Alert variant={'success'}
-                   title={i18nAlertTitle}>
-              {i18nAlertDetail}
-            </Alert>
-          </GridItem>
-        </Grid>
+        <StackItem>
+          <Alert variant={'success'}
+                 title={i18nAlertTitle}>
+            {i18nAlertDetail}
+          </Alert>
+        </StackItem>
       )}
-      <Grid sm={12} md={8}>
-        <GridItem>
-          <Form isHorizontal={true}>{children}</Form>
-        </GridItem>
-      </Grid>
-      <Grid sm={12} md={8}>
-        <GridItem>
-          <div>
-            <Button
-              data-testid={'o-auth-app-expander-body-save-button'}
-              variant={'primary'}
-              onClick={onSave}
-              disabled={disableSave}
-            >
-              {i18nSaveButtonText}
-            </Button>{' '}
-            <Button
-              data-testid={'o-auth-app-expander-body-remove-button'}
-              onClick={onRemove}
-              disabled={disableRemove}
-            >
-              {i18nRemoveButtonText}
-            </Button>
-          </div>
-        </GridItem>
-      </Grid>
-    </>
+      <StackItem>
+        <Form isHorizontal={true}>{children}</Form>
+      </StackItem>
+      <StackItem>
+        <div>
+          <Button
+            data-testid={'o-auth-app-expander-body-save-button'}
+            variant={'primary'}
+            onClick={onSave}
+            disabled={disableSave}
+          >
+            {i18nSaveButtonText}
+          </Button>{' '}
+          <Button
+            data-testid={'o-auth-app-expander-body-remove-button'}
+            onClick={onRemove}
+            disabled={disableRemove}
+          >
+            {i18nRemoveButtonText}
+          </Button>
+        </div>
+      </StackItem>
+    </Stack>
   );
 };

--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
@@ -1,5 +1,4 @@
-import { Form } from '@patternfly/react-core';
-import { Alert, Button, Col, Row } from 'patternfly-react';
+import { Alert, Button, Form, Grid, GridItem } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IOAuthAppExpanderBodyProps {
@@ -33,26 +32,26 @@ export const OAuthAppExpanderBody: React.FC<
   return (
     <>
       {showSuccess && (
-        <Row>
-          <Col xs={11}>
-            <Alert type={'success'}>
-              <strong>{i18nAlertTitle}</strong>&nbsp;
+        <Grid sm={11}>
+          <GridItem>
+            <Alert variant={'success'}
+                   title={i18nAlertTitle}>
               {i18nAlertDetail}
             </Alert>
-          </Col>
-        </Row>
+          </GridItem>
+        </Grid>
       )}
-      <Row>
-        <Col xs={12} md={8}>
+      <Grid sm={12} md={8}>
+        <GridItem>
           <Form isHorizontal={true}>{children}</Form>
-        </Col>
-      </Row>
-      <Row>
-        <Col xs={12} md={8}>
-          <>
+        </GridItem>
+      </Grid>
+      <Grid sm={12} md={8}>
+        <GridItem>
+          <div>
             <Button
               data-testid={'o-auth-app-expander-body-save-button'}
-              bsStyle="primary"
+              variant={'primary'}
               onClick={onSave}
               disabled={disableSave}
             >
@@ -65,9 +64,9 @@ export const OAuthAppExpanderBody: React.FC<
             >
               {i18nRemoveButtonText}
             </Button>
-          </>
-        </Col>
-      </Row>
+          </div>
+        </GridItem>
+      </Grid>
     </>
   );
 };

--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppExpanderBody.tsx
@@ -15,52 +15,59 @@ export interface IOAuthAppExpanderBodyProps {
   i18nAlertDetail: string;
 }
 
-export class OAuthAppExpanderBody extends React.Component<
+export const OAuthAppExpanderBody: React.FC<
   IOAuthAppExpanderBodyProps
-> {
-  constructor(props: IOAuthAppExpanderBodyProps) {
-    super(props);
-  }
-  public render() {
-    return (
-      <>
-        {this.props.showSuccess && (
-          <Row>
-            <Col xs={11}>
-              <Alert type={'success'}>
-                <strong>{this.props.i18nAlertTitle}</strong>&nbsp;
-                {this.props.i18nAlertDetail}
-              </Alert>
-            </Col>
-          </Row>
-        )}
+> = (
+  {
+    children,
+    disableRemove,
+    disableSave,
+    i18nAlertDetail,
+    i18nAlertTitle,
+    i18nRemoveButtonText,
+    i18nSaveButtonText,
+    onRemove,
+    onSave,
+    showSuccess
+  }) => {
+  return (
+    <>
+      {showSuccess && (
         <Row>
-          <Col xs={12} md={8}>
-            <Form isHorizontal={true}>{this.props.children}</Form>
+          <Col xs={11}>
+            <Alert type={'success'}>
+              <strong>{i18nAlertTitle}</strong>&nbsp;
+              {i18nAlertDetail}
+            </Alert>
           </Col>
         </Row>
-        <Row>
-          <Col xs={12} md={8}>
-            <>
-              <Button
-                data-testid={'o-auth-app-expander-body-save-button'}
-                bsStyle="primary"
-                onClick={this.props.onSave}
-                disabled={this.props.disableSave}
-              >
-                {this.props.i18nSaveButtonText}
-              </Button>{' '}
-              <Button
-                data-testid={'o-auth-app-expander-body-remove-button'}
-                onClick={this.props.onRemove}
-                disabled={this.props.disableRemove}
-              >
-                {this.props.i18nRemoveButtonText}
-              </Button>
-            </>
-          </Col>
-        </Row>
-      </>
-    );
-  }
-}
+      )}
+      <Row>
+        <Col xs={12} md={8}>
+          <Form isHorizontal={true}>{children}</Form>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12} md={8}>
+          <>
+            <Button
+              data-testid={'o-auth-app-expander-body-save-button'}
+              bsStyle="primary"
+              onClick={onSave}
+              disabled={disableSave}
+            >
+              {i18nSaveButtonText}
+            </Button>{' '}
+            <Button
+              data-testid={'o-auth-app-expander-body-remove-button'}
+              onClick={onRemove}
+              disabled={disableRemove}
+            >
+              {i18nRemoveButtonText}
+            </Button>
+          </>
+        </Col>
+      </Row>
+    </>
+  );
+};

--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppList.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppList.tsx
@@ -1,4 +1,4 @@
-import { ListView } from 'patternfly-react';
+import { DataList } from '@patternfly/react-core';
 import * as React from 'react';
 
 export interface IOAuthAppListProps {
@@ -7,4 +7,4 @@ export interface IOAuthAppListProps {
 
 export const OAuthAppList: React.FunctionComponent<IOAuthAppListProps> = ({
   children,
-}) => <ListView>{children}</ListView>;
+}) => <DataList aria-label={'oauth app list'}>{children}</DataList>;

--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppListItem.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppListItem.tsx
@@ -24,11 +24,13 @@ export const OAuthAppListItem: React.FC<IOAuthAppListItemProps> = (
   {
     children,
     configured,
+    expanded,
     i18nNotConfiguredText,
     icon,
+    id,
     name
   }) => {
-  const [rowExpanded, setRowExpanded] = useState(false);
+  const [rowExpanded, setRowExpanded] = useState(expanded);
 
   const doExpand = () => {
     setRowExpanded(!rowExpanded);
@@ -44,7 +46,7 @@ export const OAuthAppListItem: React.FC<IOAuthAppListItemProps> = (
         <DataListToggle
           onClick={doExpand}
           isExpanded={rowExpanded}
-          id={'app-item-toggle'}
+          id={'app-item-toggle-' + id}
         />
         <DataListItemCells
           dataListCells={[

--- a/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppListItem.tsx
+++ b/app/ui-react/packages/ui/src/Settings/OAuth/OAuthAppListItem.tsx
@@ -1,5 +1,13 @@
-import { ListViewItem } from 'patternfly-react';
+import {
+  DataListCell,
+  DataListContent,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  DataListToggle
+} from '@patternfly/react-core';
 import * as React from 'react';
+import { useState } from 'react';
 import { toValidHtmlId } from '../../helpers';
 
 export interface IOAuthAppListItemProps {
@@ -12,30 +20,55 @@ export interface IOAuthAppListItemProps {
   name: string;
 }
 
-export class OAuthAppListItem extends React.Component<IOAuthAppListItemProps> {
-  constructor(props: IOAuthAppListItemProps) {
-    super(props);
-  }
-  public render() {
-    return (
-      <ListViewItem
-        data-testid={`o-auth-app-list-item-${toValidHtmlId(
-          this.props.name
-        )}-list-item`}
-        key={this.props.id}
-        hideCloseIcon={true}
-        initExpanded={this.props.expanded}
-        heading={this.props.name}
-        leftContent={this.props.icon}
-        description={''}
-        additionalInfo={[
-          !this.props.configured && (
-            <i key={0}>{this.props.i18nNotConfiguredText}</i>
-          ),
-        ]}
+export const OAuthAppListItem: React.FC<IOAuthAppListItemProps> = (
+  {
+    children,
+    configured,
+    i18nNotConfiguredText,
+    icon,
+    name
+  }) => {
+  const [rowExpanded, setRowExpanded] = useState(false);
+
+  const doExpand = () => {
+    setRowExpanded(!rowExpanded);
+  };
+
+  return (
+    <DataListItem aria-labelledby={'app item'}
+                  isExpanded={rowExpanded}
+                  className={'oauth-app-list-item'}>
+      <DataListItemRow data-testid={`o-auth-app-list-item-${toValidHtmlId(
+        name
+      )}-list-item`}>
+        <DataListToggle
+          onClick={doExpand}
+          isExpanded={rowExpanded}
+          id={'app-item-toggle'}
+        />
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell id={'app-icon'} key={'icon'}  width={1}>
+              {icon}
+            </DataListCell>,
+            <DataListCell id={'app-name'} key={'name'} width={4}>
+              <b>{name}</b>
+            </DataListCell>,
+            <DataListCell id={'app-configured'} key={'configured'} width={5}>
+              {!configured && (
+                <i key={0}>{i18nNotConfiguredText}</i>
+              )}
+            </DataListCell>,
+          ]}
+        />
+      </DataListItemRow>
+      <DataListContent
+        aria-label={'App Item Content'}
+        id={'app-item'}
+        isHidden={!rowExpanded}
       >
-        {this.props.children}
-      </ListViewItem>
-    );
-  }
-}
+        {children}
+      </DataListContent>
+    </DataListItem>
+  );
+};


### PR DESCRIPTION
drops support for patternfly-react OAuth components, replace with @patternfly/react-core

related epic: [ENTESB-12896](https://issues.redhat.com/browse/ENTESB-12896)

<img width="1382" alt="Screenshot 2020-03-09 18 54 11" src="https://user-images.githubusercontent.com/3844502/76248732-cff7c180-6239-11ea-957f-164aedfb827a.png">
