### PR TITLE
fix(meta): Prometheus resource name change

### DIFF
--- a/app/meta/src/main/java/io/syndesis/connector/meta/EndpointMetricsFilter.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/EndpointMetricsFilter.java
@@ -67,7 +67,7 @@ public class EndpointMetricsFilter implements ContainerRequestFilter, ContainerR
             tags.add(Tag.of("method", getMethod(requestContext)));
             tags.add(Tag.of("status", getStatus(responseContext)));
             tags.add(Tag.of("uri", getUri()));
-            sample.stop(registry.timer("http.server.requests", tags));
+            sample.stop(registry.timer("http.meta.requests", tags));
         }
     }
 


### PR DESCRIPTION
Using a different name in order not to collide with the ones used by `server` pod.

Closes #8089

With the latest upgrade to Camel 3.1, probably because a new library update, it's not possible to register a meter with the [same name and different tags](https://github.com/syndesisio/syndesis/blob/master/app/server/runtime/src/main/java/io/syndesis/server/runtime/EndpointMetricsFilter.java#L66-L72). Actually `server` pod is already registering a meter, but with a different set of tags. Changing the name solves the problem, **but** I don't have visibility on the impact of such change. I don't know if those metrics are collected and if the name change is going to produce any disruptive change in any consumer.