### PR TITLE
user doc: Make it crystal clear that the toplevel "properties" attribute is required

### DIFF
--- a/doc/modules/customizing/c_about-extension-definitions.adoc
+++ b/doc/modules/customizing/c_about-extension-definitions.adoc
@@ -46,7 +46,7 @@ extension definition JSON file and which data structures are required.
 `description` +
 `version` +
 `extensionId` +
-`extensionType` 
+`extensionType` +
 `properties` +
 `actions` +
 `dependencies` * + 
@@ -113,7 +113,7 @@ Syndesis version 1.3, the following extension types are supported:
 ** `Connectors`
 ** `Libraries`
 
-* *properties* at the top level in a connector extension controls 
+* *properties* at the top level in a connector extension is required. It controls 
 what {prodname} displays when a {prodname} user selects the connector
 to create a connection. This `properties` object contains a set 
 of properties for each form control for creating a connection.

--- a/doc/modules/customizing/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
+++ b/doc/modules/customizing/r_descriptions-of-user-interface-properties-in-extension-definitions.adoc
@@ -69,7 +69,7 @@ image:images/integrating-applications/IRC-create-connection-fields.png[Hostname,
 
 In a connector extension:
 
-* The toplevel `properties` object controls 
+* The toplevel `properties` object is required. It controls 
 what {prodname} displays when a {prodname} user selects the connector
 to create a connection. This `properties` object contains a set 
 of properties for each form control for creating a connection.


### PR DESCRIPTION
The user doc actually already said this. But there was a format glitch that obscured this. 
And now, the doc explicitly states that the toplevel "properties" attribute is required in the JSON description file of a connector extension. Stan approved this addition. Gary too. 