### PR TITLE
fix[integration-test]: Fix some of the failing integration tests on master

### DIFF
--- a/app/connector/gmail/pom.xml
+++ b/app/connector/gmail/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.34.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/app/connector/google-calendar/pom.xml
+++ b/app/connector/google-calendar/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.34.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -29,10 +29,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <!-- To review when api client gets updated if 1.34.0 is available for this -->
-    <!-- This dependency is aligned with the camel version -->
-    <google-api-camel-client-version>1.22.0</google-api-camel-client-version>
-    <google-api-client-version>1.34.0</google-api-client-version>
+    <google-api-client-version>1.22.0</google-api-client-version>
     <google-api-services-sheets-version>v4-rev551-1.22.0</google-api-services-sheets-version>
   </properties>
 
@@ -53,11 +50,10 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- This also could be removed once we align versions up -->
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>${google-api-camel-client-version}</version>
+        <version>${google-api-client-version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -16,19 +16,16 @@
 
 package io.syndesis.test.itest.sheets;
 
-import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.http.server.HttpServer;
 import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -40,12 +37,6 @@ import static com.consol.citrus.http.actions.HttpActionBuilder.http;
  * @author Christoph Deppisch
  */
 public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
-
-    @Autowired
-    private DataSource sampleDb;
-
-    @Autowired
-    private HttpServer googleSheetsApiServer;
 
     /**
      * Integration periodically retrieves all contacts from the database and maps the entries (first_name, last_name, company) to a spreadsheet on a Google Sheets account.
@@ -65,7 +56,7 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testDBSplitToSheets(@CitrusResource TestCaseRunner runner) {
-        cleanupDatabase(runner, sampleDb);
+        cleanupDatabase(runner);
 
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -16,19 +16,16 @@
 
 package io.syndesis.test.itest.sheets;
 
-import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.http.server.HttpServer;
 import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -40,12 +37,6 @@ import static com.consol.citrus.http.actions.HttpActionBuilder.http;
  * @author Christoph Deppisch
  */
 public class DBToSheets_IT extends GoogleSheetsTestSupport {
-
-    @Autowired
-    private DataSource sampleDb;
-
-    @Autowired
-    private HttpServer googleSheetsApiServer;
 
     /**
      * Integration periodically retrieves all contacts from the database and maps the entries (first_name, last_name, company) to a spreadsheet on a Google Sheets account.
@@ -65,7 +56,7 @@ public class DBToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testDBToSheets(@CitrusResource TestCaseRunner runner) {
-        cleanupDatabase(runner, sampleDb);
+        cleanupDatabase(runner);
 
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
@@ -29,6 +29,7 @@ import com.consol.citrus.http.servlet.RequestCachingServletFilter;
 import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.itest.SyndesisIntegrationTestSupport;
 import io.syndesis.test.itest.sheets.util.GzipServletFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,6 +37,7 @@ import org.springframework.util.SocketUtils;
 import org.testcontainers.Testcontainers;
 
 import static com.consol.citrus.actions.ExecuteSQLAction.Builder.sql;
+import static com.consol.citrus.actions.PurgeEndpointAction.Builder.purgeEndpoints;
 
 /**
  * @author Christoph Deppisch
@@ -47,6 +49,12 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
     static {
         Testcontainers.exposeHostPorts(GOOGLE_SHEETS_SERVER_PORT);
     }
+
+    @Autowired
+    protected DataSource sampleDb;
+
+    @Autowired
+    protected HttpServer googleSheetsApiServer;
 
     @Configuration
     public static class EndpointConfig {
@@ -66,9 +74,12 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
         }
     }
 
-    protected void cleanupDatabase(TestCaseRunner runner, DataSource sampleDb) {
+    protected void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(purgeEndpoints()
+                    .endpoint(googleSheetsApiServer));
+
         runner.given(sql(sampleDb)
             .dataSource(sampleDb)
-            .statement("delete from todo"));
+            .statement("delete from contact"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -16,19 +16,16 @@
 
 package io.syndesis.test.itest.sheets;
 
-import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.http.server.HttpServer;
 import io.syndesis.test.SyndesisTestEnvironment;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -40,12 +37,6 @@ import static com.consol.citrus.http.actions.HttpActionBuilder.http;
  * @author Christoph Deppisch
  */
 public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
-
-    @Autowired
-    private DataSource sampleDb;
-
-    @Autowired
-    private HttpServer googleSheetsApiServer;
 
     /**
      * Integration uses multiple data buckets for a data mapping. In this case mapper maps data from two SQL queries
@@ -66,7 +57,7 @@ public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testMultiSqlMapper(@CitrusResource TestCaseRunner runner) {
-        cleanupDatabase(runner, sampleDb);
+        cleanupDatabase(runner);
 
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
@@ -19,10 +19,8 @@ package io.syndesis.test.itest.sheets;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.http.server.HttpServer;
 import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.testcontainers.containers.GenericContainer;
@@ -33,9 +31,6 @@ import static com.consol.citrus.http.actions.HttpActionBuilder.http;
  * @author Christoph Deppisch
  */
 public class SheetsToSheets_IT extends GoogleSheetsTestSupport {
-
-    @Autowired
-    private HttpServer googleSheetsApiServer;
 
     /**
      * Integration periodically retrieves all values from Google Sheets spreadsheet range A:E and maps the column names to custom names. The obtained

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -19,6 +19,7 @@ package io.syndesis.test.itest.sql;
 import javax.sql.DataSource;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
@@ -86,6 +87,7 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(httpTestServer)
                 .receive()
                 .put()
+                .selector(Collections.singletonMap("jsonPath:$.contact", "@startsWith(Joanne)@"))
                 .payload("{\"contact\":\"Joanne Jackson Red Hat\"}"));
 
         runner.then(http().server(httpTestServer)
@@ -95,6 +97,7 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(httpTestServer)
                 .receive()
                 .put()
+                .selector(Collections.singletonMap("jsonPath:$.contact", "@startsWith(Joe)@"))
                 .payload("{\"contact\":\"Joe Jackson Red Hat\"}"));
 
         runner.then(http().server(httpTestServer)

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/sheets/DBSplitToSheets-export/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/sheets/DBSplitToSheets-export/model.json
@@ -2435,7 +2435,7 @@
       ],
       "dependencies": [
         {
-          "id": "io.syndesis.connector:connector-sql:${project.version}",,
+          "id": "io.syndesis.connector:connector-sql:${project.version}",
           "type": "MAVEN"
         },
         {


### PR DESCRIPTION
- DBToHttp_IT
Order of queried entries in database seems to differ between environments (locally, CI). Added a message selector to make test more robust by selecting always the right message based on a JsonPath expression evaluated on the Http request payload.
- DBSplitToSheets_IT
Typo in model.json
- Google sheets tests
Tests need to cleanup the contact table between the tests
- Fix api client versions used in Google connectors
Revert dependabot update of api client versions. This leads to unexpected behavior and MethodNotFound errors because underlying Google Camel components still use 1.22.0 as client and api versions. If we want to update to 1.34.0 we need to update Camel components first. Otherwise we end up having mixed versions on the classpath leading to errors. Google sheets integration tests were failing because of that.