### PR TITLE
fix(build): pom_version in release

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -42,8 +42,8 @@ EOT
 get_release_version() {
 
     if [ $(hasflag --snapshot-release) ]; then
-            echo $(calc_timestamp_version "$topdir")
-            return
+        echo $(calc_timestamp_version "$topdir")
+        return 1
     fi
 
     local release_version=$(readopt --release-version)
@@ -179,8 +179,7 @@ create_moving_tag_release() {
 
 calc_timestamp_version() {
     local topdir=$1
-    cd $topdir/app
-    local pom_version=$(./mvnw -N help:evaluate -Dexpression="project.version" | grep  '^[0-9]' | sed -e 's/\([0-9]*\.[0-9]*\).*/\1/')
+    local pom_version=$(grep -oPm2 "(?<=<version>)[^<]+" "$topdir/app/pom.xml"| tail -1| sed -e 's/\([0-9]*\.[0-9]*\).*/\1/')
     if [ -z "${pom_version}" ]; then
         echo "ERROR: Cannot extract version from app/pom.xml"
         return 1
@@ -575,8 +574,8 @@ extract_minor_version() {
     local version=$1
     local minor_version=$(echo $version | sed 's/^\([0-9]*\.[0-9]*\)\.[0-9]*\(-.*\)*$/\1/')
     if [ "$minor_version" = "$version" ]; then
-        echo "ERROR: Cannot extract minor version from $version"
-        return
+        echo "ERROR: Cannot extract minor version from ${version}, computed ${minor_version}"
+        return 1
     fi
     echo $minor_version
 }


### PR DESCRIPTION
Even though the daily release passed, it did so due to poor error
handling. This should fix the error handling and the error that occurred
in the daily release.

For some reason (no error text so no way to know), fetching the version
from `pom.xml` via Maven failed. This uses the same `grep` based command
we use for incremental license format in `bin/misc/format-license.sh`
against the `app/pom.xml` to fetch the version instead of using Maven.

Should fix: `ERROR: Cannot extract version from app/pom.xml`