### PR TITLE
Fix: Initial view creation in a bad state

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -176,7 +176,7 @@ export const VirtualizationViewsPage: React.FunctionComponent = () => {
             <>
               <WithLoader
                 error={viewDefinitionDescriptorsError !== false}
-                loading={!hasViewDefinitionDescriptors}
+                loading={virtualization.name === "" || !hasViewDefinitionDescriptors}
                 loaderChildren={<ViewListSkeleton width={800} />}
                 errorChildren={
                   <ApiError error={viewDefinitionDescriptorsError as Error} />


### PR DESCRIPTION
- Jira issue https://issues.redhat.com/browse/TEIIDTOOLS-947

- Resolving the loading state in VirtualizationViewsPage component only after getting response form both "useVirtualization" and "useViewDefinitionDescriptors" API calls.