### PR TITLE
Add install_defaults.go for postgresql default image - Backport 1.9.x

### DIFF
--- a/install/operator/pkg/cmd/internal/install/install_defaults.go
+++ b/install/operator/pkg/cmd/internal/install/install_defaults.go
@@ -1,0 +1,3 @@
+package install
+
+const defaultDatabaseImage = "centos/postgresql-96-centos7"


### PR DESCRIPTION
The file `install/operator/pkg/cmd/internal/install/install_defaults.go` is generated when using the `go` build mode, but it doesn't generate when running in `docker` mode, which is the CI mode runs.