### PR TITLE
[PF4 migration] Added test-ids to API connector page

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormLabelHintComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormLabelHintComponent.tsx
@@ -15,7 +15,7 @@ export const FormLabelHintComponent: React.FunctionComponent<IFormLabelHintCompo
       bodyContent={labelHint}
       className={'form-label-hint__popover'}
     >
-      <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
+      <OutlinedQuestionCircleIcon className="pf-u-ml-xs" data-testid={'tooltip'}/>
     </Popover>
   )
 };

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListItem.tsx
@@ -98,6 +98,7 @@ export const ApiConnectorListItem: React.FC<
                 {apiConnectorIcon ? (
                   <div className={'api-connector-list-item__icon-wrapper'}>
                     <img
+                      data-testid={'api-connector-icon'}
                       src={apiConnectorIcon}
                       alt={apiConnectorName}
                       width={46}
@@ -107,16 +108,19 @@ export const ApiConnectorListItem: React.FC<
               </DataListCell>,
               <DataListCell key={'primary content'} width={4}>
                 <div className={'api-connector-list-item__text-wrapper'}>
-                  <b>{apiConnectorName}</b><br/>
-                  {
+                  <b data-testid={'api-connector-name'}>{apiConnectorName}</b><br/>
+                  <span data-testid={'api-connector-description'}>{
                     apiConnectorDescription
                       ? apiConnectorDescription
                       : ''
-                  }
+                  }</span>
                 </div>
               </DataListCell>,
               <DataListCell key={'secondary content'} width={4}>
-                <div className={'api-connector-list-item__used-by'}>
+                <div 
+                  className={'api-connector-list-item__used-by'}
+                  data-testid={'api-connector-used-by'}
+                >
                   {i18nUsedByMessage}
                 </div>
               </DataListCell>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorListView.tsx
@@ -57,7 +57,10 @@ export const ApiConnectorListView: React.FunctionComponent<IApiConnectorListView
         />
       )}
       {children ? (
-        <DataList aria-label={'api connector list'}>{children}</DataList>
+        <DataList data-testid={'api-connector-list'} 
+                  aria-label={'api connector list'}>
+            {children}
+        </DataList>
       ) : (
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon icon={AddCircleOIcon}/>


### PR DESCRIPTION
Added test id to the tooltip icon and to API Connector page to describe the different sections of the list.