### PR TITLE
fix(test): maven debug option fix

### DIFF
--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -366,7 +366,7 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
         }
 
         private static String getDebugJvmArguments() {
-            return String.format("-Drun.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s\"", SyndesisTestEnvironment.getDebugPort());
+            return String.format("-Dspring-boot.run.jvmArguments=\"-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s\"", SyndesisTestEnvironment.getDebugPort());
         }
     }
 


### PR DESCRIPTION
We were using `exec:java` debugging option instead of `spring-boot:run` option.

Fixes #8265