### PR TITLE
fix: swap out real i18n module with a dummy to help nightly build

### DIFF
--- a/app/ui-react/syndesis/src/app/App.test.tsx
+++ b/app/ui-react/syndesis/src/app/App.test.tsx
@@ -1,9 +1,18 @@
 import { render, waitForElement } from '@testing-library/react';
 import * as React from 'react';
-import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter } from 'react-router';
 import { App } from './App';
-import i18n from '../i18n';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    resources: {
+      en: {}
+    }
+  });
 
 jest.unmock('./App');
 jest.mock('./WithConfig');


### PR DESCRIPTION
for #8150

The test doesn't need to load the whole actual i18n framework, and it appears to be causing a problem for the nightly build.