### PR TITLE
(backport-1.10.x)[PF4 migration] Added DataTestIds to activity, metrics and cicd pages

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiClientConnectorCreateSecurity.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
+import { toValidHtmlId } from '../../../helpers';
 import { ButtonLink } from '../../../Layout';
 
 export interface IAuthenticationTypes {
@@ -117,6 +118,7 @@ export const ApiClientConnectorCreateSecurity: React.FunctionComponent<IApiClien
               <Radio
                 key={authType.value + '-' + idx}
                 id={'authenticationType'}
+                data-testid={`api-client-connector-auth-type-${toValidHtmlId(authType!.value)}`}
                 aria-label={authType.label || i18nNoSecurity}
                 label={authType.label || i18nNoSecurity}
                 isChecked={selectedType === authType.value}

--- a/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
@@ -25,13 +25,13 @@ export const UptimeMetric: React.FunctionComponent<IUptimeMetricProps> = ({
       <CardBody>
         <Title size="md" className="metrics-uptime__header">
           <div>{i18nTitle}</div>
-          <div className="metrics-uptime__uptime">
+          <div className="metrics-uptime__uptime" data-testid={'dashboard-page-metrics-uptime-since'}>
             {i18nSince} {startAsHuman}
           </div>
         </Title>
       </CardBody>
       <CardBody>
-        <span>{uptimeDuration}</span>
+        <span data-testid={'dashboard-page-metrics-uptime-duration'}>{uptimeDuration}</span>
       </CardBody>
     </Card>
   );

--- a/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Activity/IntegrationDetailActivityItem.tsx
@@ -113,27 +113,33 @@ export const IntegrationDetailActivityItem: React.FC<
   ];
 
   return (
-    <DataListItem aria-labelledby="activity item" isExpanded={rowExpanded} className={'integration-detail-activity-item'}>
+    <DataListItem 
+      aria-labelledby="activity item" 
+      isExpanded={rowExpanded} 
+      className={'integration-detail-activity-item'}
+      data-testid={'integration-detail-activity-item'}
+    >
       <DataListItemRow>
         <DataListToggle
           onClick={doExpand}
           isExpanded={rowExpanded}
           id="activity-item-toggle"
+          data-testid={'integration-detail-activity-item-toggle'}
         />
         <DataListItemCells
           dataListCells={[
-            <DataListCell id="activity-date" key="date">
+            <DataListCell id="activity-date" data-testid={'integration-detail-activity-item-date'} key="date">
               {date}
             </DataListCell>,
-            <DataListCell id="activity-time" key="time">
+            <DataListCell id="activity-time" data-testid={'integration-detail-activity-item-time'} key="time">
               {time}
             </DataListCell>,
-            <DataListCell id="activity-version" key="version">
+            <DataListCell id="activity-version" data-testid={'integration-detail-activity-item-version'} key="version">
               {i18nVersion}
               &nbsp;
               {version}
             </DataListCell>,
-            <DataListCell id="activity-errors" key="errors">
+            <DataListCell id="activity-errors" data-testid={'integration-detail-activity-item-errors'} key="errors">
               <div className={'integration-detail-activity-item__status-item'}>
                 {errorCount > 0 ? (
                   <>

--- a/app/ui-react/packages/ui/src/Integration/CiCd/CiCdListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/CiCd/CiCdListItem.tsx
@@ -48,12 +48,14 @@ export const CiCdListItem: React.FC<ICiCdListItemProps> = ({
         <DataListItemCells
           dataListCells={[
             <DataListCell key={'primary content'} width={2}>
-              <div className={'cicd-list-item__text-wrapper'}>
+              <div className={'cicd-list-item__text-wrapper'} data-testid={`cicd-list-item-name`}>
                 <b>{name}</b>
               </div>
             </DataListCell>,
             <DataListCell key={'secondary content'} width={4}>
-              <div className={'cicd-list-item__uses-text'}>{i18nUsesText}</div>
+              <div className={'cicd-list-item__uses-text'} data-testid={`cicd-list-item-usage`}>
+                {i18nUsesText}
+              </div>
             </DataListCell>,
           ]}
         />

--- a/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationListItem.tsx
@@ -31,6 +31,7 @@ export const TagIntegrationListItem: React.FunctionComponent<ITagIntegrationList
         <DataListCheck
           aria-labelledby="tag-integration-list-item-check"
           name="tag-integration-list-item-check"
+          data-testid={`tag-integration-list-item-check`}
           checked={itemSelected}
           // tslint:disable-next-line: jsx-no-lambda
           onChange={(checked, event) => {setItemSelected(checked); props.onChange(props.name, checked)}}
@@ -38,7 +39,10 @@ export const TagIntegrationListItem: React.FunctionComponent<ITagIntegrationList
         <DataListItemCells
           dataListCells={[
             <DataListCell key={'primary content'} width={2}>
-              <div className={'tag-integration-list-item__text-wrapper'}>
+              <div 
+                className={'tag-integration-list-item__text-wrapper'}
+                data-testid={`tag-integration-list-item-text`}
+              >
                 <b>{props.name}</b>
               </div>
             </DataListCell>,

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -52,7 +52,7 @@ export const IntegrationDetailMetrics: React.FunctionComponent<IIntegrationDetai
             </CardHeader>
             <CardBody>
               <br />
-              <Title size={'xl'}>
+              <Title size={'xl'} data-testid={'integration-detail-metrics-total-errors'}>
                 <ErrorCircleOIcon color={global_danger_color_100.value} />
                 &nbsp;{errors}
               </Title>
@@ -69,6 +69,7 @@ export const IntegrationDetailMetrics: React.FunctionComponent<IIntegrationDetai
               <Title
                 size={'xl'}
                 className="integration-detail-metrics__last-processed"
+                data-testid={'integration-detail-metrics-last-processed'}
               >
                 {lastProcessed ? lastProcessed : i18nNoDataAvailable}
               </Title>


### PR DESCRIPTION
Backport of https://github.com/syndesisio/syndesis/pull/8291 to 1.10.x