### PR TITLE
Add logging to syndesis release script

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -317,11 +317,13 @@ publish_artifacts() {
     fi
 
     for file in $top_dir/install/operator/releases/*; do
+        echo -n "Upload $file to $upload_url ..."
         curl -q -s --fail -X POST -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-Type: application/tar+gzip" \
           --data-binary "@${file}" \
           ${upload_url}?name=${file##*/} >/dev/null 2>&1
+          echo "done"
         local err=$?
         if [ $err -ne 0 ]; then
           echo "ERROR: Cannot upload release artifact $file on remote github repository"
@@ -329,11 +331,13 @@ publish_artifacts() {
         fi
     done
 
+    echo -n "Upload syndesis-cli.zip to $upload_url ..."
     (cd "$top_dir/tools/bin/" && zip -q -r - . | curl -q -s --fail -X POST -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Content-Type: application/zip" \
       --data-binary @- \
       ${upload_url}?name=syndesis-cli.zip >/dev/null) 2>&1
+      echo "done"
     local err=$?
     if [ $err -ne 0 ]; then
       echo "ERROR: Cannot upload release artifact syndesis-cli.zip on remote github repository"


### PR DESCRIPTION
The job syndesis-release-1.9.x-daily in ci.fabric8.org is failing for some builds, creating a tag with commits from master branch. For those builds that results in 1.9.x tags with commits from master it is observed the `publish_artifacts` function from `release` doesn't print any message or error, so I added some logging to see if it can help debug this problem. 
Related to #8024