### PR TITLE
Fix: Showing toast msg immediately once user publish or stop the virt…

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationActionContainer.tsx
@@ -301,6 +301,11 @@ export const VirtualizationActionContainer: React.FunctionComponent<
           const e = new Error();
           e.name = 'NoViews';
           throw e;
+        }else{
+          pushNotification(
+            (t('publishInProgress')),
+            'info'
+          );
         }
 
         publishVirtualization(props.virtualization.name).catch((e: any) => {
@@ -419,6 +424,10 @@ export const VirtualizationActionContainer: React.FunctionComponent<
       i18nLabel: t('shared:Start'),
       id: VirtualizationActionId.Start,
       onClick: async () => {
+        pushNotification(
+          (t('publishInProgress')),
+          'info'
+        );
         setPromptActionOptions({
           buttonText: t('shared:Start'),
           handleAction: async () => {
@@ -479,6 +488,10 @@ export const VirtualizationActionContainer: React.FunctionComponent<
       i18nLabel: t('shared:Stop'),
       id: VirtualizationActionId.Stop,
       onClick: async () => {
+        pushNotification(
+          (t('stopInProgress')),
+          'info'
+        );
         unpublishVirtualization(props.virtualization.name).catch((e: any) => {
           if (e.name === 'AlreadyUnpublished') {
             pushNotification(


### PR DESCRIPTION
- Jira Issue https://issues.redhat.com/browse/TEIIDTOOLS-851

- Added the "info" toast msg whenever the user clicks to Start/Stop/Publish the Virtualization.