### PR TITLE
TTOOLS-962 combine dv schema services

### DIFF
--- a/app/dv/src/main/java/io/syndesis/dv/server/V1Constants.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/V1Constants.java
@@ -135,7 +135,7 @@ public interface V1Constants extends StringConstants {
     /**
      * syndesis source summaries segment
      */
-    String SYNDESIS_SOURCE_STATUSES = "syndesisSourceStatuses"; //$NON-NLS-1$
+    String SOURCE_STATUSES = "sourceStatuses"; //$NON-NLS-1$
 
     /**
      * The view editor state of the user profile

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/IntegrationTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/IntegrationTest.java
@@ -292,7 +292,7 @@ public class IntegrationTest {
         //test that unqualified does not work
         query("select col from t union select 1 as col", dvName, false);
 
-        ResponseEntity<List> sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/syndesisSourceStatuses", List.class);
+        ResponseEntity<List> sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/sourceStatuses", List.class);
         assertEquals(HttpStatus.OK, sourceStatusResponse.getStatusCode());
         Map status = (Map)sourceStatusResponse.getBody().get(0);
         assertEquals(0, ((List)status.get("errors")).size());
@@ -352,7 +352,7 @@ public class IntegrationTest {
             }
         }
 
-        sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/syndesisSourceStatuses", List.class);
+        sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/sourceStatuses", List.class);
         assertEquals(HttpStatus.OK, sourceStatusResponse.getStatusCode());
         status = (Map)sourceStatusResponse.getBody().get(0);
         assertEquals(1, ((List)status.get("errors")).size());

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/MetadataServiceTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/MetadataServiceTest.java
@@ -108,7 +108,7 @@ public class MetadataServiceTest {
     public void testGetSchema() throws Exception {
         List<RestSchemaNode> nodes = null;
         try {
-            nodes = metadataService.getSchema("source2");
+            nodes = metadataService.getSourceSchema("source2");
             fail();
         } catch (ResponseStatusException e) {
             //no source yet
@@ -121,35 +121,41 @@ public class MetadataServiceTest {
                 "create foreign table tbl (col string) options (\"teiid_rel:fqn\" 'schema=s%20x/t%20bl=bar');"
                 + "create foreign table tbl1 (col string) options (\"teiid_rel:fqn\" 'schema=s%20x/t%20bl=bar1');");
 
-        nodes = metadataService.getSchema("source2");
-        assertEquals("[ {\n" +
-                "  \"children\" : [ {\n" +
-                "    \"children\" : [ ],\n" +
-                "    \"name\" : \"bar\",\n" +
-                "    \"teiidName\" : \"tbl\",\n" +
-                "    \"connectionName\" : \"source2\",\n" +
-                "    \"type\" : \"t bl\",\n" +
-                "    \"queryable\" : true\n" +
-                "  }, {\n" +
-                "    \"children\" : [ ],\n" +
-                "    \"name\" : \"bar1\",\n" +
-                "    \"teiidName\" : \"tbl1\",\n" +
-                "    \"connectionName\" : \"source2\",\n" +
-                "    \"type\" : \"t bl\",\n" +
-                "    \"queryable\" : true\n" +
-                "  } ],\n" +
-                "  \"name\" : \"s x\",\n" +
-                "  \"connectionName\" : \"source2\",\n" +
-                "  \"type\" : \"schema\",\n" +
-                "  \"queryable\" : false\n" +
-                "} ]", JsonMarshaller.marshall(nodes));
-    }
-
+        nodes = metadataService.getSourceSchema("source2");
+        assertEquals(
+            "[ {\n" +
+            "  \"children\" : [ {\n" +
+            "    \"children\" : [ {\n" +
+            "      \"children\" : [ ],\n" +
+            "      \"name\" : \"bar\",\n" +
+            "      \"teiidName\" : \"tbl\",\n" +
+            "      \"connectionName\" : \"source2\",\n" +
+            "      \"type\" : \"t bl\",\n" +
+            "      \"queryable\" : true\n" +
+            "    }, {\n" +
+            "      \"children\" : [ ],\n" +
+            "      \"name\" : \"bar1\",\n" +
+            "      \"teiidName\" : \"tbl1\",\n" +
+            "      \"connectionName\" : \"source2\",\n" +
+            "      \"type\" : \"t bl\",\n" +
+            "      \"queryable\" : true\n" +
+            "    } ],\n" +
+            "    \"name\" : \"s x\",\n" +
+            "    \"connectionName\" : \"source2\",\n" +
+            "    \"type\" : \"schema\",\n" +
+            "    \"queryable\" : false\n" +
+            "  } ],\n" +
+            "  \"name\" : \"source2\",\n" +
+            "  \"type\" : \"teiidSource\",\n" +
+            "  \"queryable\" : false\n" +
+            "} ]", JsonMarshaller.marshall(nodes));
+        }
+  
     @Test
     public void testGetSchemaSingleLevel() throws Exception {
         List<RestSchemaNode> nodes = null;
         try {
-            nodes = metadataService.getSchema("source3");
+            nodes = metadataService.getSourceSchema("source3");
             fail();
         } catch (ResponseStatusException e) {
             //no source yet
@@ -164,22 +170,28 @@ public class MetadataServiceTest {
                 "create foreign table tbl (col string) options (\"teiid_rel:fqn\" 'collection=bar');"
                 + "create foreign table tbl1 (col string) options (\"teiid_rel:fqn\" 'collection=bar1');");
 
-        nodes = metadataService.getSchema("source3");
-        assertEquals("[ {\n" +
-                "  \"children\" : [ ],\n" +
-                "  \"name\" : \"bar\",\n" +
-                "  \"teiidName\" : \"tbl\",\n" +
-                "  \"connectionName\" : \"source3\",\n" +
-                "  \"type\" : \"collection\",\n" +
-                "  \"queryable\" : true\n" +
-                "}, {\n" +
-                "  \"children\" : [ ],\n" +
-                "  \"name\" : \"bar1\",\n" +
-                "  \"teiidName\" : \"tbl1\",\n" +
-                "  \"connectionName\" : \"source3\",\n" +
-                "  \"type\" : \"collection\",\n" +
-                "  \"queryable\" : true\n" +
-                "} ]", JsonMarshaller.marshall(nodes));
+        nodes = metadataService.getSourceSchema("source3");
+        assertEquals(
+            "[ {\n" +
+            "  \"children\" : [ {\n" +
+            "    \"children\" : [ ],\n" +
+            "    \"name\" : \"bar\",\n" +
+            "    \"teiidName\" : \"tbl\",\n" +
+            "    \"connectionName\" : \"source3\",\n" +
+            "    \"type\" : \"collection\",\n" +
+            "    \"queryable\" : true\n" +
+            "  }, {\n" +
+            "    \"children\" : [ ],\n" +
+            "    \"name\" : \"bar1\",\n" +
+            "    \"teiidName\" : \"tbl1\",\n" +
+            "    \"connectionName\" : \"source3\",\n" +
+            "    \"type\" : \"collection\",\n" +
+            "    \"queryable\" : true\n" +
+            "  } ],\n" +
+            "  \"name\" : \"source3\",\n" +
+            "  \"type\" : \"teiidSource\",\n" +
+            "  \"queryable\" : false\n" +
+            "} ]", JsonMarshaller.marshall(nodes));
     }
 
     @Test

--- a/app/ui-react/packages/api/src/useVirtualizationConnectionSchema.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationConnectionSchema.tsx
@@ -3,8 +3,8 @@ import { useApiResource } from './useApiResource';
 
 export const useVirtualizationConnectionSchema = (teiidSourceName?: string) => {
   const url = teiidSourceName
-    ? `metadata/${teiidSourceName}/schema`
-    : `metadata/connectionSchema`;
+    ? `metadata/sourceSchema/${teiidSourceName}`
+    : `metadata/sourceSchema`;
 
   return useApiResource<SchemaNode[]>({
     defaultValue: [],

--- a/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
@@ -5,7 +5,7 @@ import { usePolling } from './usePolling';
 export const useVirtualizationConnectionStatuses = (disableUpdates: boolean = false) => {
   const { read, ...rest } = useApiResource<VirtualizationSourceStatus[]>({
     defaultValue: [],
-    url: 'metadata/syndesisSourceStatuses',
+    url: 'metadata/sourceStatuses',
     useDvApiUrl: true,
   });
 

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
@@ -157,7 +157,7 @@ export const ViewInfosContent: React.FunctionComponent<
     hasData,
     error,
     read,
-  } = useVirtualizationConnectionSchema();
+  } = useVirtualizationConnectionSchema(props.connectionTeiidName);
 
   React.useEffect(()=>{
     if (hasData) {

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -174,7 +174,7 @@ export function generateSchemaNodeInfos(
       schemaNodeInfos.push(view);
     }
     // Update path for next level
-    if (schemaNode.type !== 'root') {
+    if (schemaNode.type !== 'teiidSource') {
       sourcePath.push(schemaNode.name);
     }
     // Process this nodes children


### PR DESCRIPTION
Follow-up to TEIIDtOOLS-962.  Combines the schema service methods in MetadataService to make them consistent.
- removes the getSchema method and incorporates into getAllConnectionSchema so that returned schema structures are the same.  Renamed getAllConnectionSchema to getSourceSchema.
- renamed syndesisSourceStatuses service to sourceStatuses
- adapted the test cases and adapted the ui usages