### PR TITLE
fix(#8125): Fix empty values handling in Google sheets

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -117,7 +117,7 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
                         .entrySet()
                         .stream()
                         .filter(specEntry -> !Objects.equals("spreadsheetId", specEntry.getKey()))
-                        .forEach(specEntry -> rangeValues.add(dataShape.getOrDefault(specEntry.getKey(), null)));
+                        .forEach(specEntry -> rangeValues.add(dataShape.getOrDefault(specEntry.getKey(), "")));
 
                 values.add(rangeValues);
             }

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizerTest.java
@@ -239,12 +239,12 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(2L, valueRange.getValues().size());
         Assert.assertEquals(3L, valueRange.getValues().get(0).size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
-        Assert.assertNull(valueRange.getValues().get(0).get(1));
+        Assert.assertEquals("", valueRange.getValues().get(0).get(1));
         Assert.assertEquals("c1", valueRange.getValues().get(0).get(2));
         Assert.assertEquals(3L, valueRange.getValues().get(1).size());
         Assert.assertEquals("a2", valueRange.getValues().get(1).get(0));
         Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
-        Assert.assertNull(valueRange.getValues().get(1).get(2));
+        Assert.assertEquals("", valueRange.getValues().get(1).get(2));
     }
 
     @Test
@@ -280,12 +280,12 @@ public class GoogleSheetsUpdateValuesCustomizerTest extends AbstractGoogleSheets
         Assert.assertEquals(2L, valueRange.getValues().size());
         Assert.assertEquals(3L, valueRange.getValues().get(0).size());
         Assert.assertEquals("a1", valueRange.getValues().get(0).get(0));
-        Assert.assertNull(valueRange.getValues().get(0).get(1));
+        Assert.assertEquals("", valueRange.getValues().get(0).get(1));
         Assert.assertEquals("c1", valueRange.getValues().get(0).get(2));
         Assert.assertEquals(3L, valueRange.getValues().get(1).size());
         Assert.assertEquals("a2", valueRange.getValues().get(1).get(0));
         Assert.assertEquals("b2", valueRange.getValues().get(1).get(1));
-        Assert.assertNull(valueRange.getValues().get(1).get(2));
+        Assert.assertEquals("", valueRange.getValues().get(1).get(2));
     }
 
     @Test


### PR DESCRIPTION
Null values are skipped according to the Google docs. This leads to invalid data in value ranges for update and append operation. Using empty String values to fill in gaps that were not mapped in data mapper or mapped as Null value.