### PR TITLE
chore: migrate action select list in the editor

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorActionsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorActionsListItem.tsx
@@ -1,31 +1,54 @@
-import { ListView } from 'patternfly-react';
+import {
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { toValidHtmlId } from '../../helpers';
 
 export interface IIntegrationEditorActionsListItemProps {
-  integrationName: string;
-  integrationDescription: string;
+  name: string;
+  description: string;
   actions: any;
 }
 
-export class IntegrationEditorActionsListItem extends React.Component<
-  IIntegrationEditorActionsListItemProps
-> {
-  public render() {
-    return (
-      <ListView.Item
-        data-testid={`integration-editor-actions-list-item-${toValidHtmlId(
-          this.props.integrationName
-        )}-list-item`}
-        actions={this.props.actions}
-        heading={<b>{this.props.integrationName}</b>}
-        description={
-          this.props.integrationName === this.props.integrationDescription
-            ? undefined
-            : this.props.integrationDescription
-        }
-        stacked={false}
-      />
-    );
-  }
-}
+export const IntegrationEditorActionsListItem: React.FunctionComponent<IIntegrationEditorActionsListItemProps> = ({
+  name,
+  description,
+  actions,
+}) => {
+  const nameId = toValidHtmlId(name);
+  const ariaLabel = `actions list item ${nameId}`;
+  return (
+    <DataListItem
+      aria-labelledby={ariaLabel}
+      data-testid={`integration-editor-actions-list-item-${nameId}-list-item`}
+    >
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell
+              key={0}
+              width={2}
+              aria-label={'editor actions list item name'}
+            >
+              <b id={ariaLabel}>{name}</b>
+            </DataListCell>,
+            <DataListCell key={1} width={4}>
+              {name === description ? null : <>{description}</>}
+            </DataListCell>,
+          ]}
+        />
+        <DataListAction
+          aria-labelledby={ariaLabel}
+          id={'editor-actions-list-item-action'}
+          aria-label={'editor-actions-list-actions'}
+        >
+          {actions}
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  );
+};

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorChooseAction.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorChooseAction.tsx
@@ -1,4 +1,4 @@
-import { ListView } from 'patternfly-react';
+import { DataList } from '@patternfly/react-core';
 import * as React from 'react';
 import { PageSection } from '../../Layout';
 
@@ -10,7 +10,9 @@ export class IntegrationEditorChooseAction extends React.Component {
   public render() {
     return (
       <PageSection>
-        <ListView>{this.props.children}</ListView>
+        <DataList aria-label={'integration editor choose action list'}>
+          {this.props.children}
+        </DataList>
       </PageSection>
     );
   }

--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -49,6 +49,7 @@
       "Name": "Name",
       "NameYourView": "Name your view",
       "nameFilterPlaceholder": "Filter by Name...",
+      "NoDescriptionAvailable": "No description available.",
       "Next": "Next",
       "Pending": "Pending",
       "Publish": "Publish",

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/SelectChoiceConfigModePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/SelectChoiceConfigModePage.tsx
@@ -24,6 +24,7 @@ import {
 } from '@syndesis/ui';
 import { WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { PageTitle } from '../../../../../shared';
 import { IEditorSidebarProps } from '../EditorSidebar';
 import {
@@ -59,87 +60,99 @@ export interface ISelectChoiceConfigModePageProps
  * **Warning:** this component will throw an exception if the route state is
  * undefined.
  */
-export class SelectChoiceConfigModePage extends React.Component<
-  ISelectChoiceConfigModePageProps
-> {
-  public render() {
-    return (
-      <WithRouteData<ISelectConfigModeRouteParams, ISelectConfigModeRouteState>>
-        {(params, state) => {
-          const positionAsNumber = parseInt(params.position, 10);
-          const options = [
-            {
-              description:
-                'Provides preselected properties and condition operators for simple expressions.',
-              mode: 'basic',
-              name: 'Basic expression builder',
-            },
-            {
-              description:
-                'User provides condition language expressions for more advanced use cases.',
-              mode: 'advanced',
-              name: 'Advanced expression builder',
-            },
-          ];
-          return (
-            <>
-              <PageTitle title={'Configure Conditional Flows'} />
-              <IntegrationEditorLayout
-                title={'Configure Conditional Flows'}
-                description={
-                  'Choose how to configure the conditional flows step.'
-                }
-                toolbar={this.props.getBreadcrumb(
-                  'Configure Conditional Flows',
-                  params,
-                  state
-                )}
-                sidebar={this.props.sidebar({
-                  activeIndex: positionAsNumber,
-                  activeStep: toUIStep(state.step),
-                  steps: toUIStepCollection(
-                    getSteps(state.integration, params.flowId)
-                  ),
-                })}
-                content={
-                  <IntegrationEditorChooseAction>
-                    {options.map((option, idx) => (
-                      <IntegrationEditorActionsListItem
-                        key={idx}
-                        name={option.name}
-                        description={
-                          option.description || 'No description available.'
-                        }
-                        actions={
-                          <ButtonLink
-                            data-testid={'select-action-page-select-button'}
-                            href={this.props.selectHref(
-                              {
-                                ...params,
-                                configMode: option.mode,
-                              } as IChoiceStepRouteParams,
-                              {
-                                ...state,
-                                step: {
-                                  ...state.step,
-                                  configuredProperties: undefined,
-                                },
-                              } as IChoiceStepRouteState
-                            )}
-                          >
-                            Select
-                          </ButtonLink>
-                        }
-                      />
-                    ))}
-                  </IntegrationEditorChooseAction>
-                }
-                cancelHref={this.props.cancelHref(params, state)}
-              />
-            </>
-          );
-        }}
-      </WithRouteData>
-    );
-  }
-}
+export const SelectChoiceConfigModePage: React.FunctionComponent<ISelectChoiceConfigModePageProps> = ({
+  getBreadcrumb,
+  cancelHref,
+  sidebar,
+  selectHref,
+}) => {
+  const { t } = useTranslation(['integrations', 'shared']);
+  return (
+    <WithRouteData<ISelectConfigModeRouteParams, ISelectConfigModeRouteState>>
+      {(params, state) => {
+        const positionAsNumber = parseInt(params.position, 10);
+        const options = [
+          {
+            description: t(
+              'integrations:editor:selectChoiceMode:basicDescription'
+            ),
+            mode: 'basic',
+            name: t('integrations:editor:selectChoiceMode:basicName'),
+          },
+          {
+            description: t(
+              'integrations:editor:selectChoiceMode:advancedDescription'
+            ),
+            mode: 'advanced',
+            name: t('integrations:editor:selectChoiceMode:advancedName'),
+          },
+        ];
+        return (
+          <>
+            <PageTitle
+              title={t(
+                'integrations:editor:selectChoiceMode:ConfigureConditionalFlows'
+              )}
+            />
+            <IntegrationEditorLayout
+              title={t(
+                'integrations:editor:selectChoiceMode:ConfigureConditionalFlows'
+              )}
+              description={t(
+                'integrations:editor:selectChoiceMode:ConfigureConditionalFlows'
+              )}
+              toolbar={getBreadcrumb(
+                t(
+                  'integrations:editor:selectChoiceMode:ConfigureConditionalFlows'
+                ),
+                params,
+                state
+              )}
+              sidebar={sidebar({
+                activeIndex: positionAsNumber,
+                activeStep: toUIStep(state.step),
+                steps: toUIStepCollection(
+                  getSteps(state.integration, params.flowId)
+                ),
+              })}
+              content={
+                <IntegrationEditorChooseAction>
+                  {options.map((option, idx) => (
+                    <IntegrationEditorActionsListItem
+                      key={idx}
+                      name={option.name}
+                      description={
+                        option.description || t('shared:NoDescriptionAvailable')
+                      }
+                      actions={
+                        <ButtonLink
+                          data-testid={'select-action-page-select-button'}
+                          href={selectHref(
+                            {
+                              ...params,
+                              configMode: option.mode,
+                            } as IChoiceStepRouteParams,
+                            {
+                              ...state,
+                              step: {
+                                ...state.step,
+                                configuredProperties: undefined,
+                              },
+                            } as IChoiceStepRouteState
+                          )}
+                        >
+                          {t('shared:Select')}
+                        </ButtonLink>
+                      }
+                    />
+                  ))}
+                </IntegrationEditorChooseAction>
+              }
+              cancelHref={cancelHref(params, state)}
+            />
+          </>
+        );
+      }}
+    </WithRouteData>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/SelectChoiceConfigModePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/SelectChoiceConfigModePage.tsx
@@ -35,7 +35,8 @@ import {
 } from '../interfaces';
 import { toUIStep, toUIStepCollection } from '../utils';
 
-export interface ISelectChoiceConfigModePageProps extends IPageWithEditorBreadcrumb {
+export interface ISelectChoiceConfigModePageProps
+  extends IPageWithEditorBreadcrumb {
   cancelHref: (
     p: ISelectConfigModeRouteParams,
     s: ISelectConfigModeRouteState
@@ -58,7 +59,9 @@ export interface ISelectChoiceConfigModePageProps extends IPageWithEditorBreadcr
  * **Warning:** this component will throw an exception if the route state is
  * undefined.
  */
-export class SelectChoiceConfigModePage extends React.Component<ISelectChoiceConfigModePageProps> {
+export class SelectChoiceConfigModePage extends React.Component<
+  ISelectChoiceConfigModePageProps
+> {
   public render() {
     return (
       <WithRouteData<ISelectConfigModeRouteParams, ISelectConfigModeRouteState>>
@@ -66,15 +69,17 @@ export class SelectChoiceConfigModePage extends React.Component<ISelectChoiceCon
           const positionAsNumber = parseInt(params.position, 10);
           const options = [
             {
-              description: 'Provides preselected properties and condition operators for simple expressions.',
+              description:
+                'Provides preselected properties and condition operators for simple expressions.',
               mode: 'basic',
               name: 'Basic expression builder',
             },
             {
-              description: 'User provides condition language expressions for more advanced use cases.',
+              description:
+                'User provides condition language expressions for more advanced use cases.',
               mode: 'advanced',
               name: 'Advanced expression builder',
-            }
+            },
           ];
           return (
             <>
@@ -93,46 +98,40 @@ export class SelectChoiceConfigModePage extends React.Component<ISelectChoiceCon
                   activeIndex: positionAsNumber,
                   activeStep: toUIStep(state.step),
                   steps: toUIStepCollection(
-                    getSteps(
-                      state.integration,
-                      params.flowId
-                    )
+                    getSteps(state.integration, params.flowId)
                   ),
                 })}
                 content={
                   <IntegrationEditorChooseAction>
-                    {options
-                      .map((option, idx) => (
-                        <IntegrationEditorActionsListItem
-                          key={idx}
-                          integrationName={option.name}
-                          integrationDescription={
-                            option.description || 'No description available.'
-                          }
-                          actions={
-                            <ButtonLink
-                              data-testid={
-                                'select-action-page-select-button'
-                              }
-                              href={this.props.selectHref(
-                                {
-                                  ...params,
-                                  configMode: option.mode
-                                } as IChoiceStepRouteParams,
-                                {
-                                  ...state,
-                                  step: {
-                                    ...state.step,
-                                    configuredProperties: undefined
-                                  }
-                                } as IChoiceStepRouteState
-                              )}
-                            >
-                              Select
-                            </ButtonLink>
-                          }
-                        />
-                      ))}
+                    {options.map((option, idx) => (
+                      <IntegrationEditorActionsListItem
+                        key={idx}
+                        name={option.name}
+                        description={
+                          option.description || 'No description available.'
+                        }
+                        actions={
+                          <ButtonLink
+                            data-testid={'select-action-page-select-button'}
+                            href={this.props.selectHref(
+                              {
+                                ...params,
+                                configMode: option.mode,
+                              } as IChoiceStepRouteParams,
+                              {
+                                ...state,
+                                step: {
+                                  ...state.step,
+                                  configuredProperties: undefined,
+                                },
+                              } as IChoiceStepRouteState
+                            )}
+                          >
+                            Select
+                          </ButtonLink>
+                        }
+                      />
+                    ))}
                   </IntegrationEditorChooseAction>
                 }
                 cancelHref={this.props.cancelHref(params, state)}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -101,8 +101,8 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                                 .map((a, idx) => (
                                   <IntegrationEditorActionsListItem
                                     key={idx}
-                                    integrationName={a.name}
-                                    integrationDescription={
+                                    name={a.name}
+                                    description={
                                       a.description ||
                                       'No description available.'
                                     }

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -121,6 +121,14 @@
       "description": "Update details about this integration.",
       "saveAndPublish": "Save and publish"
     },
+    "selectChoiceMode": {
+      "basicDescription": "Provides preselected properties and condition operators for simple expressions.",
+      "basicName": "Basic expression builder",
+      "advancedDescription": "User provides condition language expressions for more advanced use cases.",
+      "advancedName": "Advanced expression builder",
+      "ConfigureConditionalFlows": "Configure Conditional",
+      "pageDescription": "Choose how to configure the conditional flows step."
+    },
     "choiceForm": {
       "conditionDescription": "Provide a condition that you want to evaluate (for example, ${header.type} == 'note' or ${body.title} contains 'Important').",
       "conditionName": "Condition",


### PR DESCRIPTION
relates to [ENTESB-12896](https://issues.redhat.com/browse/ENTESB-12896)

![image](https://user-images.githubusercontent.com/351660/76338487-2105c500-62cf-11ea-8ad1-13186e6bbc67.png)

I think we can save the text alignment for when we've removed patternfly-react and it's related stylesheet.