### PR TITLE
fix(deps): exclude javax.activation:activation

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2636,6 +2636,10 @@
             <groupId>javax.xml.stream</groupId>
             <artifactId>stax-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -2676,6 +2680,10 @@
           <exclusion>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Including both `javax.activation:activation` and
`com.sun.activation:jakarta.activation` is causing daily 1.10 builds to
fail.