### PR TITLE
fix: install fontawesome free directly

### DIFF
--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -87,6 +87,7 @@
     "react-router-dom": "^4.3.1"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.13.0",
     "@syndesis/history": "*",
     "classnames": "^2.2.6",
     "codemirror": "^5.46.0",

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -1,5 +1,6 @@
 /* pf4 base styles */
 /* @import url('~@patternfly/react-core/dist/styles/base.css'); */
+@import url('~@fortawesome/fontawesome-free/css/all.css');
 @import url('~@patternfly/patternfly/patternfly-variables.css');
 @import url('~@patternfly/patternfly/patternfly-shield-noninheritable.css');
 @import url('~@patternfly/patternfly/patternfly-common.css');

--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@allpro/react-router-pause": "^1.1.3",
     "@craco/craco": "^5.0.2",
+    "@fortawesome/fontawesome-free": "^5.13.0",
     "@patternfly/patternfly": "^2.60.1",
     "@patternfly/react-charts": "^5.2.21",
     "@patternfly/react-core": "^3.122.4",

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -1638,6 +1638,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
   integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
 
+"@fortawesome/fontawesome-free@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
+  integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
+
 "@fortawesome/free-brands-svg-icons@^5.8.1":
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.8.2.tgz#e68a509c986d5d197cc5bd9ae8d966eff513468d"


### PR DESCRIPTION
fixes #8118

Turns out patternfly ships with it's own subset of icons, this brings back in fontawesome in the short term to sort views that directly use the fontawesome classes, for example:

![image](https://user-images.githubusercontent.com/351660/77348152-58cd2d80-6d0f-11ea-8c8e-1ba9eb784b59.png)
