### PR TITLE
fix: guard against connectors that don't have properties

### DIFF
--- a/app/ui-react/packages/ui/__tests__/Connection/ConnectionDetailsForm.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Connection/ConnectionDetailsForm.spec.tsx
@@ -15,6 +15,7 @@ export default describe('ConnectionDetailsForm', () => {
 
   const props = {
     handleSubmit: jest.fn(),
+    hasProperties: true,
     i18nCancelLabel: 'Cancel',
     i18nEditLabel: 'Edit',
     i18nSaveLabel: 'Save',

--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
@@ -55,6 +55,11 @@ export interface IConnectionDetailsFormProps {
   isWorking: boolean;
 
   /**
+   * `true` if the connector has configuration fields, false if there are none
+   */
+  hasProperties: boolean;
+
+  /**
    * Form level validationResults
    */
   validationResults: IConnectionDetailsValidationResult[];
@@ -95,6 +100,7 @@ export const ConnectionDetailsForm: React.FunctionComponent<IConnectionDetailsFo
   i18nValidateLabel,
   isValid,
   isWorking,
+  hasProperties,
   validationResults,
   handleSubmit,
   onValidate,
@@ -135,13 +141,17 @@ export const ConnectionDetailsForm: React.FunctionComponent<IConnectionDetailsFo
                     {i18nValidateLabel}
                   </Button>
                 ) : (
-                  <Button
-                    data-testid={'connection-details-form-edit-button'}
-                    variant="primary"
-                    onClick={onStartEditing}
-                  >
-                    {i18nEditLabel}
-                  </Button>
+                  <>
+                    {hasProperties && (
+                      <Button
+                        data-testid={'connection-details-form-edit-button'}
+                        variant="primary"
+                        onClick={onStartEditing}
+                      >
+                        {i18nEditLabel}
+                      </Button>
+                    )}
+                  </>
                 )}
               </div>
             </Form>

--- a/app/ui-react/packages/ui/src/Connection/ConnectorNothingToConfigureAlert.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorNothingToConfigureAlert.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { SyndesisAlert, SyndesisAlertLevel } from '../Shared';
+
+export interface IConnectorNothingToConfigureAlertProps {
+  i18nAlert: string;
+}
+
+export const ConnectorNothingToConfigureAlert: React.FunctionComponent<IConnectorNothingToConfigureAlertProps> = ({
+  i18nAlert,
+}) => <SyndesisAlert level={SyndesisAlertLevel.INFO} message={i18nAlert} />;

--- a/app/ui-react/packages/ui/src/Connection/index.ts
+++ b/app/ui-react/packages/ui/src/Connection/index.ts
@@ -8,5 +8,6 @@ export * from './ConnectionsGridCell';
 export * from './ConnectionSkeleton';
 export * from './ConnectionsListView';
 export * from './ConnectorAuthorization';
+export * from './ConnectorNothingToConfigureAlert';
 export * from './ConnectorConfigurationForm';
 export * from './ConnectionSetupOAuthCard';

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigureAlert.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorNothingToConfigureAlert.tsx
@@ -1,5 +1,5 @@
-import { Text } from '@patternfly/react-core';
 import * as React from 'react';
+import { SyndesisAlert, SyndesisAlertLevel } from '../../Shared';
 
 export interface IIntegrationEditorNothingToConfigureAlertProps {
   i18nAlert: string;
@@ -7,9 +7,4 @@ export interface IIntegrationEditorNothingToConfigureAlertProps {
 
 export const IntegrationEditorNothingToConfigureAlert: React.FunctionComponent<IIntegrationEditorNothingToConfigureAlertProps> = ({
   i18nAlert,
-}) => (
-  <Text className="alert alert-info">
-    <span className="pficon pficon-info" />
-    {i18nAlert}
-  </Text>
-);
+}) => <SyndesisAlert level={SyndesisAlertLevel.INFO} message={i18nAlert} />;

--- a/app/ui-react/packages/ui/src/Shared/SyndesisAlert.tsx
+++ b/app/ui-react/packages/ui/src/Shared/SyndesisAlert.tsx
@@ -11,8 +11,8 @@ export interface ISyndesisAlertProps {
   level: SyndesisAlertLevel;
   message: string;
   detail?: string;
-  i18nTextExpanded: string;
-  i18nTextCollapsed: string;
+  i18nTextExpanded?: string;
+  i18nTextCollapsed?: string;
 }
 
 function mapLevel(incoming: SyndesisAlertLevel) {

--- a/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
@@ -19,6 +19,10 @@ export interface IWithConnectorFormChildrenProps {
    */
   fields: JSX.Element;
   /**
+   * some connectors have no configuration
+   */
+  hasProperties: boolean;
+  /**
    * true if the form has been modified.
    */
   dirty: boolean;
@@ -102,9 +106,13 @@ export interface IWithConnectorFormProps {
  * @see [moreConfigurationSteps]{@link IWithConnectorFormProps#moreConfigurationSteps}
  * @see [values]{@link IWithConnectorFormProps#values}
  */
-export const WithConnectorForm: React.FunctionComponent<
-  IWithConnectorFormProps
-> = ({ connector, disabled, initialValue = {}, onSave, children }) => {
+export const WithConnectorForm: React.FunctionComponent<IWithConnectorFormProps> = ({
+  connector,
+  disabled,
+  initialValue = {},
+  onSave,
+  children,
+}) => {
   const { t } = useTranslation('shared');
   const [
     isValidatingAgainstBackend,
@@ -113,15 +121,16 @@ export const WithConnectorForm: React.FunctionComponent<
   const [validationResults, setValidationResults] = React.useState<
     IConnectorConfigurationFormValidationResult[]
   >([]);
-
-  const definition = Object.keys(connector.properties!).reduce((def, key) => {
-    const d = connector.properties![key];
+  const properties = connector.properties || {};
+  const definition = Object.keys(properties).reduce((def, key) => {
+    const d = properties[key];
     def[key] = {
       ...d,
       disabled,
     };
     return def;
   }, {});
+  const hasProperties = Object.keys(definition).length > 0;
   return (
     <WithConnectionHelpers>
       {({ validateConfiguration }) => {
@@ -171,6 +180,7 @@ export const WithConnectorForm: React.FunctionComponent<
                 dirty,
                 fields,
                 handleSubmit,
+                hasProperties,
                 isSubmitting,
                 isValid,
                 isValidating: isValidating || isValidatingAgainstBackend,

--- a/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
   ConnectionDetailsForm,
   ConnectionDetailsHeader,
   ConnectionDetailsOauthCard,
+  ConnectorNothingToConfigureAlert,
   PageLoader,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
@@ -30,9 +31,7 @@ export interface IConnectionDetailsOauthProps {
   configuredProperties: Pick<IConnectionOverview, 'configuredProperties'>;
   onOAuthReconnect: () => void;
 }
-const ConnectionDetailsOAuth: React.FunctionComponent<
-  IConnectionDetailsOauthProps
-> = ({
+const ConnectionDetailsOAuth: React.FunctionComponent<IConnectionDetailsOauthProps> = ({
   connectorId,
   connectionName,
   configuredProperties,
@@ -54,7 +53,10 @@ const ConnectionDetailsOAuth: React.FunctionComponent<
         pushNotification(message, type)
       );
     } catch (e) {
-      pushNotification(`Connection couldn't be verified: ${e.message}`, 'error');
+      pushNotification(
+        `Connection couldn't be verified: ${e.message}`,
+        'error'
+      );
     }
   };
 
@@ -86,9 +88,9 @@ export interface IConnectionDetailsPageProps {
   edit: boolean;
 }
 
-export const ConnectionDetailsPage: React.FunctionComponent<
-  IConnectionDetailsPageProps
-> = ({ edit }) => {
+export const ConnectionDetailsPage: React.FunctionComponent<IConnectionDetailsPageProps> = ({
+  edit,
+}) => {
   const { t } = useTranslation(['connections', 'shared']);
   const { pushNotification } = React.useContext(UIContext);
   const { params, state, history, location } = useRouteData<
@@ -262,6 +264,7 @@ export const ConnectionDetailsPage: React.FunctionComponent<
             {({
               fields,
               handleSubmit,
+              hasProperties,
               validationResults,
               dirty,
               isSubmitting,
@@ -303,13 +306,22 @@ export const ConnectionDetailsPage: React.FunctionComponent<
                     handleSubmit={handleSubmit}
                     isValid={!dirty || isValid}
                     isWorking={isSubmitting || isValidating}
+                    hasProperties={hasProperties}
                     validationResults={validationResults}
                     isEditing={edit}
                     onCancelEditing={cancelEditing}
                     onStartEditing={startEditing}
                     onValidate={validateForm}
                   >
-                    {fields}
+                    <>
+                      {hasProperties ? (
+                        fields
+                      ) : (
+                        <ConnectorNothingToConfigureAlert
+                          i18nAlert={'There are no properties to configure'}
+                        />
+                      )}
+                    </>
                   </ConnectionDetailsForm>
                 )}
                 {connection.derived && (

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -6,6 +6,7 @@ import {
   ConnectionSetupOAuthCard,
   ConnectorAuthorization,
   ConnectorConfigurationForm,
+  ConnectorNothingToConfigureAlert,
   PageLoader,
   PageSection,
 } from '@syndesis/ui';
@@ -216,6 +217,7 @@ export const ConfigurationPage: React.FunctionComponent = () => {
                         {({
                           fields,
                           handleSubmit,
+                          hasProperties,
                           validationResults,
                           submitForm,
                           isSubmitting,
@@ -240,7 +242,17 @@ export const ConfigurationPage: React.FunctionComponent = () => {
                             i18nSave={t('shared:Save')}
                             i18nNext={t('shared:Next')}
                           >
-                            {fields}
+                            <>
+                              {hasProperties ? (
+                                fields
+                              ) : (
+                                <ConnectorNothingToConfigureAlert
+                                  i18nAlert={
+                                    'There are no properties to configure'
+                                  }
+                                />
+                              )}
+                            </>
                           </ConnectorConfigurationForm>
                         )}
                       </WithConnectorForm>


### PR DESCRIPTION
 fixes [ENTESB-13266](https://issues.redhat.com/browse/ENTESB-13266)

Relaxes the previous restriction that connectors have to have properties to guard
against NPE errors, adds an alert when a connector has no properties and updates
the existing "no properties" alert to use the SyndesisAlert wrapper

In the wizard:
![image](https://user-images.githubusercontent.com/351660/77765522-bfef2880-7014-11ea-908f-cfacb40bbcc1.png)

Detail page:
![image](https://user-images.githubusercontent.com/351660/77765645-ed3bd680-7014-11ea-93f2-7d61c362b470.png)