### PR TITLE
fix(#8125): Fix empty values handling in Google sheets

### DIFF
--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -117,7 +117,8 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
                         .entrySet()
                         .stream()
                         .filter(specEntry -> !Objects.equals("spreadsheetId", specEntry.getKey()))
-                        .forEach(specEntry -> rangeValues.add(dataShape.getOrDefault(specEntry.getKey(), "")));
+                        .forEach(specEntry -> rangeValues.add(Optional.ofNullable(dataShape.get(specEntry.getKey()))
+                                                                      .orElse("")));
 
                 values.add(rangeValues);
             }


### PR DESCRIPTION
The getOrDefault is not working when there is a key in the map with actual null value. So use Optional.ofNullable and make sure to handle null values and use empty String values instead.

Classic situation where unit tests where green but integration tests would have seen the error is still present.