### PR TITLE
feat(server): API query filter

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/ReflectionUtils.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/ReflectionUtils.java
@@ -44,11 +44,23 @@ public final class ReflectionUtils {
     }
 
     static Method extractMethod(Class<?> clazz, String fieldName, Class<?>... types) {
+        Method getMethod = extractMethod("get", clazz, fieldName, types);
+        if (getMethod != null){
+            return getMethod;
+        }
+        Method isMethod = extractMethod("is", clazz, fieldName, types);
+        if (isMethod != null){
+            return isMethod;
+        }
+        return null;
+    }
+
+    private static Method extractMethod(String methodPrefix, Class<?> clazz, String fieldName, Class<?>... types) {
         try {
-            Method method = clazz.getMethod("get" + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
+            Method method = clazz.getMethod(methodPrefix + fieldName.substring(0, 1).toUpperCase(Locale.US) + fieldName.substring(1));
             Class<?> returnType = method.getReturnType();
             for (Class<?> type : types) {
-                if (returnType.isAssignableFrom(type)) {
+                if (type.isAssignableFrom(returnType)) {
                     return method;
                 }
             }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectionUtilsTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectionUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.util;
+
+import java.lang.reflect.Method;
+
+import org.immutables.value.Value;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+
+    @Test
+    public void shouldGetAllClassMethods() {
+        Method intMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "anInt", Integer.class);
+        Method booleanMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "aBoolean", boolean.class);
+        Method doubleMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "aDouble", double.class);
+        Method stringMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "aString", String.class);
+        Method objectMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "anObject", Object.class);
+        Method classMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "someClass", SomeClass.class);
+        // Check inheritance
+        Method classToSomeOtherClassMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "someClass", SomeOtherClass.class);
+        // Check fallback to Object
+        Method classToObjectMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "someClass", Object.class);
+        // Check inheritance with Enum supertype
+        Method enumMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "enumType", Enum.class);
+        // Check fallback to Object
+        Method enumToObjectMethod = ReflectionUtils.getGetMethodOfType(JustForTest.class, "enumType", Object.class);
+
+        assertThat(intMethod).isNotNull();
+        assertThat(booleanMethod).isNotNull();
+        assertThat(doubleMethod).isNotNull();
+        assertThat(stringMethod).isNotNull();
+        assertThat(objectMethod).isNotNull();
+        assertThat(classMethod).isNotNull();
+        assertThat(classToSomeOtherClassMethod).isNotNull();
+        assertThat(classToObjectMethod).isNotNull();
+        assertThat(enumMethod).isNotNull();
+        assertThat(enumToObjectMethod).isNotNull();
+    }
+
+    @Value.Immutable
+    interface JustForTest{
+
+        enum Type {
+            TypeA,
+            TypeB
+        }
+
+        Integer getAnInt();
+        double getADouble();
+        boolean isABoolean();
+        String getAString();
+        Object getAnObject();
+        SomeClass getSomeClass();
+        Type getEnumType();
+    }
+
+    interface SomeClass extends SomeOtherClass {
+        Integer getAnotherInt();
+    }
+
+    interface SomeOtherClass{
+
+    }
+
+}
+
+

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveFiltererTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveFiltererTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.util;
+
+import java.util.List;
+
+import io.syndesis.common.model.ListResult;
+import io.syndesis.server.endpoint.util.test.person.TestPerson;
+import io.syndesis.server.endpoint.util.test.person.TestPersonInterface;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ReflectiveFiltererTest {
+
+    List<TestPersonInterface> data;
+
+    @Before
+    public void setup(){
+        data = TestPerson.getTestData();
+    }
+
+    @Test
+    public void filterNoQuery() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString(""));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(4);
+    }
+
+    @Test
+    public void filterWithQueryString() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("FirstName=Werner"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void filterWithQueryNoMatchingResults() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("FirstName=Pasquale"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void filterWithQueryPrimitive() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("BirthYear=1901"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void filterWithQueryEnum() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("country=UK"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void filterWithQueryBoolean() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("nobel=true"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    public void filterWithQueryOptional() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("university=Cambridge"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void filterWithQueryMulti() {
+        ReflectiveFilterer<TestPersonInterface> filter = new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("nobel=true,country=US"));
+        ListResult<TestPersonInterface> result = filter.apply(ListResult.of(data));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void invalidQueryField() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> {new ReflectiveFilterer<>(TestPersonInterface.class, FilterOptionsParser.fromString("MissingField=XYZ"));})
+            .withMessage("Cannot find field MissingField in io.syndesis.server.endpoint.util.test.person.TestPersonInterface as field");
+    }
+
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPerson.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPerson.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.util.test.person;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class TestPerson implements TestPersonInterface {
+
+    enum Country{
+        UK,
+        US,
+        AT,
+        DE
+    }
+
+    private final String firstName;
+    private final String lastName;
+    private final Optional<String> university;
+    private final int birthYear;
+    private final Country country;
+    private final boolean nobel;
+
+    TestPerson(String firstName, String lastName, int birthYear, boolean nobel, Country country, String university) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.birthYear = birthYear;
+        this.nobel = nobel;
+        this.country = country;
+        this.university = Optional.ofNullable(university);
+    }
+
+    @Override
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @Override
+    public String getLastName() {
+        return lastName;
+    }
+
+    @Override
+    public int getBirthYear() {
+        return birthYear;
+    }
+
+    @Override
+    public boolean isNobel() {
+        return nobel;
+    }
+
+    @Override
+    public Country getCountry() {
+        return country;
+    }
+
+    @Override
+    public Optional<String> getUniversity() {
+        return university;
+    }
+
+    public static List<TestPersonInterface> getTestData() {
+        return Arrays.asList(
+            new TestPerson( "Erwin", "Schrödinger", 1887, false, Country.AT, null),
+            new TestPerson( "Werner", "Heisenberg", 1901, true, Country.DE, null),
+            new TestPerson("Richard", "Feynman", 1918, true, Country.US, null),
+            new TestPerson( "James Clerk", "Maxwell", 1831, false, Country.UK, "Cambridge")
+        );
+    }
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPersonBase.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPersonBase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.util.test.person;
+
+public interface TestPersonBase {
+    String getLastName();
+}

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPersonInterface.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/test/person/TestPersonInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.endpoint.util.test.person;
+
+import java.util.Optional;
+
+public interface TestPersonInterface extends TestPersonBase {
+    String getFirstName();
+    int getBirthYear();
+    boolean isNobel();
+    TestPerson.Country getCountry();
+    Optional<String> getUniversity();
+}


### PR DESCRIPTION
* Extended the filtering feature to work with all data types, not only with String
* Fixed an issue that was not allowing to use Object super type
* Added test cases for ReflectionUtils
* Added test cases for ReflectiveFilterer

Fixes #8177 and closes ENTESB-13247

In order to ease the review, the idea is to be able to call an API by providing a query filter such as `api/v1/extensions?query=extensionType=Libraries,status=Installed` - this one, specifically was not working before this PR as the code only worked for String fields.