### PR TITLE
fix weird button issue on connection detail page

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormLabelHintComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLabelHintComponent.tsx
@@ -1,7 +1,6 @@
 import { Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { TextButton } from './TextButton';
 
 import './FormLabelHintComponent.css';
 
@@ -10,16 +9,13 @@ export interface IFormLabelHintComponentProps {
 }
 
 export const FormLabelHintComponent: React.FunctionComponent<IFormLabelHintComponentProps> = ({ labelHint }) => {
-
   return (
     <Popover
       aria-label={labelHint}
       bodyContent={labelHint}
       className={'form-label-hint__popover'}
     >
-      <TextButton className={'form-label-hint__text-button'}>
-        <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-      </TextButton>
+      <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
     </Popover>
   )
 };


### PR DESCRIPTION
not sure if there's an issue open for it, but this PR fixes this:

<img width="531" alt="Screenshot 2020-03-31 16 46 13-02" src="https://user-images.githubusercontent.com/3844502/78046803-84838f80-736f-11ea-86ed-0e95d71039fe.png">

after changes:

<img width="427" alt="Screenshot 2020-03-31 16 43 33" src="https://user-images.githubusercontent.com/3844502/78046547-31114180-736f-11ea-95d3-6f3ceb508a07.png">

<img width="482" alt="Screenshot 2020-03-31 16 43 39" src="https://user-images.githubusercontent.com/3844502/78046558-340c3200-736f-11ea-850b-6eceb1fc653f.png">

cc @gashcrumb 