### PR TITLE
fix(c/slack): don't leak the token

### DIFF
--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackMetaDataExtension.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackMetaDataExtension.java
@@ -84,7 +84,7 @@ public class SlackMetaDataExtension extends AbstractMetaDataExtension {
                                 .withAttribute(MetaData.JAVA_TYPE, String.class).withPayload(setChannels).build());
             } catch (Exception e) {
                 throw new IllegalStateException(
-                    "Get information about channels failed with token " + token + " has failed.", e);
+                    "Get information about channels failed with token has failed.", e);
             }
         } else {
             return Optional.empty();


### PR DESCRIPTION
We should not be leaking the configured token to the logs or to the caller hierarchy.