### PR TITLE
chore: upgrade pf for integration modal + dropdown components

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
@@ -1,5 +1,10 @@
 import * as H from '@syndesis/history';
-import { DropdownKebab } from 'patternfly-react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { toValidHtmlId } from '../../helpers';
@@ -8,7 +13,7 @@ import './IntegrationActions.css';
 
 export interface IIntegrationAction {
   href?: H.LocationDescriptor;
-  onClick?: (e: React.MouseEvent<any>) => any;
+  onClick?: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => void;
   label: string | JSX.Element;
 }
 
@@ -21,9 +26,7 @@ export interface IIntegrationActionsProps {
   editHref?: H.LocationDescriptor;
 }
 
-export const IntegrationActions: React.FunctionComponent<
-  IIntegrationActionsProps
-> = (
+export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProps> = (
   {
     actions,
     detailsHref,
@@ -32,6 +35,12 @@ export const IntegrationActions: React.FunctionComponent<
     i18nViewBtn,
     integrationId
   }) => {
+  const [showDropdown, setShowDropdown] = React.useState(false);
+
+  const toggleDropdown = () => {
+    setShowDropdown(!showDropdown);
+  };
+
   return (
     <>
       <ButtonLink
@@ -50,41 +59,30 @@ export const IntegrationActions: React.FunctionComponent<
       >
         {i18nViewBtn}
       </ButtonLink>
-      <DropdownKebab
-        className={'integration-actions__dropdown-kebab'}
-        id={`integration-${integrationId}-action-menu`}
-        pullRight={true}
-      >
-        {actions.map((a, idx) => (
-          <li role={'presentation'} key={idx}>
+
+      <Dropdown
+        toggle={<KebabToggle onToggle={toggleDropdown} id="toggle-dropdown"/>}
+        isOpen={showDropdown}
+        isPlain
+        role={'presentation'}
+        dropdownItems={actions.map((a, idx) => (
+          <DropdownItem key={idx}
+                        data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
+                        onClick={a.onClick}
+                        tabIndex={idx + 1}
+                        role={'menuitem'}
+          >
             {a.href ? (
-              <Link
-                data-testid={`integration-actions-${toValidHtmlId(
-                  a.label.toString()
-                )}`}
-                to={a.href}
-                onClick={a.onClick}
-                role={'menuitem'}
-                tabIndex={idx + 1}
-              >
+              <Link to={a.href}>
                 {a.label}
               </Link>
-            ) : (
-              <a
-                data-testid={`integration-actions-${toValidHtmlId(
-                  a.label.toString()
-                )}`}
-                href={'javascript:void(0)'}
-                onClick={a.onClick}
-                role={'menuitem'}
-                tabIndex={idx + 1}
-              >
-                {a.label}
-              </a>
-            )}
-          </li>
+            ) : a.label}
+          </DropdownItem>
         ))}
-      </DropdownKebab>
+        position={DropdownPosition.right}
+        className={'integration-actions__dropdown-kebab'}
+        id={`integration-${integrationId}-action-menu`}
+      />
     </>
   );
 };

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
@@ -1,10 +1,10 @@
-import * as H from '@syndesis/history';
 import {
   Dropdown,
   DropdownItem,
   DropdownPosition,
   KebabToggle
 } from '@patternfly/react-core';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { toValidHtmlId } from '../../helpers';
@@ -26,6 +26,34 @@ export interface IIntegrationActionsProps {
   editHref?: H.LocationDescriptor;
 }
 
+export const actionItem = (a: IIntegrationAction, idx: number, baseIdString: string) => {
+  if (a.href) {
+    return (
+      <li role={'menuitem'} key={idx}>
+        <Link to={a.href}
+              data-testid={baseIdString + `-${toValidHtmlId(a.label.toString())}`}
+              onClick={a.onClick}
+              tabIndex={idx + 1}
+              className={'pf-c-dropdown__menu-item'}
+        >
+          {a.label}
+        </Link>
+      </li>
+    )
+  } else {
+    return (
+      <DropdownItem key={idx}
+                    data-testid={baseIdString + `integration-actions-${toValidHtmlId(a.label.toString())}`}
+                    onClick={a.onClick}
+                    tabIndex={idx + 1}
+                    role={'menuitem'}
+      >
+        {a.label}
+      </DropdownItem>
+    );
+  }
+};
+
 export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProps> = (
   {
     actions,
@@ -41,38 +69,12 @@ export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProp
     setShowDropdown(!showDropdown);
   };
 
-  const actionItem = (a: IIntegrationAction, idx: number) => {
-    if (a.href) {
-      return (
-        <li role={'menuitem'} key={idx}>
-          <Link to={a.href}
-                data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
-                onClick={a.onClick}
-                tabIndex={idx + 1}
-                className={'pf-c-dropdown__menu-item'}
-          >
-            {a.label}
-          </Link>
-        </li>
-      )
-    } else {
-      return (
-        <DropdownItem key={idx}
-                      data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
-                      onClick={a.onClick}
-                      tabIndex={idx + 1}
-                      role={'menuitem'}
-        >
-          {a.label}
-        </DropdownItem>
-      );
-    }
-  };
+  const baseIdString = 'integration-actions';
 
   return (
     <>
       <ButtonLink
-        data-testid={'integration-actions-edit-button'}
+        data-testid={baseIdString + '-edit-button'}
         className={'edit-integration-btn'}
         href={editHref}
         as={'default'}
@@ -80,7 +82,7 @@ export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProp
         {i18nEditBtn}
       </ButtonLink>
       <ButtonLink
-        data-testid={'integration-actions-view-button'}
+        data-testid={baseIdString + '-view-button'}
         className={'view-integration-btn'}
         href={detailsHref}
         as={'default'}
@@ -91,13 +93,13 @@ export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProp
       <Dropdown
         toggle={<KebabToggle onToggle={toggleDropdown} id="toggle-dropdown"/>}
         isOpen={showDropdown}
-        isPlain
+        isPlain={true}
         role={'presentation'}
         dropdownItems={actions.map((a, idx) => {
-          return actionItem(a, idx)
+          return actionItem(a, idx, 'integration-actions')
         })}
         position={DropdownPosition.right}
-        className={'integration-actions__dropdown-kebab'}
+        className={baseIdString + '__dropdown-kebab'}
         id={`integration-${integrationId}-action-menu`}
       />
     </>

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
@@ -41,6 +41,34 @@ export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProp
     setShowDropdown(!showDropdown);
   };
 
+  const actionItem = (a: IIntegrationAction, idx: number) => {
+    if (a.href) {
+      return (
+        <li role={'menuitem'} key={idx}>
+          <Link to={a.href}
+                data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
+                onClick={a.onClick}
+                tabIndex={idx + 1}
+                className={'pf-c-dropdown__menu-item'}
+          >
+            {a.label}
+          </Link>
+        </li>
+      )
+    } else {
+      return (
+        <DropdownItem key={idx}
+                      data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
+                      onClick={a.onClick}
+                      tabIndex={idx + 1}
+                      role={'menuitem'}
+        >
+          {a.label}
+        </DropdownItem>
+      );
+    }
+  };
+
   return (
     <>
       <ButtonLink
@@ -65,20 +93,9 @@ export const IntegrationActions: React.FunctionComponent<IIntegrationActionsProp
         isOpen={showDropdown}
         isPlain
         role={'presentation'}
-        dropdownItems={actions.map((a, idx) => (
-          <DropdownItem key={idx}
-                        data-testid={`integration-actions-${toValidHtmlId(a.label.toString())}`}
-                        onClick={a.onClick}
-                        tabIndex={idx + 1}
-                        role={'menuitem'}
-          >
-            {a.href ? (
-              <Link to={a.href}>
-                {a.label}
-              </Link>
-            ) : a.label}
-          </DropdownItem>
-        ))}
+        dropdownItems={actions.map((a, idx) => {
+          return actionItem(a, idx)
+        })}
         position={DropdownPosition.right}
         className={'integration-actions__dropdown-kebab'}
         id={`integration-${integrationId}-action-menu`}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
@@ -21,64 +21,70 @@ export interface IIntegrationActionsProps {
   editHref?: H.LocationDescriptor;
 }
 
-export class IntegrationActions extends React.Component<
+export const IntegrationActions: React.FunctionComponent<
   IIntegrationActionsProps
-> {
-  public render() {
-    return (
-      <>
-        <ButtonLink
-          data-testid={'integration-actions-edit-button'}
-          className={'edit-integration-btn'}
-          href={this.props.editHref}
-          as={'default'}
-        >
-          {this.props.i18nEditBtn}
-        </ButtonLink>
-        <ButtonLink
-          data-testid={'integration-actions-view-button'}
-          className={'view-integration-btn'}
-          href={this.props.detailsHref}
-          as={'default'}
-        >
-          {this.props.i18nViewBtn}
-        </ButtonLink>
-        <DropdownKebab
-          className={'integration-actions__dropdown-kebab'}
-          id={`integration-${this.props.integrationId}-action-menu`}
-          pullRight={true}
-        >
-          {this.props.actions.map((a, idx) => (
-            <li role={'presentation'} key={idx}>
-              {a.href ? (
-                <Link
-                  data-testid={`integration-actions-${toValidHtmlId(
-                    a.label.toString()
-                  )}`}
-                  to={a.href}
-                  onClick={a.onClick}
-                  role={'menuitem'}
-                  tabIndex={idx + 1}
-                >
-                  {a.label}
-                </Link>
-              ) : (
-                <a
-                  data-testid={`integration-actions-${toValidHtmlId(
-                    a.label.toString()
-                  )}`}
-                  href={'javascript:void(0)'}
-                  onClick={a.onClick}
-                  role={'menuitem'}
-                  tabIndex={idx + 1}
-                >
-                  {a.label}
-                </a>
-              )}
-            </li>
-          ))}
-        </DropdownKebab>
-      </>
-    );
-  }
-}
+> = (
+  {
+    actions,
+    detailsHref,
+    editHref,
+    i18nEditBtn,
+    i18nViewBtn,
+    integrationId
+  }) => {
+  return (
+    <>
+      <ButtonLink
+        data-testid={'integration-actions-edit-button'}
+        className={'edit-integration-btn'}
+        href={editHref}
+        as={'default'}
+      >
+        {i18nEditBtn}
+      </ButtonLink>
+      <ButtonLink
+        data-testid={'integration-actions-view-button'}
+        className={'view-integration-btn'}
+        href={detailsHref}
+        as={'default'}
+      >
+        {i18nViewBtn}
+      </ButtonLink>
+      <DropdownKebab
+        className={'integration-actions__dropdown-kebab'}
+        id={`integration-${integrationId}-action-menu`}
+        pullRight={true}
+      >
+        {actions.map((a, idx) => (
+          <li role={'presentation'} key={idx}>
+            {a.href ? (
+              <Link
+                data-testid={`integration-actions-${toValidHtmlId(
+                  a.label.toString()
+                )}`}
+                to={a.href}
+                onClick={a.onClick}
+                role={'menuitem'}
+                tabIndex={idx + 1}
+              >
+                {a.label}
+              </Link>
+            ) : (
+              <a
+                data-testid={`integration-actions-${toValidHtmlId(
+                  a.label.toString()
+                )}`}
+                href={'javascript:void(0)'}
+                onClick={a.onClick}
+                role={'menuitem'}
+                tabIndex={idx + 1}
+              >
+                {a.label}
+              </a>
+            )}
+          </li>
+        ))}
+      </DropdownKebab>
+    </>
+  );
+};

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItemActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItemActions.tsx
@@ -1,8 +1,8 @@
-import { DropdownKebab } from 'patternfly-react';
+import {
+  Dropdown, DropdownPosition, KebabToggle } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { toValidHtmlId } from '../../helpers';
 import { IMenuActions } from '../../Shared';
+import { actionItem, IIntegrationAction } from './IntegrationActions';
 
 export interface IIntegrationDetailHistoryListViewItemActionsProps {
   actions: IMenuActions[];
@@ -16,42 +16,26 @@ export const IntegrationDetailHistoryListViewItemActions: React.FunctionComponen
     actions,
     integrationId
   }) => {
+  const [showDropdown, setShowDropdown] = React.useState(false);
+
+  const toggleDropdown = () => {
+    setShowDropdown(!showDropdown);
+  };
+
+  const baseIdString = 'integration-detail-history-list-view-item-actions';
+
   return (
-    <DropdownKebab
-      id={`integration-${integrationId}-action-menu`}
-      pullRight={true}
-    >
-      {actions.map((a, index) => {
-        return (
-          <li role={'presentation'} key={index}>
-            {a.href ? (
-              <Link
-                data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
-                  a.label.toString()
-                )}`}
-                to={a.href}
-                onClick={a.onClick}
-                role={'menuitem'}
-                tabIndex={index + 1}
-              >
-                {a.label}
-              </Link>
-            ) : (
-              <a
-                data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
-                  a.label.toString()
-                )}`}
-                href={'javascript:void(0)'}
-                onClick={a.onClick}
-                role={'menuitem'}
-                tabIndex={index + 1}
-              >
-                {a.label}
-              </a>
-            )}
-          </li>
-        );
+    <Dropdown
+      toggle={<KebabToggle onToggle={toggleDropdown} id="toggle-dropdown"/>}
+      isOpen={showDropdown}
+      isPlain={true}
+      role={'presentation'}
+      dropdownItems={actions.map((a, idx) => {
+        return actionItem(a as IIntegrationAction, idx, baseIdString)
       })}
-    </DropdownKebab>
+      position={DropdownPosition.right}
+      className={'integration-actions__dropdown-kebab'}
+      id={`integration-${integrationId}-action-menu`}
+    />
   );
 };

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItemActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItemActions.tsx
@@ -9,47 +9,49 @@ export interface IIntegrationDetailHistoryListViewItemActionsProps {
   integrationId: string;
 }
 
-export class IntegrationDetailHistoryListViewItemActions extends React.Component<
+export const IntegrationDetailHistoryListViewItemActions: React.FunctionComponent<
   IIntegrationDetailHistoryListViewItemActionsProps
-> {
-  public render() {
-    return (
-      <DropdownKebab
-        id={`integration-${this.props.integrationId}-action-menu`}
-        pullRight={true}
-      >
-        {this.props.actions.map((a, index) => {
-          return (
-            <li role={'presentation'} key={index}>
-              {a.href ? (
-                <Link
-                  data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
-                    a.label.toString()
-                  )}`}
-                  to={a.href}
-                  onClick={a.onClick}
-                  role={'menuitem'}
-                  tabIndex={index + 1}
-                >
-                  {a.label}
-                </Link>
-              ) : (
-                <a
-                  data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
-                    a.label.toString()
-                  )}`}
-                  href={'javascript:void(0)'}
-                  onClick={a.onClick}
-                  role={'menuitem'}
-                  tabIndex={index + 1}
-                >
-                  {a.label}
-                </a>
-              )}
-            </li>
-          );
-        })}
-      </DropdownKebab>
-    );
-  }
-}
+> = (
+  {
+    actions,
+    integrationId
+  }) => {
+  return (
+    <DropdownKebab
+      id={`integration-${integrationId}-action-menu`}
+      pullRight={true}
+    >
+      {actions.map((a, index) => {
+        return (
+          <li role={'presentation'} key={index}>
+            {a.href ? (
+              <Link
+                data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
+                  a.label.toString()
+                )}`}
+                to={a.href}
+                onClick={a.onClick}
+                role={'menuitem'}
+                tabIndex={index + 1}
+              >
+                {a.label}
+              </Link>
+            ) : (
+              <a
+                data-testid={`integration-detail-history-list-view-item-actions-${toValidHtmlId(
+                  a.label.toString()
+                )}`}
+                href={'javascript:void(0)'}
+                onClick={a.onClick}
+                role={'menuitem'}
+                tabIndex={index + 1}
+              >
+                {a.label}
+              </a>
+            )}
+          </li>
+        );
+      })}
+    </DropdownKebab>
+  );
+};

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, PageSection } from '../../Layout';
 
@@ -55,7 +55,7 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
   };
   const disableDiscoveryDialog = (
     <Modal
-      isSmall
+      isSmall={true}
       title={i18nDisableDiscovery}
       isOpen={showDialog}
       onClose={doHideDialog}
@@ -67,7 +67,7 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
           {i18nNo}
         </Button>
       ]}
-      isFooterLeftAligned
+      isFooterLeftAligned={true}
     >
       <p className={'lead'}>
         {i18nDisableDiscoveryConfirm}
@@ -83,7 +83,7 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
           <PageSection>
             <div className={'pf-c-content'}>
               <Modal
-                isSmall
+                isSmall={true}
                 title={i18nEnableDiscovery}
                 isOpen={showDialog}
                 onClose={doHideDialog}
@@ -95,7 +95,7 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
                     {i18nNo}
                   </Button>
                 ]}
-                isFooterLeftAligned
+                isFooterLeftAligned={true}
               >
                 <p className={'lead'}>
                   {i18nEnableDiscoveryConfirm}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
@@ -75,7 +75,7 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
       </p>
     </Modal>
   );
-  
+
   if (exposureMeans.indexOf(_3SCALE) !== -1) {
     return (
       <>

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposeVia.tsx
@@ -1,4 +1,4 @@
-import { MessageDialog } from 'patternfly-react';
+import { Modal, Button } from '@patternfly/react-core';
 import * as React from 'react';
 import { ButtonLink, PageSection } from '../../Layout';
 
@@ -54,46 +54,55 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
     setShowDialog(false);
   };
   const disableDiscoveryDialog = (
-    <MessageDialog
-      show={showDialog}
+    <Modal
+      isSmall
       title={i18nDisableDiscovery}
-      primaryContent={
-        <p className="lead">
-          {i18nDisableDiscoveryConfirm}
-          {isUnpublished ? null : <> {i18nRepublish}</>}?
-        </p>
-      }
-      primaryActionButtonContent={i18nYes}
-      primaryAction={doDisable3scale}
-      secondaryActionButtonContent={i18nNo}
-      secondaryAction={doHideDialog}
-      onHide={doHideDialog}
-      onCancel={doHideDialog}
-    />
+      isOpen={showDialog}
+      onClose={doHideDialog}
+      actions={[
+        <Button key="confirm" variant="primary" onClick={doDisable3scale}>
+          {i18nYes}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={doHideDialog}>
+          {i18nNo}
+        </Button>
+      ]}
+      isFooterLeftAligned
+    >
+      <p className={'lead'}>
+        {i18nDisableDiscoveryConfirm}
+        {isUnpublished ? null : <> {i18nRepublish}</>}?
+      </p>
+    </Modal>
   );
+  
   if (exposureMeans.indexOf(_3SCALE) !== -1) {
     return (
       <>
         {exposure !== _3SCALE ? (
           <PageSection>
-            <div className="pf-c-content">
-              <MessageDialog
-                show={showDialog}
+            <div className={'pf-c-content'}>
+              <Modal
+                isSmall
                 title={i18nEnableDiscovery}
-                primaryContent={
-                  <p className="lead">
-                    {i18nEnableDiscoveryConfirm}
-                    {isUnpublished ? null : <> {i18nRepublish}</>}?
-                  </p>
-                }
-                primaryActionButtonContent={i18nYes}
-                primaryAction={doEnable3scale}
-                secondaryActionButtonContent={i18nNo}
-                secondaryAction={doHideDialog}
-                onHide={doHideDialog}
-                onCancel={doHideDialog}
-              />
-              <div className="pf-l-split pf-m-gutter">
+                isOpen={showDialog}
+                onClose={doHideDialog}
+                actions={[
+                  <Button key="confirm" variant="primary" onClick={doEnable3scale}>
+                    {i18nYes}
+                  </Button>,
+                  <Button key="cancel" variant="link" onClick={doHideDialog}>
+                    {i18nNo}
+                  </Button>
+                ]}
+                isFooterLeftAligned
+              >
+                <p className={'lead'}>
+                  {i18nEnableDiscoveryConfirm}
+                  {isUnpublished ? null : <> {i18nRepublish}</>}?
+                </p>
+              </Modal>
+              <div className={'pf-l-split pf-m-gutter'}>
                 <div>
                   <ButtonLink
                     children={i18nEnableDiscovery}
@@ -108,9 +117,9 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
         ) : (
           <>
             <PageSection>
-              <div className="pf-c-content">
+              <div className={'pf-c-content'}>
                 {disableDiscoveryDialog}
-                <div className="pf-l-split pf-m-gutter">
+                <div className={'pf-l-split pf-m-gutter'}>
                   <div>
                     <ButtonLink
                       children={i18nDisableDiscovery}
@@ -129,9 +138,9 @@ export const IntegrationExposeVia: React.FunctionComponent<IIntegrationExposeVia
   } else {
     return exposure === _3SCALE ? (
       <PageSection>
-        <div className="pf-c-content">
+        <div className={'pf-c-content'}>
           {disableDiscoveryDialog}
-          <div className="pf-l-split pf-m-gutter">
+          <div className={'pf-l-split pf-m-gutter'}>
             <div>
               <ButtonLink
                 children={i18nDisableDiscovery}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { PageSection } from '../../Layout';
-import { CopyToClipboard } from '../../Shared/CopyToClipboard';
+import { CopyToClipboard } from '../../Shared';
 import './IntegrationExposedURL.css';
 
 export interface IIntegrationExposedURLProps {

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -145,8 +145,8 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                                           }
                                         )}
                                         editHref={editAction.href}
-                                        i18nEditBtn={'Edit'}
-                                        i18nViewBtn={'View'}
+                                        i18nEditBtn={t('integrations:Edit')}
+                                        i18nViewBtn={t('integrations:View')}
                                       />
                                     }
                                     i18nConfigurationRequired={t(

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -21,6 +21,8 @@
   "ConfirmRemoveTagDetail": "Removing a tag unassociates it from any integrations that have been marked with it and then deletes the tag. No integrations are deleted.",
   "AddTagDialogTitle": "Add Tag Name",
   "AddTagDialogDescription": "The following changes will be applied to all integrations.",
+  "Edit": "Edit",
+  "View": "View",
   "EditIntegration": "Edit Integration",
   "EditTagDialogTitle": "Edit Tag",
   "EditTagDialogDescription": "The following changes will be applied to all integrations.",


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/ENTESB-12896

## Screenshots

### `IntegrationActions` component

<img width="383" alt="Screenshot 2020-03-16 19 28 24" src="https://user-images.githubusercontent.com/3844502/76858911-3db27780-6850-11ea-8cb2-cc8711a34676.png">

<img width="1060" alt="Screenshot 2020-03-16 19 28 32" src="https://user-images.githubusercontent.com/3844502/76859347-08f2f000-6851-11ea-9a75-5013d636f6d8.png">


### `IntegrationDetailHistoryListViewItemActions` component

<img width="706" alt="Screenshot 2020-03-17 12 25 43" src="https://user-images.githubusercontent.com/3844502/76858920-4145fe80-6850-11ea-9e45-64c2f8c674fc.png">

<img width="965" alt="Screenshot 2020-03-17 13 14 09" src="https://user-images.githubusercontent.com/3844502/76859430-3b045200-6851-11ea-8217-a832f3137595.png">


### `IntegrationExposeVia` component

<img width="980" alt="Screenshot 2020-03-13 16 09 40" src="https://user-images.githubusercontent.com/3844502/76859077-7d795f00-6850-11ea-8f88-8b9a99ce3ce6.png">

<img width="1121" alt="Screenshot 2020-03-13 16 15 40" src="https://user-images.githubusercontent.com/3844502/76859007-6470ae00-6850-11ea-8bf0-a81d52e61d70.png">

