### PR TITLE
Fix daily builds on ci.fabric8.io

### DIFF
--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -87,18 +87,6 @@
           </execution>
 
           <execution>
-            <id>yarn-list</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>yarn</goal>
-            </goals>
-            <configuration>
-              <arguments>list</arguments>
-              <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
-            </configuration>
-          </execution>
-
-          <execution>
             <id>yarn-lint</id>
             <phase>verify</phase>
             <goals>

--- a/app/ui-react/syndesis/craco.config.js
+++ b/app/ui-react/syndesis/craco.config.js
@@ -16,5 +16,12 @@ module.exports = function({ env, paths }) {
         },
       }),
     },
+    jest: {
+      configure: (jestConfig, { env, paths, resolve, rootDir }) => ({
+        ...jestConfig,
+
+        moduleFileExtensions: ['ts', 'tsx', 'js'],
+      }),
+    },
   };
 };


### PR DESCRIPTION
Two changes:

chore: remove `yarn list` from build (46b5277)

This was generating a lot of output in the console/build logs, not sure
why it was added, most likely to troubleshoot an issue; and it seems no
longer needed.

fix(ui): build on ci.fabric8.io (4504ba6)

For whatever reason Jest is unable to resolve modules on ci.fabric8.io
with this error:

```
INFO] lerna ERR! yarn run test --coverage --color --runInBand stderr:
[INFO]  FAIL  src/app/App.test.tsx
[INFO]   ● Test suite failed to run
[INFO]
[INFO]     Cannot find module '/mnt/hudson_workspace/workspace/syndesis-release-daily/app/ui-react/node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/interopRequireWildcard' from 'App.tsx'
[INFO]
[INFO]     However, Jest was able to find:
[INFO]     	'./App.css'
[INFO]     	'./App.test.tsx'
[INFO]     	'./App.tsx'
[INFO]
[INFO]     You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['web.js', 'js', 'web.ts', 'ts', 'web.tsx', 'tsx', 'json', 'web.jsx', 'jsx', 'node'].
[INFO]
[INFO]     See jestjs.io/docs/en/configuration#modulefileextensions-array-string
[INFO]
[INFO]
[INFO]
[INFO]       at Resolver.resolveModule (../node_modules/jest-resolve/build/index.js:259:17)
[INFO]       at Object.<anonymous> (src/app/App.tsx:369:31)
[INFO]       at Object.<anonymous> (src/app/App.test.tsx:4:1)
```

For whatever reason this change seems to help with that.

The default `moduleFileExtensions`[1] is:

`["web.js", "js", "web.ts", "ts", "web.tsx", "tsx", "json", "web.jsx", "jsx", "node"]`

and this sets it to:

`['ts', 'tsx', 'js']`

[1] https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring

