### PR TITLE
TEIIDTOOLS-960 Resolve issue with teiid source naming

### DIFF
--- a/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
@@ -468,6 +468,7 @@ public class MetadataService extends DvService implements ServiceVdbGenerator.Sc
                 RestSyndesisSourceStatus status = new RestSyndesisSourceStatus(
                         tds.getSyndesisDataSource().getSyndesisName());
                 setSchemaStatus(tds.getSyndesisId(), status);
+                status.setTeiidName(tds.getName());
                 // Name of vdb based on source name
                 String vdbName = getWorkspaceSourceVdbName(tds.getName());
                 TeiidVdb teiidVdb = getMetadataInstance().getVdb(vdbName+LOAD_SUFFIX);

--- a/app/dv/src/main/java/io/syndesis/dv/server/endpoint/RestSyndesisSourceStatus.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/endpoint/RestSyndesisSourceStatus.java
@@ -55,6 +55,7 @@ public final class RestSyndesisSourceStatus implements V1Constants {
     }
 
     private String sourceName;
+    private String teiidName;
     private List< String > errors;
     private EntityState schemaState = EntityState.MISSING;
     private String id;
@@ -90,6 +91,7 @@ public final class RestSyndesisSourceStatus implements V1Constants {
         final RestSyndesisSourceStatus that = ( RestSyndesisSourceStatus )obj;
 
         return Objects.equals( this.sourceName, that.sourceName )
+               && Objects.equals( this.teiidName, that.teiidName )
                && Objects.equals( this.errors, that.errors )
                && Objects.equals( this.id, that.id )
                && Objects.equals(  this.schemaState, that.schemaState )
@@ -101,6 +103,13 @@ public final class RestSyndesisSourceStatus implements V1Constants {
      */
     public String getSourceName() {
         return this.sourceName;
+    }
+
+    /**
+     * @return the teiid name (can be empty)
+     */
+    public String getTeiidName() {
+        return this.teiidName;
     }
 
     /**
@@ -132,6 +141,7 @@ public final class RestSyndesisSourceStatus implements V1Constants {
     @Override
     public int hashCode() {
         return Objects.hash( this.sourceName,
+                             this.teiidName,
                              this.errors,
                              this.id,
                              this.schemaState,
@@ -143,6 +153,13 @@ public final class RestSyndesisSourceStatus implements V1Constants {
      */
     public void setSourceName( final String sourceName ) {
         this.sourceName = sourceName;
+    }
+
+    /**
+     * @param teiidName the teiid name (can be empty)
+     */
+    public void setTeiidName( final String teiidName ) {
+        this.teiidName = teiidName;
     }
 
     /**

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/RestSyndesisSourceStatusTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/RestSyndesisSourceStatusTest.java
@@ -31,6 +31,7 @@ public class RestSyndesisSourceStatusTest {
     @Test public void testSerialization() {
         RestSyndesisSourceStatus rsss = new RestSyndesisSourceStatus("x");
         rsss.setId("id");
+        rsss.setTeiidName("tName");
         rsss.setErrors(Arrays.asList("some error"));
         rsss.setSchemaState(EntityState.ACTIVE);
         rsss.setLoading(true);
@@ -38,6 +39,7 @@ public class RestSyndesisSourceStatusTest {
         String value = JsonMarshaller.marshall(rsss);
         assertEquals("{\n" +
                 "  \"sourceName\" : \"x\",\n" +
+                "  \"teiidName\" : \"tName\",\n" +
                 "  \"errors\" : [ \"some error\" ],\n" +
                 "  \"schemaState\" : \"ACTIVE\",\n" +
                 "  \"id\" : \"id\",\n" +

--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -86,6 +86,7 @@ export interface VirtualizationSourceStatus {
   loading: boolean;
   schemaState: 'ACTIVE' | 'MISSING' | 'FAILED';
   sourceName: string;
+  teiidName: string;
   lastLoad: number;
 }
 

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -15,6 +15,7 @@
     "RUNNING": "Running",
     "SUBMITTED": "Submitted"
   },
+  "connectionNotFound": "Connection not found",
   "connectionStatusPopoverLink": "Connection error",
   "connectionStatusPopoverTitle": "Connection Error",
   "createDataVirtualization": "Create $t(shared:DataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -15,6 +15,7 @@
     "RUNNING": "In Esecuzione",
     "SUBMITTED": "Inserito"
   },
+  "connectionNotFound": "Connessione non trovata",
   "connectionStatusPopoverLink": "Errore di connessione",
   "connectionStatusPopoverTitle": "Errore di connessione",
   "createDataVirtualization": "Crea $t(shared:DataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.ru.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.ru.json
@@ -15,6 +15,7 @@
     "RUNNING": "Запущено",
     "SUBMITTED": "Отправлено"
   },
+  "connectionNotFound": "Соединение не найдено",
   "connectionStatusPopoverLink": "Ошибка подключения",
   "connectionStatusPopoverTitle": "Ошибка подключения",
   "createDataVirtualization": "Создать $t(shared:DataVirtualization)",

--- a/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewsImport/SelectViewsPage.tsx
@@ -104,6 +104,14 @@ export const SelectViewsPage: React.FunctionComponent<
     return resultStatus;
   };
 
+  const getConnectionTeiidName = (
+    connectionName: string,
+    sourceStatuses: VirtualizationSourceStatus[]
+  ) => {
+    const sourceStatus = sourceStatuses.find(status => status.sourceName === connectionName);
+    return sourceStatus ? sourceStatus.teiidName : '';
+  };
+
   const getConnectionLastLoad = (
     connectionName: string,
     sourceStatuses: VirtualizationSourceStatus[]
@@ -169,6 +177,7 @@ export const SelectViewsPage: React.FunctionComponent<
           connectionName={state.connectionId}
           connectionStatus={getConnectionStatus(state.connectionId, connectionStatuses)}
           connectionStatusMessage={''}
+          connectionTeiidName={getConnectionTeiidName(state.connectionId, connectionStatuses)}
           existingViewNames={getExistingViewNames(viewDefinitionDescriptors)}
           connectionLastLoad={getConnectionLastLoad(state.connectionId, connectionStatuses)}
           onViewSelected={props.handleAddView}

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
@@ -65,6 +65,7 @@ export interface IViewInfosContentProps {
   connectionName: string;
   connectionStatus: string;
   connectionStatusMessage: string;
+  connectionTeiidName: string;
   existingViewNames: string[];
   connectionLastLoad: number;
   onViewSelected: (view: ViewInfo) => void;
@@ -136,7 +137,7 @@ export const ViewInfosContent: React.FunctionComponent<
         }),
         'info'
       );
-      await refreshConnectionSchema(connectionName);
+      await refreshConnectionSchema(props.connectionTeiidName);
     } catch (error) {
       const details = error.message ? error.message : '';
       // inform user of error
@@ -155,7 +156,7 @@ export const ViewInfosContent: React.FunctionComponent<
     hasData: hasSchema,
     error,
     read,
-  } = useVirtualizationConnectionSchema(props.connectionName);
+  } = useVirtualizationConnectionSchema(props.connectionTeiidName);
 
   React.useEffect(() => {
     if(props.connectionLastLoad > lastSchemaRefresh) {


### PR DESCRIPTION
Resolve issue with syndesis connections that have spaces or other special chars in the names.
- add 'teiidName' to RestSyndesisSourceStatus so that the ui has access to the teiid name corresponding to the syndesis connection name
- utilize the connection teiidName in the ui for fetching and refreshing the source schema