### PR TITLE
chore(build): keep up to 10 snapshot

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -151,9 +151,6 @@ release::run() {
     # Release the binaries
     publish_artifacts "${topdir}" "$release_version" $prerelease
 
-    # Cleanup old prereleases
-    delete_prereleases_older_than 40
-
     # Create release description based on commit between releases
     # if check_for_command gren; then
     #    gren release --data-source=commits --tags=$release_version --override
@@ -307,11 +304,28 @@ publish_artifacts() {
 
     local remote=$(readopt --git-remote)
     if [ -z "${remote}" ]; then
-      remote=$(git remote get-url origin)
+        remote=$(git remote get-url origin)
     fi
 
     local github_api_url=${remote/github.com/api.github.com\/repos}
     github_api_url=${github_api_url/%.git/}
+
+    if [ ${prerelease} == true ]; then
+        # keep only last 10 snapshot releases
+        local major_minor=${tag%.*} # this relies on having two dots in $tag, i.e. at least X.Y.Z
+        if [ -z "${major_minor}" ]; then
+            echo "ERROR: refusing to proceed MAJOR.MINOR version calculated as empty this would delete all releases"
+            return
+        fi
+        local versions_to_discard=$(git tag -l "${major_minor}*" --sort=taggerdate|head -n -10)
+        for version in ${versions_to_discard}; do
+            local release_url=$(curl -q -s -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} "${github_api_url}/releases/tags/${version}" | jq -r .url)
+            if [ "${release_url}" != "null" ]; then
+                curl -q -s --fail -X DELETE -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} ${release_url}
+            fi
+        done
+        git push --delete origin "${versions_to_discard}"
+    fi
 
     local upload_url=$(curl -q -s --fail \
       -X POST \
@@ -349,80 +363,6 @@ publish_artifacts() {
     if [ $err -ne 0 ]; then
       echo "ERROR: Cannot upload release artifact syndesis-cli.zip on remote github repository"
       return
-    fi
-}
-
-# return how many days since a release was published
-days_since_published() {
-    url=$1
-    published_at=$(curl -q -s --fail \
-      -X GET \
-      -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
-      ${url} | jq -r ".published_at"
-    )
-
-    if [[ $published_at == 20* ]]; then
-        days=$(( ( $(date '+%s') - $(date -d $published_at '+%s') ) / 86400 ))
-        echo $days
-    else
-        echo 0
-    fi
-}
-
-# Delete all prereleases older than $1(default 30) days that are fund in the first
-# release pagewhere an prerelease old enough is found
-delete_prereleases_older_than() {
-    delete_older_than=${1:-30}
-    page=${2:-1}
-
-    # figure out from which page on we should delete, by taking the last
-    # release from the page and checking how many days have passed since published 
-    # 
-    while [[ true ]]; do
-        last_release=$(curl -q -s --fail \
-          -X GET \
-          -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
-          https://api.github.com/repos/syndesisio/syndesis/releases?page=${page} | jq -r ".[length -1].url"
-        )
-
-        if [[ "${last_release}" != "null" ]]; then
-            dsp=$(days_since_published $last_release)
-            if (( $dsp > $delete_older_than )); then
-                break;
-            else
-                page=$((page+1))
-            fi
-        else
-            page=0
-            break;
-        fi
-    done
-
-    # at the first release page we found releases older than the desired number,
-    # iterate through all releases and delete prereleases that are older than the
-    # threshold
-    if (( $page > 0 )); then
-        releases_urls=$(curl -q -s --fail \
-          -X GET \
-          -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
-          https://api.github.com/repos/syndesisio/syndesis/releases?page=${page} | jq -r ".[].url"
-        )
-
-        for url in $releases_urls; do
-            prerelease=$(curl -q -s --fail \
-                -X GET \
-                -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} \
-                $url | jq ".prerelease"
-            )
-
-            if [[ "$prerelease" == "true" ]]; then
-                dsp=$(days_since_published $url)
-                if (( $dsp > $delete_older_than )); then
-                    echo "$url is prerelease ${dsp} days old, deleting ..."
-                    echo curl -s --fail -X DELETE -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} $url
-                fi
-            fi
-        done
     fi
 }
 


### PR DESCRIPTION
When releasing a snapshot using `syndesis release --snapshot-release`
this deletes GitHub pre-releases and tags keeping up to 10 for each
snapshot tag.

So for 1.9 snapshot releases this will delete `1.9.0-YYYYMMDD` GitHub
pre-releases and tags, i.e. it will not affect any 1.8 snapshot
git tags or GitHub pre-releases.

A bit different than keeping last n days of snapshots as in #8087.
Created for discussion.